### PR TITLE
Use refreshData instead of refresh callback

### DIFF
--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -37,6 +37,7 @@ class ContextEntityTableToolbar extends Component {
             onRefreshData,
             perPage,
             filters,
+            filterConfig,
             hasItems,
             pathPrefix,
             apiBase,
@@ -45,21 +46,26 @@ class ContextEntityTableToolbar extends Component {
             actionsConfig,
             ...props
         } = this.props;
+        const inventoryFilters = [
+            ...!hasItems ? [{
+                label: 'Name',
+                value: 'name-filter',
+                filterValues: {
+                    placeholder: 'Find system by name',
+                    value: this.state.textFilter,
+                    onChange: (_e, value) => this.onSetTextFilter(value)
+                }
+            }] : [],
+            ...(filterConfig && filterConfig.items) || []
+        ];
         return (<PrimaryToolbar
             {...props}
             className="ins-c-inventory__table--toolbar"
-            filterConfig={{
-                items: [
-                    ...!hasItems ? [{
-                        label: 'Name',
-                        value: 'name-filter',
-                        filterValues: {
-                            placeholder: 'Find system by name',
-                            value: this.state.textFilter,
-                            onChange: (_e, value) => this.onSetTextFilter(value)
-                        }
-                    }] : []
-                ]
+            {...inventoryFilters.length > 0 && {
+                filterConfig: {
+                    ...filterConfig || {},
+                    items: inventoryFilters
+                }
             }}
             actionsConfig={
                 loaded ?
@@ -89,6 +95,7 @@ const EntityTableToolbar = ({ ...props }) => (
 );
 
 EntityTableToolbar.propTypes = {
+    filterConfig: PropTypes.shape(PrimaryToolbar.propTypes.filterConfig),
     total: PropTypes.number,
     filters: PropTypes.array,
     hasItems: PropTypes.bool,

--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -4,16 +4,17 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Skeleton, SkeletonSize, PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 import debounce from 'lodash/debounce';
+import { InventoryContext } from './Inventory';
 
 const TEXT_FILTER = 'hostname_or_id';
 
-class EntityTableToolbar extends Component {
+class ContextEntityTableToolbar extends Component {
     state = {
         textFilter: ''
     }
 
     debouncedRefresh = debounce((config) => {
-        this.props.onRefresh && this.props.onRefresh(config);
+        this.props.onRefreshData && this.props.onRefreshData(config);
     }, 800);
 
     onSetTextFilter = (value) => {
@@ -33,7 +34,7 @@ class EntityTableToolbar extends Component {
         const {
             total,
             page,
-            onRefresh,
+            onRefreshData,
             perPage,
             filters,
             hasItems,
@@ -69,15 +70,23 @@ class EntityTableToolbar extends Component {
                 page,
                 itemCount: total,
                 perPage,
-                onSetPage: (_e, newPage) => onRefresh({ page: newPage, perPage, filters }),
+                onSetPage: (_e, newPage) => onRefreshData({ page: newPage, perPage, filters }),
                 // eslint-disable-next-line camelcase
-                onPerPageSelect: (_e, newPerPage) => onRefresh({ page: 1, per_page: newPerPage, filters })
+                onPerPageSelect: (_e, newPerPage) => onRefreshData({ page: 1, per_page: newPerPage, filters })
             } : <Skeleton size={SkeletonSize.lg} />}
         >
             { children }
         </PrimaryToolbar>);
     }
 }
+
+const EntityTableToolbar = ({ ...props }) => (
+    <InventoryContext.Consumer>
+        {({ onRefreshData }) => (
+            <ContextEntityTableToolbar {...props} onRefreshData={onRefreshData} />
+        )}
+    </InventoryContext.Consumer>
+);
 
 EntityTableToolbar.propTypes = {
     total: PropTypes.number,
@@ -86,12 +95,16 @@ EntityTableToolbar.propTypes = {
     pathPrefix: PropTypes.number,
     apiBase: PropTypes.string,
     page: PropTypes.number,
-    onRefresh: PropTypes.func,
     perPage: PropTypes.number,
     children: PropTypes.node,
     pagination: PrimaryToolbar.propTypes.pagination,
     loaded: PropTypes.bool,
     actionsConfig: PrimaryToolbar.propTypes.actionsConfig
+};
+
+ContextEntityTableToolbar.propTypes = {
+    ...EntityTableToolbar.propTypes,
+    onRefreshData: PropTypes.func
 };
 
 function mapStateToProps(

--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -58,18 +58,7 @@ class InventoryTable extends Component {
                     pathPrefix={ pathPrefix }
                     apiBase={ apiBase }
                     page={ page }
-                    onRefresh={ onRefresh }
                     perPage={ perPage }
-                    pagination={
-                        <Pagination
-                            totalItems={ total || (items && items.length) }
-                            page={ page }
-                            hasItems={ Boolean(items) }
-                            onRefresh={ onRefresh }
-                            perPage={ perPage }
-                            direction="down"
-                        />
-                    }
                 >
                     { children }
                 </EntityTableToolbar>


### PR DESCRIPTION
### UI changes
None

### Fixes
Filtering in inventory was not working correctly due to using `onRefresh` callback that is used to notify consumer about refresh instead of internal `onRefreshData` used by inventory component.