### PR TITLE
AddSourceWizard select application first

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -1,6 +1,15 @@
+**Table of Contents**
+- [Sources](#sources)
+- [Install](#install)
+  - [Using](#using)
+- [Additional components](#additional-components)
+  - [CardSelect](#cardselect)
+  - [SourceWizardSummary](#sourcewizardsummary)
+  - [Others](#others)
+
 # Sources
 
-This package exports **Add Source Wizard** and **Add Source button**.
+This package exports **Add Source Wizard** and **Add Source button**, as other components, which wizard uses.
 
 # Install
 
@@ -13,7 +22,7 @@ Please import styles in your scss files, where are you using AddSource Wizard or
 ```css
 @import '~@redhat-cloud-services/frontend-components-sources/index.css';
 ```
- 
+
 ## Using
 
 As a primary button
@@ -43,8 +52,21 @@ import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sour
 |afterSuccess|function|null|This function will be executed after closing the wizard successful finish step. In Sources-UI this method is used for updating the list of sources.|
 |onClose|function|null|This function will be executed after closing the wizard. Eg. set isOpen to false.|
 |successfulMessage|node|'Your source has been successfully added.'|A message shown on the last page of the wizard. Can be customized when accessing from different app (eg. 'Source was added to Cost Management')|
-|sourceTypes|array|null|SourceTypes options. This prop can be used on pages, which have already loaded the source types, so there is no need to load them in this component.|
-|applicationTypes|array|null|SourceTypes options. This prop can be used on pages, which have already loaded the application types, so there is no need to load them in this component.|
+|sourceTypes|array|null|SourceTypes array. This prop can be used on pages, which have already loaded the source types, so there is no need to load them in this component.|
+|applicationTypes|array|null|applicationTypes array. This prop can be used on pages, which have already loaded the application types, so there is no need to load them in this component.|
+|initialValues|object|{}|Object with initialValues of the form.|
+|disableAppSelection|bool|false|Flag to disable appSelection.|
+|hideSourcesButton|bool|false|hide 'Take me to sources' button.|
+
+If you need to set up and support only one application you can provide filtered `applicationTypes` with the only one application, set up `disableAppSelection` to `false` and `initialValues` to:
+
+```jsx
+{
+    application: {
+        application_type_id: 'YOUR_APP_ID'
+    }
+}
+```
 
 
 # Additional components
@@ -66,5 +88,25 @@ This components accepts all formGroup props `(label, helperText, isDisabled, isR
 |DefaultIcon|element, node, func|Default icon (default is `ServerIcon`)|
 |iconMapper*|func|You can use your own mapper `(value, DefaultIcon) => ...` |
 |multi/isMulti|bool|Allows to select more items|
+|mutator|func|`(option, formOptions) => option`, func which mutates options|
 
 \* In the future it could be replaced by data obtained from API
+
+## SourceWizardSummary
+
+Adds a summary of formValues to the form.
+
+**Props**
+
+This components accepts all formGroup props `(label, helperText, isDisabled, isRequired, ...)`
+
+
+|Prop|Type|Description|
+|----|:--:|----------:|
+|sourceTypes|array|SourceTypes array with schemas.|
+|applicationTypes|array|applicationTypes array with schemas.|
+|showApp|bool|Default: `true`, shows the application selection in the summary|
+
+## Others
+
+This package exports some other components and functions, which are used in [Sources-UI](https://github.com/ManageIQ/sources-ui). They are not intended to be used anywhere else.

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/sources#readme",
     "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^1.15.7",
-        "@data-driven-forms/react-form-renderer": "^1.15.7",
+        "@data-driven-forms/pf4-component-mapper": "^1.16.6",
+        "@data-driven-forms/react-form-renderer": "^1.16.6",
         "@patternfly/react-icons": "^3.10.9",
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",

--- a/packages/sources/src/addSourceWizard/FinalWizard.js
+++ b/packages/sources/src/addSourceWizard/FinalWizard.js
@@ -6,7 +6,7 @@ import FinishedStep from './steps/FinishedStep';
 import ErroredStep from './steps/ErroredStep';
 import LoadingStep from './steps/LoadingStep';
 
-const FinalWizard = ({ afterSubmit, afterError, isFinished, isErrored, onRetry, successfulMessage }) =>
+const FinalWizard = ({ afterSubmit, afterError, isFinished, isErrored, onRetry, successfulMessage, hideSourcesButton }) =>
     <Wizard
         isOpen={ true }
         onClose={ isFinished ? afterSubmit : afterError }
@@ -15,7 +15,7 @@ const FinalWizard = ({ afterSubmit, afterError, isFinished, isErrored, onRetry, 
         steps={ [{
             name: 'Finish',
             component: isFinished ?
-                <FinishedStep onClose={ afterSubmit } successfulMessage={ successfulMessage }/> :
+                <FinishedStep onClose={ afterSubmit } successfulMessage={ successfulMessage } hideSourcesButton={ hideSourcesButton }/> :
                 isErrored ?
                     <ErroredStep onRetry={ onRetry } onClose={ afterError }/>
                     : <LoadingStep customText='Source is being created'/>,
@@ -28,7 +28,8 @@ FinalWizard.propTypes = {
     onRetry: PropTypes.func.isRequired,
     isFinished: PropTypes.bool.isRequired,
     isErrored: PropTypes.bool.isRequired,
-    successfulMessage: PropTypes.node.isRequired
+    successfulMessage: PropTypes.node.isRequired,
+    hideSourcesButton: PropTypes.bool.isRequired
 };
 
 export default FinalWizard;

--- a/packages/sources/src/addSourceWizard/SourceAddModal.js
+++ b/packages/sources/src/addSourceWizard/SourceAddModal.js
@@ -20,11 +20,11 @@ class SourceAddModal extends React.Component {
 
     componentDidMount() {
         this._isMounted = true;
-        const { sourceTypes, applicationTypes } = this.props;
+        const { sourceTypes, applicationTypes, disableAppSelection } = this.props;
 
         if (sourceTypes && applicationTypes) {
             this.setState({
-                schema: createSchema(sourceTypes.filter(type => type.schema), applicationTypes),
+                schema: createSchema(sourceTypes.filter(type => type.schema), applicationTypes, disableAppSelection),
                 isLoading: false,
                 sourceTypes,
                 applicationTypes
@@ -49,7 +49,7 @@ class SourceAddModal extends React.Component {
                 if (this._isMounted) {
                     this.setState({
                         sourceTypes: sourceTypesFinal,
-                        schema: createSchema(sourceTypesFinal.filter(type => type.schema), applicationTypesFinal),
+                        schema: createSchema(sourceTypesFinal.filter(type => type.schema), applicationTypesFinal, disableAppSelection),
                         isLoading: false,
                         applicationTypes: applicationTypesFinal
                     });
@@ -108,11 +108,13 @@ SourceAddModal.propTypes = {
         name: PropTypes.string.isRequired,
         display_name: PropTypes.string.isRequired //eslint-disable-line camelcase
     })),
-    values: PropTypes.object
+    values: PropTypes.object,
+    disableAppSelection: PropTypes.bool
 };
 
 SourceAddModal.defaultProps = {
-    values: {}
+    values: {},
+    disableAppSelection: false
 };
 
 export default SourceAddModal;

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -7,16 +7,16 @@ import FinalWizard from './FinalWizard';
 
 import { doCreateSource } from '../api/index';
 
-const initialValues = {
+const initialValues = (initialValues) => ({
     isSubmitted: false,
     isFinished: false,
     isErrored: false,
-    values: {},
+    values: initialValues,
     createdSource: {}
-};
+});
 
 class AddSourceWizard extends React.Component {
-    state = initialValues;
+    state = initialValues(this.props.initialValues);
 
     setOnSubmitState = (values) => this.setState({
         isSubmitted: true,
@@ -52,7 +52,7 @@ class AddSourceWizard extends React.Component {
     }
 
     render() {
-        const { successfulMessage, isOpen, sourceTypes, applicationTypes } = this.props;
+        const { successfulMessage, isOpen, sourceTypes, applicationTypes, disableAppSelection, hideSourcesButton } = this.props;
         const { isErrored, isFinished, isSubmitted, values } = this.state;
 
         if (!isOpen) {
@@ -66,6 +66,7 @@ class AddSourceWizard extends React.Component {
                 onCancel={ this.onCancel }
                 sourceTypes={ sourceTypes }
                 applicationTypes={ applicationTypes }
+                disableAppSelection={ disableAppSelection }
             />;
         }
 
@@ -76,6 +77,7 @@ class AddSourceWizard extends React.Component {
             isErrored={ isErrored }
             onRetry={ this.onRetry }
             successfulMessage={ successfulMessage }
+            hideSourcesButton={ hideSourcesButton }
         />;
     }
 }
@@ -97,14 +99,22 @@ AddSourceWizard.propTypes = {
     })),
     onClose: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,
-    successfulMessage: PropTypes.node
+    successfulMessage: PropTypes.node,
+    initialValues: PropTypes.shape({
+        [PropTypes.string]: PropTypes.oneOf([ PropTypes.string, PropTypes.array, PropTypes.number, PropTypes.bool ])
+    }),
+    disableAppSelection: PropTypes.bool,
+    hideSourcesButton: PropTypes.bool
 };
 
 AddSourceWizard.defaultProps = {
     afterSuccess: () => {},
     sourceTypes: undefined,
     applicationTypes: undefined,
-    successfulMessage: 'Your source has been successfully added.'
+    successfulMessage: 'Your source has been successfully added.',
+    initialValues: {},
+    disableAppSelection: false,
+    hideSourcesButton: false
 };
 
 class AddSourceButton extends React.Component {

--- a/packages/sources/src/addSourceWizard/steps/FinishedStep.js
+++ b/packages/sources/src/addSourceWizard/steps/FinishedStep.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { EmptyStateBody, EmptyState, EmptyStateIcon, Title, Button, EmptyStateSecondaryActions, EmptyStateVariant } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 
-const FinishedStep = ({ onClose, successfulMessage }) => <div className="pf-l-bullseye">
+const FinishedStep = ({ onClose, successfulMessage, hideSourcesButton }) => <div className="pf-l-bullseye">
     <EmptyState variant={ EmptyStateVariant.full }>
         <EmptyStateIcon icon={ CheckCircleIcon } color="var(--pf-global--success-color--100)" />
         <Title headingLevel="h5" size="lg">
@@ -14,17 +14,20 @@ const FinishedStep = ({ onClose, successfulMessage }) => <div className="pf-l-bu
             { successfulMessage }
         </EmptyStateBody>
         <Button variant="primary" onClick={ onClose }>Back to my application</Button>
+        { !hideSourcesButton &&
         <EmptyStateSecondaryActions>
             <a href='/hybrid/settings/sources'>
                 <Button variant="link">Take me to sources</Button>
             </a>
         </EmptyStateSecondaryActions>
+        }
     </EmptyState>
 </div>;
 
 FinishedStep.propTypes = {
     onClose: PropTypes.func.isRequired,
-    successfulMessage: PropTypes.node.isRequired
+    successfulMessage: PropTypes.node.isRequired,
+    hideSourcesButton: PropTypes.bool.isRequired
 };
 
 export default FinishedStep;

--- a/packages/sources/src/api/index.js
+++ b/packages/sources/src/api/index.js
@@ -128,7 +128,7 @@ export function doCreateSource(formData, sourceTypes) {
 export const doLoadAllApplications = () => getSourcesApi().listApplicationTypes().then(data => data.data);
 
 export const findSource = (name) => getSourcesApi().postGraphQL({
-    query: `{ sources(filter: {name: ${name}})
+    query: `{ sources(filter: {name: "${name}"})
         { id, name }
     }`
 });

--- a/packages/sources/src/sourceFormRenderer/components/CardSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/CardSelect.js
@@ -42,7 +42,7 @@ class CardSelect extends React.Component {
         }
     }
 
-    prepareCards = () => this.props.options.map(({ value, label, isDisabled }) => {
+    prepareCards = () => this.props.options.map(option => this.props.mutator(option, this.props.formOptions)).map(({ value, label, isDisabled }) => {
         const { iconMapper, DefaultIcon } = this.props;
 
         const disabled = isDisabled || this.isDisabled;
@@ -127,7 +127,8 @@ CardSelect.propTypes = {
 CardSelect.defaultProps = {
     options: [],
     DefaultIcon: ServerIcon,
-    iconMapper: (_value, DefaultIcon) => DefaultIcon
+    iconMapper: (_value, DefaultIcon) => DefaultIcon,
+    mutator: x => x
 };
 
 const CardSelectProvider = ({ FieldProvider, ...rest }) =>

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -36,7 +36,7 @@ export const allValuesPath = (value, fields, path = undefined) => {
     return Object.keys(value).map((key) => allValuesPath(value[key], fields, path ? `${path}.${key}` : key)).filter(x => x);
 };
 
-const SourceWizardSummary = ({ sourceTypes, formOptions, applicationTypes }) => {
+const SourceWizardSummary = ({ sourceTypes, formOptions, applicationTypes, showApp }) => {
     const values = formOptions.getState().values;
     const type = sourceTypes.find(type => type.name === values.source_type);
     const fields = type.schema.fields;
@@ -57,11 +57,13 @@ const SourceWizardSummary = ({ sourceTypes, formOptions, applicationTypes }) => 
             <TextList component={ TextListVariants.dl }>
                 <TextListItem component={ TextListItemVariants.dt }>{ 'Name' }</TextListItem>
                 <TextListItem component={ TextListItemVariants.dd }>{ values.source.name }</TextListItem>
+                { showApp && <React.Fragment>
+                    <TextListItem component={ TextListItemVariants.dt }>{ 'Application' }</TextListItem>
+                    <TextListItem component={ TextListItemVariants.dd }>{ applicationName }</TextListItem>
+                </React.Fragment> }
                 <TextListItem component={ TextListItemVariants.dt }>{ 'Source Type' }</TextListItem>
                 <TextListItem component={ TextListItemVariants.dd }>{ type.product_name }</TextListItem>
                 { valuesList }
-                <TextListItem component={ TextListItemVariants.dt }>{ 'Application' }</TextListItem>
-                <TextListItem component={ TextListItemVariants.dd }>{ applicationName }</TextListItem>
             </TextList>
         </TextContent>
     );
@@ -81,7 +83,12 @@ SourceWizardSummary.propTypes = {
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
         display_name: PropTypes.string.isRequired //eslint-disable-line camelcase
-    })).isRequired
+    })).isRequired,
+    showApp: PropTypes.bool
+};
+
+SourceWizardSummary.defaultProps = {
+    showApp: true
 };
 
 export default SourceWizardSummary;

--- a/packages/sources/src/sourceFormRenderer/index.js
+++ b/packages/sources/src/sourceFormRenderer/index.js
@@ -16,7 +16,9 @@ const SourcesFormRenderer = props => (
             description: Description,
             'card-select': CardSelect
         } }
-        { ...props } />
+        subscription={ { values: true } }
+        { ...props }
+    />
 );
 
 export default SourcesFormRenderer;

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/addSourceButton.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/addSourceButton.test.js.snap
@@ -10,6 +10,9 @@ exports[`AddSourceButton renders correctly 1`] = `
   </Button>
   <AddSourceWizard
     afterSuccess={[Function]}
+    disableAppSelection={false}
+    hideSourcesButton={false}
+    initialValues={Object {}}
     isOpen={false}
     onClose={[Function]}
     successfulMessage="Your source has been successfully added."

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/addSourceWizzard.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/addSourceWizzard.test.js.snap
@@ -16,6 +16,7 @@ exports[`AddSourceWizard renders correctly with sourceTypes 1`] = `
       },
     ]
   }
