### PR TITLE
Update eslint-loader dep to support v6 eslint 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9451,9 +9451,9 @@
       }
     },
     "eslint-loader": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
-      "integrity": "sha512-1GrJFfSevQdYpoDzx8mEE2TDWsb/zmFuY09l6hURg1AeFIKQOvZ+vH0UPjzmd1CZIbfTV5HUkMeBmFiDBkgIsQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.2.1.tgz",
+      "integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
       "dev": true,
       "requires": {
         "loader-fs-cache": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "enzyme-to-json": "^3.3.4",
         "eslint": "^5.6.0",
         "eslint-config-prettier": "^3.1.0",
-        "eslint-loader": "^2.1.0",
+        "eslint-loader": "^2.2.1",
         "eslint-plugin-react": "^7.11.1",
         "file-loader": "^1.1.11",
         "glob": "^7.1.3",

--- a/packages/config/package-lock.json
+++ b/packages/config/package-lock.json
@@ -939,6 +939,11 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2025,222 +2030,15 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"eslint-loader": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.2.tgz",
-			"integrity": "sha512-rA9XiXEOilLYPOIInvVH5S/hYfyTPyxag6DZhoQOduM+3TkghAEQ3VcFO8VnX4J4qg/UIBzp72aOf/xvYmpmsg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.2.1.tgz",
+			"integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
 			"requires": {
 				"loader-fs-cache": "^1.0.0",
 				"loader-utils": "^1.0.2",
 				"object-assign": "^4.0.1",
 				"object-hash": "^1.1.4",
 				"rimraf": "^2.6.1"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-				},
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"commondir": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-				},
-				"emojis-list": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-				},
-				"find-cache-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-					"requires": {
-						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-						}
-					}
-				},
-				"loader-fs-cache": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
-					"integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
-					"requires": {
-						"find-cache-dir": "^0.1.1",
-						"mkdirp": "0.5.1"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				},
-				"object-hash": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-					"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
-				},
-				"once": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "^2.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-				},
-				"pinkie": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-				},
-				"pinkie-promise": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"requires": {
-						"pinkie": "^2.0.0"
-					}
-				},
-				"pkg-dir": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-					"requires": {
-						"find-up": "^1.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-				}
 			}
 		},
 		"esprima": {
@@ -2393,6 +2191,26 @@
 					"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 					"requires": {
 						"punycode": "^2.1.0"
+					}
+				}
+			}
+		},
+		"find-cache-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+			"requires": {
+				"commondir": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pkg-dir": "^1.0.0"
+			},
+			"dependencies": {
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"requires": {
+						"find-up": "^1.0.0"
 					}
 				}
 			}
@@ -3492,6 +3310,15 @@
 				"strip-bom": "^2.0.0"
 			}
 		},
+		"loader-fs-cache": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
+			"integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
+			"requires": {
+				"find-cache-dir": "^0.1.1",
+				"mkdirp": "0.5.1"
+			}
+		},
 		"loader-utils": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -4085,6 +3912,11 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-hash": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -6189,8 +6021,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -6208,13 +6039,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -6227,18 +6056,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -6341,8 +6167,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -6352,7 +6177,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -6365,20 +6189,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -6395,7 +6216,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -6468,8 +6288,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -6479,7 +6298,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6555,8 +6373,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6586,7 +6403,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6604,7 +6420,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6643,13 +6458,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				},

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,7 +22,7 @@
         "connect-history-api-fallback": "^1.6.0",
         "copy-webpack-plugin": "^5.0.3",
         "css-loader": "^2.1.1",
-        "eslint-loader": "^2.1.2",
+        "eslint-loader": "^2.2.1",
         "file-loader": "^3.0.1",
         "git-revision-webpack-plugin": "^3.0.3",
         "html-replace-webpack-plugin": "^2.5.5",


### PR DESCRIPTION
Apps using the common webpack config need this to be able to update to eslint v6.x

### Otherwise
<img width="1439" alt="Screen Shot 2019-07-08 at 9 13 17 AM" src="https://user-images.githubusercontent.com/6640236/60813121-020fcb80-a161-11e9-8a94-2ac6538b3a2c.png">
