### PR TITLE
Prevent default and buble on Label in Group filter

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -105,6 +105,11 @@ class Group extends Component {
                                 key={id || key}
                                 value={String(value || id || key)}
                                 onClick={e => {
+                                    if (e.target.tagName === 'LABEL') {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                    }
+
                                     const clickedGroup = {
                                         value: groupValue,
                                         label: groupLabel,


### PR DESCRIPTION
### UI changes
None

### Fixes
When user clicks on label in Grouped filter it will fire 2 actions - `onClick` and `onChange` each of them are fired from PF component so we have to prevent buble if user clicks on label otherwise the value will be selected and deselected right after.