+  disableAppSelection={false}
   onCancel={[Function]}
   onSubmit={[Function]}
   sourceTypes={
@@ -84,6 +85,7 @@ exports[`AddSourceWizard renders correctly without sourceTypes 1`] = `
       },
     ]
   }
+  disableAppSelection={false}
   onCancel={[Function]}
   onSubmit={[Function]}
   values={Object {}}

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/finalWizard.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/finalWizard.test.js.snap
@@ -63,6 +63,7 @@ exports[`Final wizard Renders renders finished step correctly 1`] = `
     Array [
       Object {
         "component": <FinishedStep
+          hideSourcesButton={false}
           onClose={[MockFunction]}
           successfulMessage="Message"
         />,

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sourceAddModal.test.js.snap
@@ -23,12 +23,12 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                     <Text
                       component="p"
                     >
-                      To import data for an application, you need to connect to a data source. To begin, input a name and select the type of source you want to collect data from.
+                      To import data for an application, you need to connect to a data source. Input a name and then proceed to the selection of application and source types.
                     </Text>
                     <Text
                       component="p"
                     >
-                      All fields are required.
+                      Name is required and has to be unique.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -44,11 +44,45 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                     [Function],
                   ],
                 },
+              ],
+              "name": "name_step",
+              "nextStep": "types_step",
+              "stepKey": 1,
+              "title": "Select a source name",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "DefaultIcon": [Function],
+                  "component": "card-select",
+                  "helperText": "Selected application will limit the options of available source types.",
+                  "isDisabled": false,
+                  "isRequired": true,
+                  "label": "Select your application",
+                  "mutator": [Function],
+                  "name": "application.application_type_id",
+                  "options": Array [
+                    Object {
+                      "label": "Catalog",
+                      "value": "1",
+                    },
+                    Object {
+                      "label": "Cost Management",
+                      "value": "2",
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required-validator",
+                    },
+                  ],
+                },
                 Object {
                   "component": "card-select",
                   "iconMapper": [Function],
                   "isRequired": true,
-                  "label": "Type",
+                  "label": "Select your source type",
+                  "mutator": [Function],
                   "name": "source_type",
                   "options": Array [
                     Object {
@@ -71,7 +105,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                   ],
                 },
               ],
