### PR TITLE
White-space pre-wrap fixes our text overflow issues for pre code blocks

### DIFF
--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/insights.scss
+++ b/packages/inventory-insights/src/insights.scss
@@ -50,7 +50,7 @@
         background-color: #f5f5f5;
         border: 1px solid #ccc;
         border-radius: 4px;
-        code { white-space: inherit; }
+        code { white-space: pre-wrap; }
     }
 
     ol {


### PR DESCRIPTION
### before 
<img width="1761" alt="Screen Shot 2019-05-31 at 11 20 10 AM" src="https://user-images.githubusercontent.com/6640236/58716212-86b73f00-8396-11e9-8e14-f524c43acb92.png">


### after
<img width="1765" alt="Screen Shot 2019-05-31 at 11 21 01 AM" src="https://user-images.githubusercontent.com/6640236/58716211-861ea880-8396-11e9-9156-341e97bdcae1.png">
