### PR TITLE
Travis: Run lint before test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ node_js:
 install:
   - npm ci
 script:
-  - npm test
   - npm run lint
+  - npm test
   - npm run coverage


### PR DESCRIPTION
**Description**

Linter is faster than tests, so it's better to have it first in case of failing.

@karelhala 