### PR TITLE
Only capitalize severity column, not whole rules table

### DIFF
--- a/packages/inventory-compliance/src/compliance.scss
+++ b/packages/inventory-compliance/src/compliance.scss
@@ -59,6 +59,6 @@
     word-wrap: break-word;
 }
 
-.compliance-rules-table {
+.compliance-rules-table td[data-label=Severity] {
     text-transform: capitalize;
 }


### PR DESCRIPTION
From Eddie Chen:

> Lastly, a small personal opinion, in the description of each rule, would it be possible to make the command not uppercased? It would make it easier for consumers to just copy and paste to the terminal. Ex...
> 
> Description
> The Rlogin Service, Which Is Available With The Rsh-Server Package And Runs As A Service Through Xinetd Or Separately As A Systemd Socket, Should Be Disabled. If Using Xinetd, Set Disable To Yes In /Etc/Xinetd.D/Rlogin. The Rlogin Socket Can Be Disabled With The Following Command: $ Sudo Systemctl Disable Rlogin.Socket

Signed-off-by: Andrew Kofink <akofink@redhat.com>