### PR TITLE
Fix problem with first action throwing error if button was not used

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/Actions.js
+++ b/packages/components/src/Components/PrimaryToolbar/Actions.js
@@ -71,7 +71,7 @@ class Actions extends Component {
                                         key="first-action"
                                         { ...actionPropsGenerator(firstAction, 'first-action') }
                                         className={
-                                            `ins-c-primary-toolbar__first-action ${firstAction.props.className || ''}`
+                                            `ins-c-primary-toolbar__first-action ${(firstAction.props && firstAction.props.className) || ''}`
                                         }
                                     />
                                 ] : [],


### PR DESCRIPTION
There was a nasty bug that was triggered when only object was sent to PrimaryToolbar instead of React component as fisrt action.