### PR TITLE
Remove copy webpack plugin

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,7 +20,6 @@
         "babel-loader": "^8.0.6",
         "clean-webpack-plugin": "^2.0.2",
         "connect-history-api-fallback": "^1.6.0",
-        "copy-webpack-plugin": "^5.0.3",
         "css-loader": "^2.1.1",
         "eslint-loader": "^2.2.1",
         "file-loader": "^3.0.1",

--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -24,7 +24,6 @@ module.exports = ({
     rootFolder,
     appDeployment,
     htmlPlugin,
-    copyPlugin,
     replacePlugin
 } = {}) => {
     const HtmlWebpackPlugin = new(require('html-webpack-plugin'))({
@@ -33,10 +32,6 @@ module.exports = ({
         template: `${rootFolder || ''}/src/index.html`,
         ...htmlPlugin || {}
     });
-    const CopyFilesWebpackPlugin = new(require('copy-webpack-plugin'))([
-        { from: `${rootFolder || ''}/static/images`, to: 'images' },
-        ...copyPlugin || []
-    ]);
 
     const HtmlReplaceWebpackPlugin = new(require('html-replace-webpack-plugin'))([
         {
@@ -53,7 +48,6 @@ module.exports = ({
         ExtractCssWebpackPlugin,
         CleanWebpackPlugin,
         HtmlWebpackPlugin,
-        CopyFilesWebpackPlugin,
         HtmlReplaceWebpackPlugin,
         WebpackHotModuleReplacement
     ];

--- a/packages/config/src/plugins.test.js
+++ b/packages/config/src/plugins.test.js
@@ -1,46 +1,25 @@
 import plugins from './plugins';
 
 const HTML_WEBPACK = 5;
-const COPYFILES = 6;
-const REPLACE = 7;
+const REPLACE = 6;
 
 describe('plugins generations, no option', () => {
     const enabledPlugins = plugins();
 
     it('should generate plugins', () => {
-        expect(enabledPlugins.length).toBe(9);
+        expect(enabledPlugins.length).toBe(8);
     });
 
     it('should generate correct template path for HtmlWebpackPlugin', () => {
         expect(enabledPlugins[HTML_WEBPACK].options.template).toBe('/src/index.html');
     });
-
-    it('should generate correct patterns for CopyFilesWebpackPlugin', () => {
-        expect(enabledPlugins[COPYFILES].patterns[0]).toEqual({
-            from: '/static/images',
-            to: 'images'
-        });
-    });
 });
 
-/*
-rootFolder,
-appDeployment
-    htmlPlugin,
-    copyPlugin,
-    replacePlugin*/
 describe('rootFolder', () => {
     const enabledPlugins = plugins({ rootFolder: '/test/folder' });
 
     it('should generate correct template path for HtmlWebpackPlugin', () => {
         expect(enabledPlugins[HTML_WEBPACK].options.template).toBe('/test/folder/src/index.html');
-    });
-
-    it('should generate correct patterns for CopyFilesWebpackPlugin', () => {
-        expect(enabledPlugins[COPYFILES].patterns[0]).toEqual({
-            from: '/test/folder/static/images',
-            to: 'images'
-        });
     });
 });
 
@@ -58,11 +37,6 @@ describe('appDeployment', () => {
 it('htmlPlugin should update', () => {
     const enabledPlugins = plugins({ htmlPlugin: { title: 'myTitle' } });
     expect(enabledPlugins[HTML_WEBPACK].options.title).toBe('myTitle');
-});
-
-it('copyPlugin should update', () => {
-    const enabledPlugins = plugins({ copyPlugin: [{}] });
-    expect(enabledPlugins[COPYFILES].patterns.length).toBe(2);
 });
 
 it('replacePlugin should update', () => {


### PR DESCRIPTION
For some reasons copy webpack plugin is failing our tests, we don't really use it anymore so no need to have it there at all.