### PR TITLE
Use calculated time in order to keep updated date in compliance

### DIFF
--- a/packages/inventory-compliance/src/SystemPolicyCard.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.test.js
@@ -1,20 +1,22 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import SystemPolicyCard from './SystemPolicyCard';
 import { IntlProvider } from 'react-intl';
 
 describe('SystemPolicyCard component', () => {
     it('should render', () => {
+        const currentTime = new Date();
+        currentTime.setMonth(currentTime.getMonth() - 6);
         const policy = {
             rulesPassed: 30,
             rulesFailed: 10,
-            lastScanned: '2019-03-06T06:20:13Z',
+            lastScanned: currentTime.toISOString(),
             refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
             name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
             compliant: false
         };
-        const wrapper = mount(
+        const wrapper = render(
             <IntlProvider locale={ navigator.language }>
                 <SystemPolicyCard policy={ policy } />
             </IntlProvider>

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
@@ -1,176 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SystemPolicyCard component should render 1`] = `
-<IntlProvider
-  locale="en-US"
+<article
+  class="pf-c-card"
 >
-  <SystemPolicyCard
-    policy={
-      Object {
-        "compliant": false,
-        "lastScanned": "2019-03-06T06:20:13Z",
-        "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
-        "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
-        "rulesFailed": 10,
-        "rulesPassed": 30,
-      }
-    }
+  <div
+    class="pf-c-card__body"
   >
-    <Card>
-      <article
-        className="pf-c-card"
+    <div
+      class="pf-c-content margin-bottom-md"
+    >
+      <small
+        class="margin-bottom-none"
+        data-pf-content="true"
       >
-        <CardBody>
-          <div
-            className="pf-c-card__body"
+        External policy
+      </small>
+      <h4
+        class="margin-bottom-top-none"
+        data-pf-content="true"
+      >
+        PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+      </h4>
+    </div>
+    <div
+      class="margin-bottom-md"
+    >
+      <div
+        class="ins-c-policy-card ins-m-noncompliant"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            transform=""
+          />
+        </svg>
+         Noncompliant
+      </div>
+      <small
+        class=""
+        data-pf-content="true"
+      >
+        30 of 40 rules passed
+      </small>
+    </div>
+    <div
+      class="margin-bottom-md"
+    >
+      <p
+        class="wrap-break-word"
+        data-pf-content="true"
+      >
+        Profile 
+        <br />
+        <span
+          width="0"
+        >
+          <span />
+          <span>
+            xccdf_org.ssgproject.content_profile_pci-dss
+          </span>
+          <span
+            style="position:fixed;visibility:hidden;top:0;left:0"
           >
-            <TextContent
-              className="margin-bottom-md"
-            >
-              <div
-                className="pf-c-content margin-bottom-md"
-              >
-                <Text
-                  className="margin-bottom-none"
-                  component="small"
-                >
-                  <small
-                    className="margin-bottom-none"
-                    data-pf-content={true}
-                  >
-                    External policy
-                  </small>
-                </Text>
-                <Text
-                  className="margin-bottom-top-none"
-                  component="h4"
-                >
-                  <h4
-                    className="margin-bottom-top-none"
-                    data-pf-content={true}
-                  >
-                    PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
-                  </h4>
-                </Text>
-              </div>
-            </TextContent>
-            <div
-              className="margin-bottom-md"
-            >
-              <div
-                className="ins-c-policy-card ins-m-noncompliant"
-              >
-                <ExclamationCircleIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                  title={null}
-                >
-                  <svg
-                    aria-hidden={true}
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                      transform=""
-                    />
-                  </svg>
-                </ExclamationCircleIcon>
-                 Noncompliant
-              </div>
-              <Text
-                component="small"
-              >
-                <small
-                  className=""
-                  data-pf-content={true}
-                >
-                  30
-                   of 
-                  40
-                   rules passed
-                </small>
-              </Text>
-            </div>
-            <div
-              className="margin-bottom-md"
-            >
-              <Text
-                className="wrap-break-word"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <p
-                  className="wrap-break-word"
-                  data-pf-content={true}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  Profile 
-                  <br />
-                  <Truncate
-                    ellipsis="…"
-                    lines={1}
-                    trimWhitespace={false}
-                    width={0}
-                  >
-                    <span
-                      width={0}
-                    >
-                      <span />
-                      <span>
-                        xccdf_org.ssgproject.content_profile_pci-dss
-                      </span>
-                      <span
-                        style={
-                          Object {
-                            "left": 0,
-                            "position": "fixed",
-                            "top": 0,
-                            "visibility": "hidden",
-                          }
-                        }
-                      >
-                        …
-                      </span>
-                    </span>
-                  </Truncate>
-                </p>
-              </Text>
-            </div>
-            <Text
-              className="margin-bottom-none"
-              component="small"
-            >
-              <small
-                className="margin-bottom-none"
-                data-pf-content={true}
-              >
-                Last scanned: 
-                <FormattedRelative
-                  updateInterval={10000}
-                  value={1551853213000}
-                >
-                  <span>
-                    6 months ago
-                  </span>
-                </FormattedRelative>
-              </small>
-            </Text>
-          </div>
-        </CardBody>
-      </article>
-    </Card>
-  </SystemPolicyCard>
-</IntlProvider>
+            …
+          </span>
+        </span>
+      </p>
+    </div>
+    <small
+      class="margin-bottom-none"
+      data-pf-content="true"
+    >
+      Last scanned: 
+      <span>
+        6 months ago
+      </span>
+    </small>
+  </div>
+</article>
 `;


### PR DESCRIPTION
There's an error in tests for system policy card, when running tests they fail because date supplied to this component is more than 6 months old react-intl calculates it correctly, but we are expecting it to be exactly 6 months (even in future). In order to test this correctly, we have to calculate 6 months from test run and use `render` instead of `mount` because we are not checking state updates etc in the initial render test.