### PR TITLE
 RHICOMPL-156 - Do not parse shortened compliance ref_ids 

### DIFF
--- a/packages/inventory-compliance/package-lock.json
+++ b/packages/inventory-compliance/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-compliance",
-    "version": "0.0.4",
+    "version": "0.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-compliance",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "Detail part of compliance for RedHat Cloud Services.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-compliance",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Detail part of compliance for RedHat Cloud Services.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -31,7 +31,14 @@ class ComplianceRemediationButton extends React.Component {
     }
 
     removeRefIdPrefix = (ref_id) => {
-        return ref_id.split('xccdf_org.ssgproject.content_profile_')[1];
+        const splitRefId = ref_id.split('xccdf_org.ssgproject.content_profile_')[1];
+        if (splitRefId) {
+            return splitRefId;
+        } else {
+            // Sometimes the reports contain IDs like "stig-rhel7-disa" which we can pass
+            // directly
+            return ref_id;
+        }
     }
 
     rulesWithRemediations = (rules, system_id) => {


### PR DESCRIPTION
Ref IDs come from reports in 2 formats, usually they come like `xccdf_org.ssgproject.content_profile_standard` - in such case, we need to strip the `xccdf_org.ssgproject.content_profile_` part before we send it to remediations. Some other reports may come with ref_ids like `stig-rhel7-disa` which we do not need to parse. 