### PR TITLE
Remove semantic release packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -878,6 +878,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz",
+      "integrity": "sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
@@ -984,6 +994,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -4248,9 +4267,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.3.1.tgz",
-      "integrity": "sha512-uHMU0g/HsnDSJRNIj52MX/frNxbtYtmW/TJXtLC13sx+GLjGRGUc+vMwYqPovY1gEk6UmDTGEi31C9POpO9dLQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.3.4.tgz",
+      "integrity": "sha512-XjITNRA/oOpJ7BfHk/WaOHs1WniYBszTde/bwADjjk1Luacpxg87jbDQVVt/oA3Zlx+MelxACRIEuRiPC5gu8g==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^2.2.0",
@@ -12611,9 +12630,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
-      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -17543,9 +17562,9 @@
       "dev": true
     },
     "npm": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.12.0.tgz",
-      "integrity": "sha512-juj5VkB3/k+PWbJUnXD7A/8oc8zLusDnK/sV9PybSalsbOVOTIp5vSE0rz5rQ7BsmUgQS47f/L2GYQnWXaKgnQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.13.0.tgz",
+      "integrity": "sha512-zjSJ8zjk0cDBZXqTWbQ6+qOdm1m2k489YDFP60RQRUhOxT5LOBhl+cDtFlEXEIblcNjofmsZ/qQ/wzmn5frimQ==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.5",
@@ -17559,7 +17578,7 @@
         "byte-size": "^5.0.1",
         "cacache": "^12.0.3",
         "call-limit": "^1.1.1",
-        "chownr": "^1.1.2",
+        "chownr": "^1.1.3",
         "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.5.1",
@@ -17577,7 +17596,7 @@
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.2.1",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.2",
+        "graceful-fs": "^4.2.3",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.8.5",
         "iferr": "^1.0.2",
@@ -17590,7 +17609,7 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.4",
+        "libcipm": "^4.0.7",
         "libnpm": "^3.0.1",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
@@ -17624,23 +17643,23 @@
         "npm-install-checks": "^3.0.2",
         "npm-lifecycle": "^3.1.4",
         "npm-package-arg": "^6.1.1",
-        "npm-packlist": "^1.4.4",
+        "npm-packlist": "^1.4.6",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.2",
-        "npm-registry-fetch": "^4.0.0",
+        "npm-registry-fetch": "^4.0.2",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.5.8",
+        "pacote": "^9.5.9",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
         "query-string": "^6.8.2",
         "qw": "~1.0.1",
         "read": "~1.0.7",
-        "read-cmd-shim": "^1.0.4",
+        "read-cmd-shim": "^1.0.5",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.1.0",
         "read-package-tree": "^5.3.1",
@@ -17657,7 +17676,7 @@
         "sorted-union-stream": "~2.1.3",
         "ssri": "^6.0.1",
         "stringify-package": "^1.0.1",
-        "tar": "^4.4.12",
+        "tar": "^4.4.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
@@ -17665,7 +17684,7 @@
         "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.3.2",
+        "uuid": "^3.3.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^1.3.1",
@@ -17948,7 +17967,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -18594,7 +18613,7 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.8.6",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -18798,7 +18817,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.2",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true
         },
@@ -18899,7 +18918,7 @@
           "dev": true
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19153,7 +19172,7 @@
           }
         },
         "libcipm": {
-          "version": "4.0.4",
+          "version": "4.0.7",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19517,28 +19536,23 @@
           "bundled": true,
           "dev": true
         },
-        "minipass": {
-          "version": "2.3.3",
+        "minizlib": {
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
-            "yallist": {
-              "version": "3.0.2",
+            "minipass": {
+              "version": "2.9.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
             }
-          }
-        },
-        "minizlib": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -19728,7 +19742,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19757,7 +19771,7 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19766,7 +19780,15 @@
             "figgy-pudding": "^3.4.1",
             "lru-cache": "^5.1.1",
             "make-fetch-happen": "^5.0.0",
-            "npm-package-arg": "^6.1.0"
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "npm-run-path": {
@@ -19902,7 +19924,7 @@
           }
         },
         "pacote": {
-          "version": "9.5.8",
+          "version": "9.5.9",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -19938,7 +19960,7 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.3.5",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20171,7 +20193,7 @@
           }
         },
         "read-cmd-shim": {
-          "version": "1.0.4",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20643,7 +20665,7 @@
           }
         },
         "tar": {
-          "version": "4.4.12",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20657,7 +20679,7 @@
           },
           "dependencies": {
             "minipass": {
-              "version": "2.8.6",
+              "version": "2.9.0",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -20844,7 +20866,7 @@
           }
         },
         "uuid": {
-          "version": "3.3.2",
+          "version": "3.3.3",
           "bundled": true,
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -75,13 +75,8 @@
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
         "@babel/runtime": "^7.4.3",
-        "@khala/commit-analyzer-wildcard": "^2.2.1",
-        "@khala/npm-release-monorepo": "^2.2.2",
-        "@khala/wildcard-release-notes": "^2.2.1",
         "@octokit/rest": "^16.34.0",
         "@patternfly/patternfly": "^2.5.0",
-        "@semantic-release/git": "^6.0.2",
-        "@semantic-release/npm": "^5.1.9",
         "axios-mock-adapter": "^1.17.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-eslint": "^10.0.1",
@@ -118,13 +113,11 @@
         "mini-css-extract-plugin": "^0.4.2",
         "mkdirp": "^0.5.1",
         "node-sass": "^4.12.0",
-        "npmview": "0.0.4",
         "react-content-loader": "^3.4.1",
         "react-intl": "^2.9.0",
         "redux-mock-store": "^1.5.3",
         "sanitize-html": "^1.20.0",
         "sass-loader": "^7.1.0",
-        "semantic-release": "^15.13.24",
         "source-map-loader": "^0.2.4",
         "style-loader": "^0.21.0",
         "topojson": "^3.0.2",
@@ -147,19 +140,9 @@
         "coverage": "codecov",
         "prepare": "npm run bootstrap && npm run build",
         "playground": "lerna run --parallel start:dev",
-        "release": "semantic-release",
         "release:bot": "node ./config/release.js",
         "lint": "eslint config packages/**/src/",
         "watch": "lerna exec --parallel --ignore=@redhat-cloud-services/frontend-components-config --no-private -- npm run build -- --watch"
-    },
-    "release": {
-        "monorepo": "./packages",
-        "plugins": [
-            "@khala/commit-analyzer-wildcard",
-            "@khala/npm-release-monorepo",
-            "@khala/wildcard-release-notes",
-            "@semantic-release/github"
-        ]
     },
     "description": "Components for Red Hat Cloud Services",
     "repository": {


### PR DESCRIPTION
Since we are not using semantic release anymore let's remove it from root package (it had a bunch of vulnerabilities anyway).