-              "name": "step_1",
+              "name": "types_step",
               "nextStep": Object {
                 "stepMapper": Object {
                   "amazon": "amazon",
@@ -80,8 +114,8 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
                 "when": "source_type",
               },
-              "stepKey": 1,
-              "title": "Select a source type",
+              "stepKey": "types_step",
+              "title": "Configure your source",
             },
             Object {
               "fields": Array [
@@ -216,7 +250,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
               ],
               "name": "amazon",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "amazon",
               "title": "Configure account access",
             },
@@ -228,7 +262,7 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
               ],
               "name": "ansible-tower",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "ansible-tower",
               "title": "AnsibleTower",
             },
@@ -341,33 +375,9 @@ exports[`Steps components renders correctly with sourceTypes and applicationType
                 },
               ],
               "name": "openshift_1",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "openshift_1",
               "title": "Enter OpenShift Container Platform information",
-            },
-            Object {
-              "fields": Array [
-                Object {
-                  "DefaultIcon": [Function],
-                  "component": "card-select",
-                  "label": "Select your application",
-                  "name": "application.application_type_id",
-                  "options": Array [
-                    Object {
-                      "label": "Catalog",
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "Cost Management",
-                      "value": "2",
-                    },
-                  ],
-                },
-              ],
-              "name": "application-type",
-              "nextStep": "summary",
-              "stepKey": "application-type",
-              "title": "Select application",
             },
             Object {
               "fields": Array [
@@ -526,12 +536,12 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                     <Text
                       component="p"
                     >
-                      To import data for an application, you need to connect to a data source. To begin, input a name and select the type of source you want to collect data from.
+                      To import data for an application, you need to connect to a data source. Input a name and then proceed to the selection of application and source types.
                     </Text>
                     <Text
                       component="p"
                     >
-                      All fields are required.
+                      Name is required and has to be unique.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -547,11 +557,45 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                     [Function],
                   ],
                 },
+              ],
+              "name": "name_step",
+              "nextStep": "types_step",
+              "stepKey": 1,
+              "title": "Select a source name",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "DefaultIcon": [Function],
+                  "component": "card-select",
+                  "helperText": "Selected application will limit the options of available source types.",
+                  "isDisabled": false,
+                  "isRequired": true,
+                  "label": "Select your application",
+                  "mutator": [Function],
+                  "name": "application.application_type_id",
+                  "options": Array [
+                    Object {
+                      "label": "Catalog",
+                      "value": "1",
+                    },
+                    Object {
+                      "label": "Cost Management",
+                      "value": "2",
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required-validator",
+                    },
+                  ],
+                },
                 Object {
                   "component": "card-select",
                   "iconMapper": [Function],
                   "isRequired": true,
-                  "label": "Type",
+                  "label": "Select your source type",
+                  "mutator": [Function],
                   "name": "source_type",
                   "options": Array [
                     Object {
@@ -574,7 +618,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                   ],
                 },
               ],
-              "name": "step_1",
+              "name": "types_step",
               "nextStep": Object {
                 "stepMapper": Object {
                   "amazon": "amazon",
@@ -583,8 +627,8 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
                 "when": "source_type",
               },
-              "stepKey": 1,
-              "title": "Select a source type",
+              "stepKey": "types_step",
+              "title": "Configure your source",
             },
             Object {
               "fields": Array [
@@ -719,7 +763,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
               ],
               "name": "amazon",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "amazon",
               "title": "Configure account access",
             },
@@ -731,7 +775,7 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
               ],
               "name": "ansible-tower",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "ansible-tower",
               "title": "AnsibleTower",
             },
@@ -844,33 +888,9 @@ exports[`Steps components renders correctly without applicationTypes 2`] = `
                 },
               ],
               "name": "openshift_1",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "openshift_1",
               "title": "Enter OpenShift Container Platform information",
