### PR TITLE
Add CardSelect

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -1,6 +1,18 @@
 # Sources
 
 This package exports **Add Source Wizard** and **Add Source button**.
+
+# Install
+
+```bash
+npm install @redhat-cloud-services/frontend-components-sources
+```
+
+Please import styles in your scss files, where are you using AddSource Wizard or CardSelect
+
+```css
+@import '~@redhat-cloud-services/frontend-components-sources/index.css';
+```
  
 ## Using
 
@@ -25,10 +37,33 @@ import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sour
 **Props**
 
 
-| Prop        | Type           | Default  | Description |
-| ------------- |:-------------:| :-----:| ------: |
-| isOpen     | bool | false | You need to control yourselves if the wizard is open or not. (Not needed for the button version) |
-| afterSuccess     | function | null | This function will be executed after closing the wizard successful finish step. In Sources-UI this method is used for updating the list of sources. |
-| onClose     | function | null | This function will be executed after closing the wizard. Eg. set isOpen to false. |
-| successfulMessage     | node | 'Your source has been successfully added.' | A message shown on the last page of the wizard. Can be customized when accessing from different app (eg. 'Source was added to Cost Management') |
-| sourceTypes     | array | null | SourceTypes options. This prop can be used on pages, which have already loaded the source types, so there is no need to load them in this component. |
+|Prop|Type|Default|Description|
+|----|:--:|:-----:|----------:|
+|isOpen|bool|false|You need to control yourselves if the wizard is open or not. (Not needed for the button version)|
+|afterSuccess|function|null|This function will be executed after closing the wizard successful finish step. In Sources-UI this method is used for updating the list of sources.|
+|onClose|function|null|This function will be executed after closing the wizard. Eg. set isOpen to false.|
+|successfulMessage|node|'Your source has been successfully added.'|A message shown on the last page of the wizard. Can be customized when accessing from different app (eg. 'Source was added to Cost Management')|
+|sourceTypes|array|null|SourceTypes options. This prop can be used on pages, which have already loaded the source types, so there is no need to load them in this component.|
+
+
+# Additional components
+
+This package also uses and exports other components:
+
+## CardSelect
+
+Use in schema as `component: 'card-select`
+
+**Props**
+
+This components accepts all formGroup props `(label, helperText, isDisabled, isRequired, ...)`
+
+
+|Prop|Type|Description|
+|----|:--:|----------:|
+|options|array|Array of options with keys `value`, `label`|
+|DefaultIcon|element, node, func|Default icon (default is `ServerIcon`)|
+|iconMapper*|func|You can use your own mapper `(value, DefaultIcon) => ...` |
+|multi/isMulti|bool|Allows to select more items|
+
+\* In the future it could be replaced by data obtained from API

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -4,10 +4,10 @@ import zipObject from 'lodash/zipObject';
 import { Popover, TextContent, TextList, TextListItem, Text, TextVariants, Title } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import SSLFormLabel from './SSLFormLabel';
