### PR TITLE
Compare previous values in order to properly render selected in ConditionalFilter

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Checkbox.js
+++ b/packages/components/src/Components/ConditionalFilter/Checkbox.js
@@ -2,11 +2,21 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import Text from './Text';
+import isEqual from 'lodash/isEqual';
 
 class Checkbox extends Component {
     state = {
         isExpanded: false,
         selected: []
+    }
+
+    componentDidUpdate({ value: prevSelected }) {
+        const { value } = this.props;
+        if (!isEqual(prevSelected, value)) {
+            this.setState({
+                selected: value
+            });
+        }
     }
 
     onToggle = isExpanded => {

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Select, SelectOption, SelectVariant, SelectGroup, Radio, Checkbox } from '@patternfly/react-core';
 import Text from './Text';
+import isEqual from 'lodash/isEqual';
 
 export const groupType = {
     checkbox: 'checkbox',
@@ -23,6 +24,15 @@ class Group extends Component {
         });
     };
 
+    componentDidUpdate({ selected: prevSelected }) {
+        const { selected } = this.props;
+        if (!isEqual(prevSelected, selected)) {
+            this.setState({
+                selected
+            });
+        }
+    }
+
     mapItems = ({ groupValue, onSelect, groupLabel, groupId, type, items, ...group }, groupKey) => {
         return items.filter(item =>
             (groupValue && this.state.filterBy.test(groupValue)) ||
@@ -35,6 +45,11 @@ class Group extends Component {
                 key={id || key}
                 value={String(value || id || key)}
                 onClick={e => {
+                    if (e.target.tagName === 'LABEL') {
+                        e.preventDefault();
+                        e.stopPropagation();
+                    }
+
                     const clickedGroup = {
                         value: groupValue,
                         label: groupLabel,


### PR DESCRIPTION
### Changes
* none

### Fixes
* When clearing all values from checkbox or group usually empty array or object is sent. This is calculated as no values and state value is used (previously selected) so we have to check if previous value differs from current and if so update state to it.