### PR TITLE
Update DateFormat tests in order to fix failing tests

### DIFF
--- a/packages/components/src/Components/DateFormat/DateFormat.test.js
+++ b/packages/components/src/Components/DateFormat/DateFormat.test.js
@@ -4,6 +4,29 @@ import toJson from 'enzyme-to-json';
 import DateFormat from './DateFormat';
 
 describe('DateFormat component', () => {
+    const _Date = Date;
+    const currDate = new Date('1970');
+    beforeAll(() => {
+        /*eslint no-global-assign:off*/
+        Date = class extends Date {
+            constructor(...props) {
+                if (props.length > 0) {
+                    return new _Date(...props);
+                }
+
+                return currDate;
+            }
+
+            static now() {
+                return new _Date('1970').getTime();
+            }
+        };
+    });
+
+    afterAll(() => {
+        Date = _Date;
+    });
+
     it('DateFormat renders with date integer', () => {
         const wrapper = shallow(<DateFormat date={10}/>);
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
+++ b/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
@@ -37,7 +37,7 @@ exports[`DateFormat component DateFormat renders with date integer 1`] = `
     zIndex={9999}
   >
     <span>
-      50 years ago
+      Just now
     </span>
   </Tooltip>
 </Fragment>


### PR DESCRIPTION
In order to properly test Date creation we have to mock Date so we have control over it.