-            },
-            Object {
-              "fields": Array [
-                Object {
-                  "DefaultIcon": [Function],
-                  "component": "card-select",
-                  "label": "Select your application",
-                  "name": "application.application_type_id",
-                  "options": Array [
-                    Object {
-                      "label": "Catalog",
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "Cost Management",
-                      "value": "2",
-                    },
-                  ],
-                },
-              ],
-              "name": "application-type",
-              "nextStep": "summary",
-              "stepKey": "application-type",
-              "title": "Select application",
             },
             Object {
               "fields": Array [
@@ -1029,12 +1049,12 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                     <Text
                       component="p"
                     >
-                      To import data for an application, you need to connect to a data source. To begin, input a name and select the type of source you want to collect data from.
+                      To import data for an application, you need to connect to a data source. Input a name and then proceed to the selection of application and source types.
                     </Text>
                     <Text
                       component="p"
                     >
-                      All fields are required.
+                      Name is required and has to be unique.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -1050,11 +1070,45 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                     [Function],
                   ],
                 },
+              ],
+              "name": "name_step",
+              "nextStep": "types_step",
+              "stepKey": 1,
+              "title": "Select a source name",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "DefaultIcon": [Function],
+                  "component": "card-select",
+                  "helperText": "Selected application will limit the options of available source types.",
+                  "isDisabled": false,
+                  "isRequired": true,
+                  "label": "Select your application",
+                  "mutator": [Function],
+                  "name": "application.application_type_id",
+                  "options": Array [
+                    Object {
+                      "label": "Catalog",
+                      "value": "1",
+                    },
+                    Object {
+                      "label": "Cost Management",
+                      "value": "2",
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required-validator",
+                    },
+                  ],
+                },
                 Object {
                   "component": "card-select",
                   "iconMapper": [Function],
                   "isRequired": true,
-                  "label": "Type",
+                  "label": "Select your source type",
+                  "mutator": [Function],
                   "name": "source_type",
                   "options": Array [
                     Object {
@@ -1077,7 +1131,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                   ],
                 },
               ],
