### PR TITLE
 Adds shorthand: true to lodash webpack plugin, redoing  #43 

### DIFF
--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -10,7 +10,8 @@ const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({
     currying: true,
     flattening: true,
     placeholders: true,
-    paths: true
+    paths: true,
+    shorthands: true
 });
 const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
     chunkFilename: 'css/[name].css',


### PR DESCRIPTION
identical to https://github.com/RedHatInsights/frontend-components/pull/43 

cept in the right place, sorry, `@redhat-cloud-services/frontend-components-config` is a tough package for me to find apparently :sob: