### PR TITLE
Intlhelper provides access to intl for a non-components (constants) 🤗

### DIFF
--- a/packages/translations/README.md
+++ b/packages/translations/README.md
@@ -160,3 +160,27 @@ export default () => {
 }
 
 ```
+
+## Providing access to intl for a non-components
+
+A file contaning app constants, that is very much not a component can still leverage 
+translations by using the `intlHelper` function in the following way.
+
+```JS
+import { createIntl, createIntlCache } from 'react-intl';
+import { intlHelper } from '@redhat-cloud-services/frontend-components-translations';
+import messages from './Messages';
+const cache = createIntlCache();
+const intl = createIntl({
+    onError: console.log, 
+    locale: navigator.language
+}, cache);
+const intlSettings = {locale: navigator.language}
+
+const IMPACT_LABEL = {
+    1: intlHelper(intl.formatMessage(messages.low), intlSettings),
+    2: intlHelper(intl.formatMessage(messages.moderate),  intlSettings)),
+    3: intlHelper(intl.formatMessage(messages.important),  intlSettings)),
+    4: intlHelper(intl.formatMessage(messages.critical),  intlSettings))
+    };
+```

--- a/packages/translations/src/index.js
+++ b/packages/translations/src/index.js
@@ -1,3 +1,4 @@
 export { default as IntlProvider, updateLocaleData } from './Provider';
 export { default as defaultMessages } from './messages';
 export const LOCALSTORAGE_KEY = 'rhcs-language';
+export { default as intlHelper } from './intlHelper';

--- a/packages/translations/src/intlHelper.js
+++ b/packages/translations/src/intlHelper.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { IntlProvider } from './Provider';
+
+const intlHelper = (message, settings) => <IntlProvider { ...settings }>{message}</IntlProvider>;
+
+export default intlHelper;


### PR DESCRIPTION
will be consumed by https://github.com/RedHatInsights/insights-advisor-frontend/pull/445 (n anyone else that desires a taste)