### PR TITLE
Add unit tests for getBaseName

### DIFF
--- a/packages/utils/src/helpers.js
+++ b/packages/utils/src/helpers.js
@@ -69,7 +69,7 @@ export const RowLoader = props => (
 
 export function getBaseName(pathname) {
     let release = '/';
-    const pathName = pathname.split('/');
+    const pathName = pathname.replace(/(#|\?).*/, '').split('/');
 
     pathName.shift();
 
@@ -78,5 +78,5 @@ export function getBaseName(pathname) {
         release = `/beta/`;
     }
 
-    return `${release}${pathName[0]}/${pathName[1]}`;
+    return `${release}${pathName[0]}/${pathName[1] || ''}`;
 }

--- a/packages/utils/src/helpers.test.js
+++ b/packages/utils/src/helpers.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { RowLoader, processDate, parseCvssScore, downloadFile, mergeArraysByKey } from './helpers';
+import { RowLoader, processDate, parseCvssScore, downloadFile, mergeArraysByKey, getBaseName } from './helpers';
 
 describe('mergeArraysByKey', () => {
     it('should join two arrays by ID', () => {
@@ -124,4 +124,20 @@ describe('RowLoader', () => {
         const wrapper = shallow(<RowLoader />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
+});
+
+describe('getBaseName', () => {
+    [
+        [ '/group/application', '/group/application' ],
+        [ '/group/application/navigation', '/group/application' ],
+        [ '/group', '/group/' ],
+        [ '/beta/group/application', '/beta/group/application' ],
+        [ '/beta/group', '/beta/group/' ],
+        [ '/group/application#id', '/group/application' ],
+        [ '/group/application?param=value', '/group/application' ]
+    ].map(([ pathName, baseName ]) =>
+        it(`should return ${baseName} for ${pathName}`, () => {
+            expect(getBaseName(pathName)).toBe(baseName);
+        })
+    );
 });


### PR DESCRIPTION
- Add unit tests for `getBaseName` in helpers.
- Fix id and get params striping
- Fix when only `group` is provided (app name defaults to empty string now)  

cc @karelhala 