### PR TITLE
AddSourceWizard UX enhancements

### DIFF
--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/sources#readme",
     "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^1.19.2",
-        "@data-driven-forms/react-form-renderer": "^1.19.2",
+        "@data-driven-forms/pf4-component-mapper": "^1.20.2",
+        "@data-driven-forms/react-form-renderer": "^1.20.2",
         "@patternfly/react-icons": "^3.10.9",
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
-import { TextContent, Text, TextVariants, Title } from '@patternfly/react-core';
+import { TextContent, Text, TextVariants } from '@patternfly/react-core';
 import { AwsIcon, OpenshiftIcon, MicrosoftIcon } from '@patternfly/react-icons';
 import debouncePromise from '../utilities/debouncePromise';
 import { findSource } from '../api';
@@ -77,11 +77,6 @@ const typesStep = (sourceTypes, applicationTypes, disableAppSelection) => ({
     },
     fields: [
         {
-            component: 'description',
-            name: 'description-source-type',
-            content: <Title headingLevel="h3" size="2xl">Configure your source</Title>
-        },
-        {
             component: 'card-select',
             name: 'application.application_type_id',
             label: 'Select your application',
@@ -117,7 +112,6 @@ const nameStep = () => ({
             component: 'description',
             name: 'description-summary',
             content: <TextContent key='step1'>
-                <Title headingLevel="h3" size="2xl">Select source name</Title>
                 <Text component={ TextVariants.p }>
                 To import data for an application, you need to connect to a data source.
                 Input a name and then proceed to the selection of application and source types.
@@ -147,7 +141,6 @@ const summaryStep = (sourceTypes, applicationTypes) => ({
             component: 'description',
             name: 'description-summary',
             content: <TextContent>
-                <Title headingLevel="h3" size="2xl">Review source details</Title>
                 <Text component={ TextVariants.p }>
             Review the information below and click Finish to add your source. Use the Back button to make changes.
                 </Text>
@@ -175,6 +168,7 @@ export default (sourceTypes, applicationTypes, disableAppSelection) => (
             buttonLabels: {
                 submit: 'Finish'
             },
+            showTitles: true,
             fields: [
                 nameStep(),
                 typesStep(sourceTypes, applicationTypes, disableAppSelection),

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -1,6 +1,4 @@
-import React from 'react';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
-import { Title } from '@patternfly/react-core';
 import hardcodedSchemas from './hardcodedSchemas';
 import get from 'lodash/get';
 
@@ -20,19 +18,10 @@ export const getAdditionalAuthFields = (type, auth) => get(hardcodedSchemas, [ t
 
 export const getAdditionalEndpointFields = (type) => get(hardcodedSchemas, [ type, 'endpoint', 'additionalFields' ], []);
 
-export const createTitle = (title) => ({
-    component: 'description',
-    name: `description-title-${title}`,
-    content: <Title headingLevel="h3" size="2xl">{title}</Title>
-});
-
 export const createAuthSelection = (type, applicationTypes, sourceTypes, endpointFields = [], disableAuthType = false) => {
     const auths = type.schema.authentication;
 
-    const fields = [
-        createTitle('Configure credentials'),
-        ...endpointFields
-    ];
+    const fields = [ ...endpointFields ];
 
     const stepMapper = {};
 
@@ -81,7 +70,6 @@ export const createAuthSelection = (type, applicationTypes, sourceTypes, endpoin
 export const createEndpointStep = (endpoint, typeName) => ({
     ...endpoint,
     fields: [
-        createTitle(endpoint.title),
         ...getAdditionalEndpointFields(typeName),
         ...injectEndpointFieldsInfo(endpoint.fields, typeName)
     ],
@@ -93,10 +81,7 @@ export const createAdditionalSteps = (additionalSteps, name, authName, hasEndpoi
     stepKey: `${name}-${authName}-additional-step`,
     nextStep: hasEndpointStep ? `${name}-endpoint` : 'summary',
     ...step,
-    fields: [
-        createTitle(step.title),
-        ...injectAuthFieldsInfo(step.fields, name, authName)
-    ]
+    fields: [ ...injectAuthFieldsInfo(step.fields, name, authName) ]
 }));
 
 export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -37,7 +37,8 @@ export const createAuthSelection = (type, applicationTypes, sourceTypes, endpoin
             index,
             applicationTypes,
             sourceTypes,
-            disableAuthType
+            disableAuthType,
+            authsCount: auths.length
         });
         fields.push({
             component: componentTypes.SUB_FORM,

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -58,7 +58,7 @@ export const createAuthSelection = (type, applicationTypes, sourceTypes, endpoin
     return ({
         name: type.name,
         stepKey: type.name,
-        title: 'Configure credentials',
+        title: `Configure ${type.product_name} credentials`,
         fields,
         nextStep: {
             when: 'auth_select',

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -42,6 +42,7 @@ export const createAuthSelection = (type, applicationTypes, sourceTypes, endpoin
         fields.push({
             component: componentTypes.SUB_FORM,
             name: `${auth.type}-subform`,
+            className: 'pf-u-pl-md',
             fields: [
                 ...getAdditionalAuthFields(type.name, auth.type),
                 ...injectAuthFieldsInfo(auth.fields, type.name, auth.type)

--- a/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Radio, FormHelperText } from '@patternfly/react-core';
 
-const AuthRadio = ({ label, input, authName, index, formOptions, applicationTypes, sourceTypes, disableAuthType }) => {
+const AuthRadio = ({ label, input, authName, index, formOptions, applicationTypes, sourceTypes, disableAuthType, authsCount }) => {
     let application = {};
     let isDisabled = false;
     const values = formOptions.getState().values;
@@ -24,6 +24,10 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
 
     if (disableAuthType && !isSelected) {
         isDisabled = true;
+    }
+
+    if (!input.value && !isDisabled && authsCount === 1) {
+        input.onChange(authName);
     }
 
     return (
@@ -71,7 +75,8 @@ AuthRadio.propTypes = {
     })).isRequired,
     authName: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
-    disableAuthType: PropTypes.bool
+    disableAuthType: PropTypes.bool,
+    authsCount: PropTypes.number.isRequired
 };
 
 AuthRadio.defaultProps = {

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
@@ -1,12 +1,8 @@
-import React from 'react';
-import { Title } from '@patternfly/react-core';
-
 import {
     injectAuthFieldsInfo,
     injectEndpointFieldsInfo,
     getAdditionalAuthFields,
     getAdditionalEndpointFields,
-    createTitle,
     createAuthSelection,
     createEndpointStep,
     createAdditionalSteps,
@@ -17,18 +13,6 @@ import sourceTypes from '../helpers/sourceTypes';
 import applicationTypes from '../helpers/applicationTypes';
 
 describe('schema builder', () => {
-    describe('createTitle', () => {
-        it('should return title step', () => {
-            const TITLE = 'title title tile';
-
-            expect(createTitle(TITLE)).toEqual({
-                component: 'description',
-                name: `description-title-${TITLE}`,
-                content: <Title headingLevel="h3" size="2xl">{TITLE}</Title>
-            });
-        });
-    });
-
     describe('getAdditionalEndpointFields', () => {
         it('returns additionalEndpointFields for openshift', () => {
             expect(getAdditionalEndpointFields('openshift')).toEqual(
@@ -120,7 +104,6 @@ describe('schema builder', () => {
             expect(createEndpointStep(ENDPOINT, 'openshift')).toEqual(
                 expect.objectContaining({
                     fields: [
-                        createTitle(ENDPOINT.title),
                         ...getAdditionalEndpointFields('openshift'),
                         ...injectEndpointFieldsInfo(ENDPOINT.fields, 'openshift')
                     ],

--- a/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
@@ -31,7 +31,8 @@ describe('AuthSelect component', () => {
             label: 'Test',
             name: 'auth-select',
             authName: 'access_key_secret_key',
-            index: 0
+            index: 0,
+            authsCount: 2
         };
     });
 
@@ -61,6 +62,20 @@ describe('AuthSelect component', () => {
         wrapper.find('input').simulate('change');
 
         expect(spyOnChange).toHaveBeenCalledWith(initialProps.authName);
+    });
+
+    it('calls onChange after render, when only one authtype is available', () => {
+        const OPENSHIFT_FORM_OPTIONS = {
+            getState: () => ({
+                values: {
+                    source_type: 'openshift'
+                }
+            })
+        };
+        const OPENSHIFT_AUTH_NAME = 'token';
+
+        mount(<AuthSelect { ...initialProps } formOptions={OPENSHIFT_FORM_OPTIONS} authName={OPENSHIFT_AUTH_NAME} authsCount={1}/>);
+        expect(spyOnChange).toHaveBeenCalledWith(OPENSHIFT_AUTH_NAME);
     });
 
     it('renders correctly with unsupported application', () => {


### PR DESCRIPTION
**Description**

- updates DDF to latest
- `showTitles` prop is used to generate title (no custom logic)
- A `product_name` is added to step title
- Nested subforms have padding left
- when only one auth_type, it is selected automatically

**Before**

initial

![image](https://user-images.githubusercontent.com/32869456/66747382-ae5dfe00-ee84-11e9-915f-52341a811c97.png)

selected

![image](https://user-images.githubusercontent.com/32869456/66747407-bc138380-ee84-11e9-8f4f-3386627e802c.png)

**After**

initial/selected

![image](https://user-images.githubusercontent.com/32869456/66747368-a43bff80-ee84-11e9-800c-9ef035fe7a29.png)

@Hyperkid123 
@terezanovotna