### PR TITLE
Ensures correct sanitization of >, <, &

### DIFF
--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/ReportDetails.js
+++ b/packages/inventory-insights/src/ReportDetails.js
@@ -14,11 +14,17 @@ class ReportDetails extends React.Component {
     templateProcessor = (template, definitions) => {
         const DOT_SETTINGS = { ...doT.templateSettings, varname: [ 'pydata' ], strip: false };
         const sanitizeOptions = {
-            allowedAttributes: {
-                '*': [ 'style' ]
-            },
+            allowedAttributes: { ...sanitizeHtml.defaults.allowedAttributes, '*': [ 'style' ]},
             transformTags: {
-                ul: sanitizeHtml.simpleTransform('ul', { class: 'pf-c-list' })
+                ul (tagName, attribs) {
+                    return {
+                        tagName: 'ul',
+                        attribs: { class: 'pf-c-list' }
+                    };
+                }
+            },
+            textFilter (text) {
+                return text.replace(/&amp;/g, '&').replace(/&gt;/g, '>').replace(/&lt;/g, '<');
             }
         };
         const externalLinkIcon = '';
@@ -31,7 +37,7 @@ class ReportDetails extends React.Component {
                 __html: compiledMd
                 .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
                 .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`)
-            } } />;
+            } }/>;
         } catch (error) {
             console.warn(error, definitions, template); // eslint-disable-line no-console
             return <React.Fragment> Ouch. We were unable to correctly render this text, instead please enjoy the raw data.
@@ -40,7 +46,7 @@ class ReportDetails extends React.Component {
         }
     };
 
-    render() {
+    render () {
         const { report, kbaDetail } = this.props;
         const rule = report.rule || report;
         let rulesCardClasses = classNames(
@@ -54,7 +60,7 @@ class ReportDetails extends React.Component {
                         <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <BullseyeIcon />
+                                    <BullseyeIcon/>
                                     <strong> Detected issues</strong>
                                 </CardHeader>
                                 <CardBody>
@@ -65,7 +71,7 @@ class ReportDetails extends React.Component {
                         <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <ThumbsUpIcon />
+                                    <ThumbsUpIcon/>
                                     <strong> Steps to resolve</strong>
                                 </CardHeader>
                                 <CardBody>
@@ -76,17 +82,17 @@ class ReportDetails extends React.Component {
                         { kbaDetail && kbaDetail.view_uri && <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <LightbulbIcon /><strong> Related Knowledgebase article: </strong>
+                                    <LightbulbIcon/><strong> Related Knowledgebase article: </strong>
                                 </CardHeader>
                                 <CardBody>
-                                    <a href={ `${kbaDetail.view_uri}` } rel="noopener">{ kbaDetail.publishedTitle } <ExternalLinkAltIcon /></a>
+                                    <a href={ `${kbaDetail.view_uri}` } rel="noopener">{ kbaDetail.publishedTitle } <ExternalLinkAltIcon/></a>
                                 </CardBody>
                             </Card>
                         </StackItem> }
                         <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <InfoCircleIcon /><strong> Additional info:</strong>
+                                    <InfoCircleIcon/><strong> Additional info:</strong>
                                 </CardHeader>
                                 <CardBody>
                                     { rule.more_info && this.templateProcessor(rule.more_info) }
@@ -94,17 +100,17 @@ class ReportDetails extends React.Component {
                                         <ListItem>
                                             { `To learn how to upgrade packages, see ` }<a href="https://access.redhat.com/solutions/9934"
                                                 rel="noopener">
-                                                What is yum and how do I use it? <ExternalLinkAltIcon />
+                                            What is yum and how do I use it? <ExternalLinkAltIcon/>
                                             </a>{ `.` }
                                         </ListItem>
                                         <ListItem>{ `The Customer Portal page for the ` }
                                             <a href="https://access.redhat.com/security/" rel="noopener">Red Hat Security Team
-                                                <ExternalLinkAltIcon /></a> { ` contains more information about policies, procedures, and alerts for
+                                                <ExternalLinkAltIcon/></a> { ` contains more information about policies, procedures, and alerts for
                                                 Red Hat Products.` }
                                         </ListItem>
                                         <ListItem>{ `The Security Team also maintains a frequently updated blog at ` }
                                             <a href="https://securityblog.redhat.com"
-                                                rel="noopener">securityblog.redhat.com <ExternalLinkAltIcon /></a>.
+                                                rel="noopener">securityblog.redhat.com <ExternalLinkAltIcon/></a>.
                                         </ListItem>
                                     </List>
                                 </CardBody>


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721265

We gotta sanitize, but also gotta accurately represent code elements... (sanitation seeeeees these a open brackets, kills em)

### See now we render it correctly!
<img width="1148" alt="Screen Shot 2019-06-17 at 5 38 31 PM" src="https://user-images.githubusercontent.com/6640236/59639528-8c987880-9129-11e9-8b38-31807f54e4fc.png">
