### PR TITLE
Addresses various inv-insights table ux review feedbacks

### DIFF
--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "0.1.19",
+    "version": "0.1.20",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/MessageState.js
+++ b/packages/inventory-insights/src/MessageState.js
@@ -3,23 +3,25 @@ import { EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } 
 import PropTypes from 'prop-types';
 import { CubesIcon } from '@patternfly/react-icons';
 
-const MessageState = ({ children, icon, iconStyle, text, title, variant }) => (
-    <EmptyState variant={ variant }>
-        <EmptyStateIcon style={ iconStyle } icon={ icon } size="lg" />
-        <Title headingLevel="h5" size="lg">
-            { title }
+const MessageState = ({ children, icon, iconClass, iconStyle, size, text, title, variant }) => (
+    <EmptyState variant={variant}>
+        {icon !== 'none' && <EmptyStateIcon className={iconClass} style={iconStyle} icon={icon} size={size} />}
+        <Title headingLevel='h5' size='lg'>
+            {title}
         </Title>
-        <EmptyStateBody style={ { marginBottom: '16px' } }>
-            { text }
+        <EmptyStateBody style={{ marginBottom: '16px' }}>
+            {text}
         </EmptyStateBody>
-        { children }
+        {children}
     </EmptyState>
 );
 
 MessageState.propTypes = {
     children: PropTypes.any,
     icon: PropTypes.any,
+    iconClass: PropTypes.any,
     iconStyle: PropTypes.any,
+    size: PropTypes.string,
     text: PropTypes.any,
     title: PropTypes.string,
     variant: PropTypes.any
@@ -28,7 +30,8 @@ MessageState.propTypes = {
 MessageState.defaultProps = {
     icon: CubesIcon,
     title: '',
-    variant: EmptyStateVariant.full
+    variant: EmptyStateVariant.full,
+    size: ''
 };
 
 export default MessageState;


### PR DESCRIPTION
Updates table check marks (ansible/empty state) to align with ux spec
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2759
also fixes https://projects.engineering.redhat.com/browse/RHCLOUD-2266

#### looks like this
<img width="1709" alt="Screen Shot 2019-10-17 at 11 21 00 AM" src="https://user-images.githubusercontent.com/6640236/67023089-3ab03100-f0d0-11e9-962f-c9bcaf9c55a5.png">
<img width="1710" alt="Screen Shot 2019-10-17 at 11 20 51 AM" src="https://user-images.githubusercontent.com/6640236/67023090-3ab03100-f0d0-11e9-900b-1c18df0c505c.png">

#### satellite managed message
<img width="1437" alt="Screen Shot 2019-10-17 at 10 41 23 AM" src="https://user-images.githubusercontent.com/6640236/67019776-2f0e3b80-f0cb-11e9-9949-2c4b79c817cf.png">

#### also fixes the issue of unremediable rules enabling the remediate button (🤗 @psav )
<img width="1041" alt="Screen Shot 2019-10-17 at 11 11 47 AM" src="https://user-images.githubusercontent.com/6640236/67022883-eb6a0080-f0cf-11e9-8736-bd3ec5aeb7ae.png">

