### PR TITLE
RHICOMPL-275 - Allow to select all rules

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -320,7 +320,7 @@ class SystemRulesTable extends React.Component {
 
     selectedRules = () => {
         const { currentRows, profiles, refIds } = this.state;
-        return currentRows.filter(row => row.selected && !row.cells[REMEDIATIONS_COLUMN].title.props.unsupported).map(row => ({
+        return currentRows.filter(row => row.selected && row.cells[REMEDIATIONS_COLUMN].original).map(row => ({
             // We want to match this response with a similar response from GraphQL
             refId: refIds[row.cells[0].original],
             profiles: [{ refId: profiles[row.cells[0].original] }],


### PR DESCRIPTION
The previous method does not work since we don't have the `<Ansible>` component with `title.props.unsupported`. Right now we can just check the `original` value - which tells us whether the remediation is available or not with `true` or `false`

![Peek 2019-07-30 09-26](https://user-images.githubusercontent.com/598891/62109261-32541100-b2ac-11e9-9008-e377b4199871.gif)
