### PR TITLE
PATCH cost management source after authentication was created

### DIFF
--- a/packages/sources/src/api/createSource.js
+++ b/packages/sources/src/api/createSource.js
@@ -69,14 +69,6 @@ export const doCreateSource = async (formData, sourceTypes) => {
 
         const [ endpointDataOut, applicationDataOut ] = await Promise.all(promises);
 
-        if (formData.credentials || formData.billing_source) {
-            const { credentials, billing_source } = formData;
-            let data = {};
-            data = credentials ? { authentication: { credentials } } : {};
-            data = billing_source ? { ...data, billing_source } : data;
-            await patchSource({ id: sourceDataOut.id, ...data });
-        }
-
         if (endpointDataOut) {
             const authenticationData = {
                 ...formData.authentication,
@@ -85,6 +77,14 @@ export const doCreateSource = async (formData, sourceTypes) => {
             };
 
             await getSourcesApi().createAuthentication(authenticationData);
+        }
+
+        if (formData.credentials || formData.billing_source) {
+            const { credentials, billing_source } = formData;
+            let data = {};
+            data = credentials ? { authentication: { credentials } } : {};
+            data = billing_source ? { ...data, billing_source } : data;
+            await patchSource({ id: sourceDataOut.id, ...data });
         }
 
         return {


### PR DESCRIPTION
**Note**: This is a workaround till Cost Management fixes a case where "Authentication.create" event was sent but it wasn't handled on their side.

This is necessary because only after the authentication is created cost management is able to get credentials data like:
 - tenant id
 - client id
 - client secret

which most of the time fixes the "Missing credentials key" error when later updating the source again.

//cc @rvsia @dccurtis @maskarb