### PR TITLE
Update Summary screen according to design

### DIFF
--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -296,20 +296,22 @@ const sourceTypeSteps = sourceTypes =>
     sourceTypes.map(t => fieldsToSteps(sourceTypeSchema(t), t.name, 'summary'))
     .flatMap((x) => x);
 
-const summaryStep = () => ({
+const summaryStep = (sourceTypes) => ({
     fields: [
         {
             component: 'description',
             name: 'description-summary',
             content: <TextContent>
+                <Title headingLevel="h3" size="2xl">Review source details</Title>
                 <Text component={ TextVariants.p }>
-            Review source details and click Add source to complete source creation. Click Back to revise.
+            Review the information below and click Finish to configure your project. Use the Back button to make changes.
                 </Text>
             </TextContent>
         },
         {
             name: 'summary',
-            component: 'summary'
+            component: 'summary',
+            sourceTypes
         }],
     stepKey: 'summary',
     name: 'summary',
@@ -324,10 +326,13 @@ export default (sourceTypes) => (
             title: 'Add a source',
             inModal: true,
             description: 'You are importing data into this platform',
+            buttonLabels: {
+                submit: 'Finish'
+            },
             fields: [
                 firstStepNew(sourceTypes),
                 ...sourceTypeSteps(sourceTypes),
-                summaryStep()
+                summaryStep(sourceTypes)
             ]
         }
     ]});

--- a/packages/sources/src/index.js
+++ b/packages/sources/src/index.js
@@ -1,3 +1,4 @@
 import { AddSourceButton, AddSourceWizard } from './addSourceWizard/index';
+import SummaryStep from './sourceFormRenderer/components/SourceWizardSummary';
 
-export { AddSourceButton, AddSourceWizard };
+export { AddSourceButton, AddSourceWizard, SummaryStep };

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -1,108 +1,48 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { FormGroup, TextInput } from '@patternfly/react-core';
-import find from 'lodash/find';
-
-const openShiftSummary = ({ url, certificate_authority }) => (
-    <React.Fragment>
-        <FormGroup
-            label="URL"
-            fieldId='summary-url'
-        >
-            <TextInput
-                isDisabled
-                type="text"
-                id="summary-url"
-                value={ url }
-            />
-        </FormGroup>
-        <FormGroup
-            label = "SSL Certificate"
-            fieldId='summary-ssl-cert'
-        >
-            <TextInput
-                isDisabled
-                type="text"
-                id="summary-ssl-cert"
-                value={ certificate_authority }
-            />
-        </FormGroup>
-    </React.Fragment>
-);
-openShiftSummary.propTypes = {
-    url: PropTypes.string.isRequired,
-    certificate_authority: PropTypes.string.isRequired
-};
-
-const awsSummary = ({ username, password }) => (
-    <React.Fragment>
-        <FormGroup
-            label = "Access Key ID"
-        >
-            <TextInput
-                isDisabled
-                type="text"
-                id="summary-id"
-                value={ username }
-            />
-        </FormGroup>
-        <FormGroup
-            label = "Secret access key"
-            fieldId='summary-ssl-cert'
-        >
-            <TextInput
-                isDisabled
-                type="text"
-                id="summary-ssl-cert"
-                value={ password }
-            />
-        </FormGroup>
-    </React.Fragment>
-);
-awsSummary.propTypes = {
-    username: PropTypes.string.isRequired,
-    password: PropTypes.string.isRequired
-};
-
-const typeSpecificSummary = (type, props) => type === 'openshift' ?
-    openShiftSummary(props) : type === 'amazon' ?
-        awsSummary(props) : null;
-
-const niceTypeName = (name, types) => {
-    const sourceType = find(types, { name });
-    return sourceType && sourceType.product_name || name;
-};
+import { TextContent, TextListItem, TextListItemVariants, TextListVariants, TextList } from '@patternfly/react-core';
 
 const SourceWizardSummary = ({ sourceTypes, formOptions }) => {
-    const { source_name, source_type, ...rest } = formOptions.getState().values;
-    return (
-        <React.Fragment>
-            <FormGroup
-                label = "name"
-                fieldId="summary-name"
-            >
-                <TextInput
-                    isDisabled
-                    type="text"
-                    id="summary-name"
-                    value={ source_name }
-                />
-            </FormGroup>
-            <FormGroup
-                label = "Type"
-                fieldId="summary-type"
-            >
-                <TextInput
-                    isDisabled
-                    type="text"
-                    id="summary-type"
-                    value={ niceTypeName(source_type, sourceTypes) }
-                />
-            </FormGroup>
-            { typeSpecificSummary(source_type, rest) }
-        </React.Fragment>
-    );
+    const values = formOptions.getState().values;
+    const type = sourceTypes.find(type => type.name === values.source_type);
+    const fields = type.schema.fields;
+
+    const valuesList = Object.keys(values).map((key) => {
+        const formField = fields.find((field) => field.name === key);
+        let value = values[key];
+
+        // not in field, probably source_name or type, handled seperately
+        if (!formField) {
+            return undefined;
+        }
+
+        // do not show hidden fields
+        if (formField.type === 'hidden') {
+            return undefined;
+        }
+
+        // Boolean value convert to Yes / No
+        if (typeof values[key] === 'boolean') {
+            value = values[key] ? 'Yes' : 'No';
+        }
+
+        return (
+            <React.Fragment key={ key }>
+                <TextListItem component={ TextListItemVariants.dt }>{ formField.label }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dd }>{ value }</TextListItem>
+            </React.Fragment>
+        );
+    });
+
+    return (<TextContent>
+        <TextList component={ TextListVariants.dl }>
+            <TextListItem component={ TextListItemVariants.dt }>{ 'Name' }</TextListItem>
+            <TextListItem component={ TextListItemVariants.dd }>{ values.source_name }</TextListItem>
+            <TextListItem component={ TextListItemVariants.dt }>{ 'Source Type' }</TextListItem>
+            <TextListItem component={ TextListItemVariants.dd }>{ type.product_name }</TextListItem>
+            { valuesList }
+        </TextList>
+    </TextContent>);
 };
 
 SourceWizardSummary.propTypes = {

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
@@ -3,11 +3,15 @@
 exports[`Steps components renders correctly with sourceTypes 1`] = `
 <SourcesFormRenderer
   initialValues={Object {}}
+  onCancel={[MockFunction]}
   onSubmit={[Function]}
   schema={
     Object {
       "fields": Array [
         Object {
+          "buttonLabels": Object {
+            "submit": "Finish",
+          },
           "component": "wizard",
           "description": "You are importing data into this platform",
           "fields": Array [
@@ -332,10 +336,16 @@ exports[`Steps components renders correctly with sourceTypes 1`] = `
                 Object {
                   "component": "description",
                   "content": <TextContent>
+                    <Title
+                      headingLevel="h3"
+                      size="2xl"
+                    >
+                      Review source details
+                    </Title>
                     <Text
                       component="p"
                     >
-                      Review source details and click Add source to complete source creation. Click Back to revise.
+                      Review the information below and click Finish to configure your project. Use the Back button to make changes.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -343,6 +353,50 @@ exports[`Steps components renders correctly with sourceTypes 1`] = `
                 Object {
                   "component": "summary",
                   "name": "summary",
+                  "sourceTypes": Array [
+                    Object {
+                      "id": "1",
+                      "name": "openshift",
+                      "product_name": "OpenShift Container Platform",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "openshift",
+                      },
+                    },
+                    Object {
+                      "id": "2",
+                      "name": "amazon",
+                      "product_name": "Amazon Web Services",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "AWS",
+                      },
+                    },
+                    Object {
+                      "id": "3",
+                      "name": "ansible-tower",
+                      "product_name": "Ansible Tower",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "AnsibleTower",
+                      },
+                    },
+                  ],
                 },
               ],
               "name": "summary",
@@ -378,6 +432,7 @@ exports[`Steps components renders correctly without sourceTypes 1`] = `
   isOpen={true}
   nextButtonText="Next"
   onBack={null}
+  onClose={[MockFunction]}
   onGoToStep={null}
   onNext={null}
   startAtStep={1}
@@ -386,6 +441,7 @@ exports[`Steps components renders correctly without sourceTypes 1`] = `
       Object {
         "component": <LoadingStep
           customText="Loading, please wait."
+          onClose={[MockFunction]}
         />,
         "isFinishedStep": true,
         "name": "Loading",
@@ -400,11 +456,15 @@ exports[`Steps components renders correctly without sourceTypes 1`] = `
 exports[`Steps components renders correctly without sourceTypes 2`] = `
 <SourcesFormRenderer
   initialValues={Object {}}
+  onCancel={[MockFunction]}
   onSubmit={[Function]}
   schema={
     Object {
       "fields": Array [
         Object {
+          "buttonLabels": Object {
+            "submit": "Finish",
+          },
           "component": "wizard",
           "description": "You are importing data into this platform",
           "fields": Array [
@@ -729,10 +789,16 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 Object {
                   "component": "description",
                   "content": <TextContent>
+                    <Title
+                      headingLevel="h3"
+                      size="2xl"
+                    >
+                      Review source details
+                    </Title>
                     <Text
                       component="p"
                     >
-                      Review source details and click Add source to complete source creation. Click Back to revise.
+                      Review the information below and click Finish to configure your project. Use the Back button to make changes.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -740,6 +806,50 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 Object {
                   "component": "summary",
                   "name": "summary",
+                  "sourceTypes": Array [
+                    Object {
+                      "id": "1",
+                      "name": "openshift",
+                      "product_name": "OpenShift Container Platform",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "openshift",
+                      },
+                    },
+                    Object {
+                      "id": "2",
+                      "name": "amazon",
+                      "product_name": "Amazon Web Services",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "AWS",
+                      },
+                    },
+                    Object {
+                      "id": "3",
+                      "name": "ansible-tower",
+                      "product_name": "Ansible Tower",
+                      "schema": Object {
+                        "fields": Array [
+                          Object {
+                            "component": "text-field",
+                            "name": "field",
+                          },
+                        ],
+                        "title": "AnsibleTower",
+                      },
+                    },
+                  ],
                 },
               ],
               "name": "summary",

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -18,7 +18,8 @@ describe('AddSourceButton', () => {
     beforeEach(() => {
         initialProps = {
             isOpen: true,
-            sourceTypes
+            sourceTypes,
+            onClose: jest.fn()
         };
     });
 

--- a/packages/sources/src/tests/addSourceWizard/sourceAddModal.test.js
+++ b/packages/sources/src/tests/addSourceWizard/sourceAddModal.test.js
@@ -16,7 +16,9 @@ describe('Steps components', () => {
 
         initialProps = {
             isOpen: true,
-            refreshSources: spyFunction
+            refreshSources: spyFunction,
+            onCancel: jest.fn(),
+            onSubmit: jest.fn()
         };
     });
 

--- a/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
+++ b/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
@@ -1,185 +1,238 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SourceWizardSummary component should render correctly amazon 1`] = `
-<Fragment>
-  <FormGroup
-    fieldId="summary-name"
-    label="name"
+<TextContent>
+  <TextList
+    component="dl"
   >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-name"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="openshift"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-type"
-    label="Type"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-type"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="Amazon Web Services"
-    />
-  </FormGroup>
-  <FormGroup
-    label="Access Key ID"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-id"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="user_name"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-ssl-cert"
-    label="Secret access key"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-ssl-cert"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="123456"
-    />
-  </FormGroup>
-</Fragment>
+    <TextListItem
+      component="dt"
+    >
+      Name
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      openshift
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Source Type
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Amazon Web Services
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Certificate Authority
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      authority
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Password
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      123456
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Should validate?
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Yes
+    </TextListItem>
+  </TextList>
+</TextContent>
 `;
 
 exports[`SourceWizardSummary component should render correctly ansible-tower 1`] = `
-<Fragment>
-  <FormGroup
-    fieldId="summary-name"
-    label="name"
+<TextContent>
+  <TextList
+    component="dl"
   >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-name"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="openshift"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-type"
-    label="Type"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-type"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="Ansible Tower"
-    />
-  </FormGroup>
-</Fragment>
+    <TextListItem
+      component="dt"
+    >
+      Name
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      openshift
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Source Type
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Ansible Tower
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Certificate Authority
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      authority
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Password
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      123456
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Should validate?
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Yes
+    </TextListItem>
+  </TextList>
+</TextContent>
 `;
 
 exports[`SourceWizardSummary component should render correctly openshift 1`] = `
-<Fragment>
-  <FormGroup
-    fieldId="summary-name"
-    label="name"
+<TextContent>
+  <TextList
+    component="dl"
   >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-name"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="openshift"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-type"
-    label="Type"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-type"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="OpenShift Container Platform"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-url"
-    label="URL"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-url"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="neznam.cz"
-    />
-  </FormGroup>
-  <FormGroup
-    fieldId="summary-ssl-cert"
-    label="SSL Certificate"
-  >
-    <TextInput
-      aria-label={null}
-      className=""
-      id="summary-ssl-cert"
-      isDisabled={true}
-      isReadOnly={false}
-      isRequired={false}
-      isValid={true}
-      onChange={[Function]}
-      type="text"
-      value="authority"
-    />
-  </FormGroup>
-</Fragment>
+    <TextListItem
+      component="dt"
+    >
+      Name
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      openshift
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Source Type
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      OpenShift Container Platform
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Certificate Authority
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      authority
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Password
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      123456
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Should validate?
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Yes
+    </TextListItem>
+  </TextList>
+</TextContent>
 `;

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -7,8 +7,38 @@ describe('SourceWizardSummary component', () => {
     describe('should render correctly', () => {
         let formOptions;
         let sourceTypes;
+        let schema;
 
         beforeEach(() => {
+            schema = {
+                fields: [
+                    {
+                        name: 'username',
+                        label: 'Username'
+                    },
+                    {
+                        name: 'certificate_authority',
+                        label: 'Certificate Authority'
+                    },
+                    {
+                        name: 'url',
+                        label: 'URL'
+                    },
+                    {
+                        name: 'password',
+                        label: 'Password'
+                    },
+                    {
+                        name: 'role',
+                        type: 'hidden'
+                    },
+                    {
+                        name: 'validate',
+                        label: 'Should validate?'
+                    }
+                ]
+            };
+
             formOptions = (source_type) => ({
                 getState: () => ({
                     values: {
@@ -17,7 +47,9 @@ describe('SourceWizardSummary component', () => {
                         certificate_authority: 'authority',
                         url: 'neznam.cz',
                         password: '123456',
-                        source_type
+                        source_type,
+                        role: 'kubernetes',
+                        validate: true
                     }
                 })
             });
@@ -25,17 +57,20 @@ describe('SourceWizardSummary component', () => {
                 {
                     id: '1',
                     name: 'openshift',
-                    product_name: 'OpenShift Container Platform'
+                    product_name: 'OpenShift Container Platform',
+                    schema
                 },
                 {
                     id: '2',
                     name: 'amazon',
-                    product_name: 'Amazon Web Services'
+                    product_name: 'Amazon Web Services',
+                    schema
                 },
                 {
                     id: '3',
                     name: 'ansible-tower',
-                    product_name: 'Ansible Tower'
+                    product_name: 'Ansible Tower',
+                    schema
                 }
             ];
         });


### PR DESCRIPTION
**Description**

Updates summary screen according to design

- the summary is generated from values, labels are taken from API schema
- boolean values are converted into Yes / No
- exceptions (types and name) are handled separately

**Design**

![image](https://user-images.githubusercontent.com/32869456/61903517-faa03e80-af24-11e9-9411-ed115ca1fd51.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/61903475-e4927e00-af24-11e9-91d9-a83a71b2e5aa.png)

![image](https://user-images.githubusercontent.com/32869456/61903495-f116d680-af24-11e9-96cf-976ccd673952.png)

**edit**: added Review title

![image](https://user-images.githubusercontent.com/32869456/61905127-9ed7b480-af28-11e9-8498-b93248355c95.png)


@terezanovotna

I have a few questions:

1. Should we show empty fields in the summary?
2. Is okay to converts boolean (checkbox) to Yes, No?
3. What about the styling? I wasn't able to find the correct PF4 component to match your design.
4. What about ordering? Right now, because of the algorithm which gets the values, the first field in the summary is the first field which was changed by a user (so, name can be first or second..) Should I implement some hardcoded order?