+import { AwsIcon, OpenshiftIcon } from '@patternfly/react-icons';
 
 const compileAllSourcesComboOptions = (sourceTypes) => (
     [
-        { label: 'Choose a type' },
         ...sourceTypes.map(t => ({
             value: t.name,
             label: t.product_name
@@ -20,6 +20,11 @@ const compileStepMapper = (sourceTypes) => {
     const names = sourceTypes.map(t => t.name);
     return zipObject(names, names);
 };
+
+const iconMapper = (name, DefaultIcon) => ({
+    openshift: OpenshiftIcon,
+    amazon: AwsIcon
+}[name] || DefaultIcon);
 
 const firstStepNew = (sourceTypes) => ({
     title: 'Select a source type',
@@ -54,14 +59,15 @@ const firstStepNew = (sourceTypes) => ({
                 type: validatorTypes.REQUIRED
             }]
         }, {
-            component: componentTypes.SELECT_COMPONENT,
+            component: 'card-select',
             name: 'source_type',
-            label: 'Type',
             isRequired: true,
-            options: compileAllSourcesComboOptions(sourceTypes),
+            label: 'Type',
+            iconMapper,
             validate: [{
                 type: validatorTypes.REQUIRED
-            }]
+            }],
+            options: compileAllSourcesComboOptions(sourceTypes)
         }]
 });
 

--- a/packages/sources/src/index.js
+++ b/packages/sources/src/index.js
@@ -1,4 +1,6 @@
 import { AddSourceButton, AddSourceWizard } from './addSourceWizard/index';
 import SummaryStep from './sourceFormRenderer/components/SourceWizardSummary';
+import CardSelect from './sourceFormRenderer/components/CardSelect';
+import './styles/cardSelect.scss';
 
-export { AddSourceButton, AddSourceWizard, SummaryStep };
+export { AddSourceButton, AddSourceWizard, CardSelect, SummaryStep };

--- a/packages/sources/src/sourceFormRenderer/components/CardSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/CardSelect.js
@@ -1,0 +1,138 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card, CardHeader, CardBody, FormGroup, Grid, GridItem, Bullseye } from '@patternfly/react-core';
+import { ServerIcon } from '@patternfly/react-icons';
+
+class CardSelect extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedValues: this.props.input.value ? this.props.input.value : this.isMulti ? [] : undefined
+        };
+    }
+
+    isMulti = this.props.isMulti || this.props.multi;
+
+    isDisabled = this.props.isDisabled || this.props.isReadOnly;
+
+    change = () => this.props.input.onChange(this.state.selectedValues);
+
+    handleMulti = (value) => this.state.selectedValues.includes(value) ?
+        this.setState(({ selectedValues }) => ({ selectedValues: selectedValues.filter(valueSelect => valueSelect !== value) }), this.change)
+        : this.setState(({ selectedValues }) => ({ selectedValues: [ ...selectedValues, value ]}), this.change);
+
+    handleSingle = (value) => this.setState(() => ({ selectedValues: this.state.selectedValues === value ? undefined : value }), this.change);
+
+    handleClick = (value) => {this.isMulti ? this.handleMulti(value) : this.handleSingle(value);}
+
+    handleCompare = (value) => this.isMulti ? this.state.selectedValues.includes(value) : this.state.selectedValues === value;
+
+    onClick = value => {
+        if (this.isDisabled) {
+            return undefined;
+        }
+
+        this.handleClick(value);
+        this.props.input.onBlur();
+    }
+
+    handleKeyPress = (event, value) => {
+        if (event.key === 'Enter') {
+            this.onClick(value);
+        }
+    }
+
+    prepareCards = () => this.props.options.map(({ value, label }) => {
+        const { iconMapper, DefaultIcon } = this.props;
+
+        if (!value) {
+            return undefined;
+        }
+
+        const Component = iconMapper(value, DefaultIcon);
+
+        return (
+            <GridItem sm={ 1 } md={ 4 } key={ value }>
+                <Card
+                    className={ `ins-c-sources__wizard--card${this.handleCompare(value) ? ' selected' : ''}${this.isDisabled ? ' disabled' : ''}` }
+                    onClick={ () => this.onClick(value) }
+                    tabIndex={ this.isDisabled ? -1 : 0 }
+                    onKeyPress={ (e) => this.handleKeyPress(e, value) }
+                    isHoverable={ !this.isDisabled }
+                    isCompact={ true }
+                >
+                    <div className={ this.isDisabled ? 'disabled' : '' }>
+                        <CardHeader>
+                            { label }
+                        </CardHeader>
+                        <CardBody>
+                            <Bullseye>
+                                <Component size="xl"/>
+                            </Bullseye>
+                        </CardBody>
+                    </div>
+                </Card>
+            </GridItem>
+        );
+    })
+
+    render() {
+        const { FieldProvider, isRequired, label, helperText, hideLabel, name, meta, input, ...rest } = this.props;
+        const { error, touched } = meta;
+        const showError = touched && error;
+
+        return (
+            <FormGroup
+                isRequired={ isRequired }
+                label={ !hideLabel && label }
+                fieldId={ input.name }
+                isValid={ !showError }
+                helperText={ helperText }
+                helperTextInvalid={ error }
+            >
+                <Grid gutter="md">
+                    { this.prepareCards() }
+                </Grid>
+                <br />
+            </FormGroup>
+        );
+    }
+}
+
+CardSelect.propTypes = {
+    multi: PropTypes.bool,
+    isMulti: PropTypes.bool,
+    label: PropTypes.string,
+    isRequired: PropTypes.bool,
+    helperText: PropTypes.string,
+    meta: PropTypes.object.isRequired,
+    description: PropTypes.string,
+    hideLabel: PropTypes.bool,
+    name: PropTypes.string.isRequired,
+    FieldProvider: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
+    options: PropTypes.array,
+    input: PropTypes.shape({
+        value: PropTypes.any,
+        onChange: PropTypes.func,
+        onBlur: PropTypes.func
+    }).isRequired,
+    DefaultIcon: PropTypes.oneOfType([ PropTypes.node, PropTypes.func, PropTypes.element ]),
+    iconMapper: PropTypes.func,
+    isDisabled: PropTypes.bool,
+    isReadOnly: PropTypes.bool
+};
+
+CardSelect.defaultProps = {
+    options: [],
+    DefaultIcon: ServerIcon,
+    iconMapper: (_value, DefaultIcon) => DefaultIcon
+};
+
+const CardSelectProvider = ({ FieldProvider, ...rest }) =>
+    (
+        <FieldProvider { ...rest }>
+            { (props) =>  <CardSelect  { ...props } name={ props.input.name }/> }
+        </FieldProvider>
+    );
+
+export default CardSelectProvider;

