### PR TITLE
Hides reports if show_satellite_managed is false

### DIFF
--- a/packages/inventory-insights/package-lock.json
+++ b/packages/inventory-insights/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.8",
+    "version": "0.1.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.8",
+    "version": "0.1.10",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/Constants.js
+++ b/packages/inventory-insights/src/Constants.js
@@ -7,7 +7,7 @@ export const ANSIBLE_ICON = <svg version="1.1" id="ansible_icon" width="18px" he
         className="st0"/>
 </svg>;
 
-export const SYSTEM_FETCH_URL = '/api/insights/v1/system/';
+export const BASE_FETCH_URL = '/api/insights/v1/';
 
 export const FILTER_CATEGORIES = [
     {


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-1547

We need the 
* ~`show_satellite_hosts` attribute to show up on the entityDetails state~ ends up satellite_id is sufficient
* ~to GET to api/insights/v1/account_setting/ (but maybe account settings should also be on the platform state)~ maybe one day we'll pull it from the state, till then this'll work

### (updated) what it looks like when we don't show reports for satellite managed systems
<img width="1710" alt="Screen Shot 2019-07-15 at 11 50 29 AM" src="https://user-images.githubusercontent.com/6640236/61229958-1e7aad80-a6f7-11e9-8c32-4792318cd2ec.png">
