### PR TITLE
Prepare AddSourceWizard for nested names in schema

### DIFF
--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -23,8 +23,8 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",
-        "@data-driven-forms/pf4-component-mapper": "^1.13.1",
-        "@data-driven-forms/react-form-renderer": "^1.13.1",
+        "@data-driven-forms/pf4-component-mapper": "^1.15.7",
+        "@data-driven-forms/react-form-renderer": "^1.15.7",
         "@patternfly/react-icons": "^3.10.9",
         "@redhat-cloud-services/sources-client": "^1.0.23",
         "js-base64": "^2.5.1"

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -76,7 +76,7 @@ const firstStepNew = (sourceTypes) => ({
         }]
 });
 
-const temporaryHardcodedSourceSchemas = {
+export const temporaryHardcodedSourceSchemas = {
     openshift: [
         {
             title: 'Add source credentials',

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -212,9 +212,9 @@ export const temporaryHardcodedSourceSchemas = {
             validate: [{ type: 'required-validator' }]
         }, {
             component: componentTypes.TEXT_FIELD,
-            name: 'password',
+            name: 'authentication.password',
             label: 'Secret Key',
-            type: 'authentication.password',
+            type: 'password',
             helperText: 'For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
             isRequired: true,
             validate: [{ type: 'required-validator' }]

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -55,7 +55,7 @@ const firstStepNew = (sourceTypes) => ({
         },
         {
             component: componentTypes.TEXT_FIELD,
-            name: 'source_name',
+            name: 'source.name',
             type: 'text',
             label: 'Name',
             helperText: 'For example, Source_1',
@@ -109,7 +109,7 @@ const temporaryHardcodedSourceSchemas = {
                 </TextContent>
             }, {
                 component: componentTypes.TEXTAREA_FIELD,
-                name: 'token',
+                name: 'authentication.password',
                 label: 'Token'
             }]
         }, {
@@ -124,15 +124,6 @@ const temporaryHardcodedSourceSchemas = {
                 </TextContent>
             }, {
                 component: componentTypes.TEXT_FIELD,
-                name: 'role',
-                type: 'hidden',
-                initialValue: 'kubernetes' // value of 'role' for the endpoint
-            }, {
-                component: componentTypes.TEXT_FIELD,
-                name: 'authtype',
-                initialValue: 'token'
-            }, {
-                component: componentTypes.TEXT_FIELD,
                 name: 'url',
                 label: 'URL',
                 helperText: 'For example, https://myopenshiftcluster.mycompany.com',
@@ -140,16 +131,26 @@ const temporaryHardcodedSourceSchemas = {
                 validate: [{ type: 'required-validator' }]
             }, {
                 component: componentTypes.CHECKBOX,
-                name: 'verify_ssl',
+                name: 'endpoint.verify_ssl',
                 label: 'Verify SSL'
             }, {
                 component: componentTypes.TEXTAREA_FIELD,
-                name: 'certificate_authority',
+                name: 'endpoint.certificate_authority',
                 label: <SSLFormLabel />,
                 condition: {
-                    when: 'verify_ssl',
+                    when: 'endpoint.verify_ssl',
                     is: true
                 }
+            }, {
+                component: componentTypes.TEXT_FIELD,
+                name: 'endpoint.role',
+                type: 'hidden',
+                initialValue: 'kubernetes' // value of 'role' for the endpoint
+            }, {
+                component: componentTypes.TEXT_FIELD,
+                name: 'authentication.authtype',
+                initialValue: 'token',
+                type: 'hidden'
             }]
         }
     ],
@@ -164,7 +165,6 @@ const temporaryHardcodedSourceSchemas = {
                         <Popover
                             aria-label="Help text"
                             position="bottom"
-                            maxWidth="50%"
                             bodyContent={
                                 <React.Fragment>
                                     <Text component={ TextVariants.p }>
@@ -205,16 +205,7 @@ const temporaryHardcodedSourceSchemas = {
             </TextContent>
         }, {
             component: componentTypes.TEXT_FIELD,
-            name: 'role',
-            type: 'hidden',
-            initialValue: 'aws' // value of 'role' for the endpoint
-        }, {
-            component: componentTypes.TEXT_FIELD,
-            name: 'authtype',
-            initialValue: 'access_key_secret_key'
-        }, {
-            component: componentTypes.TEXT_FIELD,
-            name: 'username',
+            name: 'authentication.username',
             label: 'Access Key ID',
             helperText: 'For example, AKIAIOSFODNN7EXAMPLE',
             isRequired: true,
@@ -223,55 +214,29 @@ const temporaryHardcodedSourceSchemas = {
             component: componentTypes.TEXT_FIELD,
             name: 'password',
             label: 'Secret Key',
-            type: 'password',
+            type: 'authentication.password',
             helperText: 'For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
             isRequired: true,
             validate: [{ type: 'required-validator' }]
+        }, {
+            component: componentTypes.TEXT_FIELD,
+            name: 'endpoint.role',
+            type: 'hidden',
+            initialValue: 'aws' // value of 'role' for the endpoint
+        }, {
+            component: componentTypes.TEXT_FIELD,
+            name: 'authentication.authtype',
+            initialValue: 'access_key_secret_key',
+            type: 'hidden'
         }]
-    },
-    'mock-source': {
-        title: 'Configure Mock Source',
-        fields: [
-            // Save to Endpoint
-            {
-                component: 'select-field',
-                name: 'host',
-                label: 'Config',
-                validate: [{ type: 'required-validator' }],
-                isRequired: true,
-                initialValue: 'default',
-                options: [
-                    { label: 'Multi-threaded with events', value: 'default' },
-                    { label: 'Single-threaded full refresh', value: 'simple' }
-                ]
-            },
-            // Save to endpoint
-            // FIXME: name => 'path'?
-            {
-                component: 'select-field',
-                name: 'path',
-                label: 'Amount',
-                validate: [{ type: 'required-validator' }],
-                isRequired: true,
-                initialValue: 'default',
-                options: [
-                    { label: 'All collections | Small', value: 'small' },
-                    { label: 'All collections | Medium', value: 'default' },
-                    { label: 'All collections | Large', value: 'large' },
-                    { label: 'Amazon | Small', value: 'amazon/small' },
-                    { label: 'Amazon | Medium', value: 'amazon/default' },
-                    { label: 'Amazon | Large', value: 'amazon/large' },
-                    { label: 'Openshift | Small', value: 'openshift/small' },
-                    { label: 'Openshift | Medium', value: 'openshift/default' },
-                    { label: 'Openshift | Large', value: 'openshift/large' }
-                ]
-            }
-        ]
     }
 };
 
 /* Switch between using hard-coded provider schemas and schemas from the api/source_types */
-const sourceTypeSchemaHardcodedWithFallback = t => (temporaryHardcodedSourceSchemas[t.name] || t.schema);
+const sourceTypeSchemaHardcodedWithFallback = t => (
+    temporaryHardcodedSourceSchemas[t.name] ||
+    { ...t.schema, fields: t.schema.fields.sort((_a, b) => b.type === 'hidden' ? -1 : 0) }
+);
 const sourceTypeSchemaWithFallback = t => (t.schema || temporaryHardcodedSourceSchemas[t.name]);
 const sourceTypeSchemaHardcoded = t => temporaryHardcodedSourceSchemas[t.name];
 const sourceTypeSchemaServer = t => t.schema;
@@ -338,7 +303,7 @@ const applicationStep = (applicationTypes) => ({
     fields: [
         {
             component: 'card-select',
-            name: 'app_type',
+            name: 'application.application_type_id',
             label: 'Select your application',
             DefaultIcon: () => <React.Fragment />,
             options: compileAllApplicationComboOptions(applicationTypes)

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -11,7 +11,8 @@ const initialValues = {
     isSubmitted: false,
     isFinished: false,
     isErrored: false,
-    values: {}
+    values: {},
+    createdSource: {}
 };
 
 class AddSourceWizard extends React.Component {
@@ -24,8 +25,8 @@ class AddSourceWizard extends React.Component {
 
     onSubmit = (formValues, sourceTypes) => {
         this.setOnSubmitState(formValues);
-        return doCreateSource(formValues, sourceTypes).then(() => {
-            this.setState({ isFinished: true });
+        return doCreateSource(formValues, sourceTypes).then((data) => {
+            this.setState({ isFinished: true, createdSource: data });
         })
         .catch(() => {
             this.setState({ isErrored: true });
@@ -37,7 +38,7 @@ class AddSourceWizard extends React.Component {
 
         onClose();
         this.setState({ ...initialValues });
-        afterSuccess();
+        afterSuccess(this.state.createdSource);
     }
 
     onRetry = () => this.setState({

--- a/packages/sources/src/api/index.js
+++ b/packages/sources/src/api/index.js
@@ -98,7 +98,7 @@ export function doCreateSource(formData, sourceTypes) {
             promises.push(getSourcesApi().createApplication(applicationData));
         }
 
-        return Promise.all(promises).then(([ endpointDataOut, _applicationData = undefined ]) => {
+        return Promise.all(promises).then(([ endpointDataOut, applicationDataOut = undefined ]) => {
             const authenticationData = {
                 ...formData.authentication,
                 resource_id: endpointDataOut.id,
@@ -106,7 +106,11 @@ export function doCreateSource(formData, sourceTypes) {
             };
 
             return getSourcesApi().createAuthentication(authenticationData).then((authenticationDataOut) => {
-                return authenticationDataOut;
+                return {
+                    ...sourceDataOut,
+                    endpoint: [ endpointDataOut ],
+                    applications: [ applicationDataOut ]
+                };
             }, (error) => {
                 console.error('Authentication creation failure:', error);
                 throw { error };

--- a/packages/sources/src/api/index.js
+++ b/packages/sources/src/api/index.js
@@ -70,33 +70,28 @@ const parseUrl = url => {
 const urlOrHost = formData => formData.url ? parseUrl(formData.url) : formData;
 
 export function doCreateSource(formData, sourceTypes) {
-    let sourceData = {
-        name: formData.source_name,
-        source_type_id: sourceTypes.find((x) => x.name === formData.source_type).id
-    };
+    const source_type_id = sourceTypes.find((x) => x.name === formData.source_type).id;
 
-    return getSourcesApi().createSource(sourceData).then((sourceDataOut) => {
+    return getSourcesApi().createSource({ ...formData.source, source_type_id }).then((sourceDataOut) => {
         const { scheme, host, port, path } = urlOrHost(formData);
 
         const endPointPort = parseInt(port, 10);
 
         const endpointData = {
+            ...formData.endpoint,
             default: true,
             source_id: sourceDataOut.id,
-            role: formData.role,
             scheme,
             host,
             port: isNaN(endPointPort) ? undefined : endPointPort,
-            path,
-            verify_ssl: formData.verify_ssl,
-            certificate_authority: formData.certificate_authority
+            path
         };
 
         const promises = [ getSourcesApi().createEndpoint(endpointData) ];
 
-        if (formData.app_type) {
+        if (formData.application.application_type_id) {
             const applicationData = {
-                application_type_id: formData.app_type,
+                ...formData.application,
                 source_id: sourceDataOut.id
             };
 
@@ -105,11 +100,9 @@ export function doCreateSource(formData, sourceTypes) {
 
         return Promise.all(promises).then(([ endpointDataOut, _applicationData = undefined ]) => {
             const authenticationData = {
+                ...formData.authentication,
                 resource_id: endpointDataOut.id,
-                resource_type: 'Endpoint',
-                username: formData.username,
-                password: formData.token || formData.password,
-                authtype: formData.authtype
+                resource_type: 'Endpoint'
             };
 
             return getSourcesApi().createAuthentication(authenticationData).then((authenticationDataOut) => {

--- a/packages/sources/src/index.js
+++ b/packages/sources/src/index.js
@@ -2,6 +2,15 @@ import { AddSourceButton, AddSourceWizard } from './addSourceWizard/index';
 import SummaryStep from './sourceFormRenderer/components/SourceWizardSummary';
 import CardSelect from './sourceFormRenderer/components/CardSelect';
 import SourceWizardSummary, * as summaryHelpers from './sourceFormRenderer/components/SourceWizardSummary';
+import { temporaryHardcodedSourceSchemas } from './addSourceWizard/SourceAddSchema';
 import './styles/cardSelect.scss';
 
-export { AddSourceButton, AddSourceWizard, CardSelect, SummaryStep, SourceWizardSummary, summaryHelpers };
+export {
+    AddSourceButton,
+    AddSourceWizard,
+    CardSelect,
+    SourceWizardSummary,
+    SummaryStep,
+    summaryHelpers,
+    temporaryHardcodedSourceSchemas
+};

--- a/packages/sources/src/index.js
+++ b/packages/sources/src/index.js
@@ -1,6 +1,7 @@
 import { AddSourceButton, AddSourceWizard } from './addSourceWizard/index';
 import SummaryStep from './sourceFormRenderer/components/SourceWizardSummary';
 import CardSelect from './sourceFormRenderer/components/CardSelect';
+import SourceWizardSummary, * as summaryHelpers from './sourceFormRenderer/components/SourceWizardSummary';
 import './styles/cardSelect.scss';
 
-export { AddSourceButton, AddSourceWizard, CardSelect, SummaryStep };
+export { AddSourceButton, AddSourceWizard, CardSelect, SummaryStep, SourceWizardSummary, summaryHelpers };

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -5,7 +5,6 @@ import flattenDeep from 'lodash/flattenDeep';
 
 export const createItem = (value, fields, path) => {
     const formField = fields.find((field) => field.name === path);
-
     // not in field, probably source_name or type, handled seperately
     if (!formField) {
         return undefined;
@@ -14,6 +13,11 @@ export const createItem = (value, fields, path) => {
     // do not show hidden fields
     if (formField.type === 'hidden') {
         return undefined;
+    }
+
+    // Hide password
+    if (formField.type === 'password') {
+        value = '●●●●●●●●●●●●';
     }
 
     // Boolean value convert to Yes / No

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -1,52 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TextContent, TextListItem, TextListItemVariants, TextListVariants, TextList } from '@patternfly/react-core';
+import flattenDeep from 'lodash/flattenDeep';
+
+const createItem = (value, fields, path) => {
+    const formField = fields.find((field) => field.name === path);
+
+    // not in field, probably source_name or type, handled seperately
+    if (!formField) {
+        return undefined;
+    }
+
+    // do not show hidden fields
+    if (formField.type === 'hidden') {
+        return undefined;
+    }
+
+    // Boolean value convert to Yes / No
+    if (typeof value === 'boolean') {
+        value = value ? 'Yes' : 'No';
+    }
+
+    return ({ label: formField.label,  value });
+};
+
+const allValuesPath = (value, fields, path = undefined) => {
+    if (typeof value !== 'object') {
+        return createItem(value, fields, path);
+    }
+
+    return Object.keys(value).map((key) => allValuesPath(value[key], fields, path ? `${path}.${key}` : key)).filter(x => x);
+};
 
 const SourceWizardSummary = ({ sourceTypes, formOptions, applicationTypes }) => {
     const values = formOptions.getState().values;
     const type = sourceTypes.find(type => type.name === values.source_type);
     const fields = type.schema.fields;
-    const application = applicationTypes.find(type => type.id === values.app_type);
+    const application = values.application ? applicationTypes.find(type => type.id === values.application.application_type_id) : undefined;
     const applicationName = application ? application.display_name : 'Not selected';
 
-    const valuesList = Object.keys(values).map((key) => {
-        const formField = fields.find((field) => field.name === key);
-        let value = values[key];
+    const valuesInfo = [ ...flattenDeep(allValuesPath(values, fields)) ].filter(x => x);
 
-        // not in field, probably source_name or type, handled seperately
-        if (!formField) {
-            return undefined;
-        }
+    const valuesList = valuesInfo.map(({ label, value }) => (
+        <React.Fragment key={ `${label}--${value}` }>
+            <TextListItem component={ TextListItemVariants.dt }>{ label }</TextListItem>
+            <TextListItem component={ TextListItemVariants.dd }>{ value }</TextListItem>
+        </React.Fragment>
+    ));
 
-        // do not show hidden fields
-        if (formField.type === 'hidden') {
-            return undefined;
-        }
-
-        // Boolean value convert to Yes / No
-        if (typeof values[key] === 'boolean') {
-            value = values[key] ? 'Yes' : 'No';
-        }
-
-        return (
-            <React.Fragment key={ key }>
-                <TextListItem component={ TextListItemVariants.dt }>{ formField.label }</TextListItem>
-                <TextListItem component={ TextListItemVariants.dd }>{ value }</TextListItem>
-            </React.Fragment>
-        );
-    });
-
-    return (<TextContent>
-        <TextList component={ TextListVariants.dl }>
-            <TextListItem component={ TextListItemVariants.dt }>{ 'Name' }</TextListItem>
-            <TextListItem component={ TextListItemVariants.dd }>{ values.source_name }</TextListItem>
-            <TextListItem component={ TextListItemVariants.dt }>{ 'Source Type' }</TextListItem>
-            <TextListItem component={ TextListItemVariants.dd }>{ type.product_name }</TextListItem>
-            { valuesList }
-            <TextListItem component={ TextListItemVariants.dt }>{ 'Application' }</TextListItem>
-            <TextListItem component={ TextListItemVariants.dd }>{ applicationName }</TextListItem>
-        </TextList>
-    </TextContent>);
+    return (
+        <TextContent>
+            <TextList component={ TextListVariants.dl }>
+                <TextListItem component={ TextListItemVariants.dt }>{ 'Name' }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dd }>{ values.source.name }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dt }>{ 'Source Type' }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dd }>{ type.product_name }</TextListItem>
+                { valuesList }
+                <TextListItem component={ TextListItemVariants.dt }>{ 'Application' }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dd }>{ applicationName }</TextListItem>
+            </TextList>
+        </TextContent>
+    );
 };
 
 SourceWizardSummary.propTypes = {

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { TextContent, TextListItem, TextListItemVariants, TextListVariants, TextList } from '@patternfly/react-core';
 import flattenDeep from 'lodash/flattenDeep';
 
-const createItem = (value, fields, path) => {
+export const createItem = (value, fields, path) => {
     const formField = fields.find((field) => field.name === path);
 
     // not in field, probably source_name or type, handled seperately
@@ -24,7 +24,7 @@ const createItem = (value, fields, path) => {
     return ({ label: formField.label,  value });
 };
 
-const allValuesPath = (value, fields, path = undefined) => {
+export const allValuesPath = (value, fields, path = undefined) => {
     if (typeof value !== 'object') {
         return createItem(value, fields, path);
     }

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
@@ -38,7 +38,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                   "helperText": "For example, Source_1",
                   "isRequired": true,
                   "label": "Name",
-                  "name": "source_name",
+                  "name": "source.name",
                   "type": "text",
                   "validate": Array [
                     Object {
@@ -130,7 +130,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 Object {
                   "component": "textarea-field",
                   "label": "Token",
-                  "name": "token",
+                  "name": "authentication.password",
                 },
               ],
               "name": "openshift",
@@ -153,17 +153,6 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "kubernetes",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "token",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, https://myopenshiftcluster.mycompany.com",
                   "isRequired": true,
                   "label": "URL",
@@ -177,16 +166,28 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 Object {
                   "component": "checkbox",
                   "label": "Verify SSL",
-                  "name": "verify_ssl",
+                  "name": "endpoint.verify_ssl",
                 },
                 Object {
                   "component": "textarea-field",
                   "condition": Object {
                     "is": true,
-                    "when": "verify_ssl",
+                    "when": "endpoint.verify_ssl",
                   },
                   "label": <SSLFormLabel />,
-                  "name": "certificate_authority",
+                  "name": "endpoint.certificate_authority",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "kubernetes",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "token",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "openshift_1",
@@ -251,7 +252,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                           headerContent={null}
                           hideOnOutsideClick={true}
                           isVisible={null}
-                          maxWidth="50%"
+                          maxWidth="calc(2rem + 18.75rem)"
                           onHidden={[Function]}
                           onHide={[Function]}
                           onMount={[Function]}
@@ -290,21 +291,10 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "aws",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "access_key_secret_key",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, AKIAIOSFODNN7EXAMPLE",
                   "isRequired": true,
                   "label": "Access Key ID",
-                  "name": "username",
+                  "name": "authentication.username",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -317,12 +307,24 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                   "isRequired": true,
                   "label": "Secret Key",
                   "name": "password",
-                  "type": "password",
+                  "type": "authentication.password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
                     },
                   ],
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "aws",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "access_key_secret_key",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "amazon",
@@ -348,7 +350,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                   "DefaultIcon": [Function],
                   "component": "card-select",
                   "label": "Select your application",
-                  "name": "app_type",
+                  "name": "application.application_type_id",
                   "options": Array [
                     Object {
                       "label": "Catalog",
@@ -538,7 +540,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                   "helperText": "For example, Source_1",
                   "isRequired": true,
                   "label": "Name",
-                  "name": "source_name",
+                  "name": "source.name",
                   "type": "text",
                   "validate": Array [
                     Object {
@@ -630,7 +632,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 Object {
                   "component": "textarea-field",
                   "label": "Token",
-                  "name": "token",
+                  "name": "authentication.password",
                 },
               ],
               "name": "openshift",
@@ -653,17 +655,6 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "kubernetes",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "token",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, https://myopenshiftcluster.mycompany.com",
                   "isRequired": true,
                   "label": "URL",
@@ -677,16 +668,28 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 Object {
                   "component": "checkbox",
                   "label": "Verify SSL",
-                  "name": "verify_ssl",
+                  "name": "endpoint.verify_ssl",
                 },
                 Object {
                   "component": "textarea-field",
                   "condition": Object {
                     "is": true,
-                    "when": "verify_ssl",
+                    "when": "endpoint.verify_ssl",
                   },
                   "label": <SSLFormLabel />,
-                  "name": "certificate_authority",
+                  "name": "endpoint.certificate_authority",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "kubernetes",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "token",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "openshift_1",
@@ -751,7 +754,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                           headerContent={null}
                           hideOnOutsideClick={true}
                           isVisible={null}
-                          maxWidth="50%"
+                          maxWidth="calc(2rem + 18.75rem)"
                           onHidden={[Function]}
                           onHide={[Function]}
                           onMount={[Function]}
@@ -790,21 +793,10 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "aws",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "access_key_secret_key",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, AKIAIOSFODNN7EXAMPLE",
                   "isRequired": true,
                   "label": "Access Key ID",
-                  "name": "username",
+                  "name": "authentication.username",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -817,12 +809,24 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                   "isRequired": true,
                   "label": "Secret Key",
                   "name": "password",
-                  "type": "password",
+                  "type": "authentication.password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
                     },
                   ],
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "aws",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "access_key_secret_key",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "amazon",
@@ -848,7 +852,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                   "DefaultIcon": [Function],
                   "component": "card-select",
                   "label": "Select your application",
-                  "name": "app_type",
+                  "name": "application.application_type_id",
                   "options": Array [
                     Object {
                       "label": "Catalog",
@@ -1038,7 +1042,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   "helperText": "For example, Source_1",
                   "isRequired": true,
                   "label": "Name",
-                  "name": "source_name",
+                  "name": "source.name",
                   "type": "text",
                   "validate": Array [
                     Object {
@@ -1130,7 +1134,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 Object {
                   "component": "textarea-field",
                   "label": "Token",
-                  "name": "token",
+                  "name": "authentication.password",
                 },
               ],
               "name": "openshift",
@@ -1153,17 +1157,6 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "kubernetes",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "token",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, https://myopenshiftcluster.mycompany.com",
                   "isRequired": true,
                   "label": "URL",
@@ -1177,16 +1170,28 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 Object {
                   "component": "checkbox",
                   "label": "Verify SSL",
-                  "name": "verify_ssl",
+                  "name": "endpoint.verify_ssl",
                 },
                 Object {
                   "component": "textarea-field",
                   "condition": Object {
                     "is": true,
-                    "when": "verify_ssl",
+                    "when": "endpoint.verify_ssl",
                   },
                   "label": <SSLFormLabel />,
-                  "name": "certificate_authority",
+                  "name": "endpoint.certificate_authority",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "kubernetes",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "token",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "openshift_1",
@@ -1251,7 +1256,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                           headerContent={null}
                           hideOnOutsideClick={true}
                           isVisible={null}
-                          maxWidth="50%"
+                          maxWidth="calc(2rem + 18.75rem)"
                           onHidden={[Function]}
                           onHide={[Function]}
                           onMount={[Function]}
@@ -1290,21 +1295,10 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "aws",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "access_key_secret_key",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, AKIAIOSFODNN7EXAMPLE",
                   "isRequired": true,
                   "label": "Access Key ID",
-                  "name": "username",
+                  "name": "authentication.username",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -1317,12 +1311,24 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   "isRequired": true,
                   "label": "Secret Key",
                   "name": "password",
-                  "type": "password",
+                  "type": "authentication.password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
                     },
                   ],
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "aws",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "access_key_secret_key",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "amazon",
@@ -1348,7 +1354,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   "DefaultIcon": [Function],
                   "component": "card-select",
                   "label": "Select your application",
-                  "name": "app_type",
+                  "name": "application.application_type_id",
                   "options": Array [
                     Object {
                       "label": "Catalog",
@@ -1538,7 +1544,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                   "helperText": "For example, Source_1",
                   "isRequired": true,
                   "label": "Name",
-                  "name": "source_name",
+                  "name": "source.name",
                   "type": "text",
                   "validate": Array [
                     Object {
@@ -1630,7 +1636,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 Object {
                   "component": "textarea-field",
                   "label": "Token",
-                  "name": "token",
+                  "name": "authentication.password",
                 },
               ],
               "name": "openshift",
@@ -1653,17 +1659,6 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "kubernetes",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "token",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, https://myopenshiftcluster.mycompany.com",
                   "isRequired": true,
                   "label": "URL",
@@ -1677,16 +1672,28 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 Object {
                   "component": "checkbox",
                   "label": "Verify SSL",
-                  "name": "verify_ssl",
+                  "name": "endpoint.verify_ssl",
                 },
                 Object {
                   "component": "textarea-field",
                   "condition": Object {
                     "is": true,
-                    "when": "verify_ssl",
+                    "when": "endpoint.verify_ssl",
                   },
                   "label": <SSLFormLabel />,
-                  "name": "certificate_authority",
+                  "name": "endpoint.certificate_authority",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "kubernetes",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "token",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "openshift_1",
@@ -1751,7 +1758,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                           headerContent={null}
                           hideOnOutsideClick={true}
                           isVisible={null}
-                          maxWidth="50%"
+                          maxWidth="calc(2rem + 18.75rem)"
                           onHidden={[Function]}
                           onHide={[Function]}
                           onMount={[Function]}
@@ -1790,21 +1797,10 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
                 Object {
                   "component": "text-field",
-                  "initialValue": "aws",
-                  "name": "role",
-                  "type": "hidden",
-                },
-                Object {
-                  "component": "text-field",
-                  "initialValue": "access_key_secret_key",
-                  "name": "authtype",
-                },
-                Object {
-                  "component": "text-field",
                   "helperText": "For example, AKIAIOSFODNN7EXAMPLE",
                   "isRequired": true,
                   "label": "Access Key ID",
-                  "name": "username",
+                  "name": "authentication.username",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -1817,12 +1813,24 @@ exports[`Steps components renders correctly without sourceTypes and application 
                   "isRequired": true,
                   "label": "Secret Key",
                   "name": "password",
-                  "type": "password",
+                  "type": "authentication.password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
                     },
                   ],
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "aws",
+                  "name": "endpoint.role",
+                  "type": "hidden",
+                },
+                Object {
+                  "component": "text-field",
+                  "initialValue": "access_key_secret_key",
+                  "name": "authentication.authtype",
+                  "type": "hidden",
                 },
               ],
               "name": "amazon",
@@ -1848,7 +1856,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                   "DefaultIcon": [Function],
                   "component": "card-select",
                   "label": "Select your application",
-                  "name": "app_type",
+                  "name": "application.application_type_id",
                   "options": Array [
                     Object {
                       "label": "Catalog",

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
@@ -306,8 +306,8 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                   "helperText": "For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                   "isRequired": true,
                   "label": "Secret Key",
-                  "name": "password",
-                  "type": "authentication.password",
+                  "name": "authentication.password",
+                  "type": "password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -808,8 +808,8 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                   "helperText": "For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                   "isRequired": true,
                   "label": "Secret Key",
-                  "name": "password",
-                  "type": "authentication.password",
+                  "name": "authentication.password",
+                  "type": "password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -1310,8 +1310,8 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   "helperText": "For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                   "isRequired": true,
                   "label": "Secret Key",
-                  "name": "password",
-                  "type": "authentication.password",
+                  "name": "authentication.password",
+                  "type": "password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",
@@ -1812,8 +1812,8 @@ exports[`Steps components renders correctly without sourceTypes and application 
                   "helperText": "For example, wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                   "isRequired": true,
                   "label": "Secret Key",
-                  "name": "password",
-                  "type": "authentication.password",
+                  "name": "authentication.password",
+                  "type": "password",
                   "validate": Array [
                     Object {
                       "type": "required-validator",

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -42,7 +42,7 @@ describe('AddSourceButton', () => {
         const wrapper = mount(<AddSourceWizard { ...initialProps }/>);
         const form = wrapper.find(FormRenderer).children().children().instance().form;
 
-        form.change('source_name', 'nameee');
+        form.change('source.name', 'nameee');
         form.change('source_type', 'openshift');
         form.submit().then(() => {
             wrapper.update();
@@ -58,7 +58,7 @@ describe('AddSourceButton', () => {
         const wrapper = mount(<AddSourceWizard { ...initialProps }/>);
         const form = wrapper.find(FormRenderer).children().children().instance().form;
 
-        form.change('source_name', 'nameee');
+        form.change('source.name', 'nameee');
         form.change('source_type', 'openshift');
         form.submit().then(() => {
             wrapper.update();

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { Button } from '@patternfly/react-core';
 
 import { AddSourceWizard } from '../../addSourceWizard/index';
 import FormRenderer from '../../sourceFormRenderer/index';
@@ -49,6 +50,23 @@ describe('AddSourceButton', () => {
             expect(wrapper.find(FinalWizard).length).toBe(1);
             expect(wrapper.find(FinishedStep).length).toBe(1);
             expect(wrapper.find(ErroredStep).length).toBe(0);
+        });
+    });
+
+    it('show pass created source to afterSubmit function', () => {
+        const afterSubmitMock = jest.fn();
+        dependency.doCreateSource = jest.fn(() => new Promise((resolve) => resolve({ name: 'source' })));
+
+        const wrapper = mount(<AddSourceWizard { ...initialProps } afterSubmit={ afterSubmitMock }/>);
+        const form = wrapper.find(FormRenderer).children().children().instance().form;
+
+        form.change('source.name', 'nameee');
+        form.change('source_type', 'openshift');
+        form.submit().then(() => {
+            wrapper.update();
+            wrapper.find(Button).at(0).simulate('click');
+
+            expect(afterSubmitMock).toHaveBeenCalledWith({ name: 'source' });
         });
     });
 

--- a/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
+++ b/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
@@ -43,7 +43,7 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     <TextListItem
       component="dd"
     >
-      123456
+      ●●●●●●●●●●●●
     </TextListItem>
     <TextListItem
       component="dt"
@@ -142,7 +142,7 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
     <TextListItem
       component="dd"
     >
-      123456
+      ●●●●●●●●●●●●
     </TextListItem>
     <TextListItem
       component="dt"
@@ -241,7 +241,7 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
     <TextListItem
       component="dd"
     >
-      123456
+      ●●●●●●●●●●●●
     </TextListItem>
     <TextListItem
       component="dt"
@@ -340,7 +340,7 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
     <TextListItem
       component="dd"
     >
-      123456
+      ●●●●●●●●●●●●
     </TextListItem>
     <TextListItem
       component="dt"

--- a/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
+++ b/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
@@ -28,32 +28,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     <TextListItem
       component="dt"
     >
-      Username
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      user_name
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
       Certificate Authority
     </TextListItem>
     <TextListItem
       component="dd"
     >
       authority
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      URL
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -68,12 +48,42 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     <TextListItem
       component="dt"
     >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
       Should validate?
     </TextListItem>
     <TextListItem
       component="dd"
     >
       Yes
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Tenant Region
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      tenant1234
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -117,32 +127,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
     <TextListItem
       component="dt"
     >
-      Username
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      user_name
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
       Certificate Authority
     </TextListItem>
     <TextListItem
       component="dd"
     >
       authority
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      URL
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -157,12 +147,42 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
     <TextListItem
       component="dt"
     >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
       Should validate?
     </TextListItem>
     <TextListItem
       component="dd"
     >
       Yes
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Tenant Region
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      tenant1234
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -206,32 +226,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
     <TextListItem
       component="dt"
     >
-      Username
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      user_name
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
       Certificate Authority
     </TextListItem>
     <TextListItem
       component="dd"
     >
       authority
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      URL
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -246,12 +246,42 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
     <TextListItem
       component="dt"
     >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
       Should validate?
     </TextListItem>
     <TextListItem
       component="dd"
     >
       Yes
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Tenant Region
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      tenant1234
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -295,32 +325,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
     <TextListItem
       component="dt"
     >
-      Username
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      user_name
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
       Certificate Authority
     </TextListItem>
     <TextListItem
       component="dd"
     >
       authority
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      URL
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"
@@ -335,12 +345,42 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
     <TextListItem
       component="dt"
     >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
       Should validate?
     </TextListItem>
     <TextListItem
       component="dd"
     >
       Yes
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Tenant Region
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      tenant1234
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
     </TextListItem>
     <TextListItem
       component="dt"

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -18,11 +18,11 @@ describe('SourceWizardSummary component', () => {
                 title: 'Title',
                 fields: [
                     {
-                        name: 'username',
+                        name: 'authentication.username',
                         label: 'Username'
                     },
                     {
-                        name: 'certificate_authority',
+                        name: 'endpoint.certificate_authority',
                         label: 'Certificate Authority'
                     },
                     {
@@ -30,32 +30,47 @@ describe('SourceWizardSummary component', () => {
                         label: 'URL'
                     },
                     {
-                        name: 'password',
+                        name: 'authentication.password',
                         label: 'Password'
                     },
                     {
-                        name: 'role',
+                        name: 'authentication.role',
                         type: 'hidden'
                     },
                     {
-                        name: 'validate',
+                        name: 'authentication.validate',
                         label: 'Should validate?'
+                    },
+                    {
+                        name: 'authentication.extra.tenant',
+                        label: 'Tenant Region'
                     }
                 ]
             };
 
-            formOptions = (source_type, app_type) => ({
+            formOptions = (source_type, application_type_id, validate = true) => ({
                 getState: () => ({
                     values: {
-                        source_name: 'openshift',
-                        username: 'user_name',
-                        certificate_authority: 'authority',
+                        source: {
+                            name: 'openshift'
+                        },
+                        endpoint: {
+                            certificate_authority: 'authority'
+                        },
+                        authentication: {
+                            role: 'kubernetes',
+                            password: '123456',
+                            username: 'user_name',
+                            validate,
+                            extra: {
+                                tenant: 'tenant1234'
+                            }
+                        },
                         url: 'neznam.cz',
-                        password: '123456',
                         source_type,
-                        role: 'kubernetes',
-                        validate: true,
-                        app_type
+                        application: {
+                            application_type_id
+                        }
                     }
                 })
             });
@@ -125,6 +140,13 @@ describe('SourceWizardSummary component', () => {
         it('render boolean as Yes', () => {
             const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower') } />);
             expect(wrapper.contains('Yes')).toEqual(true);
+            expect(wrapper.contains('No')).toEqual(false);
+        });
+
+        it('render boolean as No', () => {
+            const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower', '1', false) } />);
+            expect(wrapper.contains('No')).toEqual(true);
+            expect(wrapper.contains('Yes')).toEqual(false);
         });
     });
 });

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -31,7 +31,8 @@ describe('SourceWizardSummary component', () => {
                     },
                     {
                         name: 'authentication.password',
-                        label: 'Password'
+                        label: 'Password',
+                        type: 'password'
                     },
                     {
                         name: 'authentication.role',
@@ -147,6 +148,12 @@ describe('SourceWizardSummary component', () => {
             const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower', '1', false) } />);
             expect(wrapper.contains('No')).toEqual(true);
             expect(wrapper.contains('Yes')).toEqual(false);
+        });
+
+        it('render password as dots', () => {
+            const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower', '1', false) } />);
+            expect(wrapper.contains('●●●●●●●●●●●●')).toEqual(true);
+            expect(wrapper.contains('123456')).toEqual(false);
         });
     });
 });


### PR DESCRIPTION
**Description**

This PR prepares AddSourceWizard for changes in https://github.com/ManageIQ/sources-api/pull/74

\+ Additional enhancements (you don't need to release it separately!)
- password is rendered as dots
- wizzard returns the created source
- exposes summary components and schemas
- sorting schemas to push hidden fields to end (they still take some 'empty' space in the grid system)