### PR TITLE
Allow custom components in Primary toolbar

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.js
@@ -60,13 +60,21 @@ class PrimaryToolbar extends Component {
                             {
                                 bulkSelect &&
                                 <DataToolbarItem>
-                                    <BulkSelect { ...bulkSelect } />
+                                    {
+                                        React.isValidElement(bulkSelect) ?
+                                            bulkSelect :
+                                            <BulkSelect {...bulkSelect } />
+                                    }
                                 </DataToolbarItem>
                             }
                             {
                                 filterConfig &&
                                 <DataToolbarItem className="ins-c-primary-toolbar__filter">
-                                    <ConditionalFilter { ...filterConfig } />
+                                    {
+                                        React.isValidElement(filterConfig) ?
+                                            filterConfig :
+                                            <ConditionalFilter { ...filterConfig } />
+                                    }
                                 </DataToolbarItem>
                             }
                         </DataToolbarGroup>
@@ -75,29 +83,44 @@ class PrimaryToolbar extends Component {
                         (
                             (actionsConfig && actionsConfig.actions && actionsConfig.actions.length > 0) ||
                             sortByConfig
-                        ) &&
-                        <Actions
-                            { ...actionsConfig || {} }
-                            overflowActions={ overflowActions }
-                        />
+                        ) && (
+                            React.isValidElement(actionsConfig) ?
+                                actionsConfig :
+                                <Actions
+                                    {...actionsConfig || {}}
+                                    overflowActions={overflowActions}
+                                />
+                        )
                     }
                     {
                         sortByConfig &&
                         <DataToolbarItem className="ins-c-primary-toolbar__sort-by">
-                            <SortBy { ...sortByConfig } />
+                            {
+                                React.isValidElement(sortByConfig) ?
+                                    sortByConfig :
+                                    <SortBy  {...sortByConfig }/>
+                            }
                         </DataToolbarItem>
                     }
                     {
                         exportConfig &&
                         <DataToolbarItem>
-                            <DownloadButton  { ...exportConfig }/>
+                            {
+                                React.isValidElement(exportConfig) ?
+                                    exportConfig :
+                                    <DownloadButton  { ...exportConfig }/>
+                            }
                         </DataToolbarItem>
                     }
                     { children }
                     {
                         pagination &&
                         <DataToolbarItem className="ins-c-primary-toolbar__pagination">
-                            <Pagination isCompact { ...pagination } />
+                            {
+                                React.isValidElement(pagination) ?
+                                    pagination :
+                                    <Pagination isCompact {...pagination} />
+                            }
                         </DataToolbarItem>
                     }
                 </DataToolbarContent>
@@ -105,7 +128,11 @@ class PrimaryToolbar extends Component {
                     activeFiltersConfig &&
                     <DataToolbarContent>
                         <DataToolbarItem>
-                            <FilterChips { ...activeFiltersConfig } />
+                            {
+                                React.isValidElement(activeFiltersConfig) ?
+                                    activeFiltersConfig :
+                                    <FilterChips { ...activeFiltersConfig } />
+                            }
                         </DataToolbarItem>
                     </DataToolbarContent>
                 }

--- a/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.test.js
+++ b/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.test.js
@@ -81,6 +81,15 @@ describe('PrimaryToolbar', () => {
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
+        it('elements instead of data', () => {
+            const elementsConfig = Object.keys(config).map(key => ({
+                [key]: <div>Loading...</div>
+            })).reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+            const wrapper = shallow(<PrimaryToolbar {...elementsConfig} />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
         describe('with data', () => {
             it('full config', () => {
                 const wrapper = shallow(<PrimaryToolbar {...config} />);

--- a/packages/components/src/Components/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
+++ b/packages/components/src/Components/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
@@ -24,6 +24,72 @@ exports[`PrimaryToolbar should render custom id 1`] = `
 </DataToolbar>
 `;
 
+exports[`PrimaryToolbar should render elements instead of data 1`] = `
+<DataToolbar
+  className=" ins-c-primary-toolbar"
+  id="ins-primary-data-toolbar"
+  isExpanded={false}
+  showClearFiltersButton={false}
+  toggleIsExpanded={[Function]}
+>
+  <DataToolbarContent>
+    <DataToolbarGroup
+      className="ins-c-primary-toolbar__group-filter"
+      itemSpacers={
+        Array [
+          Object {
+            "spacerSize": "md",
+          },
+        ]
+      }
+      variant="filter-group"
+    >
+      <DataToolbarItem>
+        <div>
+          Loading...
+        </div>
+      </DataToolbarItem>
+      <DataToolbarItem
+        className="ins-c-primary-toolbar__filter"
+      >
+        <div>
+          Loading...
+        </div>
+      </DataToolbarItem>
+    </DataToolbarGroup>
+    <div>
+      Loading...
+    </div>
+    <DataToolbarItem
+      className="ins-c-primary-toolbar__sort-by"
+    >
+      <div>
+        Loading...
+      </div>
+    </DataToolbarItem>
+    <DataToolbarItem>
+      <div>
+        Loading...
+      </div>
+    </DataToolbarItem>
+    <DataToolbarItem
+      className="ins-c-primary-toolbar__pagination"
+    >
+      <div>
+        Loading...
+      </div>
+    </DataToolbarItem>
+  </DataToolbarContent>
+  <DataToolbarContent>
+    <DataToolbarItem>
+      <div>
+        Loading...
+      </div>
+    </DataToolbarItem>
+  </DataToolbarContent>
+</DataToolbar>
+`;
+
 exports[`PrimaryToolbar should render no data 1`] = `
 <DataToolbar
   className=" ins-c-primary-toolbar"


### PR DESCRIPTION
This PR will enable custom somponents be part of Primary toolbar in order to allow rewriting of certain parts.