### PR TITLE
Fix the request payload when PATCHing source on cost management

### DIFF
--- a/packages/sources/src/api/createSource.js
+++ b/packages/sources/src/api/createSource.js
@@ -72,7 +72,7 @@ export const doCreateSource = async (formData, sourceTypes) => {
         if (formData.credentials || formData.billing_source) {
             const { credentials, billing_source } = formData;
             let data = {};
-            data = credentials ? { credentials } : {};
+            data = credentials ? { authentication: { credentials } } : {};
             data = billing_source ? { ...data, billing_source } : data;
             await patchSource({ id: sourceDataOut.id, ...data });
         }

--- a/packages/sources/src/tests/api/createSource.test.js
+++ b/packages/sources/src/tests/api/createSource.test.js
@@ -368,7 +368,9 @@ describe('doCreateSource', () => {
                         storage_account: 'sa'
                     }
                 },
-                credentials: 'MY_CREDS_1'
+                authentication: {
+                    credentials: 'MY_CREDS_1'
+                }
             };
 
             api.getSourcesApi = () => mocks;


### PR DESCRIPTION
This patch fixes a mistake in the payload that is sent to cost management when a new Azure source is created.

The credentials data should be under authentication and not the root.

//cc @dccurtis @rvsia 