### PR TITLE
Allow to use different steps for combinations of types/apps

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -3,6 +3,7 @@
 - [Install](#install)
   - [Using](#using)
 - [Format for sourceType schema](#format-for-sourcetype-schema)
+  - [Hardcoded component schema](#hardcoded-component-schema)
 - [Additional components](#additional-components)
   - [CardSelect](#cardselect)
   - [SourceWizardSummary](#sourcewizardsummary)
@@ -102,6 +103,17 @@ schema = {
   }
 }
 ```
+
+## Hardcoded component schema
+
+In [hardcodedSchema](src/addSourceWizard/hardcodedSchemas.js), there is an object which defines additional UI enhancements of the flow for combinations of sourceTypes and appTypes. The format has following structure: `source-type-name.authenication.auth-type.app-name`. For generic steps use as the app-name `generic`. Each of these objects has following keys:
+
+|key|description|
+|---|-----------|
+|`additionalFields`|These fields are appended to the authType selection page.|
+|name of field (ex. `authentication.password`|This defines additional props for the field (can be used for enhancing of API fields).|
+|`additionalSteps`|Defines additional steps.|
+|`skipSelection`|If there is only one authType, this flag will cause to skip the selection page.|
 
 # Additional components
 

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/sources#readme",
     "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^1.21.1",
-        "@data-driven-forms/react-form-renderer": "^1.21.1",
+        "@data-driven-forms/pf4-component-mapper": "^1.22.0",
+        "@data-driven-forms/react-form-renderer": "^1.22.0",
         "@patternfly/react-icons": "^3.10.9",
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -21,8 +21,8 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/sources#readme",
     "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^1.22.0",
-        "@data-driven-forms/react-form-renderer": "^1.22.0",
+        "@data-driven-forms/pf4-component-mapper": "^1.22.6",
+        "@data-driven-forms/react-form-renderer": "^1.22.6",
         "@patternfly/react-icons": "^3.10.9",
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -5,7 +5,6 @@ import { AwsIcon, OpenshiftIcon, MicrosoftIcon } from '@patternfly/react-icons';
 import debouncePromise from '../utilities/debouncePromise';
 import { findSource } from '../api';
 import { schemaBuilder } from './schemaBuilder';
-import hardcodedSchemas from './hardcodedSchemas';
 
 export const asyncValidator = (value, sourceId = undefined) => findSource(value).then(({ data: { sources } }) => {
     if (sources.find(({ id }) => id !== sourceId)) {
@@ -65,20 +64,10 @@ const iconMapper = (name, DefaultIcon) => ({
     azure: MicrosoftIcon
 }[name] || DefaultIcon);
 
-export const nextStep = ({ values: { application, source_type } }, applicationTypes) => {
+export const nextStep = ({ values: { application, source_type } }) => {
     const appId = application && application.application_type_id;
-    const app = appId && applicationTypes.find(({ id }) => id === appId);
+    const resultedStep = appId ? `${source_type}-${appId}` : source_type;
 
-    let hasSpecificSteps = false;
-
-    if (app && hardcodedSchemas[source_type] && hardcodedSchemas[source_type].authentication) {
-        const schema = hardcodedSchemas[source_type].authentication;
-        hasSpecificSteps = Object.keys(schema).some((key) => schema[key].hasOwnProperty(app.name));
-    }
-
-    const resultedStep = appId && hasSpecificSteps ? `${source_type}-${appId}` : source_type;
-
-    console.log(resultedStep);
     return resultedStep;
 };
 
@@ -86,7 +75,7 @@ const typesStep = (sourceTypes, applicationTypes, disableAppSelection) => ({
     title: 'Configure your source',
     name: 'types_step',
     stepKey: 'types_step',
-    nextStep: (args) => nextStep(args, applicationTypes),
+    nextStep,
     fields: [
         {
             component: 'card-select',

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { validatorTypes, componentTypes } from '@data-driven-forms/react-form-renderer';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
 import SSLFormLabel from './SSLFormLabel';
 
@@ -89,6 +89,7 @@ export default {
                     'authentication.password': arnField
                 },
                 '/insights/platform/cost-management': {
+                    skipSelection: true,
                     'authentication.password': arnField,
                     'arn-description': {
                         Content: AwsArn.ArnDescription
@@ -123,6 +124,15 @@ export default {
                         fields: [{
                             name: 'usage-description',
                             component: 'description'
+                        },  {
+                            name: 'billing_source.bucket',
+                            component: componentTypes.TEXT_FIELD,
+                            label: 'S3 bucket name'
+                        }, {
+                            component: componentTypes.TEXT_FIELD,
+                            name: 'authentication.authtype',
+                            hideField: true,
+                            initialValue: 'arn'
                         }]
                     }, {
                         title: 'Activate tags',

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -7,15 +7,33 @@ import * as OpenshiftToken from './hardcodedComponents/openshift/token';
 import * as AwsSecret from './hardcodedComponents/aws/access_key';
 import * as AwsArn from './hardcodedComponents/aws/arn';
 
+const arnField = {
+    placeholder: 'arn:aws:iam:123456789:role/CostManagement',
+    isRequired: true,
+    validate: [{
+        type: validatorTypes.REQUIRED
+    },  {
+        type: validatorTypes.PATTERN_VALIDATOR,
+        pattern: /^arn:aws:.*/,
+        message: 'ARN must start with arn:aws:'
+    }, {
+        type: validatorTypes.MIN_LENGTH,
+        threshold: 10,
+        message: 'ARN should have at least 10 characters'
+    }]
+};
+
 export default {
     openshift: {
         authentication: {
             token: {
-                additionalFields: [{
-                    component: 'description',
-                    name: 'description-summary',
-                    Content: OpenshiftToken.DescriptionSummary
-                }]
+                generic: {
+                    additionalFields: [{
+                        component: 'description',
+                        name: 'description-summary',
+                        Content: OpenshiftToken.DescriptionSummary
+                    }]
+                }
             }
         },
         endpoint: {
@@ -45,110 +63,104 @@ export default {
     amazon: {
         authentication: {
             access_key_secret_key: {
-                additionalFields: [
-                    {
-                        component: 'description',
-                        name: 'description-summary',
-                        Content: AwsSecret.DescriptionSummary
+                generic: {
+                    additionalFields: [
+                        {
+                            component: 'description',
+                            name: 'description-summary',
+                            Content: AwsSecret.DescriptionSummary
+                        }
+                    ],
+                    'authentication.username': {
+                        placeholder: 'AKIAIOSFODNN7EXAMPLE',
+                        isRequired: true,
+                        validate: [{ type: validatorTypes.REQUIRED }]
+                    },
+                    'authentication.password': {
+                        placeholder: 'wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+                        isRequired: true,
+                        validate: [{ type: validatorTypes.REQUIRED }]
                     }
-                ],
-                'authentication.username': {
-                    placeholder: 'AKIAIOSFODNN7EXAMPLE',
-                    isRequired: true,
-                    validate: [{ type: validatorTypes.REQUIRED }]
-                },
-                'authentication.password': {
-                    placeholder: 'wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-                    isRequired: true,
-                    validate: [{ type: validatorTypes.REQUIRED }]
                 }
             },
             arn: {
-                'authentication.password': {
-                    placeholder: 'arn:aws:iam:123456789:role/CostManagement',
-                    isRequired: true,
-                    validate: [{
-                        type: validatorTypes.REQUIRED
-                    },  {
-                        type: validatorTypes.PATTERN_VALIDATOR,
-                        pattern: /^arn:aws:.*/,
-                        message: 'ARN must start with arn:aws:'
+                generic: {
+                    includeStepKeyFields: [ 'arn' ],
+                    'authentication.password': arnField
+                },
+                '/insights/platform/cost-management': {
+                    'authentication.password': arnField,
+                    'arn-description': {
+                        Content: AwsArn.ArnDescription
+                    },
+                    'iam-role-description': {
+                        Content: AwsArn.IAMRoleDescription
+                    },
+                    'iam-policy-description': {
+                        Content: AwsArn.IAMPolicyDescription,
+                        assignFormOptions: true
+                    },
+                    'tags-description': {
+                        Content: AwsArn.TagsDescription
+                    },
+                    'usage-description': {
+                        Content: AwsArn.UsageDescription
+                    },
+                    'billing_source.bucket': {
+                        placeholder: 'cost-usage-bucket',
+                        validate: [{
+                            type: validatorTypes.REQUIRED
+                        }, {
+                            type: validatorTypes.PATTERN_VALIDATOR,
+                            pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
+                            message: 'S3 bucket name must start with alphanumeric character and can contain underscore and hyphen'
+                        }],
+                        isRequired: true
+                    },
+                    additionalSteps: [{
+                        title: 'Configure cost and usage reporting',
+                        nextStep: 'iam-policy',
+                        fields: [{
+                            name: 'usage-description',
+                            component: 'description'
+                        }]
                     }, {
-                        type: validatorTypes.MIN_LENGTH,
-                        threshold: 10,
-                        message: 'ARN should have at least 10 characters'
-                    }]
-                },
-                'arn-description': {
-                    Content: AwsArn.ArnDescription
-                },
-                'iam-role-description': {
-                    Content: AwsArn.IAMRoleDescription
-                },
-                'iam-policy-description': {
-                    Content: AwsArn.IAMPolicyDescription,
-                    assignFormOptions: true
-                },
-                'tags-description': {
-                    Content: AwsArn.TagsDescription
-                },
-                'usage-description': {
-                    Content: AwsArn.UsageDescription
-                },
-                'billing_source.bucket': {
-                    placeholder: 'cost-usage-bucket',
-                    validate: [{
-                        type: validatorTypes.REQUIRED
+                        title: 'Activate tags',
+                        stepKey: 'tags',
+                        nextStep: 'iam-policy',
+                        fields: [{
+                            name: 'tags-description',
+                            component: 'description'
+                        }]
+                    },
+                    {
+                        title: 'Create IAM policy',
+                        stepKey: 'iam-policy',
+                        nextStep: 'iam-role',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'iam-policy-description',
+                            component: 'description'
+                        }]
                     }, {
-                        type: validatorTypes.PATTERN_VALIDATOR,
-                        pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                        message: 'S3 bucket name must start with alphanumeric character and can contain underscore and hyphen'
-                    }],
-                    isRequired: true
-                },
-                additionalSteps: [{
-                    title: 'Configure cost and usage reporting',
-                    nextStep: 'iam-policy',
-                    fields: [{
-                        name: 'usage-description',
-                        component: 'description'
+                        title: 'Create IAM role',
+                        stepKey: 'iam-role',
+                        nextStep: 'arn',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'iam-role-description',
+                            component: 'description'
+                        }]
+                    }, {
+                        title: 'Enter ARN',
+                        stepKey: 'arn',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'arn-description',
+                            component: 'description'
+                        }]
                     }]
-                }, {
-                    title: 'Activate tags',
-                    stepKey: 'tags',
-                    nextStep: 'iam-policy',
-                    fields: [{
-                        name: 'tags-description',
-                        component: 'description'
-                    }]
-                },
-                {
-                    title: 'Create IAM policy',
-                    stepKey: 'iam-policy',
-                    nextStep: 'iam-role',
-                    substepOf: 'Enable account access',
-                    fields: [{
-                        name: 'iam-policy-description',
-                        component: 'description'
-                    }]
-                }, {
-                    title: 'Create IAM role',
-                    stepKey: 'iam-role',
-                    nextStep: 'arn',
-                    substepOf: 'Enable account access',
-                    fields: [{
-                        name: 'iam-role-description',
-                        component: 'description'
-                    }]
-                }, {
-                    title: 'Enter ARN',
-                    stepKey: 'arn',
-                    substepOf: 'Enable account access',
-                    fields: [{
-                        name: 'arn-description',
-                        component: 'description'
-                    }]
-                }]
+                }
             }
         },
         endpoint: {}

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -2,13 +2,22 @@ import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-re
 import hardcodedSchemas from './hardcodedSchemas';
 import get from 'lodash/get';
 
+export const hardcodedSchema = (typeName, authName, appName) =>
+    get(hardcodedSchemas, [ typeName, 'authentication', authName, appName ], undefined);
+
 export const getAdditionalSteps = (typeName, authName, appName = 'generic') =>
     get(hardcodedSchemas, [ typeName, 'authentication', authName, appName, 'additionalSteps' ], []);
+
+export const shouldSkipSelection = (typeName, authName, appName = 'generic') =>
+    get(hardcodedSchemas, [ typeName, 'authentication', authName, appName, 'skipSelection' ], false);
+
+export const getAdditionalStepKeys = (typeName, authName, appName = 'generic') =>
+    get(hardcodedSchemas, [ typeName, 'authentication', authName, appName, 'includeStepKeyFields' ], []);
 
 export const getAdditionalStepFields = (fields, stepKey) => fields.filter(field => field.stepKey === stepKey)
 .map(field => ({ ...field, stepKey: undefined }));
 
-export const getNoStepsFields = (fields) => fields.filter(field => !field.stepKey);
+export const getNoStepsFields = (fields, additionalStepKeys = []) => fields.filter(field => !field.stepKey || additionalStepKeys.includes(field.stepKey));
 
 export const injectAuthFieldsInfo = (fields, type, auth, applicationName) => fields.map((field) => {
     const specificFields = get(hardcodedSchemas, [ type, 'authentication', auth, applicationName ]);
@@ -25,196 +34,10 @@ export const injectEndpointFieldsInfo = (fields, type) => fields.map((field) => 
     return hardcodedField ? { ...field, ...hardcodedField } : field;
 });
 
-export const getAdditionalAuthFields = (type, auth, applicationName) => {
-    const specificFields = get(hardcodedSchemas, [ type, 'authentication', auth, applicationName, 'additionalFields' ]);
-
-    return specificFields ? specificFields :
-        get(hardcodedSchemas, [ type, 'authentication', auth, 'generic', 'additionalFields' ], []);
-};
+export const getAdditionalAuthFields = (type, auth, applicationName = 'generic') =>
+    get(hardcodedSchemas, [ type, 'authentication', auth, applicationName, 'additionalFields' ], []);
 
 export const getAdditionalEndpointFields = (type) => get(hardcodedSchemas, [ type, 'endpoint', 'additionalFields' ], []);
-
-export const createAuthSelection = (type, applicationTypes, sourceTypes, endpointFields = [], disableAuthType = false) => {
-    const auths = type.schema.authentication;
-
-    let fields = [ ...endpointFields ];
-
-    const stepMapper = {};
-
-    // generic <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-    const genericSelection = {
-        component: componentTypes.SUB_FORM,
-        name: 'generic-selection',
-        fields: [{
-            component: 'description',
-            name: 'pokus',
-            Content: () => `POKUS generic ${type.name}`
-        }],
-        condition: {
-            when: 'application.application_type_id',
-            isEmpty: true
-        }
-    };
-
-    fields.push(genericSelection);
-
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-    // preprocess for multiauth <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-    const authTypes = applicationTypes.map(({ id, supported_authentication_types }) => {
-        const appSupportedAuthTypes = supported_authentication_types[type.name];
-        const appSupportsSourceType = appSupportedAuthTypes && appSupportedAuthTypes.length > 0;
-
-        return appSupportsSourceType ? ({
-            id,
-            supportedAuthTypes: appSupportedAuthTypes.map((authType) => authType)
-        }) : undefined;
-    }).filter(x => x);
-
-    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-
-    const applicationSelection = authTypes.map((authType => {
-        let index = 0;
-        let authSelects;
-
-        const application = applicationTypes.find(({ id }) => id === authType.id);
-        const hasOnlyOneType = authType.supportedAuthTypes.length === 1;
-
-        if (hasOnlyOneType) {
-            const supportedType = authType.supportedAuthTypes[0];
-            const authentication = type.schema.authentication.find(({ type }) => type === supportedType);
-
-            if (!authentication) {
-                return ([]);
-            }
-
-            return ({
-                component: componentTypes.SUB_FORM,
-                name: `${type.name}-${authType.id}`,
-                fields: [
-                    {
-                        component: 'description',
-                        name: 'pokus',
-                        Content: () => `POKUS ${type.name} ${authType.id} ${JSON.stringify(authTypes)}`
-                    },
-                    ...getAdditionalAuthFields(type.name, supportedType, application.name),
-                    ...injectAuthFieldsInfo(getNoStepsFields(authentication.fields), type.name, supportedType, application.name)
-                ],
-                condition: {
-                    when: 'application.application_type_id',
-                    is: authType.id
-                }
-            });
-        } else {
-            authSelects = authType.supportedAuthTypes.map((supportedType) => {
-                const authentication = type.schema.authentication.find(({ type }) => type === supportedType);
-                const authenticationName = authentication && authentication.name;
-
-                if (!authentication || !authenticationName) {
-                    return ([]);
-                }
-
-                const selection = {
-                    component: 'auth-select',
-                    name: 'auth_select',
-                    label: authenticationName,
-                    authName: `${supportedType}-${authType.id}`,
-                    validate: [{
-                        type: validatorTypes.REQUIRED
-                    }],
-                    index: index++,
-                    applicationTypes,
-                    sourceTypes,
-                    disableAuthType,
-                    authsCount: auths.length
-                };
-
-                const authFields = {
-                    component: componentTypes.SUB_FORM,
-                    name: `${supportedType}-subform`,
-                    className: 'pf-u-pl-md',
-                    fields: [
-                        ...getAdditionalAuthFields(type.name, supportedType, application.name),
-                        ...injectAuthFieldsInfo(getNoStepsFields(authentication.fields), type.name, supportedType, application.name)
-                    ],
-                    condition: {
-                        when: 'auth_select',
-                        is: `${supportedType}-${authType.id}`
-                    }
-                };
-
-                return ([
-                    selection,
-                    authFields
-                ]);
-            }).flatMap(x => x);
-
-            return ({
-                component: componentTypes.SUB_FORM,
-                name: `${type.name}-${authType.id}`,
-                fields: [
-                    {
-                        component: 'description',
-                        name: 'pokus',
-                        Content: () => `POKUS ${type.name} ${authType.id} ${JSON.stringify(authTypes)}`
-                    },
-                    ...authSelects
-                ],
-                condition: {
-                    when: 'application.application_type_id',
-                    is: authType.id
-                }
-            });
-        }
-    }));
-
-    fields = [ ...fields, ...applicationSelection ];
-
-    /*auths.forEach((auth, index) => {
-        fields.push({
-            component: 'auth-select',
-            name: 'auth_select',
-            label: auth.name,
-            authName: auth.type,
-            validate: [{
-                type: validatorTypes.REQUIRED
-            }],
-            index,
-            applicationTypes,
-            sourceTypes,
-            disableAuthType,
-            authsCount: auths.length
-        });
-        fields.push({
-            component: componentTypes.SUB_FORM,
-            name: `${auth.type}-subform`,
-            className: 'pf-u-pl-md',
-            fields: [
-                ...getAdditionalAuthFields(type.name, auth.type),
-                ...injectAuthFieldsInfo(getNoStepsFields(auth.fields), type.name, auth.type)
-            ],
-            condition: {
-                when: 'auth_select',
-                is: auth.type
-            }
-        });
-        stepMapper[auth.type] = getAdditionalSteps(type.name, auth.type).length > 0 ? `${type.name}-${auth.type}-additional-step` :
-            endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
-    });*/
-
-    return ({
-        name: type.name,
-        stepKey: type.name,
-        title: `Configure ${type.product_name} credentials`,
-        fields,
-        nextStep: {
-            when: 'auth_select',
-            stepMapper
-        }
-    });
-};
 
 export const createEndpointStep = (endpoint, typeName) => ({
     ...endpoint,
@@ -226,22 +49,21 @@ export const createEndpointStep = (endpoint, typeName) => ({
     nextStep: 'summary'
 });
 
-export const createAdditionalSteps = (additionalSteps, name, authName, hasEndpointStep, fields) => additionalSteps.map((step) => {
-    const stepKey = step.stepKey || `${name}-${authName}-additional-step`;
+export const createAdditionalSteps = (additionalSteps, name, authName, hasEndpointStep, fields, appName = 'generic') => additionalSteps.map((step) => {
+    const stepKey = step.stepKey || `${name}-${authName}-${appName}-additional-step`;
 
     return ({
         stepKey: stepKey,
         nextStep: hasEndpointStep ? `${name}-endpoint` : 'summary',
         ...step,
         fields: [
-            ...injectAuthFieldsInfo(step.fields, name, authName),
-            ...injectAuthFieldsInfo(getAdditionalStepFields(fields, stepKey), name, authName)
+            ...injectAuthFieldsInfo(step.fields, name, authName, appName),
+            ...injectAuthFieldsInfo(getAdditionalStepFields(fields, stepKey), name, authName, appName)
         ]
     });
 });
 
-export const createGenericAuthTypeSelection = (type, endpointFields, disableAuthType, applicationTypes, sourceTypes) => {
-    // get all authentication types
+export const createGenericAuthTypeSelection = (type, endpointFields, disableAuthType) => {
     const auths = type.schema.authentication;
     const hasMultipleAuthTypes = auths.length > 1;
 
@@ -249,7 +71,8 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
     const stepMapper = {};
 
     if (hasMultipleAuthTypes) {
-        auths.forEach((auth, index) => {
+        auths.forEach((auth) => {
+            const additionalIncludesStepKeys = getAdditionalStepKeys(type.name, auth.type);
             fields.push({
                 component: 'auth-select',
                 name: 'auth_select',
@@ -258,11 +81,7 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
                 validate: [{
                     type: validatorTypes.REQUIRED
                 }],
-                index,
-                applicationTypes,
-                sourceTypes,
-                disableAuthType,
-                authsCount: auths.length
+                disableAuthType
             });
             fields.push({
                 component: componentTypes.SUB_FORM,
@@ -270,7 +89,7 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
                 className: 'pf-u-pl-md',
                 fields: [
                     ...getAdditionalAuthFields(type.name, auth.type),
-                    ...injectAuthFieldsInfo(getNoStepsFields(auth.fields), type.name, auth.type)
+                    ...injectAuthFieldsInfo(getNoStepsFields(auth.fields, additionalIncludesStepKeys), type.name, auth.type)
                 ],
                 condition: {
                     when: 'auth_select',
@@ -293,27 +112,137 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
         });
     } else {
         const auth = auths[0];
+        const additionalStepName = `${type.name}-${auth.type}-generic-additional-step`;
 
-        const nextStep = getAdditionalSteps(type.name, auth.type).length > 0 ? `${type.name}-${auth.type}-additional-step` :
+        const nextStep = getAdditionalSteps(type.name, auth.type).length > 0 ? additionalStepName :
             endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
+
+        const additionalIncludesStepKeys = getAdditionalStepKeys(type.name, auth.type);
+        const hasCustomStep = shouldSkipSelection(type.name, auth.type);
+
+        let stepProps = {};
+
+        if (hasCustomStep) {
+            const firstAdditonalStep = getAdditionalSteps(type.name, auth.type).find(({ stepKey }) => !stepKey);
+            const additionalFields = getAdditionalStepFields(auth.fields, additionalStepName);
+
+            stepProps = {
+                ...firstAdditonalStep,
+                fields: [
+                    ...fields,
+                    ...injectAuthFieldsInfo([ ...firstAdditonalStep.fields, ...additionalFields ], type.name, auth.type)
+                ],
+                stepKey: type.name
+            };
+        }
+
+        return ({
+            name: type.name,
+            stepKey: type.name,
+            title: `Configure ${type.product_name} - ${auth.name} credentials`,
+            fields: [
+                ...fields,
+                ...getAdditionalAuthFields(type.name, auth.type),
+                ...injectAuthFieldsInfo(getNoStepsFields(auth.fields, additionalIncludesStepKeys), type.name, auth.type)
+            ],
+            nextStep,
+            ...stepProps
+        });
+    }
+};
+
+export const createSpecificAuthTypeSelection = (type, appType, endpointFields, disableAuthType) => {
+    const auths = type.schema.authentication;
+    const supportedAuthTypes = appType.supported_authentication_types[type.name];
+    const hasMultipleAuthTypes = supportedAuthTypes.length > 1;
+
+    const fields = [ ...endpointFields ];
+    const stepMapper = {};
+
+    if (hasMultipleAuthTypes) {
+        auths.filter(({ type: authType }) => supportedAuthTypes.includes(authType)).forEach((auth) => {
+            const appName = hardcodedSchema(type.name, auth.type, appType.name) ? appType.name : 'generic';
+
+            const additionalIncludesStepKeys = getAdditionalStepKeys(type.name, auth.type, appName);
+            fields.push({
+                component: 'auth-select',
+                name: 'auth_select',
+                label: auth.name,
+                authName: auth.type,
+                validate: [{
+                    type: validatorTypes.REQUIRED
+                }],
+                supportedAuthTypes: appType.supported_authentication_types[type.name],
+                disableAuthType
+            });
+            fields.push({
+                component: componentTypes.SUB_FORM,
+                name: `${auth.type}-subform`,
+                className: 'pf-u-pl-md',
+                fields: [
+                    ...getAdditionalAuthFields(type.name, auth.type, appName),
+                    ...injectAuthFieldsInfo(getNoStepsFields(auth.fields, additionalIncludesStepKeys), type.name, auth.type, appName)
+                ],
+                condition: {
+                    when: 'auth_select',
+                    is: auth.type
+                }
+            });
+            stepMapper[auth.type] = getAdditionalSteps(type.name, auth.type, appType.name).length > 0 ? `${type.name}-${auth.type}-additional-step` :
+                endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
+        });
 
         return ({
             name: type.name,
             stepKey: type.name,
             title: `Configure ${type.product_name} credentials`,
+            fields,
+            nextStep: {
+                when: 'auth_select',
+                stepMapper
+            }
+        });
+    } else {
+        const auth = auths.find(({ type: authType }) => supportedAuthTypes.includes(authType));
+        const appName = hardcodedSchema(type.name, auth.type, appType.name) ? appType.name : 'generic';;
+
+        const additionalStepName = `${type.name}-${auth.type}-${appType.name}-additional-step`;
+
+        const nextStep = getAdditionalSteps(type.name, auth.type, appName).length > 0 ? additionalStepName :
+            endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
+
+        const additionalIncludesStepKeys = getAdditionalStepKeys(type.name, auth.type, appName);
+        const hasCustomStep = shouldSkipSelection(type.name, auth.type, appName);
+
+        let stepProps = {};
+
+        if (hasCustomStep) {
+            const firstAdditonalStep = getAdditionalSteps(type.name, auth.type, appName).find(({ stepKey }) => !stepKey);
+            const additionalFields = getAdditionalStepFields(auth.fields, additionalStepName);
+
+            stepProps = {
+                ...firstAdditonalStep,
+                fields: [
+                    ...fields,
+                    ...injectAuthFieldsInfo([ ...firstAdditonalStep.fields, ...additionalFields ], type.name, auth.type, appName)
+                ],
+                stepKey: `${type.name}-${appType.id}`
+            };
+        }
+
+        return ({
+            stepKey: `${type.name}-${appType.id}`,
+            name: `${type.name}-${appType.id}`,
+            title: `Configure ${type.product_name} - ${auth.name} credentials`,
             fields: [
                 ...fields,
-                ...getAdditionalAuthFields(type.name, auth.type),
-                ...injectAuthFieldsInfo(getNoStepsFields(auth.fields), type.name, auth.type)
+                ...getAdditionalAuthFields(type.name, auth.type, appName),
+                ...injectAuthFieldsInfo(getNoStepsFields(auth.fields, additionalIncludesStepKeys), type.name, auth.type, appName)
             ],
-            nextStep
+            nextStep,
+            ...stepProps
         });
     }
-};
-
-export const createSpecificAuthTypeSelection = (sourceType, appType, hasEndpointStep, sourceTypes, appTypes, disableAuthType) => {
-
-    return { stepKey: `${sourceType.name}-${appType.id}`, name: `${sourceType.name}-${appType.id}`, fields: [] };
 };
 
 export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
@@ -323,27 +252,28 @@ export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
         const appendEndpoint = type.schema.endpoint.hidden ? type.schema.endpoint.fields : [];
         const hasEndpointStep = appendEndpoint.length === 0;
 
-        schema.push(createGenericAuthTypeSelection(type, appendEndpoint, disableAuthType, appTypes, sourceTypes));
+        schema.push(createGenericAuthTypeSelection(type, appendEndpoint, disableAuthType));
 
         appTypes.forEach(appType => {
             if (appType.supported_source_types.includes(type.name)) {
-                const hardSchema = hardcodedSchemas[type.name] && hardcodedSchemas[type.name].authentication;
-                if (hardSchema) {
-                    const hasSpecificSteps = Object.keys(hardSchema).some((key) => hardSchema[key].hasOwnProperty(appType.name));
-
-                    console.log(type.name, appType.display_name, hasSpecificSteps ? `pushuji ${type.name}-${appType.id}` : 'pouze generic');
-                    schema.push(createSpecificAuthTypeSelection(type, appType, appendEndpoint, disableAuthType, appTypes, sourceTypes));
-                }
+                schema.push(createSpecificAuthTypeSelection(type, appType, appendEndpoint, disableAuthType));
             }
         });
 
-        //schema.push(createAuthSelection(type, appTypes, sourceTypes, appendEndpoint, disableAuthType));
-
         type.schema.authentication.forEach(auth => {
             const additionalSteps = getAdditionalSteps(type.name, auth.type);
+
             if (additionalSteps.length > 0) {
                 schema.push(...createAdditionalSteps(additionalSteps, type.name, auth.type, hasEndpointStep, auth.fields));
             }
+
+            appTypes.forEach(appType => {
+                const appAdditionalSteps = getAdditionalSteps(type.name, auth.type, appType.name);
+
+                if (appAdditionalSteps.length > 0) {
+                    schema.push(...createAdditionalSteps(appAdditionalSteps, type.name, auth.type, hasEndpointStep, auth.fields, appType.name));
+                }
+            });
         });
 
         if (hasEndpointStep) {

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -2,15 +2,19 @@ import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-re
 import hardcodedSchemas from './hardcodedSchemas';
 import get from 'lodash/get';
 
-export const getAdditionalSteps = (typeName, authName) => get(hardcodedSchemas, [ typeName, 'authentication', authName, 'additionalSteps' ], []);
+export const getAdditionalSteps = (typeName, authName, appName = 'generic') =>
+    get(hardcodedSchemas, [ typeName, 'authentication', authName, appName, 'additionalSteps' ], []);
 
 export const getAdditionalStepFields = (fields, stepKey) => fields.filter(field => field.stepKey === stepKey)
 .map(field => ({ ...field, stepKey: undefined }));
 
 export const getNoStepsFields = (fields) => fields.filter(field => !field.stepKey);
 
-export const injectAuthFieldsInfo = (fields, type, auth) => fields.map((field) => {
-    const hardcodedField = get(hardcodedSchemas, [ type, 'authentication', auth, field.name ]);
+export const injectAuthFieldsInfo = (fields, type, auth, applicationName) => fields.map((field) => {
+    const specificFields = get(hardcodedSchemas, [ type, 'authentication', auth, applicationName ]);
+
+    const hardcodedField = specificFields ? get(specificFields, field.name) :
+        get(hardcodedSchemas, [ type, 'authentication', auth, 'generic', field.name ]);
 
     return hardcodedField ? { ...field, ...hardcodedField } : field;
 });
@@ -21,18 +25,154 @@ export const injectEndpointFieldsInfo = (fields, type) => fields.map((field) => 
     return hardcodedField ? { ...field, ...hardcodedField } : field;
 });
 
-export const getAdditionalAuthFields = (type, auth) => get(hardcodedSchemas, [ type, 'authentication', auth, 'additionalFields' ], []);
+export const getAdditionalAuthFields = (type, auth, applicationName) => {
+    const specificFields = get(hardcodedSchemas, [ type, 'authentication', auth, applicationName, 'additionalFields' ]);
+
+    return specificFields ? specificFields :
+        get(hardcodedSchemas, [ type, 'authentication', auth, 'generic', 'additionalFields' ], []);
+};
 
 export const getAdditionalEndpointFields = (type) => get(hardcodedSchemas, [ type, 'endpoint', 'additionalFields' ], []);
 
 export const createAuthSelection = (type, applicationTypes, sourceTypes, endpointFields = [], disableAuthType = false) => {
     const auths = type.schema.authentication;
 
-    const fields = [ ...endpointFields ];
+    let fields = [ ...endpointFields ];
 
     const stepMapper = {};
 
-    auths.forEach((auth, index) => {
+    // generic <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    const genericSelection = {
+        component: componentTypes.SUB_FORM,
+        name: 'generic-selection',
+        fields: [{
+            component: 'description',
+            name: 'pokus',
+            Content: () => `POKUS generic ${type.name}`
+        }],
+        condition: {
+            when: 'application.application_type_id',
+            isEmpty: true
+        }
+    };
+
+    fields.push(genericSelection);
+
+    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    // preprocess for multiauth <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    const authTypes = applicationTypes.map(({ id, supported_authentication_types }) => {
+        const appSupportedAuthTypes = supported_authentication_types[type.name];
+        const appSupportsSourceType = appSupportedAuthTypes && appSupportedAuthTypes.length > 0;
+
+        return appSupportsSourceType ? ({
+            id,
+            supportedAuthTypes: appSupportedAuthTypes.map((authType) => authType)
+        }) : undefined;
+    }).filter(x => x);
+
+    // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+    const applicationSelection = authTypes.map((authType => {
+        let index = 0;
+        let authSelects;
+
+        const application = applicationTypes.find(({ id }) => id === authType.id);
+        const hasOnlyOneType = authType.supportedAuthTypes.length === 1;
+
+        if (hasOnlyOneType) {
+            const supportedType = authType.supportedAuthTypes[0];
+            const authentication = type.schema.authentication.find(({ type }) => type === supportedType);
+
+            if (!authentication) {
+                return ([]);
+            }
+
+            return ({
+                component: componentTypes.SUB_FORM,
+                name: `${type.name}-${authType.id}`,
+                fields: [
+                    {
+                        component: 'description',
+                        name: 'pokus',
+                        Content: () => `POKUS ${type.name} ${authType.id} ${JSON.stringify(authTypes)}`
+                    },
+                    ...getAdditionalAuthFields(type.name, supportedType, application.name),
+                    ...injectAuthFieldsInfo(getNoStepsFields(authentication.fields), type.name, supportedType, application.name)
+                ],
+                condition: {
+                    when: 'application.application_type_id',
+                    is: authType.id
+                }
+            });
+        } else {
+            authSelects = authType.supportedAuthTypes.map((supportedType) => {
+                const authentication = type.schema.authentication.find(({ type }) => type === supportedType);
+                const authenticationName = authentication && authentication.name;
+
+                if (!authentication || !authenticationName) {
+                    return ([]);
+                }
+
+                const selection = {
+                    component: 'auth-select',
+                    name: 'auth_select',
+                    label: authenticationName,
+                    authName: `${supportedType}-${authType.id}`,
+                    validate: [{
+                        type: validatorTypes.REQUIRED
+                    }],
+                    index: index++,
+                    applicationTypes,
+                    sourceTypes,
+                    disableAuthType,
+                    authsCount: auths.length
+                };
+
+                const authFields = {
+                    component: componentTypes.SUB_FORM,
+                    name: `${supportedType}-subform`,
+                    className: 'pf-u-pl-md',
+                    fields: [
+                        ...getAdditionalAuthFields(type.name, supportedType, application.name),
+                        ...injectAuthFieldsInfo(getNoStepsFields(authentication.fields), type.name, supportedType, application.name)
+                    ],
+                    condition: {
+                        when: 'auth_select',
+                        is: `${supportedType}-${authType.id}`
+                    }
+                };
+
+                return ([
+                    selection,
+                    authFields
+                ]);
+            }).flatMap(x => x);
+
+            return ({
+                component: componentTypes.SUB_FORM,
+                name: `${type.name}-${authType.id}`,
+                fields: [
+                    {
+                        component: 'description',
+                        name: 'pokus',
+                        Content: () => `POKUS ${type.name} ${authType.id} ${JSON.stringify(authTypes)}`
+                    },
+                    ...authSelects
+                ],
+                condition: {
+                    when: 'application.application_type_id',
+                    is: authType.id
+                }
+            });
+        }
+    }));
+
+    fields = [ ...fields, ...applicationSelection ];
+
+    /*auths.forEach((auth, index) => {
         fields.push({
             component: 'auth-select',
             name: 'auth_select',
@@ -62,7 +202,7 @@ export const createAuthSelection = (type, applicationTypes, sourceTypes, endpoin
         });
         stepMapper[auth.type] = getAdditionalSteps(type.name, auth.type).length > 0 ? `${type.name}-${auth.type}-additional-step` :
             endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
-    });
+    });*/
 
     return ({
         name: type.name,
@@ -100,6 +240,82 @@ export const createAdditionalSteps = (additionalSteps, name, authName, hasEndpoi
     });
 });
 
+export const createGenericAuthTypeSelection = (type, endpointFields, disableAuthType, applicationTypes, sourceTypes) => {
+    // get all authentication types
+    const auths = type.schema.authentication;
+    const hasMultipleAuthTypes = auths.length > 1;
+
+    const fields = [ ...endpointFields ];
+    const stepMapper = {};
+
+    if (hasMultipleAuthTypes) {
+        auths.forEach((auth, index) => {
+            fields.push({
+                component: 'auth-select',
+                name: 'auth_select',
+                label: auth.name,
+                authName: auth.type,
+                validate: [{
+                    type: validatorTypes.REQUIRED
+                }],
+                index,
+                applicationTypes,
+                sourceTypes,
+                disableAuthType,
+                authsCount: auths.length
+            });
+            fields.push({
+                component: componentTypes.SUB_FORM,
+                name: `${auth.type}-subform`,
+                className: 'pf-u-pl-md',
+                fields: [
+                    ...getAdditionalAuthFields(type.name, auth.type),
+                    ...injectAuthFieldsInfo(getNoStepsFields(auth.fields), type.name, auth.type)
+                ],
+                condition: {
+                    when: 'auth_select',
+                    is: auth.type
+                }
+            });
+            stepMapper[auth.type] = getAdditionalSteps(type.name, auth.type).length > 0 ? `${type.name}-${auth.type}-additional-step` :
+                endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
+        });
+
+        return ({
+            name: type.name,
+            stepKey: type.name,
+            title: `Configure ${type.product_name} credentials`,
+            fields,
+            nextStep: {
+                when: 'auth_select',
+                stepMapper
+            }
+        });
+    } else {
+        const auth = auths[0];
+
+        const nextStep = getAdditionalSteps(type.name, auth.type).length > 0 ? `${type.name}-${auth.type}-additional-step` :
+            endpointFields.length === 0 ? `${type.name}-endpoint` : 'summary';
+
+        return ({
+            name: type.name,
+            stepKey: type.name,
+            title: `Configure ${type.product_name} credentials`,
+            fields: [
+                ...fields,
+                ...getAdditionalAuthFields(type.name, auth.type),
+                ...injectAuthFieldsInfo(getNoStepsFields(auth.fields), type.name, auth.type)
+            ],
+            nextStep
+        });
+    }
+};
+
+export const createSpecificAuthTypeSelection = (sourceType, appType, hasEndpointStep, sourceTypes, appTypes, disableAuthType) => {
+
+    return { stepKey: `${sourceType.name}-${appType.id}`, name: `${sourceType.name}-${appType.id}`, fields: [] };
+};
+
 export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
     const schema = [];
 
@@ -107,7 +323,21 @@ export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
         const appendEndpoint = type.schema.endpoint.hidden ? type.schema.endpoint.fields : [];
         const hasEndpointStep = appendEndpoint.length === 0;
 
-        schema.push(createAuthSelection(type, appTypes, sourceTypes, appendEndpoint, disableAuthType));
+        schema.push(createGenericAuthTypeSelection(type, appendEndpoint, disableAuthType, appTypes, sourceTypes));
+
+        appTypes.forEach(appType => {
+            if (appType.supported_source_types.includes(type.name)) {
+                const hardSchema = hardcodedSchemas[type.name] && hardcodedSchemas[type.name].authentication;
+                if (hardSchema) {
+                    const hasSpecificSteps = Object.keys(hardSchema).some((key) => hardSchema[key].hasOwnProperty(appType.name));
+
+                    console.log(type.name, appType.display_name, hasSpecificSteps ? `pushuji ${type.name}-${appType.id}` : 'pouze generic');
+                    schema.push(createSpecificAuthTypeSelection(type, appType, appendEndpoint, disableAuthType, appTypes, sourceTypes));
+                }
+            }
+        });
+
+        //schema.push(createAuthSelection(type, appTypes, sourceTypes, appendEndpoint, disableAuthType));
 
         type.schema.authentication.forEach(auth => {
             const additionalSteps = getAdditionalSteps(type.name, auth.type);
@@ -121,5 +351,6 @@ export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
         }
     });
 
+    console.log(schema);
     return schema;
 };

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -281,6 +281,5 @@ export const schemaBuilder = (sourceTypes, appTypes, disableAuthType) => {
         }
     });
 
-    console.log(schema);
     return schema;
 };

--- a/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
@@ -2,34 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Radio, FormHelperText } from '@patternfly/react-core';
 
-const AuthRadio = ({ label, input, authName, index, formOptions, applicationTypes, sourceTypes, disableAuthType, authsCount }) => {
-    let application = {};
-    let isDisabled = false;
-    const values = formOptions.getState().values;
+const AuthRadio = ({ label, input, authName, supportedAuthTypes, disableAuthType }) => {
+    let isDisabled = disableAuthType;
     const isSelected = input.value === authName;
-    const supportedAuthTypes = sourceTypes.find(type => type.name === values.source_type).schema.authentication.map((auth) => auth.type);
 
-    /*
-    if (values.application) {
-        application = applicationTypes.find(({ id }) => id === values.application.application_type_id);
-        //isDisabled = !application.supported_authentication_types[values.source_type].includes(authName);
-    }
-
-    if (isDisabled && isSelected) {
+    if (input.value && supportedAuthTypes && !supportedAuthTypes.includes(input.value)) {
         input.onChange(undefined);
     }
-
-    if (input.value && !supportedAuthTypes.includes(input.value)) {
-        input.onChange(undefined);
-    }
-
-    if (disableAuthType && !isSelected) {
-        isDisabled = true;
-    }
-
-    if (!input.value && !isDisabled && authsCount === 1) {
-        input.onChange(authName);
-    }*/
 
     return (
         <React.Fragment>
@@ -39,7 +18,7 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
                 name={input.name}
                 onChange={() => input.onChange(authName)}
                 label={label}
-                id={`${input.name}-${index}`}
+                id={`${input.name}-${authName}`}
                 isDisabled={isDisabled}
             />
             {disableAuthType && !isSelected && <FormHelperText isHidden={false} className="pf-m-disabled">
@@ -51,30 +30,14 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
 
 AuthRadio.propTypes = {
     label: PropTypes.string,
-    formOptions: PropTypes.any,
     input: PropTypes.shape({
         value: PropTypes.any,
         onChange: PropTypes.func.isRequired,
         name: PropTypes.string.isRequired
     }).isRequired,
-    sourceTypes: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        product_name: PropTypes.string.isRequired,
-        schema: PropTypes.shape({
-            authentication: PropTypes.array,
-            endpoint: PropTypes.object
-        })
-    })).isRequired,
-    applicationTypes: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        display_name: PropTypes.string.isRequired
-    })).isRequired,
     authName: PropTypes.string.isRequired,
-    index: PropTypes.number.isRequired,
     disableAuthType: PropTypes.bool,
-    authsCount: PropTypes.number.isRequired
+    supportedAuthTypes: PropTypes.arrayOf(PropTypes.string)
 };
 
 AuthRadio.defaultProps = {

--- a/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
@@ -9,9 +9,10 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
     const isSelected = input.value === authName;
     const supportedAuthTypes = sourceTypes.find(type => type.name === values.source_type).schema.authentication.map((auth) => auth.type);
 
-    if (values.application && values.application.application_type_id) {
+    /*
+    if (values.application) {
         application = applicationTypes.find(({ id }) => id === values.application.application_type_id);
-        isDisabled = !application.supported_authentication_types[values.source_type].includes(authName);
+        //isDisabled = !application.supported_authentication_types[values.source_type].includes(authName);
     }
 
     if (isDisabled && isSelected) {
@@ -28,7 +29,7 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
 
     if (!input.value && !isDisabled && authsCount === 1) {
         input.onChange(authName);
-    }
+    }*/
 
     return (
         <React.Fragment>
@@ -41,9 +42,6 @@ const AuthRadio = ({ label, input, authName, index, formOptions, applicationType
                 id={`${input.name}-${index}`}
                 isDisabled={isDisabled}
             />
-            {isDisabled && !disableAuthType && <FormHelperText isHidden={false} className="pf-m-disabled">
-                {application.display_name} does not support this authentication type.
-            </FormHelperText>}
             {disableAuthType && !isSelected && <FormHelperText isHidden={false} className="pf-m-disabled">
                 You cannot change the authtype, when editing.
             </FormHelperText>}

--- a/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
@@ -1,0 +1,41 @@
+import { nextStep } from '../../addSourceWizard/SourceAddSchema';
+
+describe('Add source schema', () => {
+    describe('nextStep', () => {
+        const OPENSHIFT = 'openshift';
+        const APP_ID = '666';
+        let formState = {
+            values: {
+                source_type: OPENSHIFT
+            }
+        };
+
+        it('returns nextstep without selected app', () => {
+            expect(nextStep(formState)).toEqual(OPENSHIFT);
+        });
+
+        it('returns nextstep with selected app', () => {
+            formState = {
+                values: {
+                    ...formState.values,
+                    application: {
+                        application_type_id: APP_ID
+                    }
+                }
+            };
+
+            expect(nextStep(formState)).toEqual(`${OPENSHIFT}-${APP_ID}`);
+        });
+
+        it('returns nextstep with empty application', () => {
+            formState = {
+                values: {
+                    ...formState.values,
+                    application: {}
+                }
+            };
+
+            expect(nextStep(formState)).toEqual(OPENSHIFT);
+        });
+    });
+});

--- a/packages/sources/src/tests/helpers/applicationTypes.js
+++ b/packages/sources/src/tests/helpers/applicationTypes.js
@@ -1,4 +1,4 @@
-export default [
+const applicationTypes = [
     {
         created_at: '2019-04-05T17:54:38Z',
         dependent_applications: [
@@ -27,7 +27,7 @@ export default [
         name: '/insights/platform/cost-management',
         supported_authentication_types: {
             azure: [
-                'username_password'
+                'tenant_id_client_id_client_secret'
             ],
             amazon: [
                 'arn'
@@ -53,7 +53,7 @@ export default [
         name: '/insights/platform/topological-inventory',
         supported_authentication_types: {
             azure: [
-                'username_password'
+                'tenant_id_client_id_client_secret'
             ],
             amazon: [
                 'access_key_secret_key'
@@ -74,3 +74,8 @@ export default [
         updated_at: '2019-09-23T14:04:02Z'
     }
 ];
+
+export default applicationTypes;
+
+export const COST_MANAGEMENT_APP = applicationTypes[1];
+export const TOPOLOGY_INV_APP = applicationTypes[2];

--- a/packages/sources/src/tests/helpers/sourceTypes.js
+++ b/packages/sources/src/tests/helpers/sourceTypes.js
@@ -1,4 +1,4 @@
-export default [
+const sourceTypes = [
     {
         created_at: '2019-03-26T14:05:45Z',
         icon_url: '/openshift_logo.png',
@@ -250,14 +250,14 @@ export default [
         product_name: 'Microsoft Azure',
         schema: {
             authentication: [{
-                type: 'access_key_secret_key',
-                name: 'Username and password',
+                type: 'tenant_id_client_id_client_secret',
+                name: 'Tenant ID, Client ID, Client Secret',
                 fields: [
                     {
                         component: 'text-field',
                         name: 'authentication.authtype',
                         hideField: true,
-                        initialValue: 'access_key_secret_key'
+                        initialValue: 'tenant_id_client_id_client_secret'
                     },
                     {
                         component: 'text-field',
@@ -294,3 +294,9 @@ export default [
         vendor: 'Azure'
     }
 ];
+
+export default sourceTypes;
+
+export const AMAZON_TYPE = sourceTypes[1];
+export const OPENSHIFT_TYPE = sourceTypes[0];
+export const AZURE_TYPE = sourceTypes[7];

--- a/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
@@ -4,8 +4,6 @@ import { Radio, FormHelperText } from '@patternfly/react-core';
 
 import AuthSelect from '../../../sourceFormRenderer/components/AuthSelect';
 import FieldProvider from '../../__mocks__/FieldProvider';
-import applicationTypes from '../../helpers/applicationTypes';
-import sourceTypes from '../../helpers/sourceTypes';
 
 describe('AuthSelect component', () => {
     let initialProps;
@@ -14,25 +12,14 @@ describe('AuthSelect component', () => {
     beforeEach(() => {
         spyOnChange = jest.fn();
         initialProps = {
-            applicationTypes,
-            sourceTypes,
             FieldProvider,
             input: {
                 name: 'auth-select',
                 onChange: spyOnChange
             },
-            formOptions: {
-                getState: () => ({
-                    values: {
-                        source_type: 'amazon'
-                    }
-                })
-            },
             label: 'Test',
             name: 'auth-select',
-            authName: 'access_key_secret_key',
-            index: 0,
-            authsCount: 2
+            authName: 'access_key_secret_key'
         };
     });
 
@@ -64,33 +51,10 @@ describe('AuthSelect component', () => {
         expect(spyOnChange).toHaveBeenCalledWith(initialProps.authName);
     });
 
-    it('calls onChange after render, when only one authtype is available', () => {
-        const OPENSHIFT_FORM_OPTIONS = {
-            getState: () => ({
-                values: {
-                    source_type: 'openshift'
-                }
-            })
-        };
-        const OPENSHIFT_AUTH_NAME = 'token';
-
-        mount(<AuthSelect { ...initialProps } formOptions={OPENSHIFT_FORM_OPTIONS} authName={OPENSHIFT_AUTH_NAME} authsCount={1}/>);
-        expect(spyOnChange).toHaveBeenCalledWith(OPENSHIFT_AUTH_NAME);
-    });
-
-    it('renders correctly with unsupported application', () => {
+    it('renders correctly when editing', () => {
         initialProps = {
             ...initialProps,
-            formOptions: {
-                getState: () => ({
-                    values: {
-                        source_type: 'amazon',
-                        application: {
-                            application_type_id: '2'
-                        }
-                    }
-                })
-            }
+            disableAuthType: true
         };
         const wrapper = mount(<AuthSelect { ...initialProps }/>);
 
@@ -98,36 +62,14 @@ describe('AuthSelect component', () => {
         expect(wrapper.find(FormHelperText)).toHaveLength(1);
     });
 
-    it('reset the value when unsupported/not-existent auth type is selected', () => {
-        initialProps = {
-            ...initialProps,
-            input: {
-                ...initialProps.input,
-                value: 'username_password'
-            }
-        };
-        mount(<AuthSelect { ...initialProps }/>);
-
-        expect(spyOnChange).toHaveBeenCalledWith(undefined);
-    });
-
     it('reset the value when unsupported auth type for application is selected', () => {
         initialProps = {
             ...initialProps,
-            formOptions: {
-                getState: () => ({
-                    values: {
-                        source_type: 'amazon',
-                        application: {
-                            application_type_id: '2'
-                        }
-                    }
-                })
-            },
             input: {
                 ...initialProps.input,
                 value: 'access_key_secret_key'
-            }
+            },
+            supportedAuthTypes: [ 'arn' ]
         };
         mount(<AuthSelect { ...initialProps }/>);
 


### PR DESCRIPTION
**Description**

New steps for authentication when
- no application selected (generic fields)
- specific application (generic or specific fields)

It differs when
- only one available auth type => no selection
   - if it has custom steps and no generic fields, the first custom step is used instead of selection page
- multiple auth types => selection

![dynamicwizard](https://user-images.githubusercontent.com/32869456/68119576-58b8c680-ff03-11e9-805d-b1f4b56cd616.gif)

TODO:

- [x] tests
- [x] only one authtype with custom steps
- [x] authtype selection for applications
- [x] use newer DDF https://github.com/data-driven-forms/react-forms/pull/190