### PR TITLE
Adds rules to support ts and tsx files using ts-loader

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -34,6 +34,8 @@
         "sass-loader": "^7.1.0",
         "source-map-loader": "^0.2.4",
         "style-loader": "^0.23.1",
+        "ts-loader": "^6.2.1",
+        "webpack": "^4.41.2",
         "webpack-dev-server": "^3.4.1",
         "webpack-hot-client": "^4.1.1",
         "webpack-serve": "1.0.2",

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -7,9 +7,10 @@ module.exports = ({
     publicPath,
     appEntry,
     rootFolder,
-    https
+    https,
+    useTypescript
 } = {}) => {
-    return {
+    const config = {
         mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
         devtool: 'source-map',
         optimization: {
@@ -80,4 +81,16 @@ module.exports = ({
             add: app => app.use(convert(history({})))
         }
     };
+    if (useTypescript === true) {
+        config.module.rules.push({
+            test: /\.tsx?$/,
+            loader: 'ts-loader',
+            exclude: /(node_modules)/i
+        });
+        config.resolve = {
+            extensions: [ '.ts', '.tsx', '.js' ]
+        };
+    }
+
+    return config;
 };

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -7,10 +7,9 @@ module.exports = ({
     publicPath,
     appEntry,
     rootFolder,
-    https,
-    useTypescript
+    https
 } = {}) => {
-    const config = {
+    return {
         mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
         devtool: 'source-map',
         optimization: {
@@ -41,6 +40,10 @@ module.exports = ({
                 exclude: /(node_modules|bower_components)/i,
                 use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }, { loader: 'eslint-loader' }]
             }, {
+                test: /src\/.*\.tsx?$/,
+                loader: 'ts-loader',
+                exclude: /(node_modules)/i
+            }, {
                 test: /\.s?[ac]ss$/,
                 use: [
                     process.env.NODE_ENV === 'production' ? 'style-loader' : MiniCssExtractPlugin.loader,
@@ -62,6 +65,9 @@ module.exports = ({
                 }]
             }]
         },
+        resolve: {
+            extensions: [ '.ts', '.tsx', '.js', '.scss' ]
+        },
         devServer: {
             contentBase: `${rootFolder || ''}/dist`,
             hot: true,
@@ -81,16 +87,4 @@ module.exports = ({
             add: app => app.use(convert(history({})))
         }
     };
-    if (useTypescript === true) {
-        config.module.rules.push({
-            test: /\.tsx?$/,
-            loader: 'ts-loader',
-            exclude: /(node_modules)/i
-        });
-        config.resolve = {
-            extensions: [ '.ts', '.tsx', '.js' ]
-        };
-    }
-
-    return config;
 };


### PR DESCRIPTION
I was trying to add support for typescript into a copy of the starter-app and had to patch [1] some configuration from webpack to have it working.
I was working if it would make sense to have it here instead.

If this makes sense, i could write a README on how to use typescript with the starter-app or have a branch that uses typescript.

Note that this `module.rules[]` could be added by default to every project and shouldn't matter as long as there is no ts file. If there is one, it will be handled by `ts-loader` (fail if `ts-loader` is not installed, or missing a `tsconfig.json` file)

[1] https://github.com/josejulio/insights-frontend-starter-app/commit/c296da118f7d6fce6315689bfcdf9ce07c580e98#diff-15993b2c8c6dac58acfc99f3e39f91f4R17-R33
