### PR TITLE
Add tags count and tags modal to inventory

### DIFF
--- a/packages/inventory/src/EntityDetail.js
+++ b/packages/inventory/src/EntityDetail.js
@@ -19,7 +19,8 @@ import get from 'lodash/get';
 import { connect } from 'react-redux';
 import ApplicationDetails from './ApplicationDetails';
 import { editDisplayName, editAnsibleHost, loadEntity } from './redux/actions';
-
+import TagWithDialog from './TagWithDialog';
+import TagsModal from './TagsModal';
 class EntityDetails extends Component {
     state = {
         isOpen: false,
@@ -119,7 +120,7 @@ class EntityDetails extends Component {
     }
 
     render() {
-        const { useCard } = this.props;
+        const { useCard, loaded, entity } = this.props;
 
         return (
             <div className="ins-entity-detail">
@@ -135,6 +136,14 @@ class EntityDetails extends Component {
                     <Fragment>
                         { this.generateTop() }
                         { this.generateFacts() }
+                        {
+                            localStorage.getItem('rhcs-tags') === 'true' && (
+                                loaded ?
+                                    <TagWithDialog count={ entity.tagCount } systemId={ entity.id } /> :
+                                    <Skeleton size={SkeletonSize.sm}>&nbsp;</Skeleton>
+                            )
+                        }
+                        <TagsModal />
                     </Fragment>
                 }
                 <ApplicationDetails />
@@ -147,6 +156,7 @@ EntityDetails.propTypes = {
     loaded: PropTypes.bool.isRequired,
     entity: PropTypes.object,
     useCard: PropTypes.bool,
+    tagCount: PropTypes.number,
     setDisplayName: PropTypes.func,
     setAnsibleHost: PropTypes.func,
     actions: PropTypes.arrayOf(PropTypes.shape({

--- a/packages/inventory/src/EntityTable.js
+++ b/packages/inventory/src/EntityTable.js
@@ -21,6 +21,7 @@ import {
     sortable
 } from '@patternfly/react-table';
 import { SkeletonTable, EmptyTable } from '@redhat-cloud-services/frontend-components';
+import TagsModal from './TagsModal';
 
 class EntityTable extends React.Component {
     onRowClick = (_event, key, application) => {
@@ -83,7 +84,12 @@ class EntityTable extends React.Component {
         }
 
         return [
-            ...columns.map(({ key, composed, isTime }) => this.renderCol(item, key, composed, isTime))
+            ...columns.map(({ key, composed, isTime, renderFunc }) => {
+                const oneColumn = this.renderCol(item, key, composed, isTime, renderFunc);
+                return renderFunc ? {
+                    title: renderFunc(oneColumn, item.id)
+                } : oneColumn;
+            })
         ].filter(cell => cell !== false && cell !== undefined);
     }
 
@@ -188,6 +194,7 @@ class EntityTable extends React.Component {
                     </PfTable> :
                     <SkeletonTable colSize={ 2 } rowSize={ 15 } />
                 }
+                <TagsModal />
             </React.Fragment>
         );
     }
@@ -219,7 +226,8 @@ EntityTable.propTypes = {
         [PropTypes.string]: PropTypes.any
     }),
     selectEntity: PropTypes.func,
-    onDetailSelect: PropTypes.func
+    onDetailSelect: PropTypes.func,
+    onToggleTagModal: PropTypes.func
 };
 
 EntityTable.defaultProps = {
@@ -233,6 +241,7 @@ EntityTable.defaultProps = {
     onExpandClick: () => undefined,
     selectEntity: () => undefined,
     onDetailSelect: () => undefined,
+    onToggleTagModal: () => undefined,
     tableProps: {}
 };
 

--- a/packages/inventory/src/InventoryList.scss
+++ b/packages/inventory/src/InventoryList.scss
@@ -1,6 +1,8 @@
 @import "~@patternfly/patternfly/utilities/Flex/flex.css";
 @import "~@patternfly/patternfly/utilities/Display/display.css";
 @import '~@redhat-cloud-services/frontend-components-utilities/files/Utilities/_all';
+@import '~@redhat-cloud-services/frontend-components/components/TagCount.css';
+@import '~@redhat-cloud-services/frontend-components/components/TagModal.css';
 
 .ins-c-table__toolbar.ins-c-inventory__table--toolbar {
     .pf-c-pagination__nav-page-select input { @include rem('min-width', 75px); }

--- a/packages/inventory/src/TagWithDialog.js
+++ b/packages/inventory/src/TagWithDialog.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { TagCount } from '@redhat-cloud-services/frontend-components/components/TagCount';
+import { loadTags } from './redux/actions';
+
+const TagWithDialog = ({ count, loadTags, systemId }) => (
+    <TagCount count={count} onTagClick={() => loadTags(systemId, count)} />
+);
+
+TagWithDialog.propTypes = {
+    count: PropTypes.number,
+    loadTags: PropTypes.func,
+    systemId: PropTypes.string
+};
+
+TagWithDialog.defaultProps = {
+    loadTags: () => undefined
+};
+
+const dispatchToProps = (dispatch) => ({
+    loadTags: (systemId, count) => {
+        dispatch(loadTags(systemId, count));
+    }
+});
+
+export default connect(() => ({}), dispatchToProps)(TagWithDialog);

--- a/packages/inventory/src/TagsModal.js
+++ b/packages/inventory/src/TagsModal.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { toggleTagModal } from './redux/actions';
+import { TagModal, Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
+
+const TagsModal = ({ showTagDialog, tagsLoaded, tags, activeSystemTag, tagCount, onToggleTagModal }) => {
+    return (
+        <TagModal
+            width="auto"
+            isOpen={ showTagDialog }
+            toggleModal={() => onToggleTagModal()}
+            systemName={ `${activeSystemTag.display_name} (${tagCount})` }
+            rows={
+                tagsLoaded ?
+                    tags.map(({ tagName, tagValue }) => ([ tagName, tagValue ])) :
+                    [ ...Array(tagCount) ].map(() => ([
+                        { title: <Skeleton size={ SkeletonSize.md }>&nbsp;</Skeleton> },
+                        { title: <Skeleton size={SkeletonSize.md}>&nbsp;</Skeleton> }
+                    ]))
+            }
+        />
+    );
+};
+
+TagsModal.propTypes = {
+    showTagDialog: PropTypes.bool,
+    tagsLoaded: PropTypes.bool,
+    tags: PropTypes.arrayOf(PropTypes.shape({
+        tagName: PropTypes.node,
+        tagValue: PropTypes.node
+    })),
+    tagCount: PropTypes.number,
+    activeSystemTag: PropTypes.shape({
+        id: PropTypes.string,
+        // eslint-disable-next-line camelcase
+        display_name: PropTypes.string
+    }),
+    onToggleTagModal: PropTypes.func
+};
+
+TagsModal.defaultProps = {
+    showTagDialog: false,
+    tagCount: 0,
+    tags: [],
+    activeSystemTag: {},
+    onToggleTagModal: () => undefined
+};
+
+export default connect(({ entities, entityDetails }) => {
+    const { showTagDialog, tagsLoaded, tags, activeSystemTag, tagCount } = entities || entityDetails || {};
+    return ({
+        showTagDialog,
+        tagsLoaded,
+        tags,
+        activeSystemTag,
+        tagCount
+    });
+}, (dispatch) => ({
+    onToggleTagModal: () => dispatch(toggleTagModal(false))
+}))(TagsModal);

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -24,7 +24,10 @@ export const mapData = ({ facts = {}, ...oneResult }) => ({
         .reduce(
             (acc, curr) => ({ ...acc, ...(typeof curr !== 'string') ? curr : {} }), {}
         )
-    }
+    },
+    ...localStorage.getItem('rhcs-tags') === 'true' ? {
+        tagCount: Math.floor(Math.random() * Math.floor(11))
+    } : {}
 });
 
 export function getEntities(items, {
@@ -80,3 +83,11 @@ export function getEntities(items, {
 
 export const getEntitySystemProfile = (item) => hosts.apiHostGetHostSystemProfileById([ item ]);
 
+export function getTags(systemId, count) {
+    return new Promise(res => setTimeout(() => res({
+        results: [ ...Array(count) ].map(() => ({
+            tagName: 'Tag name',
+            tagValue: `Some tag=${systemId}`
+        }))
+    }), 1000));
+}

--- a/packages/inventory/src/redux/action-types.js
+++ b/packages/inventory/src/redux/action-types.js
@@ -3,7 +3,8 @@ const asyncInventory = [
     'LOAD_ENTITY',
     'LOAD_SYSTEM_PROFILE',
     'SET_DISPLAY_NAME',
-    'SET_ANSIBLE_HOST'
+    'SET_ANSIBLE_HOST',
+    'LOAD_TAGS'
 ].reduce((acc, curr) => [
     ...acc,
     ...[ curr, `${curr}_PENDING`, `${curr}_FULFILLED`, `${curr}_REJECTED` ]
@@ -38,3 +39,4 @@ export const SHOW_ENTITIES = 'SHOW_ENTITIES';
 export const FILTER_SELECT = 'FILTER_SELECT';
 export const ENTITIES_LOADING = 'ENTITIES_LOADING';
 export const CLEAR_FILTERS = 'CLEAR_FILTERS';
+export const TOGGLE_TAG_MODAL = 'TOGGLE_TAG_MODAL';

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -8,9 +8,10 @@ import {
     FILTER_SELECT,
     UPDATE_ENTITIES,
     ENTITIES_LOADING,
-    CLEAR_FILTERS
+    CLEAR_FILTERS,
+    TOGGLE_TAG_MODAL
 } from './action-types';
-import { getEntities, getEntitySystemProfile, hosts } from '../api';
+import { getEntities, getEntitySystemProfile, hosts, getTags } from '../api';
 
 export const loadEntities = (items = [], config) => ({
     type: ACTION_TYPES.LOAD_ENTITIES,
@@ -103,5 +104,21 @@ export const editAnsibleHost = (id, value) => ({
                 dismissable: true
             }
         }
+    }
+});
+
+export const loadTags = (systemId, count) => ({
+    type: ACTION_TYPES.LOAD_TAGS,
+    payload: getTags(systemId, count),
+    meta: {
+        systemId,
+        count
+    }
+});
+
+export const toggleTagModal = (isOpen) => ({
+    type: TOGGLE_TAG_MODAL,
+    payload: {
+        isOpen: isOpen
     }
 });

--- a/packages/inventory/src/redux/entityDetails.js
+++ b/packages/inventory/src/redux/entityDetails.js
@@ -1,5 +1,5 @@
-import { ACTION_TYPES, APPLICATION_SELECTED } from './action-types';
-
+import { ACTION_TYPES, APPLICATION_SELECTED, TOGGLE_TAG_MODAL } from './action-types';
+import { tagsLoading, tagsFulfilled, toggleTagModal } from './entities';
 export const defaultState = { loaded: false };
 
 function entityDetailPending(state) {
@@ -28,5 +28,8 @@ export default {
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: () => defaultState,
     [ACTION_TYPES.LOAD_ENTITY_PENDING]: entityDetailPending,
     [ACTION_TYPES.LOAD_ENTITY_FULFILLED]: entityDetailLoaded,
-    [APPLICATION_SELECTED]: onApplicationSelected
+    [APPLICATION_SELECTED]: onApplicationSelected,
+    [ACTION_TYPES.LOAD_TAGS_PENDING]: tagsLoading,
+    [ACTION_TYPES.LOAD_TAGS_FULFILLED]: tagsFulfilled,
+    [TOGGLE_TAG_MODAL]: toggleTagModal
 };


### PR DESCRIPTION
This PR adds tag count and tag dialog when `window.localStorage.setItem('rhcs-tags', true)` tag count is randomly generated so clicking from table to detail will reset the counter.

![Screenshot from 2019-09-30 17-28-33](https://user-images.githubusercontent.com/3439771/65893202-e145c380-e3a7-11e9-985d-2ef24188984d.png)

![Screenshot from 2019-09-30 17-28-40](https://user-images.githubusercontent.com/3439771/65893209-e30f8700-e3a7-11e9-8649-ed70c72ee88b.png)

![Screenshot from 2019-09-30 17-28-55](https://user-images.githubusercontent.com/3439771/65893216-e571e100-e3a7-11e9-9b79-756c5433beff.png)
