### PR TITLE
Send inifity to chipCount and merge props to selected in primary filter

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -28,6 +28,7 @@ class Group extends Component {
         if (activeGroup) {
             if (type !== groupType.radio && activeGroup[itemKey]) {
                 return {
+                    ...propSelected,
                     ...selected,
                     [groupKey]: {
                         ...activeGroup || {},
@@ -37,6 +38,7 @@ class Group extends Component {
             }
 
             return {
+                ...propSelected,
                 ...selected,
                 [groupKey]: {
                     ...type !== groupType.radio ? (activeGroup || {}) : {},
@@ -57,10 +59,13 @@ class Group extends Component {
     onSelect = (event, group, item, groupKey, itemKey) => {
         const newSelection = this.calculateSelected(group, groupKey, itemKey);
         const { onChange } = this.props;
-        onChange(event, newSelection, group, item);
-        this.setState({
-            selected: newSelection
-        });
+        if (onChange) {
+            onChange(event, newSelection, group, item);
+        } else {
+            this.setState({
+                selected: newSelection
+            });
+        }
     };
 
     isChecked = (groupValue, itemValue) => {
@@ -205,7 +210,6 @@ Group.propTypes = {
 
 Group.defaultProps = {
     selected: {},
-    onChange: () => undefined,
     groups: []
 };
 

--- a/packages/components/src/Components/ConditionalFilter/Group.test.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.test.js
@@ -103,8 +103,7 @@ describe('Group - component', () => {
             expect(onChange).toHaveBeenCalled();
         });
         it('should update selected', () => {
-            const onChange = jest.fn();
-            const wrapper = mount(<Group {...config} onChange={onChange} />);
+            const wrapper = mount(<Group {...config} />);
             wrapper.find('button.pf-c-select__toggle').first().simulate('click');
             wrapper.update();
             wrapper.find('.pf-c-select__menu-item').first().simulate('click');

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
@@ -4,7 +4,6 @@ exports[`Group - component render should render correctly 1`] = `
 <Fragment>
   <Text
     groups={Array []}
-    onChange={[Function]}
     onSubmit={[Function]}
     selected={Object {}}
     value="[object Object]"

--- a/packages/components/src/Components/FilterChips/FilterChips.js
+++ b/packages/components/src/Components/FilterChips/FilterChips.js
@@ -28,7 +28,7 @@ const FilterChips = ({ filters, onDelete }) => {
 
     return (
         <span className="ins-c-chip-filters">
-            <ChipGroup withToolbar>
+            <ChipGroup withToolbar numChips={ Infinity }>
                 { groupedFilters }
                 { plainFilters &&
                     <ChipGroupToolbarItem

--- a/packages/components/src/Components/FilterChips/__snapshots__/FilterChips.test.js.snap
+++ b/packages/components/src/Components/FilterChips/__snapshots__/FilterChips.test.js.snap
@@ -9,7 +9,7 @@ exports[`FilterChips component should render - no data 1`] = `
     collapsedText="\${remaining} more"
     defaultIsOpen={false}
     expandedText="Show Less"
-    numChips={3}
+    numChips={Infinity}
     withToolbar={true}
   >
     <ChipGroupToolbarItem
@@ -36,7 +36,7 @@ exports[`FilterChips component should render 1`] = `
     collapsedText="\${remaining} more"
     defaultIsOpen={false}
     expandedText="Show Less"
-    numChips={3}
+    numChips={Infinity}
     withToolbar={true}
   >
     <ChipGroupToolbarItem


### PR DESCRIPTION
### Ui changes
None

### Fixes
* When more than 3 filters were passed to PF filter group `Show more` or `Show less` was shown - pass `Infinity` to chip group to prevent this
* Incorrect calculation of groupped filter, by merging only state's selected values instead of combindation of props and state