### PR TITLE
Show inv-insights app fetch failure message only if reports fetch fails

### DIFF
--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.18",
+    "version": "0.1.19",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -40,7 +40,6 @@ class InventoryRuleList extends Component {
             { title: 'Description', transforms: [ sortable ] },
             { title: 'Added', transforms: [ sortable, cellWidth(15) ] },
             { title: 'Total risk', transforms: [ sortable ] },
-            { title: 'Risk of change', transforms: [ sortable ] },
             { title: <span className='ansibleCol'>
                 { AnsibeTowerIcon && <AnsibeTowerIcon size='md' /> } Ansible
             </span>, transforms: [ sortable ] }
@@ -72,23 +71,25 @@ class InventoryRuleList extends Component {
     async fetchEntityRules() {
         const { entity } = this.props;
         const { filters, searchValue } = this.state;
+        let reportsData = {};
         try {
             await insights.chrome.auth.getUser();
             const reportsFetch = await fetch(`${BASE_FETCH_URL}system/${entity.id}/reports/`, { credentials: 'include' });
-            const reportsData = await reportsFetch.json();
-            const activeRuleFirstReportsData = this.activeRuleFirst(reportsData);
-            this.fetchKbaDetails(activeRuleFirstReportsData);
-            this.setState({
-                rows: this.buildRows(activeRuleFirstReportsData, {}, filters, searchValue, true),
-                inventoryReportFetchStatus: 'fulfilled',
-                activeReports: activeRuleFirstReportsData
-            });
+            reportsData = await reportsFetch.json();
         } catch (error) {
             this.setState({
                 inventoryReportFetchStatus: 'failed'
             });
             console.warn(error, 'Entity rules fetch failed.');
         }
+
+        const activeRuleFirstReportsData = this.activeRuleFirst(reportsData);
+        this.fetchKbaDetails(activeRuleFirstReportsData);
+        this.setState({
+            rows: this.buildRows(activeRuleFirstReportsData, {}, filters, searchValue, true),
+            inventoryReportFetchStatus: 'fulfilled',
+            activeReports: activeRuleFirstReportsData
+        });
     }
 
     fetchKbaDetails = async (reportsData) => {
@@ -107,7 +108,7 @@ class InventoryRuleList extends Component {
     activeRuleFirst = (activeReports) => {
         const { routerData } = this.props;
         const reports = [ ...activeReports ];
-        const activeRuleIndex = routerData && routerData.params ?
+        const activeRuleIndex = routerData && (typeof(routerData.params) !== 'undefined') ?
             activeReports.findIndex(report => report.rule.rule_id === this.props.routerData.params.id)
             : -1;
         const activeReport = reports.splice(activeRuleIndex, 1);
@@ -148,14 +149,6 @@ class InventoryRuleList extends Component {
                                     severity={ rule.total_risk }
                                 />
                             </div>
-                        }, {
-                            title: <div className='pf-m-center' key={ key } style={ { verticalAlign: 'top' } }>
-                                <Battery
-                                    label='Risk of change'
-                                    labelHidden
-                                    severity={ resolution.resolution_risk.risk }
-                                />
-                            </div>
                         },
                         {
                             title: <div className='pf-m-center ' key={ key }>
@@ -179,7 +172,6 @@ class InventoryRuleList extends Component {
                 const filterValues = filters[key];
                 const rowValue = {
                     has_playbook: value.resolution.has_playbook,
-                    risk: value.resolution.resolution_risk.risk,
                     publish_date: rule.publish_date,
                     total_risk: rule.total_risk
                 };
@@ -241,8 +233,7 @@ class InventoryRuleList extends Component {
             2: sortBy(activeReports, [ result => result.rule.description ]),
             3: sortBy(activeReports, [ result => result.rule.publish_date ]),
             4: sortBy(activeReports, [ result => result.rule.total_risk ]),
-            5: sortBy(activeReports, [ result => result.resolution.resolution_risk.risk ]),
-            6: sortBy(activeReports, [ result => result.resolution.has_playbook ])
+            5: sortBy(activeReports, [ result => result.resolution.has_playbook ])
         };
         const sortedReportsDirectional = direction === SortByDirection.asc ? sortedReports[index] : sortedReports[index].reverse();
         this.setState({
@@ -374,7 +365,7 @@ class InventoryRuleList extends Component {
                                 <TableBody />
                             </Table>
                             { results === 0 &&
-                                <MessageState icon={ TimesCircleIcon } title='No matching systems found'
+                                <MessageState icon={ TimesCircleIcon } title='No matching rules found'
                                     text={ `This filter criteria matches no rules. Try changing your filter settings.` } />
                             }
                         </Fragment>

--- a/packages/inventory-insights/src/ReportDetails.js
+++ b/packages/inventory-insights/src/ReportDetails.js
@@ -84,7 +84,7 @@ class ReportDetails extends React.Component {
                         <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <LightbulbIcon /><strong> Related Knowledgebase article: </strong>
+                                    <LightbulbIcon /><strong> Related Knowledgebase article </strong>
                                 </CardHeader>
                                 <CardBody>
                                     { kbaDetail && kbaDetail.view_uri ?
@@ -99,7 +99,7 @@ class ReportDetails extends React.Component {
                         <StackItem>
                             <Card className='ins-m-card__flat'>
                                 <CardHeader>
-                                    <InfoCircleIcon /><strong> Additional info:</strong>
+                                    <InfoCircleIcon /><strong> Additional info </strong>
                                 </CardHeader>
                                 <CardBody>
                                     { rule.more_info && this.templateProcessor(rule.more_info) }


### PR DESCRIPTION
This fixes the intermittent 'fetch failure' issue, encloses ONLY the fetch in a try/catch also tests if `.params` is  undefined rather than relying on the quick evaluation

also include some ui feedback from here https://docs.google.com/document/d/16okflGNsDw4NvirZO7DG0vMm5LnSEc8TIswP4tXdhiE/ (change words, remove colons and risk of change column) 

<img width="1400" alt="Screen Shot 2019-10-15 at 10 16 10 AM" src="https://user-images.githubusercontent.com/6640236/66839747-e9b80580-ef34-11e9-888a-c15d767be271.png">
