### PR TITLE
Add UI for rule references/identifiers

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -46,9 +46,17 @@ query System($systemId: String!){
                 refId
                 description
                 compliant(systemId: $systemId)
+                identifier {
+                    label
+                    system
+                }
+                references {
+                    label
+                    href
+                }
             }
         }
-	}
+    }
 }
 `;
 

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -14,6 +14,8 @@ import {
     EmptyStateVariant,
     Level,
     LevelItem,
+    Grid,
+    GridItem,
     Stack,
     StackItem,
     Pagination,
@@ -247,7 +249,15 @@ class SystemRulesTable extends React.Component {
         ]
     })
 
-    calculateChild = ({ description, rationale }, key) => ({
+    conditionalLink = (children, href, additionalProps) => (
+        href && <a href={ href } { ...additionalProps }>{ children }</a> || children
+    )
+
+    referencesList = (references) => references.reduce((acc, reference, i) => ([
+        acc, ', ', this.conditionalLink(reference.label, reference.href, { target: '_blank', key: i + 1 })
+    ]), this.conditionalLink(references[0].label, references[0].href, { target: '_blank', key: 0 }));
+
+    calculateChild = ({ description, rationale, identifier, references }, key) => ({
         parent: key * 2,
         cells: [{
             title: (
@@ -258,6 +268,19 @@ class SystemRulesTable extends React.Component {
                                 <Text component={ TextVariants.h5 }><b>Description</b></Text>
                             </StackItem>
                             <StackItem isFilled>{ description }</StackItem>
+                        </Stack>
+                        <Stack id={ `rule-identifiers-references-${key}` } className='margin-bottom-lg'>
+                            <Grid>
+                                <GridItem span={ 2 }>
+                                    <Text component={ TextVariants.h5 }><b>Identifier</b></Text>
+                                    <Text>{ identifier && this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
+                                </GridItem>
+
+                                { references.length > 0 ? <GridItem span={ 10 }>
+                                    <Text component={ TextVariants.h5 }><b>References</b></Text>
+                                    <Text>{ this.referencesList(references) }</Text>
+                                </GridItem> : '' }
+                            </Grid>
                         </Stack>
                         { rationale &&
                         <Stack id={ `rule-rationale-${key}` } style={ { marginBottom: 'var(--pf-global--spacer--lg)' } }>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/761923/61893390-f1d74a80-aedb-11e9-8de4-bdee680aee53.png)

If no references:

![image](https://user-images.githubusercontent.com/761923/61978505-73ec6f80-afbf-11e9-8dca-43ff376cbf7a.png)

With some references that don't have an href:

![image](https://user-images.githubusercontent.com/761923/61978813-363c1680-afc0-11e9-806a-000ade06c323.png)

@katierik please take a look as well. Do you think we should hide labels if no data exists? @dLobatog should we display references is any particular order?

Signed-off-by: Andrew Kofink <akofink@redhat.com>