### PR TITLE
Fix pagination and reloads of inventory

### DIFF
--- a/packages/inventory/src/InventoryList.js
+++ b/packages/inventory/src/InventoryList.js
@@ -16,7 +16,7 @@ class ContextInventoryList extends React.Component {
     loadEntities = (options = {}, reload = true) => {
         const { page, perPage, onRefresh, items, hasItems, sortBy, activeFilters } = this.props;
         options = {
-            page: options.page || page,
+            page: hasItems ? 1 : options.page || page,
             // eslint-disable-next-line camelcase
             per_page: options.per_page || perPage,
             orderBy: sortBy && sortBy.key,
@@ -50,12 +50,8 @@ class ContextInventoryList extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { items, hasItems, sortBy, perPage, page } = this.props;
-        if (hasItems &&
-            (JSON.stringify(items) !== JSON.stringify(prevProps.items)) ||
-            (perPage !== prevProps.perPage) ||
-            (page !== prevProps.page)
-        ) {
+        const { items, hasItems, sortBy } = this.props;
+        if (hasItems && (JSON.stringify(items) !== JSON.stringify(prevProps.items))) {
             this.loadEntities({}, false);
         } else if (!hasItems && JSON.stringify(prevProps.sortBy) !== JSON.stringify(sortBy)) {
             this.loadEntities({}, false);


### PR DESCRIPTION
There is a bug in inventory when changing page on embeded inventory no request is called becasue wrong page is used (we want to use first page for embeded inventory everytime)

Also there is long running bug that whenever user changes page two consequent requests are fired. That was caused by wrong check for changes, firstly it was triggered by inner code and second one was triggered by page change.