--- a/packages/sources/src/sourceFormRenderer/index.js
+++ b/packages/sources/src/sourceFormRenderer/index.js
@@ -5,6 +5,7 @@ import { layoutMapper, formFieldsMapper } from '@data-driven-forms/pf4-component
 
 import SourceWizardSummary from './components/SourceWizardSummary';
 import Description from './components/Description';
+import CardSelect from './components/CardSelect';
 
 const SourcesFormRenderer = props => (
     <FormRenderer
@@ -12,7 +13,8 @@ const SourcesFormRenderer = props => (
         formFieldsMapper={ {
             ...formFieldsMapper,
             summary: SourceWizardSummary,
-            description: Description
+            description: Description,
+            'card-select': CardSelect
         } }
         { ...props } />
 );

--- a/packages/sources/src/styles/cardSelect.scss
+++ b/packages/sources/src/styles/cardSelect.scss
@@ -1,0 +1,30 @@
+.ins-c-sources__wizard--card {
+    min-height: 120px;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 4px 11px 0 rgba(0, 0, 0, 0.12);
+    cursor: pointer;
+
+    &:focus {
+      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.42), 0 4px 11px 0 rgba(0, 0, 0, 0.42);
+      outline: none;
+    }
+
+    &.selected {
+      border:1px solid;
+      border-color: var(--pf-global--primary-color--100);
+    }
+
+    &.disabled {
+      cursor: not-allowed;
+      background-color: var(--pf-global--BorderColor--100);
+      opacity: 0.5;
+      pointer-events: none;
+
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
+
+    .disabled {
+      z-index: -1;
+    }
+}

--- a/packages/sources/src/tests/__mocks__/FieldProvider.js
+++ b/packages/sources/src/tests/__mocks__/FieldProvider.js
@@ -1,0 +1,24 @@
+import { createElement } from 'react';
+
+const MockFieldProvider = ({ input, render, meta, component, children, ...rest }) => {
+    const fieldInput = {
+        onChange: jest.fn(),
+        ...input
+    };
+    const fieldMeta = {
+        ...meta
+    };
+
+    if (typeof children === 'function') {
+        return children({ ...rest, input: fieldInput, meta: fieldMeta });
+    }
+
+    if (typeof component === 'object') {
+        return createElement(component, { ...rest, input: fieldInput, meta: fieldMeta, children });
+    }
+
+    return render({ ...rest, input: fieldInput, meta: fieldMeta, children });
+
+};
+
+export default MockFieldProvider;

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
@@ -47,14 +47,12 @@ exports[`Steps components renders correctly with sourceTypes 1`] = `
                   ],
                 },
                 Object {
-                  "component": "select-field",
+                  "component": "card-select",
+                  "iconMapper": [Function],
                   "isRequired": true,
                   "label": "Type",
                   "name": "source_type",
                   "options": Array [
-                    Object {
-                      "label": "Choose a type",
-                    },
                     Object {
                       "label": "OpenShift Container Platform",
                       "value": "openshift",
@@ -500,14 +498,12 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   ],
                 },
                 Object {
-                  "component": "select-field",
+                  "component": "card-select",
+                  "iconMapper": [Function],
                   "isRequired": true,
                   "label": "Type",
                   "name": "source_type",
                   "options": Array [
-                    Object {
-                      "label": "Choose a type",
-                    },
                     Object {
                       "label": "OpenShift Container Platform",
                       "value": "openshift",

--- a/packages/sources/src/tests/sourceFormRenderer/components/cardSelect.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/cardSelect.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import CardSelect from '../../../sourceFormRenderer/components/CardSelect';
+import FieldProvider from '../../__mocks__/FieldProvider';
+import { Card, CardHeader } from '@patternfly/react-core';
+import { AwsIcon, OpenshiftIcon } from '@patternfly/react-icons';
+
+describe('CardSelect component', () => {
+    let initialProps;
+    let spyOnChange;
+    let spyOnBlur;
+
+    beforeEach(() => {
+        spyOnChange = jest.fn();
+        spyOnBlur = jest.fn();
+        initialProps = {
+            FieldProvider,
+            options: [
+                { value: 'ops', label: 'openshift' },
+                { value: 'aws', label: 'aws' },
+                { label: 'Choose one (this should not be displayed)' }
+            ],
+            input: {
+                name: 'card-select',
+                onChange: spyOnChange,
+                onBlur: spyOnBlur
+            }
+        };
+    });
+
+    afterEach(() => {
+        spyOnChange.mockReset();
+        spyOnBlur.mockReset();
+    });
+
+    it('should render correctly', () => {
+        const wrapper = mount(<CardSelect { ...initialProps }/>);
+
+        expect(wrapper.find(Card).length).toEqual(2);
+        expect(wrapper.find(CardHeader).length).toEqual(2);
+        expect(wrapper.find(CardHeader).first().text()).toEqual('openshift');
+        expect(wrapper.find(CardHeader).last().text()).toEqual('aws');
+    });
+
+    it('should render correctly with default icon', () => {
+        const wrapper = mount(<CardSelect { ...initialProps } DefaultIcon={ AwsIcon }/>);
+
+        expect(wrapper.find(AwsIcon).length).toEqual(2);
+    });
+
+    it('should render correctly with iconMapper', () => {
+        const iconMapper = (value, defaultIcon) => ({
+            aws: AwsIcon,
+            ops: OpenshiftIcon
+        }[value] || defaultIcon);
+
+        const wrapper = mount(<CardSelect { ...initialProps } iconMapper={ iconMapper }/>);
+
+        expect(wrapper.find(AwsIcon).length).toEqual(1);
+        expect(wrapper.find(OpenshiftIcon).length).toEqual(1);
+    });
+
+    it('should set default value', () => {
+        const wrapper = mount(<CardSelect { ...initialProps } input={ { ...initialProps.input, value: 'ops' } }/>);
+
+        // value is set, we click on the card and check if clicking on it will unselect it
+        wrapper.find(Card).first().simulate('click');
+
+        expect(spyOnChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should clicked single select', () => {
+        const wrapper = mount(<CardSelect { ...initialProps }/>);
+
+        wrapper.find(Card).first().simulate('click');
+
+        expect(spyOnChange).toHaveBeenCalledWith('ops');
+        expect(spyOnBlur).toHaveBeenCalled();
+    });
+
+    it('should change by pressing enter single select', () => {
+        const wrapper = mount(<CardSelect { ...initialProps }/>);
+
+        wrapper.find(Card).last().simulate('keypress', { key: 'Enter' });
+
+        expect(spyOnChange).toHaveBeenCalledWith('aws');
+        expect(spyOnBlur).toHaveBeenCalled();
+
+        // unselect
+        wrapper.find(Card).last().simulate('keypress', { key: 'Enter' });
+        expect(spyOnChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should not change by pressing enter single select', () => {
+        const wrapper = mount(<CardSelect { ...initialProps }/>);
+
+        wrapper.find(Card).last().simulate('keypress', { key: 'Shift' });
+
+        expect(spyOnChange).not.toHaveBeenCalledWith();
+        expect(spyOnBlur).not.toHaveBeenCalled();
+    });
+
+    it('should not clicked disabled', () => {
+        const wrapper = mount(<CardSelect { ...initialProps } isDisabled/>);
+
+        wrapper.find(Card).first().simulate('click');
+
+        expect(spyOnChange).not.toHaveBeenCalled();
+        expect(spyOnBlur).not.toHaveBeenCalled();
+    });
+
+    it('should clicked multiSelect select', () => {
+        let formState;
+
+        const onChange = (value) => formState = value;
+
+        const wrapper = mount(<CardSelect { ...initialProps } isMulti input={ { ...initialProps.input, onChange } }/>);
+
+        wrapper.find(Card).first().simulate('click');
+        wrapper.find(Card).last().simulate('click');
+
+        expect(formState).toEqual([ 'ops', 'aws' ]);
+
+        // unselect
+        wrapper.update();
+        wrapper.find(Card).first().simulate('click');
+
+        expect(formState).toEqual([ 'aws' ]);
+    });
+});


### PR DESCRIPTION
**Description**

- Adds CardSelect component to schema
- allows multi select
- replaces Select in Source Type selection

**Docs**

## CardSelect

Use in schema as `component: 'card-select`

**Props**

This components accepts all formGroup props `(label, helperText, isDisabled, isRequired, ...)`


|Prop|Type|Description|
|----|:--:|----------:|
|options|array|Array of options with keys `value`, `label`|
|DefaultIcon|node, element, func|Default icon (default is `ServerIcon`)|
|iconMapper*|func|You can use your own mapper `(value, DefaultIcon) => ...` |
|multi/isMulti|bool|Allows to select more items|

* In the future it could be replaced by data obtained from API

**Design**

![image](https://user-images.githubusercontent.com/32869456/62326928-9561c580-b4af-11e9-88a4-652da0d24626.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/62326913-8713a980-b4af-11e9-970c-a58a31266887.png)


Todo:
- [x] OnChange
- [x] build styles (need help by @karelhala )
- [x] UX review
- [x] Tests
- [x] Docs 
- [x] expose outside

**More GIFs!** :tada: :champagne: :chart_with_upwards_trend: :money_mouth_face: 

![cardselect](https://user-images.githubusercontent.com/32869456/62327048-db1e8e00-b4af-11e9-812f-244b89687ec6.gif)

@terezanovotna

Please, tell me what you think about it! I have made cards bigger: the labels are too long, they wrap into second line and it looks _meh_ And with this width I can easily use a grid system (span 4). 

Icons are manually mapped and used by PatternFly Icons, however, this solution is not future-proof. (New source types = new icons.. but with only three sources it works now.)