-              "name": "step_1",
+              "name": "types_step",
               "nextStep": Object {
                 "stepMapper": Object {
                   "amazon": "amazon",
@@ -1086,8 +1140,8 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
                 "when": "source_type",
               },
-              "stepKey": 1,
-              "title": "Select a source type",
+              "stepKey": "types_step",
+              "title": "Configure your source",
             },
             Object {
               "fields": Array [
@@ -1222,7 +1276,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
               ],
               "name": "amazon",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "amazon",
               "title": "Configure account access",
             },
@@ -1234,7 +1288,7 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
               ],
               "name": "ansible-tower",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "ansible-tower",
               "title": "AnsibleTower",
             },
@@ -1347,33 +1401,9 @@ exports[`Steps components renders correctly without sourceTypes 2`] = `
                 },
               ],
               "name": "openshift_1",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "openshift_1",
               "title": "Enter OpenShift Container Platform information",
-            },
-            Object {
-              "fields": Array [
-                Object {
-                  "DefaultIcon": [Function],
-                  "component": "card-select",
-                  "label": "Select your application",
-                  "name": "application.application_type_id",
-                  "options": Array [
-                    Object {
-                      "label": "Catalog",
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "Cost Management",
-                      "value": "2",
-                    },
-                  ],
-                },
-              ],
-              "name": "application-type",
-              "nextStep": "summary",
-              "stepKey": "application-type",
-              "title": "Select application",
             },
             Object {
               "fields": Array [
@@ -1532,12 +1562,12 @@ exports[`Steps components renders correctly without sourceTypes and application 
                     <Text
                       component="p"
                     >
