### PR TITLE
Fixes RHICOMPL-223: Handle errored remediations

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -131,7 +131,7 @@ class SystemRulesTable extends React.Component {
 
         return window.insights.chrome.auth.getUser()
         .then(() => {
-            return remediationsApi.getResolutionsBatch(ruleIds)
+            return remediationsApi.getResolutionsBatch(ruleIds).catch(e => newRows)
             .then(response => newRows.map(({ cells, ...row }) => ({
                 ...row,
                 cells: [


### PR DESCRIPTION
If the remediations API fails for whatever reason, we should handle it
as gracefully as possible in the system details rules table.

If the remediations API is down, the table will just show that no remediation is available. I think this is fine, because the remediation isn't available _at this time_, at least.

Signed-off-by: Andrew Kofink <akofink@redhat.com>