### PR TITLE
Add unit tests for DarkContext provider

### DIFF
--- a/packages/components/src/Components/Dark/DarkContext.test.js
+++ b/packages/components/src/Components/Dark/DarkContext.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import DarkContext from './DarkContext';
+import ThemeContext from './configContext';
+
+describe('DarkContext', () => {
+    it('should render children', () => {
+        const wrapper = shallow(
+            <DarkContext>
+                <div id='isPresent' />
+            </DarkContext>
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.exists('#isPresent')).toBeTruthy();
+    });
+
+    it('should pass props', () => {
+        const wrapper = mount(
+            <DarkContext>
+                <ThemeContext.Consumer>
+                    { value => <div value={value} id='consumer'/> }
+                </ThemeContext.Consumer>
+            </DarkContext>
+        );
+        expect(wrapper.find('#consumer').props()).toEqual(expect.objectContaining({ value: 'dark' }));
+    });
+});

--- a/packages/components/src/Components/Dark/__snapshots__/DarkContext.test.js.snap
+++ b/packages/components/src/Components/Dark/__snapshots__/DarkContext.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DarkContext should render children 1`] = `
+<ContextProvider
+  value="dark"
+>
+  <div
+    id="isPresent"
+  />
+</ContextProvider>
+`;


### PR DESCRIPTION
Test rendering and context value passing for `DarkContext` provider

cc @karelhala