### PR TITLE
Allow passing an object/component for Filters label prop

### DIFF
--- a/packages/components/src/Components/Filters/FilterDropdown.js
+++ b/packages/components/src/Components/Filters/FilterDropdown.js
@@ -82,7 +82,7 @@ FilterDropdown.propTypes = {
             )
         })
     ),
-    label: PropTypes.string
+    label: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ])
 };
 
 FilterDropdown.defaultProps = {

--- a/packages/components/src/Components/Filters/FilterDropdown.js
+++ b/packages/components/src/Components/Filters/FilterDropdown.js
@@ -82,7 +82,10 @@ FilterDropdown.propTypes = {
             )
         })
     ),
-    label: PropTypes.oneOfType([ PropTypes.string, PropTypes.object ])
+    label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
+    ])
 };
 
 FilterDropdown.defaultProps = {

--- a/packages/components/src/Components/Filters/FilterDropdown.test.js
+++ b/packages/components/src/Components/Filters/FilterDropdown.test.js
@@ -3,10 +3,6 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import FilterDropdown from './FilterDropdown';
 
-const TestComponent = () => {
-    return 'TestComponent';
-};
-
 describe('FilterDropdown component', () => {
     const defaultProps = {
         filters: {},
@@ -24,9 +20,9 @@ describe('FilterDropdown component', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('should render with an object/component as label', () => {
+    it('should render with a component as label', () => {
         const wrapper = shallow(
-            <FilterDropdown { ...defaultProps } label={ <TestComponent /> }/>
+            <FilterDropdown { ...defaultProps } label={ <React.Fragment /> }/>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/components/src/Components/Filters/FilterDropdown.test.js
+++ b/packages/components/src/Components/Filters/FilterDropdown.test.js
@@ -3,15 +3,30 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import FilterDropdown from './FilterDropdown';
 
+const TestComponent = () => {
+    return 'TestComponent';
+};
+
 describe('FilterDropdown component', () => {
+    const defaultProps = {
+        filters: {},
+        addFilter: jest.fn(),
+        removeFilter: jest.fn(),
+        filterCategories: [
+            { title: '', type: '', urlParam: '', values: [{ label: '', value: '' }] }
+        ]
+    };
+
     it('should render', () => {
         const wrapper = shallow(
-            <FilterDropdown
-                filters={ {} }
-                addFilter={ jest.fn() }
-                removeFilter={ jest.fn() }
-                filterCategories={ [{ title: '', type: '', urlParam: '', values: [{ label: '', value: '' }] }] }
-            />
+            <FilterDropdown { ...defaultProps }/>
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render with an object/component as label', () => {
+        const wrapper = shallow(
+            <FilterDropdown { ...defaultProps } label={ <TestComponent /> }/>
         );
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
+++ b/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
@@ -36,3 +36,40 @@ exports[`FilterDropdown component should render 1`] = `
   </div>
 </Dropdown>
 `;
+
+exports[`FilterDropdown component should render with an object/component as label 1`] = `
+<Dropdown
+  className="ins-c-filter__dropdown"
+  isOpen={false}
+  toggle={
+    <DropdownToggle
+      onToggle={[Function]}
+    >
+      <TestComponent />
+    </DropdownToggle>
+  }
+>
+  <div
+    className="pf-c-dropdown__menu-item"
+  >
+    <div
+      className="filterTitle"
+      key="0"
+    >
+      <FilterInput
+        addRemoveFilters={[Function]}
+        aria-label=""
+        className={null}
+        currentPage={null}
+        filters={Object {}}
+        id="0"
+        key="check00"
+        label=""
+        param=""
+        type=""
+        value=""
+      />
+    </div>
+  </div>
+</Dropdown>
+`;

--- a/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
+++ b/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
@@ -45,7 +45,7 @@ exports[`FilterDropdown component should render with an object/component as labe
     <DropdownToggle
       onToggle={[Function]}
     >
-      <TestComponent />
+      <React.Fragment />
     </DropdownToggle>
   }
 >

--- a/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
+++ b/packages/components/src/Components/Filters/__snapshots__/FilterDropdown.test.js.snap
@@ -37,7 +37,7 @@ exports[`FilterDropdown component should render 1`] = `
 </Dropdown>
 `;
 
-exports[`FilterDropdown component should render with an object/component as label 1`] = `
+exports[`FilterDropdown component should render with a component as label 1`] = `
 <Dropdown
   className="ins-c-filter__dropdown"
   isOpen={false}


### PR DESCRIPTION
In the compliancce frontend we pass an icon component as `label`<sup>[1]</sup>, which causes a prop validation error, as it is expecting a string. This adds objects as a valid prop type for label.

[1] https://github.com/RedHatInsights/compliance-frontend/blob/1531fb26ec0a67805d9c4d6b4e7a1526c4009e77/src/SmartComponents/SystemsComplianceFilter/SystemsComplianceFilter.js#L70