-                      To import data for an application, you need to connect to a data source. To begin, input a name and select the type of source you want to collect data from.
+                      To import data for an application, you need to connect to a data source. Input a name and then proceed to the selection of application and source types.
                     </Text>
                     <Text
                       component="p"
                     >
-                      All fields are required.
+                      Name is required and has to be unique.
                     </Text>
                   </TextContent>,
                   "name": "description-summary",
@@ -1553,11 +1583,45 @@ exports[`Steps components renders correctly without sourceTypes and application 
                     [Function],
                   ],
                 },
+              ],
+              "name": "name_step",
+              "nextStep": "types_step",
+              "stepKey": 1,
+              "title": "Select a source name",
+            },
+            Object {
+              "fields": Array [
+                Object {
+                  "DefaultIcon": [Function],
+                  "component": "card-select",
+                  "helperText": "Selected application will limit the options of available source types.",
+                  "isDisabled": false,
+                  "isRequired": true,
+                  "label": "Select your application",
+                  "mutator": [Function],
+                  "name": "application.application_type_id",
+                  "options": Array [
+                    Object {
+                      "label": "Catalog",
+                      "value": "1",
+                    },
+                    Object {
+                      "label": "Cost Management",
+                      "value": "2",
+                    },
+                  ],
+                  "validate": Array [
+                    Object {
+                      "type": "required-validator",
+                    },
+                  ],
+                },
                 Object {
                   "component": "card-select",
                   "iconMapper": [Function],
                   "isRequired": true,
-                  "label": "Type",
+                  "label": "Select your source type",
+                  "mutator": [Function],
                   "name": "source_type",
                   "options": Array [
                     Object {
@@ -1580,7 +1644,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                   ],
                 },
               ],
-              "name": "step_1",
+              "name": "types_step",
               "nextStep": Object {
                 "stepMapper": Object {
                   "amazon": "amazon",
@@ -1589,8 +1653,8 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
                 "when": "source_type",
               },
-              "stepKey": 1,
-              "title": "Select a source type",
+              "stepKey": "types_step",
+              "title": "Configure your source",
             },
             Object {
               "fields": Array [
@@ -1725,7 +1789,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
               ],
               "name": "amazon",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "amazon",
               "title": "Configure account access",
             },
@@ -1737,7 +1801,7 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
               ],
               "name": "ansible-tower",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "ansible-tower",
               "title": "AnsibleTower",
             },
@@ -1850,33 +1914,9 @@ exports[`Steps components renders correctly without sourceTypes and application 
                 },
               ],
               "name": "openshift_1",
