### PR TITLE
RHICOMPL-167 - Correct loading skeleton of AppInfo

### DIFF
--- a/packages/inventory/src/AppInfo.js
+++ b/packages/inventory/src/AppInfo.js
@@ -1,8 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { BulletList } from 'react-content-loader';
-import { CardBody, Card } from '@patternfly/react-core';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
 
 class AppInfo extends Component {
     render () {
@@ -13,11 +12,7 @@ class AppInfo extends Component {
                 { activeApp && <div className={ `ins-active-app-${activeApp.name}` }>
                     { activeApp.component ? <activeApp.component /> : 'missing component' }
                 </div> }
-                { !loaded && <Card>
-                    <CardBody>
-                        <BulletList />
-                    </CardBody>
-                </Card> }
+                { !loaded && <Skeleton size={ SkeletonSize.md } /> }
             </Fragment>
         );
     }


### PR DESCRIPTION
Using a Card and BulletList disrupts the layout while loading,
![Screenshot 2019-10-11 at 11 10 22](https://user-images.githubusercontent.com/7757/66640395-363fd000-ec19-11e9-8471-dcf45214496d.png)

using a simple loading Skeleton avoids the disrpution.

![Screenshot 2019-10-11 at 11 14 29](https://user-images.githubusercontent.com/7757/66640411-3a6bed80-ec19-11e9-8f5d-e120d704aaca.png)