### PR TITLE
[RHICOMPL-420] - Re-enable search by references on Compliance

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -48,6 +48,10 @@ query System($systemId: String!){
                 description
                 compliant(systemId: $systemId)
                 remediationAvailable
+                references {
+                    label
+                    href
+                }
                 identifier {
                     label
                     system

--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -36,10 +36,10 @@ query System($systemId: String!){
         profiles {
             name
             refId
-            compliant(systemId: $systemId)
-            rulesFailed(systemId: $systemId)
-            rulesPassed(systemId: $systemId)
-            lastScanned(systemId: $systemId)
+            compliant
+            rulesFailed
+            rulesPassed
+            lastScanned
             rules(systemId: $systemId) {
                 title
                 severity

--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -40,22 +40,16 @@ query System($systemId: String!){
             rulesFailed
             rulesPassed
             lastScanned
-            rules(systemId: $systemId) {
+            rules {
                 title
                 severity
                 rationale
                 refId
                 description
-                compliant(systemId: $systemId)
+                compliant
                 remediationAvailable
-                references {
-                    label
-                    href
-                }
-                identifier {
-                    label
-                    system
-                }
+                references
+                identifier
             }
         }
     }

--- a/packages/inventory-compliance/src/Fixtures.js
+++ b/packages/inventory-compliance/src/Fixtures.js
@@ -32,11 +32,11 @@ export const profileRules = [
                 refId: 'xccdf_org.ssgproject.content_rule_docker_storage_configured',
                 description: 'foodescription',
                 compliant: true,
-                identifier: {
+                identifier: JSON.stringify({
                     label: 'CCE-80441-9',
                     system: 'https://nvd.nist.gov/cce/index.cfm'
-                },
-                references: []
+                }),
+                references: JSON.stringify([])
             },
             {
                 title: 'Enable the Docker service',
@@ -45,11 +45,11 @@ export const profileRules = [
                 refId: 'xccdf_org.ssgproject.content_rule_service_docker_enabled',
                 description: 'foodescription',
                 compliant: true,
-                identifier: {
+                identifier: JSON.stringify({
                     label: 'CCE-80440-1',
                     system: 'https://nvd.nist.gov/cce/index.cfm'
-                },
-                references: []
+                }),
+                references: JSON.stringify([])
             },
             {
                 title: 'Disable At Service (atd)',

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -228,8 +228,8 @@ class SystemRulesTable extends React.Component {
     )
 
     referencesList = (references) => references.reduce((acc, reference, i) => ([
-        acc, ', ', this.conditionalLink(reference.label, reference.href, { target: '_blank', key: i + 1 })
-    ]), this.conditionalLink(references[0].label, references[0].href, { target: '_blank', key: 0 }));
+        acc, i !== 0 ? ', ' : '', this.conditionalLink(reference.label, reference.href, { target: '_blank', key: i + 1 })
+    ]), []);
 
     calculateChild = ({ description, rationale, identifier, references }, key) => ({
         parent: key * 2,
@@ -520,7 +520,7 @@ class SystemRulesTable extends React.Component {
                                         updateFilter={ this.updateFilter } />
                                     <SimpleTableFilter buttonTitle={ null }
                                         onFilterChange={ this.handleSearch }
-                                        placeholder="Search by name or identifier" />
+                                        placeholder="Search by name, identifer, or reference" />
                                 </InputGroup>
                             </LevelItem>
                             <LevelItem>

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -3,9 +3,8 @@ import propTypes from 'prop-types';
 import ComplianceRemediationButton from './ComplianceRemediationButton';
 import { CheckIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SimpleTableFilter, TableToolbar } from '@redhat-cloud-services/frontend-components';
-import { Table, TableHeader, TableBody, sortable, SortByDirection } from '@patternfly/react-table';
+import { Table, TableHeader, TableBody, SortByDirection } from '@patternfly/react-table';
 import {
-    Checkbox,
     InputGroup,
     Level,
     LevelItem,
@@ -32,30 +31,25 @@ import {
     SEVERITY_COLUMN,
     POLICY_COLUMN,
     TITLE_COLUMN,
-    ANSIBLE_ICON,
     HIGH_SEVERITY,
     MEDIUM_SEVERITY,
     LOW_SEVERITY
 } from './Constants';
 
 class SystemRulesTable extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            columns: props.columns,
-            page: 1,
-            itemsPerPage: props.itemsPerPage,
-            rows: [],
-            hidePassed: props.hidePassed,
-            severity: [],
-            policy: [],
-            currentRows: [],
-            refIds: {},
-            profiles: {},
-            sortBy: {}
-        };
-
-    }
+    state = {
+        columns: this.props.columns,
+        page: 1,
+        itemsPerPage: this.props.itemsPerPage,
+        rows: [],
+        hidePassed: this.props.hidePassed,
+        severity: [],
+        policy: [],
+        currentRows: [],
+        refIds: {},
+        profiles: {},
+        sortBy: {}
+    };
 
     removeRefIdPrefix = (refId) => {
         const splitRefId = refId.toLowerCase().split('xccdf_org.ssgproject.content_profile_')[1];
@@ -228,48 +222,54 @@ class SystemRulesTable extends React.Component {
     )
 
     referencesList = (references) => references.reduce((acc, reference, i) => ([
-        acc, i !== 0 ? ', ' : '', this.conditionalLink(reference.label, reference.href, { target: '_blank', key: i + 1 })
-    ]), []);
+        ...acc,
+        i !== 0 ? ', ' : '',
+        this.conditionalLink(reference.label, reference.href, { target: '_blank', key: i + 1 })
+    ]), [])
 
-    calculateChild = ({ description, rationale, identifier, references }, key) => ({
-        parent: key * 2,
-        cells: [{
-            originalIdentifier: identifier ? identifier.label : '',
-            originalReferences: references && references.length ? references.map((r) => r.label).join() : '',
-            title: (
-                <React.Fragment key={ key }>
-                    <div className='margin-top-lg'>
-                        <Stack id={ `rule-description-${key}` } className='margin-bottom-lg'>
-                            <StackItem style={ { marginBottom: 'var(--pf-global--spacer--sm)' } }>
-                                <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Description</b></Text>
-                            </StackItem>
-                            <StackItem isFilled>{ description }</StackItem>
-                        </Stack>
-                        <Stack id={ `rule-identifiers-references-${key}` } className='margin-bottom-lg'>
-                            <Grid>
-                                { identifier && <GridItem span={ 2 }>
-                                    <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Identifier</b></Text>
-                                    <Text>{ this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
-                                </GridItem> }
+    calculateChild = ({ description, rationale, identifier: JSONidentifier, references: JSONreferences }, key) => {
+        const references = JSON.parse(JSONreferences);
+        const identifier = JSON.parse(JSONidentifier);
+        return {
+            parent: key * 2,
+            cells: [{
+                originalIdentifier: identifier ? identifier.label : '',
+                originalReferences: references && references.length ? references.map((r) => r.label).join() : '',
+                title: (
+                    <React.Fragment key={ key }>
+                        <div className='margin-top-lg'>
+                            <Stack id={ `rule-description-${key}` } className='margin-bottom-lg'>
+                                <StackItem style={ { marginBottom: 'var(--pf-global--spacer--sm)' } }>
+                                    <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Description</b></Text>
+                                </StackItem>
+                                <StackItem isFilled>{ description }</StackItem>
+                            </Stack>
+                            <Stack id={ `rule-identifiers-references-${key}` } className='margin-bottom-lg'>
+                                <Grid>
+                                    { identifier && <GridItem span={ 2 }>
+                                        <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Identifier</b></Text>
+                                        <Text>{ this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
+                                    </GridItem> }
 
-                                { references && references.length > 0 ? <GridItem span={ 10 }>
-                                    <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>References</b></Text>
-                                    <Text>{ this.referencesList(references) }</Text>
-                                </GridItem> : '' }
-                            </Grid>
-                        </Stack>
-                        { rationale &&
-                        <Stack id={ `rule-rationale-${key}` } style={ { marginBottom: 'var(--pf-global--spacer--lg)' } }>
-                            <StackItem style={ { marginBottom: 'var(--pf-global--spacer--sm)' } }>
-                                <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Rationale</b></Text>
-                            </StackItem>
-                            <StackItem isFilled>{ rationale }</StackItem>
-                        </Stack>
-                        }
-                    </div>
-                </React.Fragment>
-            ) }]
-    })
+                                    { references && references.length > 0 ? <GridItem span={ 10 }>
+                                        <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>References</b></Text>
+                                        <Text>{ this.referencesList(references) }</Text>
+                                    </GridItem> : '' }
+                                </Grid>
+                            </Stack>
+                            { rationale &&
+                            <Stack id={ `rule-rationale-${key}` } style={ { marginBottom: 'var(--pf-global--spacer--lg)' } }>
+                                <StackItem style={ { marginBottom: 'var(--pf-global--spacer--sm)' } }>
+                                    <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>Rationale</b></Text>
+                                </StackItem>
+                                <StackItem isFilled>{ rationale }</StackItem>
+                            </Stack>
+                            }
+                        </div>
+                    </React.Fragment>
+                ) }]
+        };
+    }
 
     rulesToRows = (profileRules) => {
         const refIds = {};

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -179,7 +179,7 @@ class SystemRulesTable extends React.Component {
             let tableHeader;
 
             if (column.title === 'Rule') {
-                tableHeader = { title: this.ruleTitleCell(title, identifier), original: title };
+                tableHeader = { title: this.ruleTitleCell(title, JSON.parse(identifier)), original: title };
             } else if (column.title === 'Policy') {
                 tableHeader = { title: profile.name, original: profile.name };
             } else if (column.title === 'Severity') {
@@ -228,13 +228,13 @@ class SystemRulesTable extends React.Component {
     ]), [])
 
     calculateChild = ({ description, rationale, identifier: JSONidentifier, references: JSONreferences }, key) => {
-        const references = JSON.parse(JSONreferences);
-        const identifier = JSON.parse(JSONidentifier);
+        const references = JSONreferences && JSONreferences.length && JSON.parse(JSONreferences);
+        const identifier = JSONidentifier && JSON.parse(JSONidentifier);
         return {
             parent: key * 2,
             cells: [{
                 originalIdentifier: identifier ? identifier.label : '',
-                originalReferences: references && references.length ? references.map((r) => r.label).join() : '',
+                originalReferences: references ? references.map((r) => r.label).join() : '',
                 title: (
                     <React.Fragment key={ key }>
                         <div className='margin-top-lg'>
@@ -251,7 +251,7 @@ class SystemRulesTable extends React.Component {
                                         <Text>{ this.conditionalLink(identifier.label, identifier.system, { target: '_blank' }) }</Text>
                                     </GridItem> }
 
-                                    { references && references.length > 0 ? <GridItem span={ 10 }>
+                                    { references ? <GridItem span={ 10 }>
                                         <Text className='pf-c-form__label' component={ TextVariants.h5 }><b>References</b></Text>
                                         <Text>{ this.referencesList(references) }</Text>
                                     </GridItem> : '' }

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -243,7 +243,19 @@ exports[`SystemRulesTable component should render 1`] = `
                           </a>
                         </Text>
                       </GridItem>
-
+                      <GridItem
+                        span={10}
+                      >
+                        <Text
+                          className="pf-c-form__label"
+                          component="h5"
+                        >
+                          <b>
+                            References
+                          </b>
+                        </Text>
+                        <Text />
+                      </GridItem>
                     </Grid>
                   </Stack>
                   <Stack
@@ -395,7 +407,19 @@ exports[`SystemRulesTable component should render 1`] = `
                           </a>
                         </Text>
                       </GridItem>
-
+                      <GridItem
+                        span={10}
+                      >
+                        <Text
+                          className="pf-c-form__label"
+                          component="h5"
+                        >
+                          <b>
+                            References
+                          </b>
+                        </Text>
+                        <Text />
+                      </GridItem>
                     </Grid>
                   </Stack>
                   <Stack
@@ -442,7 +466,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable At Service (atd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -519,7 +543,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-2"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -566,7 +590,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Network Router Discovery Daemon (rdisc)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -643,7 +667,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-3"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -690,7 +714,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Odd Job Daemon (oddjobd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -767,7 +791,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-4"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -814,7 +838,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Apache Qpid (qpidd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -891,7 +915,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-5"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -938,7 +962,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Automatic Bug Reporting Tool (abrtd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -1015,7 +1039,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-6"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -1062,7 +1086,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable ntpdate Service (ntpdate)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -1139,7 +1163,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-7"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -1186,7 +1210,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Ensure auditd Collects Information on Kernel Module Loading and Unloading
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -1263,7 +1287,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-8"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -1310,7 +1334,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Record Attempts to Alter Time Through stime
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -1387,7 +1411,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-9"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -1622,7 +1646,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
             onButtonClick={[Function]}
             onFilterChange={[Function]}
             onOptionSelect={[Function]}
-            placeholder="Search by name or identifier"
+            placeholder="Search by name, identifer, or reference"
             searchIcon={true}
           />
         </InputGroup>
@@ -1821,7 +1845,19 @@ exports[`SystemRulesTable component should render without remediations if prop p
                           </a>
                         </Text>
                       </GridItem>
-
+                      <GridItem
+                        span={10}
+                      >
+                        <Text
+                          className="pf-c-form__label"
+                          component="h5"
+                        >
+                          <b>
+                            References
+                          </b>
+                        </Text>
+                        <Text />
+                      </GridItem>
                     </Grid>
                   </Stack>
                   <Stack
@@ -1973,7 +2009,19 @@ exports[`SystemRulesTable component should render without remediations if prop p
                           </a>
                         </Text>
                       </GridItem>
-
+                      <GridItem
+                        span={10}
+                      >
+                        <Text
+                          className="pf-c-form__label"
+                          component="h5"
+                        >
+                          <b>
+                            References
+                          </b>
+                        </Text>
+                        <Text />
+                      </GridItem>
                     </Grid>
                   </Stack>
                   <Stack
@@ -2020,7 +2068,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable At Service (atd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2097,7 +2145,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-2"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2144,7 +2192,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Network Router Discovery Daemon (rdisc)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2221,7 +2269,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-3"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2268,7 +2316,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Odd Job Daemon (oddjobd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2345,7 +2393,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-4"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2392,7 +2440,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Apache Qpid (qpidd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2469,7 +2517,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-5"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2516,7 +2564,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Automatic Bug Reporting Tool (abrtd)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2593,7 +2641,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-6"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2640,7 +2688,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable ntpdate Service (ntpdate)
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2717,7 +2765,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-7"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2764,7 +2812,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Ensure auditd Collects Information on Kernel Module Loading and Unloading
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2841,7 +2889,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-8"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack
@@ -2888,7 +2936,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Record Attempts to Alter Time Through stime
                 </StackItem>
-
+                
               </Stack>,
             },
             Object {
@@ -2965,7 +3013,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-9"
                   >
                     <Grid>
-
+                      
                     </Grid>
                   </Stack>
                   <Stack

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -30,7 +30,7 @@ exports[`SystemRulesTable component should render 1`] = `
             onButtonClick={[Function]}
             onFilterChange={[Function]}
             onOptionSelect={[Function]}
-            placeholder="Search by name or identifier"
+            placeholder="Search by name, identifer, or reference"
             searchIcon={true}
           />
         </InputGroup>
@@ -243,7 +243,7 @@ exports[`SystemRulesTable component should render 1`] = `
                           </a>
                         </Text>
                       </GridItem>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -395,7 +395,7 @@ exports[`SystemRulesTable component should render 1`] = `
                           </a>
                         </Text>
                       </GridItem>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -442,7 +442,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable At Service (atd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -519,7 +519,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-2"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -566,7 +566,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Network Router Discovery Daemon (rdisc)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -643,7 +643,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-3"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -690,7 +690,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Odd Job Daemon (oddjobd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -767,7 +767,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-4"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -814,7 +814,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Apache Qpid (qpidd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -891,7 +891,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-5"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -938,7 +938,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable Automatic Bug Reporting Tool (abrtd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -1015,7 +1015,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-6"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -1062,7 +1062,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Disable ntpdate Service (ntpdate)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -1139,7 +1139,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-7"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -1186,7 +1186,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Ensure auditd Collects Information on Kernel Module Loading and Unloading
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -1263,7 +1263,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-8"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -1310,7 +1310,7 @@ exports[`SystemRulesTable component should render 1`] = `
                 <StackItem>
                   Record Attempts to Alter Time Through stime
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -1387,7 +1387,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     id="rule-identifiers-references-9"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -1821,7 +1821,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                           </a>
                         </Text>
                       </GridItem>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -1973,7 +1973,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                           </a>
                         </Text>
                       </GridItem>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2020,7 +2020,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable At Service (atd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2097,7 +2097,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-2"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2144,7 +2144,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Network Router Discovery Daemon (rdisc)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2221,7 +2221,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-3"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2268,7 +2268,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Odd Job Daemon (oddjobd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2345,7 +2345,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-4"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2392,7 +2392,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Apache Qpid (qpidd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2469,7 +2469,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-5"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2516,7 +2516,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable Automatic Bug Reporting Tool (abrtd)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2593,7 +2593,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-6"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2640,7 +2640,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Disable ntpdate Service (ntpdate)
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2717,7 +2717,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-7"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2764,7 +2764,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Ensure auditd Collects Information on Kernel Module Loading and Unloading
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2841,7 +2841,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-8"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack
@@ -2888,7 +2888,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                 <StackItem>
                   Record Attempts to Alter Time Through stime
                 </StackItem>
-                
+
               </Stack>,
             },
             Object {
@@ -2965,7 +2965,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     id="rule-identifiers-references-9"
                   >
                     <Grid>
-                      
+
                     </Grid>
                   </Stack>
                   <Stack


### PR DESCRIPTION
Given the amount of rules we load now is much smaller than before, and we don't have to wait for a 2nd request to get `remediation_available`, it seems that we can turn back on this feature.  

![Peek 2019-11-15 18-02](https://user-images.githubusercontent.com/598891/68961247-3b70db80-07d2-11ea-82e4-2b9d02fec8a1.gif)
