### PR TITLE
Handle rules without identifiers

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -281,10 +281,10 @@ class SystemRulesTable extends React.Component {
                         </Stack>
                         <Stack id={ `rule-identifiers-references-${key}` } className='margin-bottom-lg'>
                             <Grid>
-                                <GridItem span={ 2 }>
+                                { identifier && <GridItem span={ 2 }>
                                     <Text component={ TextVariants.h5 }><b>Identifier</b></Text>
-                                    <Text>{ identifier && this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
-                                </GridItem>
+                                    <Text>{ this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
+                                </GridItem> }
 
                                 { references && references.length > 0 ? <GridItem span={ 10 }>
                                     <Text component={ TextVariants.h5 }><b>References</b></Text>


### PR DESCRIPTION
While this shouldn't ever happen, we have no checks to ensure a rule has
an identifier, so we should handle the case at least in the frontend.

Signed-off-by: Andrew Kofink <akofink@redhat.com>