-              "nextStep": "application-type",
+              "nextStep": "summary",
               "stepKey": "openshift_1",
               "title": "Enter OpenShift Container Platform information",
-            },
-            Object {
-              "fields": Array [
-                Object {
-                  "DefaultIcon": [Function],
-                  "component": "card-select",
-                  "label": "Select your application",
-                  "name": "application.application_type_id",
-                  "options": Array [
-                    Object {
-                      "label": "Catalog",
-                      "value": "1",
-                    },
-                    Object {
-                      "label": "Cost Management",
-                      "value": "2",
-                    },
-                  ],
-                },
-              ],
-              "name": "application-type",
-              "nextStep": "summary",
-              "stepKey": "application-type",
-              "title": "Select application",
             },
             Object {
               "fields": Array [

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/steps.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/steps.test.js.snap
@@ -79,6 +79,36 @@ exports[`Steps components FinishedStep renders correctly 1`] = `
 </div>
 `;
 
+exports[`Steps components FinishedStep renders withou takemetosources button 1`] = `
+<div
+  className="pf-l-bullseye"
+>
+  <EmptyState
+    variant="full"
+  >
+    <EmptyStateIcon
+      color="var(--pf-global--success-color--100)"
+      icon={[Function]}
+    />
+    <Title
+      headingLevel="h5"
+      size="lg"
+    >
+      Configuration successful
+    </Title>
+    <EmptyStateBody>
+      Here I Am
+    </EmptyStateBody>
+    <Button
+      onClick={[MockFunction]}
+      variant="primary"
+    >
+      Back to my application
+    </Button>
+  </EmptyState>
+</div>
+`;
+
 exports[`Steps components LoadingStep renders correctly 1`] = `
 <div
   className="pf-l-bullseye"

--- a/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
@@ -19,7 +19,8 @@ describe('Final wizard', () => {
                 onRetry: jest.fn(),
                 isFinished: false,
                 isErrored: false,
-                successfulMessage: 'Message'
+                successfulMessage: 'Message',
+                hideSourcesButton: false
             };
         });
 

--- a/packages/sources/src/tests/addSourceWizard/steps.test.js
+++ b/packages/sources/src/tests/addSourceWizard/steps.test.js
@@ -27,7 +27,8 @@ describe('Steps components', () => {
         beforeEach(() => {
             initialProps = {
                 onClose: spyFunction,
-                successfulMessage: 'Here I Am'
+                successfulMessage: 'Here I Am',
+                hideSourcesButton: false
             };
         });
 
@@ -36,6 +37,12 @@ describe('Steps components', () => {
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('a[href="/hybrid/settings/sources"]').length).toBe(1);
             expect(wrapper.find(EmptyStateBody).html().includes('Here I Am')).toBe(true);
+        });
+
+        it('renders withou takemetosources button', () => {
+            const wrapper = shallow(<FinishedStep { ...initialProps } hideSourcesButton={ true }/>);
+            expect(toJson(wrapper)).toMatchSnapshot();
+            expect(wrapper.find('a[href="/hybrid/settings/sources"]').length).toBe(0);
         });
 
         it('calls onClose function', () => {

--- a/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
+++ b/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
@@ -18,6 +18,16 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     <TextListItem
       component="dt"
     >
+      Application
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Not selected
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
       Source Type
     </TextListItem>
     <TextListItem
@@ -85,6 +95,25 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     >
       neznam.cz
     </TextListItem>
+  </TextList>
+</TextContent>
+`;
+
+exports[`SourceWizardSummary component should render correctly ansible-tower 1`] = `
+<TextContent>
+  <TextList
+    component="dl"
+  >
+    <TextListItem
+      component="dt"
+    >
+      Name
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      openshift
+    </TextListItem>
     <TextListItem
       component="dt"
     >
@@ -95,11 +124,81 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
     >
       Not selected
     </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Source Type
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Ansible Tower
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Certificate Authority
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      authority
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Password
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      ●●●●●●●●●●●●
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Username
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      user_name
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Should validate?
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Yes
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Tenant Region
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      tenant1234
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      URL
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      neznam.cz
+    </TextListItem>
   </TextList>
 </TextContent>
 `;
 
-exports[`SourceWizardSummary component should render correctly ansible-tower 1`] = `
+exports[`SourceWizardSummary component should render correctly hide application 1`] = `
 <TextContent>
   <TextList
     component="dl"
@@ -184,16 +283,6 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
     >
       neznam.cz
     </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      Application
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      Not selected
-    </TextListItem>
   </TextList>
 </TextContent>
 `;
@@ -212,6 +301,16 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
       component="dd"
     >
       openshift
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Application
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Not selected
     </TextListItem>
     <TextListItem
       component="dt"
@@ -283,21 +382,11 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
     >
       neznam.cz
     </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      Application
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      Not selected
-    </TextListItem>
   </TextList>
 </TextContent>
 `;
 
-exports[`SourceWizardSummary component should render correctly selected Catalog application 1`] = `
+exports[`SourceWizardSummary component should render correctly selected Catalog application, is second 1`] = `
 <TextContent>
   <TextList
     component="dl"
@@ -311,6 +400,16 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
       component="dd"
     >
       openshift
+    </TextListItem>
+    <TextListItem
+      component="dt"
+    >
+      Application
+    </TextListItem>
+    <TextListItem
+      component="dd"
+    >
+      Catalog
     </TextListItem>
     <TextListItem
       component="dt"
@@ -381,16 +480,6 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
       component="dd"
     >
       neznam.cz
-    </TextListItem>
-    <TextListItem
-      component="dt"
-    >
-      Application
-    </TextListItem>
-    <TextListItem
-      component="dd"
-    >
-      Catalog
     </TextListItem>
   </TextList>
 </TextContent>

--- a/packages/sources/src/tests/sourceFormRenderer/components/cardSelect.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/cardSelect.test.js
@@ -24,6 +24,9 @@ describe('CardSelect component', () => {
                 name: 'card-select',
                 onChange: spyOnChange,
                 onBlur: spyOnBlur
+            },
+            formOptions: {
+                something: '1'
             }
         };
     });
