### PR TITLE
Adds pick-ah-row for ansible remediation

### DIFF
--- a/packages/inventory-insights/package-lock.json
+++ b/packages/inventory-insights/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@redhat-cloud-services/frontend-components-inventory-insights",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1704

When no rows are highlighted, our button is disabled, if you select all rows, we only process those with playbooks (duh 😏 )

### Looks like...
<img width="1392" alt="Screen Shot 2019-07-02 at 8 53 47 AM" src="https://user-images.githubusercontent.com/6640236/60514418-72bd7080-9ca7-11e9-87d9-98977a4cc8d9.png">
<img width="901" alt="Screen Shot 2019-07-02 at 8 53 34 AM" src="https://user-images.githubusercontent.com/6640236/60514419-72bd7080-9ca7-11e9-8a92-ae673ee5d991.png">
<img width="1219" alt="Screen Shot 2019-07-02 at 10 06 26 AM" src="https://user-images.githubusercontent.com/6640236/60519362-66d6ac00-9cb1-11e9-83a8-0e406963858d.png">
