### PR TITLE
Inv-insights dep cleanup, fixes loading blip, loads rule id from redux

### DIFF
--- a/packages/inventory-insights/config/webpack.constants.js
+++ b/packages/inventory-insights/config/webpack.constants.js
@@ -30,13 +30,6 @@ module.exports = {
         'prop-types': 'prop-types',
         react: 'react',
         'react-redux': 'react-redux',
-        'react-dom': 'react-dom',
-        'react-router-dom': {
-            commonjs: 'react-router-dom',
-            commonjs2: 'react-router-dom',
-            amd: 'react-router-dom',
-            root: 'ReactRouterDOM'
-        },
         urijs: 'urijs',
         classnames: 'classnames',
         dot: 'dot',

--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {
@@ -26,19 +26,17 @@
         "@patternfly/react-table": ">=2.1.6",
         "prop-types": ">=15.6.2",
         "react": ">=16.5.1",
-        "react-dom": ">=16.5.1",
         "react-content-loader": ">=3.4.1",
-        "react-redux": ">=5.0.7",
-        "react-router-dom": ">=4.2.2"
+        "react-redux": ">=5.0.7"
     },
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-notifications": "*",
         "@redhat-cloud-services/frontend-components-remediations": "*",
-        "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",
-        "dot": "^1.1.2",
-        "marked": "^0.6.0",
-        "moment": "^2.24.0",
-        "sanitize-html": "^1.20.0"
+        "@redhat-cloud-services/frontend-components-utilities": "0.0.8",
+        "dot": "1.1.2",
+        "marked": "0.7.0",
+        "moment": "2.24.0",
+        "sanitize-html": "^1.20.1"
     }
 }

--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -19,11 +19,10 @@ import {
     ToolbarGroup,
     ToolbarItem
 } from '@patternfly/react-core';
-import { CheckIcon, ExternalLinkAltIcon, SearchIcon, TimesCircleIcon, PficonSatelliteIcon  } from '@patternfly/react-icons';
+import { CheckIcon, ExternalLinkAltIcon, SearchIcon, TimesCircleIcon, PficonSatelliteIcon } from '@patternfly/react-icons';
 import { cellWidth, sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { filter, flatten, sortBy } from 'lodash';
+import { flatten, sortBy } from 'lodash';
 import { global_success_color_200 } from '@patternfly/react-tokens';
-import { withRouter } from 'react-router-dom';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import moment from 'moment';
 import { Battery, FilterDropdown, TableToolbar } from '@redhat-cloud-services/frontend-components';
@@ -105,7 +104,7 @@ class InventoryRuleList extends Component {
 
     activeRuleFirst = (activeReports) => {
         const reports = [ ...activeReports ];
-        const activeRuleIndex = activeReports.findIndex(report => report.rule.rule_id === this.props.match.params.id);
+        const activeRuleIndex = activeReports.findIndex(report => report.rule.rule_id === this.props.routerData.params.id);
         const activeReport = reports.splice(activeRuleIndex, 1);
 
         return activeRuleIndex !== -1 ? [ activeReport[0], ...reports ] : activeReports;
@@ -351,34 +350,37 @@ class InventoryRuleList extends Component {
                     </CardBody>
                 </Card>
             ) }
-            { inventoryReportFetchStatus === 'fulfilled' && hideResultsSatelliteManaged ?
-                <MessageState icon={ PficonSatelliteIcon } title='Satellite managed system'
-                    text={ <span key='satellite managed system'>Insights results can not be displayed for this host, as the &quot;Hide
-                    Satellite Managed Systems&quot; setting has been enabled by an org admin.<br/>For more information on this setting
-                    and how to modify it,
-                    <a href='https://access.redhat.com/solutions/4281761' rel="noopener"> Please visit this Knowledgebase Article
-                        <ExternalLinkAltIcon />
-                    </a>.</span> } />
-                :
-                (activeReports.length > 0 ?
-                    <Fragment><Table aria-label={ 'rule-table' } onCollapse={ this.handleOnCollapse } rows={ rows } cells={ cols } sortBy={ sortBy }
-                        onSort={ this.onSort }
-                        onSelect={ this.onSelect }>
-                        <TableHeader />
-                        <TableBody />
-                    </Table>
-                    { results === 0 &&
-                            <MessageState icon={ TimesCircleIcon } title='No matching systems found'
-                                text={ `This filter criteria matches no rules. Try changing your filter settings.` } />
-                    }
-                    </Fragment>
+            { inventoryReportFetchStatus === 'fulfilled' &&
+                (hideResultsSatelliteManaged ?
+                    <MessageState icon={ PficonSatelliteIcon } title='Satellite managed system'
+                        text={ <span key='satellite managed system'>Insights results can not be displayed for this host, as the &quot;Hide
+                    Satellite Managed Systems&quot; setting has been enabled by an org admin.<br />For more information on this setting
+                                and how to modify it,
+                        <a href='https://access.redhat.com/solutions/4281761' rel="noopener"> Please visit this Knowledgebase Article
+                            <ExternalLinkAltIcon />
+                        </a>.</span> } />
                     :
-                    <Card>
-                        <CardBody>
-                            <MessageState icon={ CheckIcon } iconStyle={ { color: global_success_color_200.value } } title='No rule hits'
-                                text={ `No known rules affect this system` } />
-                        </CardBody></Card>
-                )
+                    (activeReports.length > 0 ?
+                        <Fragment>
+                            <Table aria-label={ 'rule-table' } onCollapse={ this.handleOnCollapse } rows={ rows } cells={ cols } sortBy={ sortBy }
+                                onSort={ this.onSort }
+                                onSelect={ this.onSelect }>
+                                <TableHeader />
+                                <TableBody />
+                            </Table>
+                            { results === 0 &&
+                                <MessageState icon={ TimesCircleIcon } title='No matching systems found'
+                                    text={ `This filter criteria matches no rules. Try changing your filter settings.` } />
+                            }
+                        </Fragment>
+                        :
+                        <Card>
+                            <CardBody>
+                                <MessageState icon={ CheckIcon } iconStyle={ { color: global_success_color_200.value } } title='No rule hits'
+                                    text={ `No known rules affect this system` } />
+                            </CardBody>
+                        </Card>
+                    ))
             }
             { inventoryReportFetchStatus === 'failed' && this.props.entity &&
                 <MessageState icon={ TimesCircleIcon } title='Error getting rules'
@@ -393,18 +395,19 @@ class InventoryRuleList extends Component {
 InventoryRuleList.propTypes = {
     entity: PropTypes.object,
     addNotification: PropTypes.func,
-    match: PropTypes.object
+    routerData: PropTypes.object
 };
 
-const mapStateToProps = ({ entityDetails: { entity }}) => ({
-    entity
+const mapStateToProps = (state) => ({
+    entity: state.entityDetails.entity,
+    routerData: state.routerData
 });
 
 const mapDispatchToProps = dispatch => ({
     addNotification: data => dispatch(addNotification(data))
 });
 
-export default withRouter(connect(
+export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(InventoryRuleList));
+)(InventoryRuleList);


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2010

Does the following: 
* removes a number of unused deps
* refactors how we pull in the rule id (off routerData rather than using withRouter)
* the double loading and no rule state blip that can sometimes occur
* fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2010 (but this issue only shows up on beta, so unsure what to make of that)
* linting? 
* nothing is broken 😏 