@@ -40,6 +43,15 @@ describe('CardSelect component', () => {
         expect(wrapper.find(CardHeader).length).toEqual(2);
         expect(wrapper.find(CardHeader).first().text()).toEqual('openshift');
         expect(wrapper.find(CardHeader).last().text()).toEqual('aws');
+    });
+
+    it('should render correctly with mutator and it passes formOptions', () => {
+        const wrapper = mount(<CardSelect { ...initialProps } mutator={ ({ label, value }, formOptions) => ({ label: `AAA-${label}-${formOptions.something}`, value }) }/>);
+
+        expect(wrapper.find(Card).length).toEqual(2);
+        expect(wrapper.find(CardHeader).length).toEqual(2);
+        expect(wrapper.find(CardHeader).first().text()).toEqual('AAA-openshift-1');
+        expect(wrapper.find(CardHeader).last().text()).toEqual('AAA-aws-1');
     });
 
     it('should render correctly with default icon', () => {

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -112,9 +112,9 @@ describe('SourceWizardSummary component', () => {
             expect(wrapper.find(TextListItem).at(1).children().first().text()).toEqual('openshift');
         });
 
-        it('type is second', () => {
+        it('type is third', () => {
             const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('openshift') }/>);
-            expect(wrapper.find(TextListItem).at(3).children().first().text()).toEqual('OpenShift Container Platform');
+            expect(wrapper.find(TextListItem).at(5).children().first().text()).toEqual('OpenShift Container Platform');
         });
 
         it('amazon', () => {
@@ -127,10 +127,17 @@ describe('SourceWizardSummary component', () => {
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
-        it('selected Catalog application', () => {
+        it('selected Catalog application, is second', () => {
             const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower', '1') } />);
             expect(toJson(wrapper)).toMatchSnapshot();
-            expect(wrapper.find(TextListItem).last().children().first().text()).toEqual('Catalog');
+            expect(wrapper.find(TextListItem).at(3).children().first().text()).toEqual('Catalog');
+        });
+
+        it('hide application', () => {
+            const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions('ansible-tower', '1') } showApp={ false }/>);
+            expect(toJson(wrapper)).toMatchSnapshot();
+            expect(wrapper.find(TextListItem).at(3).children().first().text()).not.toEqual('Catalog');
+            expect(wrapper.contains('Catalog')).toEqual(false);
         });
 
         it('do not contain hidden field', () => {


### PR DESCRIPTION
**Description**

Combines SourceType and AppType selection to one screen with dynamic limitation.

Prepares to AddSourceWizard to use in different applications:
- new options to customize the form (initialValues, disable app selection)

Hide application selection in the summary (for edit form variant, where user is not selecting the app)

Little fixes, updates of readme, etc.

![sourceTypesSelection](https://user-images.githubusercontent.com/32869456/65329981-e93c8100-dbb9-11e9-9c21-e1491958267b.gif)

**TODO**
- [x] tests
- [x] docs

@terezanovotna @gtanzillo