### PR TITLE
Increases cond-filter selector size, lowercase active placeholder

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -80,7 +80,7 @@ class ConditionalFilter extends Component {
                                         {
                                         ...activeItem.type !== conditionalFilterType.custom &&
                                             {
-                                                placeholder: placeholder || activeItem.placeholder || `Filter by ${activeItem.label}`,
+                                                placeholder: placeholder || activeItem.placeholder || `Filter by ${activeItem.label.toLowerCase()}`,
                                                 id: (activeItem.filterValues && activeItem.filterValues.id) || currentValue
                                             }
                                         }

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
@@ -107,7 +107,7 @@ exports[`ConditionalFilter render should render correctly Checkbox with value ch
           ]
         }
         onChange={[Function]}
-        placeholder="Filter by Checkbox"
+        placeholder="Filter by checkbox"
         value={Array []}
       />
     </SplitItem>
@@ -189,7 +189,7 @@ exports[`ConditionalFilter render should render correctly No value with value un
       <Text
         id=""
         onSubmit={[Function]}
-        placeholder="Filter by Simple text 1"
+        placeholder="Filter by simple text 1"
         value=""
       />
     </SplitItem>
@@ -285,7 +285,7 @@ exports[`ConditionalFilter render should render correctly Radio filter with valu
           ]
         }
         onChange={[Function]}
-        placeholder="Filter by Radio filter"
+        placeholder="Filter by radio filter"
       />
     </SplitItem>
   </Split>
@@ -366,7 +366,7 @@ exports[`ConditionalFilter render should render correctly Simple text 1 with val
       <Text
         id="simple-text-1"
         onSubmit={[Function]}
-        placeholder="Filter by Simple text 1"
+        placeholder="Filter by simple text 1"
         value=""
       />
     </SplitItem>
@@ -448,7 +448,7 @@ exports[`ConditionalFilter render should render correctly Simple text 2 with val
       <Text
         id="simple-text-2"
         onSubmit={[Function]}
-        placeholder="Filter by Simple text 2"
+        placeholder="Filter by simple text 2"
         value="some-value blaa"
       />
     </SplitItem>
@@ -529,7 +529,7 @@ exports[`ConditionalFilter render should render correctly with config 1`] = `
     >
       <Text
         onSubmit={[Function]}
-        placeholder="Filter by No value"
+        placeholder="Filter by no value"
         value=""
       />
     </SplitItem>
@@ -547,7 +547,7 @@ exports[`ConditionalFilter render should render correctly with one filter 1`] = 
     >
       <Text
         onSubmit={[Function]}
-        placeholder="Filter by Simple text 1"
+        placeholder="Filter by simple text 1"
         value=""
       />
     </SplitItem>

--- a/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
@@ -6,7 +6,7 @@
     }
 
     .ins-c-conditional-filter__group .pf-c-dropdown__toggle-text {
-        width: 100px;
+        width: 102px;
         text-align: left;
 
         & > svg {


### PR DESCRIPTION
As per conversations with @terezanovotna, this pr 

#### makes conditional filter active description lowercase

<img width="417" alt="Screen Shot 2020-01-07 at 1 53 48 PM" src="https://user-images.githubusercontent.com/6640236/71921392-c62ce180-3156-11ea-83d5-c958c788983f.png">
<img width="461" alt="Screen Shot 2020-01-07 at 1 53 38 PM" src="https://user-images.githubusercontent.com/6640236/71921393-c62ce180-3156-11ea-81e5-2b399641df78.png">


#### increases the conditional selector text box size so the filter 'description' fits without truncation 
<img width="1920" alt="Screen Shot 2020-01-07 at 1 52 56 PM" src="https://user-images.githubusercontent.com/6640236/71921394-c62ce180-3156-11ea-8837-80874fbbdd99.png">

fixes https://projects.engineering.redhat.com/browse/RHCLOUD-3893

