### PR TITLE
Unit tests for FilterChips

### DIFF
--- a/packages/components/src/Components/FilterChips/FilterChips.js
+++ b/packages/components/src/Components/FilterChips/FilterChips.js
@@ -12,7 +12,10 @@ const FilterChips = ({ filters, onDelete }) => {
             { group.chips.map(chip => (
                 <Chip
                     key={ `group_${group.category}_chip_${chip.name}` }
-                    onClick={ (event) => onDelete(event, [{ category: group.category, chips: [ chip ]}]) }
+                    onClick={ (event) => {
+                        event.stopPropagation();
+                        onDelete(event, [{ category: group.category, chips: [ chip ] }]);
+                    }}
                 >
                     { chip.name }
                     { chip.count && <Badge key={ `chip_badge_${chip.id}` } isRead={ chip.isRead }>{ chip.count }</Badge> }
@@ -36,7 +39,10 @@ const FilterChips = ({ filters, onDelete }) => {
                         { plainFilters.map(chip => (
                             <Chip
                                 key={ `group_plain_chip_${chip.name}` }
-                                onClick={ (event) => onDelete(event, [{ category: 'group_plain', chips: [ chip ]}]) }
+                                onClick={ (event) => {
+                                    event.stopPropagation();
+                                    onDelete(event, [ chip ]);
+                                }}
                             >
                                 { chip.name }
                                 { chip.count && <Badge key={ `chip_badge_${chip.id}` } isRead={ chip.isRead }>{ chip.count }</Badge> }
@@ -71,6 +77,11 @@ FilterChips.propTypes = {
         ])
     ),
     onDelete: PropTypes.func
+};
+
+FilterChips.defaultProps = {
+    filters: [],
+    onDelete: () => undefined
 };
 
 export default FilterChips;

--- a/packages/components/src/Components/FilterChips/FilterChips.test.js
+++ b/packages/components/src/Components/FilterChips/FilterChips.test.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import FilterChips from './FilterChips';
+
+const filters = [
+    {
+        category: 'Group 1',
+        chips: [
+            {
+                name: 'Chip 1',
+                isRead: true
+            },
+            {
+                name: 'Chip 2',
+                count: 3
+            }
+        ]
+    },
+    {
+        name: 'Chip 3'
+    },
+    {
+        name: 'Chip 4'
+    }
+];
+
+describe('FilterChips component', () => {
+    it('should render - no data', () => {
+        const wrapper = shallow(<FilterChips/>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render', () => {
+        const wrapper = shallow(
+            <FilterChips filters={ filters } />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    describe('API', () => {
+        it('should have default onDelete handle', () => {
+            const onDelete = FilterChips.defaultProps.onDelete;
+            expect(onDelete).toBeDefined();
+            expect(onDelete()).toEqual(undefined);
+        });
+
+        it('should call onDelete when deleting a single chip', () => {
+            const onDelete = jest.fn();
+            const wrapper = mount(<FilterChips filters={ filters } onDelete={ onDelete } />);
+            wrapper.find('.pf-c-chip button').last().simulate('click');
+            expect(onDelete).toHaveBeenCalledWith(expect.anything(), [{ name: 'Chip 4' }]);
+            expect(onDelete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call onDelete when deleting a single chip in group', () => {
+            const onDelete = jest.fn();
+            const wrapper = mount(<FilterChips filters={ filters } onDelete={ onDelete } />);
+            wrapper.find('.pf-c-chip button').first().simulate('click');
+            expect(onDelete).toHaveBeenCalledWith(expect.anything(), [{
+                category: 'Group 1',
+                chips: [
+                    {
+                        name: 'Chip 1',
+                        isRead: true
+                    }
+                ]
+            }]);
+            expect(onDelete).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call onDelete when deleting all chips', () => {
+            const onDelete = jest.fn();
+            const wrapper = mount(<FilterChips filters={ filters } onDelete={ onDelete } />);
+            wrapper.find('button').last().simulate('click');
+            expect(onDelete).toHaveBeenCalledWith(expect.anything(), filters, true);
+            expect(onDelete).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/components/src/Components/FilterChips/__snapshots__/FilterChips.test.js.snap
+++ b/packages/components/src/Components/FilterChips/__snapshots__/FilterChips.test.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterChips component should render - no data 1`] = `
+<span
+  className="ins-c-chip-filters"
+>
+  <ChipGroup
+    className=""
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    numChips={3}
+    withToolbar={true}
+  >
+    <ChipGroupToolbarItem
+      className="ins-c-chip-group__plain"
+      key="group_plain"
+      onClick={[Function]}
+    />
+  </ChipGroup>
+  <Component
+    onClick={[Function]}
+    variant="link"
+  >
+    Clear filters
+  </Component>
+</span>
+`;
+
+exports[`FilterChips component should render 1`] = `
+<span
+  className="ins-c-chip-filters"
+>
+  <ChipGroup
+    className=""
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    numChips={3}
+    withToolbar={true}
+  >
+    <ChipGroupToolbarItem
+      categoryName="Group 1"
+      key="group_Group 1"
+      onClick={[Function]}
+    >
+      <Chip
+        className=""
+        closeBtnAriaLabel="close"
+        component="div"
+        isOverflowChip={false}
+        isReadOnly={false}
+        key="group_Group 1_chip_Chip 1"
+        onClick={[Function]}
+        tooltipPosition="top"
+      >
+        Chip 1
+      </Chip>
+      <Chip
+        className=""
+        closeBtnAriaLabel="close"
+        component="div"
+        isOverflowChip={false}
+        isReadOnly={false}
+        key="group_Group 1_chip_Chip 2"
+        onClick={[Function]}
+        tooltipPosition="top"
+      >
+        Chip 2
+        <Badge
+          key="chip_badge_undefined"
+        >
+          3
+        </Badge>
+      </Chip>
+    </ChipGroupToolbarItem>
+    <ChipGroupToolbarItem
+      className="ins-c-chip-group__plain"
+      key="group_plain"
+      onClick={[Function]}
+    >
+      <Chip
+        className=""
+        closeBtnAriaLabel="close"
+        component="div"
+        isOverflowChip={false}
+        isReadOnly={false}
+        key="group_plain_chip_Chip 3"
+        onClick={[Function]}
+        tooltipPosition="top"
+      >
+        Chip 3
+      </Chip>
+      <Chip
+        className=""
+        closeBtnAriaLabel="close"
+        component="div"
+        isOverflowChip={false}
+        isReadOnly={false}
+        key="group_plain_chip_Chip 4"
+        onClick={[Function]}
+        tooltipPosition="top"
+      >
+        Chip 4
+      </Chip>
+    </ChipGroupToolbarItem>
+  </ChipGroup>
+  <Component
+    onClick={[Function]}
+    variant="link"
+  >
+    Clear filters
+  </Component>
+</span>
+`;


### PR DESCRIPTION
Add unit tests for FilterChips

Covers:
- [x] rendering
- [x] API `onDelete` handler
- [x] defaults

Not covered:
- Group delete via `onDelete` since this is missing from design

cc @karelhala 