### PR TITLE
Hook tag filtering to real API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3757,9 +3757,9 @@
       "integrity": "sha512-30OuHWE+ik3SsL9qTc+22ziVlW9PjcVItJtXVAzCr1oqo4UUqTj8tU4oyvKaI8cbpS8wRKa7o+sqc/s0Eq/BmA=="
     },
     "@redhat-cloud-services/host-inventory-client": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.39.tgz",
-      "integrity": "sha512-HIEdi6n4sG1NQyB8vkqXd04RlFYsMfUtt+1/UhKYU6IN024EM0s0mWC5kl+fKM4Mi8qmd5I/O/Ee1utS9o5DRw==",
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.0.48.tgz",
+      "integrity": "sha512-RXAeYUDQogHQ5vlmQQUVm6pwozLs3fnpx+LF2iQGXBNljiWDjSaas30KOXgi2y+NT+u5UG8uRo8d6RrHy/ZXgg==",
       "requires": {
         "axios": "^0.19.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@patternfly/react-core": "3.115.2",
         "@patternfly/react-icons": "^3.14.8",
         "@patternfly/react-table": "2.23.8",
-        "@redhat-cloud-services/host-inventory-client": "1.0.39",
+        "@redhat-cloud-services/host-inventory-client": "1.0.48",
         "abortcontroller-polyfill": "^1.2.1",
         "apollo-boost": "^0.1.23",
         "axios": "^0.19.0",

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -16,7 +16,7 @@ class Group extends Component {
         selected: {},
         filterBy: ''
     }
-s
+
     onToggle = isExpanded => {
         this.setState({
             isExpanded

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -126,7 +126,9 @@ class Group extends Component {
         const { selected: propSelected } = this.props;
         const activeGroup = selected[groupKey] || propSelected[groupKey];
         if (activeGroup) {
-            if (type !== groupType.radio && activeGroup[itemKey]) {
+            if (type !== groupType.radio && (
+                activeGroup[itemKey] instanceof Object ? activeGroup[itemKey].isSelected : Boolean(activeGroup[itemKey])
+            )) {
                 return {
                     ...propSelected,
                     ...selected,
@@ -182,7 +184,9 @@ class Group extends Component {
             return false;
         }
 
-        return Boolean(selected[groupValue][itemValue]);
+        return selected[groupValue][itemValue] instanceof Object ?
+            selected[groupValue][itemValue].isSelected :
+            Boolean(selected[groupValue][itemValue]);
     }
 
     customFilter = (e) => {
@@ -260,7 +264,12 @@ const itemsProps = PropTypes.arrayOf(
 Group.propTypes = {
     selected: PropTypes.shape({
         [PropTypes.string]: PropTypes.shape({
-            [PropTypes.string]: PropTypes.bool
+            [PropTypes.string]: PropTypes.oneOfType([
+                PropTypes.bool,
+                PropTypes.shape({
+                    isSelected: PropTypes.bool
+                })
+            ])
         })
     }),
     onChange: PropTypes.func,

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -45,7 +45,7 @@ class Group extends Component {
                 key={id || key}
                 value={String(value || id || key)}
                 onClick={e => {
-                    if (e.target.tagName === 'LABEL') {
+                    if (e.target.tagName !== 'INPUT') {
                         e.preventDefault();
                         e.stopPropagation();
                     }
@@ -214,7 +214,7 @@ class Group extends Component {
                                 {...group}
                                 key={groupId || groupValue || groupKey}
                                 label={groupLabel}
-                                id={groupId || `groups-${groupValue || groupKey}`}
+                                id={groupId || `group-${groupValue || groupKey}`}
                             > {filteredItems} </SelectGroup>
                             : <Fragment/>;
                     })

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -214,12 +214,12 @@ class Group extends Component {
                                 {...group}
                                 key={groupId || groupValue || groupKey}
                                 label={groupLabel}
-                                id={groupId || `group-${groupValue || groupKey}`}
+                                id={groupId || `groups-${groupValue || groupKey}`}
                             > {filteredItems} </SelectGroup>
                             : <Fragment/>;
                     })
                 ) : (
-                    this.mapItems({ items }).length > 0 || <Fragment/>
+                    this.mapItems({ items })
                 ) }
             </Select> }
         </Fragment>);

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
@@ -19,6 +19,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
     aria-label="Select Input"
     isExpanded={false}
     isGrouped={true}
+    onClear={[Function]}
     onSelect={[Function]}
     onToggle={[Function]}
     placeholderText="some placeholder"
@@ -28,6 +29,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       id="group-0"
       key="0"
       label="First value"
+      value={0}
     >
        
       <SelectOption
@@ -70,6 +72,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       id="group-second"
       key="second"
       label="Second value"
+      value="second"
     >
        
       <SelectOption
@@ -130,6 +133,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       id="group-third"
       key="third"
       label="Third value"
+      value="third"
     >
        
       <SelectOption
@@ -198,6 +202,7 @@ exports[`Group - component render should render correctly with items 1`] = `
     aria-label="Select Input"
     isExpanded={false}
     isGrouped={true}
+    onClear={[Function]}
     onSelect={[Function]}
     onToggle={[Function]}
     variant="single"
@@ -206,6 +211,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       id="group-0"
       key="0"
       label="First value"
+      value={0}
     >
        
       <SelectOption
@@ -248,6 +254,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       id="group-second"
       key="second"
       label="Second value"
+      value="second"
     >
        
       <SelectOption
@@ -308,6 +315,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       id="group-third"
       key="third"
       label="Third value"
+      value="third"
     >
        
       <SelectOption
@@ -376,6 +384,7 @@ exports[`Group - component render should render correctly with items and default
     aria-label="Select Input"
     isExpanded={false}
     isGrouped={true}
+    onClear={[Function]}
     onSelect={[Function]}
     onToggle={[Function]}
     variant="single"
@@ -384,6 +393,7 @@ exports[`Group - component render should render correctly with items and default
       id="group-0"
       key="0"
       label="First value"
+      value={0}
     >
        
       <SelectOption
@@ -426,6 +436,7 @@ exports[`Group - component render should render correctly with items and default
       id="group-second"
       key="second"
       label="Second value"
+      value="second"
     >
        
       <SelectOption
@@ -486,6 +497,7 @@ exports[`Group - component render should render correctly with items and default
       id="group-third"
       key="third"
       label="Third value"
+      value="third"
     >
        
       <SelectOption
@@ -554,6 +566,7 @@ exports[`Group - component render should render correctly with items and selecte
     aria-label="Select Input"
     isExpanded={false}
     isGrouped={true}
+    onClear={[Function]}
     onSelect={[Function]}
     onToggle={[Function]}
     variant="single"
@@ -562,6 +575,7 @@ exports[`Group - component render should render correctly with items and selecte
       id="group-0"
       key="0"
       label="First value"
+      value={0}
     >
        
       <SelectOption
@@ -604,6 +618,7 @@ exports[`Group - component render should render correctly with items and selecte
       id="group-second"
       key="second"
       label="Second value"
+      value="second"
     >
        
       <SelectOption
@@ -664,6 +679,7 @@ exports[`Group - component render should render correctly with items and selecte
       id="group-third"
       key="third"
       label="Third value"
+      value="third"
     >
        
       <SelectOption

--- a/packages/inventory-general-info/package.json
+++ b/packages/inventory-general-info/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.7",
-        "@redhat-cloud-services/host-inventory-client": "1.0.39",
+        "@redhat-cloud-services/host-inventory-client": "1.0.48",
         "@redhat-cloud-services/frontend-components-inventory": ">=0.0.13"
     }
 }

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.15",
-        "@redhat-cloud-services/host-inventory-client": "1.0.39",
+        "@redhat-cloud-services/host-inventory-client": "1.0.46",
         "axios": "^0.19.0"
     }
 }

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": ">=0.0.15",
-        "@redhat-cloud-services/host-inventory-client": "1.0.46",
+        "@redhat-cloud-services/host-inventory-client": "1.0.48",
         "axios": "^0.19.0"
     }
 }

--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -55,8 +55,8 @@ class ContextEntityTableToolbar extends Component {
     }
 
     applyTags = (newSelection, debounced = true) => {
-        const { allTags, perPage, filters, onRefreshData } = this.props;
-        const tagFilters = mapGroups(newSelection, allTags);
+        const { perPage, filters, onRefreshData } = this.props;
+        const tagFilters = mapGroups(newSelection);
         const tagFiltersIndex = filters.findIndex((value) => value.hasOwnProperty('tagFilters'));
         if (tagFiltersIndex !== -1) {
             filters.splice(tagFiltersIndex, 1);
@@ -74,7 +74,7 @@ class ContextEntityTableToolbar extends Component {
     }
 
     createTagsFilter = () => {
-        const { allTags, allTagsLoaded, additionalTagsCount } = this.props;
+        const { allTags, allTagsLoaded, additionalTagsCount, getAllTags } = this.props;
         const { selected } = this.state;
         return {
             label: 'Tags',
@@ -83,11 +83,19 @@ class ContextEntityTableToolbar extends Component {
             placeholder: 'Filter system by tag',
             filterValues: {
                 className: 'ins-c-inventory__tags-filter',
-                onFilter: (e) => this.debounceGetAllTags(e.target.value),
-                onChange: (e, newSelection) => this.setState(
-                    { selected: newSelection },
-                    () =>  this.applyTags(newSelection)
-                ),
+                onFilter: (value) => this.debounceGetAllTags(value),
+                onChange: (_e, newSelection, group, item, groupKey, itemKey) => {
+                    const isSelected = newSelection[groupKey][itemKey];
+                    newSelection[groupKey][itemKey] = {
+                        isSelected,
+                        group,
+                        item
+                    };
+                    this.setState(
+                        { selected: newSelection },
+                        () => this.applyTags(newSelection)
+                    );
+                },
                 selected,
                 ...allTagsLoaded && allTags.length > 0 ? {
                     groups: [
@@ -118,11 +126,11 @@ class ContextEntityTableToolbar extends Component {
     }
 
     constructFilters = () => {
-        const { allTags, perPage, onRefreshData, onClearFilters, activeFiltersConfig } = this.props;
+        const { perPage, onRefreshData, onClearFilters, activeFiltersConfig } = this.props;
         const { selected, textFilter } = this.state;
         return {
             filters: [
-                ...mapGroups(selected, allTags, 'chips'),
+                ...mapGroups(selected, 'chips'),
                 ...textFilter.length > 0 ? [{
                     category: 'Display name',
                     type: TEXTUAL_CHIP,

--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -58,14 +58,10 @@ class ContextEntityTableToolbar extends Component {
     applyTags = (newSelection, debounced = true) => {
         const { perPage, filters, onRefreshData } = this.props;
         const tagFilters = mapGroups(newSelection);
-        const tagFiltersIndex = filters.findIndex((value) => value.hasOwnProperty('tagFilters'));
-        if (tagFiltersIndex !== -1) {
-            filters.splice(tagFiltersIndex, 1);
-        }
 
         const refresh = debounced ? this.debouncedRefresh : onRefreshData;
         const newFilters = [
-            ...filters,
+            ...filters.filter(oneFilter => !oneFilter.hasOwnProperty('tagFilters')),
             { tagFilters }
         ];
         refresh({

--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -112,7 +112,9 @@ class ContextEntityTableToolbar extends Component {
                     items: [
                         {
                             label: !allTagsLoaded ? <Fragment>
+                                <span>
                                     Loading... <Spinner size="md" />
+                                </span>
                             </Fragment> : <div className="ins-c-inventory__tags-no-tags">
                                 No tags available
                             </div>,

--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -106,7 +106,7 @@ class ContextEntityTableToolbar extends Component {
                             label: !allTagsLoaded ? <Fragment>
                                     Loading... <Spinner size="md" />
                             </Fragment> : <div className="ins-c-inventory__tags-no-tags">
-                                No tags available!
+                                No tags available
                             </div>,
                             isDisabled: true,
                             className: 'ins-c-inventory__tags-tail'

--- a/packages/inventory/src/InventoryList.scss
+++ b/packages/inventory/src/InventoryList.scss
@@ -25,21 +25,15 @@
         display: flex;
         width: 100%;
 
-        .pf-c-badge {
-            margin-left: auto;
-        }
+        .pf-c-badge { margin-left: auto; }
     }
 
     .ins-c-inventory__tags-tail {
         display: flex;
 
-        .ins-c-inventory__tags-no-tags {
-            margin: auto;
-        }
+        .ins-c-inventory__tags-no-tags { margin: auto; }
 
-        .pf-c-spinner {
-            margin-left: auto;
-        }
+        .pf-c-spinner { margin-left: auto; }
     }
 }
 

--- a/packages/inventory/src/InventoryList.scss
+++ b/packages/inventory/src/InventoryList.scss
@@ -20,6 +20,33 @@
     }
 }
 
+.ins-c-inventory__tags-filter ul {
+    label.pf-c-check__label {
+        display: flex;
+        width: 100%;
+
+        .pf-c-badge {
+            margin-left: auto;
+        }
+    }
+
+    .ins-c-inventory__tags-more-items {
+        text-align: center;
+    }
+    
+    .ins-c-inventory__tags-tail {
+        display: flex;
+
+        .ins-c-inventory__tags-no-tags {
+            margin: auto;
+        }
+
+        .pf-c-spinner {
+            margin-left: auto;
+        }
+    }
+}
+
 .ins-c-entity-table.pf-c-table {
 
     .ins-composed-col div:nth-child(2) {

--- a/packages/inventory/src/InventoryList.scss
+++ b/packages/inventory/src/InventoryList.scss
@@ -30,10 +30,6 @@
         }
     }
 
-    .ins-c-inventory__tags-more-items {
-        text-align: center;
-    }
-    
     .ins-c-inventory__tags-tail {
         display: flex;
 

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -71,6 +71,7 @@ export function getEntities(items, {
     orderBy = 'updated',
     orderDirection = 'DESC'
 }) {
+    console.log(TagsApi, 'sdf');
     const { hostnameOrId, tagFilters } = filters ? filters.reduce(filtersReducer, {}) : {};
     if (hasItems && items.length > 0) {
         return hosts.apiHostGetHostById(items, undefined, perPage, page, undefined, undefined, { cancelToken: controller && controller.token })

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -71,7 +71,6 @@ export function getEntities(items, {
     orderBy = 'updated',
     orderDirection = 'DESC'
 }) {
-    console.log(TagsApi, 'sdf');
     const { hostnameOrId, tagFilters } = filters ? filters.reduce(filtersReducer, {}) : {};
     if (hasItems && items.length > 0) {
         return hosts.apiHostGetHostById(items, undefined, perPage, page, undefined, undefined, { cancelToken: controller && controller.token })

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -3,9 +3,10 @@ import flatMap from 'lodash/flatMap';
 export const INVENTORY_API_BASE = '/api/inventory/v1';
 
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
-import { HostsApi } from '@redhat-cloud-services/host-inventory-client';
+import { HostsApi, TagsApi } from '@redhat-cloud-services/host-inventory-client';
 
 export const hosts = new HostsApi(undefined, INVENTORY_API_BASE, instance);
+export const tags = new TagsApi(undefined, INVENTORY_API_BASE, instance);
 
 /* eslint camelcase: off */
 export const mapData = ({ facts = {}, ...oneResult }) => ({
@@ -75,11 +76,12 @@ export function getEntities(items, {
             hostnameOrId && hostnameOrId.filter,
             undefined,
             undefined,
-            undefined,
             perPage,
             page,
             orderBy,
             orderDirection,
+            '',
+            '',
             { cancelToken: controller && controller.token }
         )
         .then((data) => mapTags(data, { orderBy, orderDirection }))
@@ -108,15 +110,6 @@ export function getTags(systemId) {
     return hosts.apiHostGetHostTags(systemId).then(({ results }) => ({ results: Object.values(results)[0] }));
 }
 
-export function getAllTags() {
-    return new Promise(res => setTimeout(() => res({
-        // Fake it till you make it
-        results: [ ...Array(Math.round(Math.random() * Math.floor(5))) ].map(() => ({
-            name: Math.random().toString(36).substring(Math.round(Math.random() * Math.floor(10))),
-            tags: [ ...Array(Math.round(Math.random() * Math.floor(10))) ].map(() => ({
-                tagName: Math.random().toString(36).substring(Math.round(Math.random() * Math.floor(10))),
-                tagValue: `Some tag=${Math.random().toString(36).substring(Math.round(Math.random() * Math.floor(10)))}`
-            }))
-        }))
-    }), 1000));
+export function getAllTags(search) {
+    return tags.apiTagGetTags(undefined, undefined, undefined, undefined, search);
 }

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -125,5 +125,5 @@ export function getTags(systemId) {
 }
 
 export function getAllTags(search) {
-    return tags.apiTagGetTags(undefined, undefined, undefined, undefined, undefined, undefined, search);
+    return tags.apiTagGetTags(undefined, undefined, undefined, 25, undefined, undefined, search);
 }

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -124,6 +124,15 @@ export function getTags(systemId) {
     return hosts.apiHostGetHostTags(systemId).then(({ results }) => ({ results: Object.values(results)[0] }));
 }
 
-export function getAllTags(search) {
-    return tags.apiTagGetTags(undefined, undefined, undefined, 25, undefined, undefined, search);
+export function getAllTags(search, { filters } = {}) {
+    const { tagFilters } = filters ? filters.reduce(filtersReducer, {}) : {};
+    return tags.apiTagGetTags(
+        tagFilters ? constructTags(tagFilters) : undefined,
+        undefined,
+        undefined,
+        10,
+        undefined,
+        undefined,
+        search
+    );
 }

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Badge } from '@patternfly/react-core';
+
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
 export const TAG_CHIP = 'tags';
@@ -5,10 +8,12 @@ export const TAG_CHIP = 'tags';
 export function constructValues(groupValue, tags) {
     return Object.entries(groupValue).map(([ key, value ]) => {
         if (value) {
-            const { key: tagKey, value } = tags[key];
+            const { tag: { key: tagKey, value: tagValue } } = tags[key];
             return {
                 key,
-                name: `${tagKey} - ${value}`
+                tagKey,
+                value: tagValue,
+                name: `${tagKey}: ${tagValue}`
             };
         }
     }).filter(Boolean);
@@ -41,8 +46,11 @@ export function constructGroups(allTags) {
         label: name,
         value: key,
         type: 'checkbox',
-        items: tags.map(({ key: tagKey, value }) => ({
-            label: `${tagKey} - ${value}`
+        items: tags.map(({ count,  tag: { key: tagKey, value } }) => ({
+            label: <React.Fragment>
+                <div>{tagKey}: {value}</div>
+                <Badge>{ count }</Badge>
+            </React.Fragment>
         }))
     }));
 }
@@ -51,7 +59,7 @@ export function reduceFilters(filters) {
     return filters.reduce((acc, oneFilter) => {
         if (oneFilter.value === TEXT_FILTER) {
             return { ...acc, textFilter: oneFilter.filter };
-        } else if ('tagFilters' in  oneFilter) {
+        } else if ('tagFilters' in oneFilter) {
             return {
                 ...acc,
                 tagFilters: filterToGroup(oneFilter.tagFilters)

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -63,7 +63,7 @@ export function constructGroups(allTags) {
                 <Tooltip
                     position="right"
                     enableFlip
-                    content={`Applicable to ${count} systems.`}
+                    content={`Applicable to ${count} system${count === 1 ? '' : 's'}.`}
                 >
                     <Badge isRead={count <= 0}>{ count }</Badge>
                 </Tooltip>

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -37,7 +37,18 @@ export function mapGroups(currSelection, valuesKey = 'values') {
 export function filterToGroup(filter = [], valuesKey = 'values') {
     return filter.reduce((accGroup, group) => ({
         ...accGroup,
-        [group.key]: group[valuesKey].reduce((acc, curr) => ({ ...acc, [curr.key]: true }), {})
+        [group.key]: group[valuesKey].reduce((acc, curr) => ({ ...acc, [curr.key]: {
+            isSelected: true,
+            group: curr.group,
+            item: {
+                meta: {
+                    tag: {
+                        key: curr.key,
+                        value: curr.value
+                    }
+                }
+            }
+        } }), {})
     }), {});
 }
 

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -1,33 +1,33 @@
 import React from 'react';
-import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Badge, Tooltip } from '@patternfly/react-core';
 
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
 export const TAG_CHIP = 'tags';
 
-export function constructValues(groupValue, tags) {
-    return Object.entries(groupValue).map(([ key, value ]) => {
-        if (value) {
-            const { tag: { key: tagKey, value: tagValue } } = tags[key];
+export function constructValues(groupValue) {
+    return Object.entries(groupValue).map(([ key, { isSelected, group, item }]) => {
+        if (isSelected) {
+            const { tag: { key: tagKey, value: tagValue } } = item.meta;
             return {
                 key,
                 tagKey,
                 value: tagValue,
-                name: `${tagKey}: ${tagValue}`
+                name: `${tagKey}: ${tagValue}`,
+                group
             };
         }
     }).filter(Boolean);
 }
 
-export function mapGroups(currSelection, allTags, valuesKey = 'values') {
+export function mapGroups(currSelection, valuesKey = 'values') {
     return Object.entries(currSelection).map(([ groupKey, groupValue ]) => {
-        const { tags, name } = allTags[groupKey];
-        const values = constructValues(groupValue, tags);
+        const values = constructValues(groupValue, groupKey);
         if (values && values.length > 0) {
             return {
                 type: 'tags',
                 key: groupKey,
-                category: name,
+                category: values[0].group.label,
                 [valuesKey]: values
             };
         }
@@ -46,7 +46,7 @@ export function constructGroups(allTags) {
         label: name,
         value: key,
         type: 'checkbox',
-        items: tags.map(({ count,  tag: { key: tagKey, value } }) => ({
+        items: tags.map(({ count, tag: { key: tagKey, value } }) => ({
             label: <React.Fragment>
                 <div>{tagKey}: {value}</div>
                 <Tooltip
@@ -56,7 +56,15 @@ export function constructGroups(allTags) {
                 >
                     <Badge isRead={count <= 0}>{ count }</Badge>
                 </Tooltip>
-            </React.Fragment>
+            </React.Fragment>,
+            meta: {
+                count,
+                tag: {
+                    key: tagKey,
+                    value
+                }
+            },
+            value: tagKey
         }))
     }));
 }

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -5,10 +5,10 @@ export const TAG_CHIP = 'tags';
 export function constructValues(groupValue, tags) {
     return Object.entries(groupValue).map(([ key, value ]) => {
         if (value) {
-            const { tagName, tagValue } = tags[key];
+            const { key: tagKey, value } = tags[key];
             return {
                 key,
-                name: `${tagName} - ${tagValue}`
+                name: `${tagKey} - ${value}`
             };
         }
     }).filter(Boolean);
@@ -41,8 +41,8 @@ export function constructGroups(allTags) {
         label: name,
         value: key,
         type: 'checkbox',
-        items: tags.map(({ tagName, tagValue }) => ({
-            label: `${tagName} - ${tagValue}`
+        items: tags.map(({ key: tagKey, value }) => ({
+            label: `${tagKey} - ${value}`
         }))
     }));
 }

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Badge } from '@patternfly/react-core';
+import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
 export const TEXT_FILTER = 'hostname_or_id';
 export const TEXTUAL_CHIP = 'textual';
@@ -49,7 +49,13 @@ export function constructGroups(allTags) {
         items: tags.map(({ count,  tag: { key: tagKey, value } }) => ({
             label: <React.Fragment>
                 <div>{tagKey}: {value}</div>
-                <Badge>{ count }</Badge>
+                <Tooltip
+                    position="right"
+                    enableFlip
+                    content={`Applicable to ${count} systems.`}
+                >
+                    <Badge isRead={count <= 0}>{ count }</Badge>
+                </Tooltip>
             </React.Fragment>
         }))
     }));

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -9,10 +9,9 @@ import {
     UPDATE_ENTITIES,
     ENTITIES_LOADING,
     CLEAR_FILTERS,
-    TOGGLE_TAG_MODAL,
-    TAGS_SELECTED
+    TOGGLE_TAG_MODAL
 } from './action-types';
-import { getEntities, getEntitySystemProfile, hosts, getTags, getAllTags } from '../api';
+import { getEntities, getEntitySystemProfile, hosts, getAllTags } from '../api';
 
 export const loadEntities = (items = [], config) => ({
     type: ACTION_TYPES.LOAD_ENTITIES,
@@ -120,7 +119,7 @@ export const toggleTagModal = (isOpen) => ({
     }
 });
 
-export const fetchAllTags = () => ({
+export const fetchAllTags = (search) => ({
     type: ACTION_TYPES.ALL_TAGS,
-    payload: getAllTags()
+    payload: getAllTags(search)
 });

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -119,7 +119,7 @@ export const toggleTagModal = (isOpen) => ({
     }
 });
 
-export const fetchAllTags = (search) => ({
+export const fetchAllTags = (search, options) => ({
     type: ACTION_TYPES.ALL_TAGS,
-    payload: getAllTags(search)
+    payload: getAllTags(search, options)
 });

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -13,6 +13,7 @@ import {
 } from './action-types';
 import { mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import TagWithDialog from '../TagWithDialog';
+import groupBy from 'lodash/groupBy';
 
 export const defaultState = { loaded: false, tagsLoaded: false, allTagsLoaded: false };
 
@@ -131,9 +132,19 @@ export function toggleTagModal(state, { payload: { isOpen } }) {
 }
 
 export function allTags(state, { payload: { results } }) {
+    // TODO: Remove me! I am just for testing purposes
+    const fakeResults = results.length > 0 ? results : [{
+        namespace: 'one',
+        key: 'some',
+        value: 'anothefr'
+    }];
+
     return {
         ...state,
-        allTags: results,
+        allTags: Object.entries(groupBy(fakeResults, ({ namespace }) => namespace)).map(([ key, value ]) => ({
+            name: key,
+            tags: value
+        })),
         allTagsLoaded: true
     };
 }

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -132,20 +132,13 @@ export function toggleTagModal(state, { payload: { isOpen } }) {
 }
 
 export function allTags(state, { payload: { results, total, per_page: perPage } }) {
-    // TODO: Remove me! I am just for testing purposes
-    const fakeResults = results.length > 0 ? results : [{
-        namespace: 'one',
-        key: 'some',
-        value: 'anothefr'
-    }];
-
     return {
         ...state,
-        allTags: Object.entries(groupBy(fakeResults, ({ namespace }) => namespace)).map(([ key, value ]) => ({
+        allTags: Object.entries(groupBy(results, ({ tag: { namespace } }) => namespace)).map(([ key, value ]) => ({
             name: key,
             tags: value
         })),
-        additionalTagsCount: total > perPage ? total - perPage : 500,
+        additionalTagsCount: total > perPage ? total - perPage : 0,
         allTagsLoaded: true
     };
 }

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -131,7 +131,7 @@ export function toggleTagModal(state, { payload: { isOpen } }) {
     };
 }
 
-export function allTags(state, { payload: { results } }) {
+export function allTags(state, { payload: { results, total, per_page: perPage } }) {
     // TODO: Remove me! I am just for testing purposes
     const fakeResults = results.length > 0 ? results : [{
         namespace: 'one',
@@ -145,6 +145,7 @@ export function allTags(state, { payload: { results } }) {
             name: key,
             tags: value
         })),
+        additionalTagsCount: total > perPage ? total - perPage : 500,
         allTagsLoaded: true
     };
 }


### PR DESCRIPTION
### Enhancements
* [x] hook tags fetch to real API
* [x] add filter by selected tags
### UI changes
* [x] tags typeahead
* [x] add loading state to tags filter
* [x] add no tags when no tags are present
* [x] add `${x} more tags` at the end of filter tags list when more than curr page of tags is present in DB

### UI changes
* Typeahead (I had not actual data so the string is not filtered, this is just to show interaction when user types in something. Also the loading styling is a bit off please refer to `Tags loading` point how it actually looks like)
![Peek 2019-12-27 20-57](https://user-images.githubusercontent.com/3439771/71531174-ca066b80-28ed-11ea-8df3-dc6ce0b477f6.gif)

* No tags
![Screenshot from 2019-12-27 21-12-27](https://user-images.githubusercontent.com/3439771/71531210-ec988480-28ed-11ea-9d49-294c18bc88f6.png)

* Tags loading
![Screenshot from 2019-12-27 21-06-54](https://user-images.githubusercontent.com/3439771/71531215-f4f0bf80-28ed-11ea-9e4b-3f8493d5efa7.png)

* More tags available
![Screenshot from 2019-12-27 21-06-19](https://user-images.githubusercontent.com/3439771/71531226-00dc8180-28ee-11ea-9e0f-b0626447826c.png)

_Used data were placeholder data mocked based on API_

#### JIRA
RHCLOUD-3736
RHCLOUD-3746