### PR TITLE
Update translations to new version of react-intl

### DIFF
--- a/packages/translations/config/webpack.constants.js
+++ b/packages/translations/config/webpack.constants.js
@@ -36,6 +36,7 @@ module.exports = {
             root: 'ReactRouterDOM'
         },
         urijs: 'urijs',
+        'react-intl': 'react-intl',
         classnames: 'classnames'
     }
 };

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-translations",
-    "version": "0.0.1",
+    "version": "0.0.4",
     "description": "Translations package for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {
@@ -20,8 +20,10 @@
         "url": "https://github.com/RedHatInsights/frontend-components/issues"
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/translations#readme",
+    "peerDependencies": {
+        "react-intl": ">=2.9.2"
+    },
     "dependencies": {
-        "react-intl": "^2.9.0",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7"
     },
     "devDependencies": {

--- a/packages/translations/src/Provider.js
+++ b/packages/translations/src/Provider.js
@@ -13,7 +13,10 @@ const IntlProvider = ({
     messages,
     ...props
 }) => {
-    addLocaleData(defaultLocale);
+    if (addLocaleData) {
+        addLocaleData(defaultLocale);
+    }
+
     const language = locale || localStorage.getItem(LOCALSTORAGE_KEY) || navigator.language.split(/[-_]/)[0] || 'en';
     return (
         <ReactIntlProvider


### PR DESCRIPTION
New version of `react-intl` was released and this version does not support `addLocaleData` so we have to check if this function exists (for older versions of `react-intl`).

Also mark `react-intl` as external, so consumers can increase the version bythemeselves.