### PR TITLE
Add getting started message for systems with insight_id = null

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -1,14 +1,13 @@
 /* eslint-disable camelcase */
 import './insights.scss';
 
-import { AnsibeTowerIcon, CheckCircleIcon, CheckIcon, ExternalLinkAltIcon, PficonSatelliteIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { AnsibeTowerIcon, ChartSpikeIcon, CheckCircleIcon, CheckIcon, ExternalLinkAltIcon, PficonSatelliteIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import { BASE_FETCH_URL, FILTER_CATEGORIES as FC } from './Constants';
 import { Battery, PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
-import { Card, CardBody, ToolbarItem } from '@patternfly/react-core';
+import { Bullseye, Button, Card, CardBody, ClipboardCopy, Stack, StackItem, ToolbarItem } from '@patternfly/react-core';
 import React, { Component, Fragment } from 'react';
 import { SortByDirection, Table, TableBody, TableHeader, cellWidth, sortable } from '@patternfly/react-table';
 import { flatten, sortBy } from 'lodash';
-import { global_BackgroundColor_100, global_success_color_200 } from '@patternfly/react-tokens';
 
 import { List } from 'react-content-loader';
 import MessageState from './MessageState';
@@ -268,7 +267,7 @@ class InventoryRuleList extends Component {
     }
 
     onChipDelete = (event, itemsToRemove, isAll) => {
-        const { filters, activeReports, kbaDetailsData, searchValue } = this.state;
+        const { filters, activeReports, kbaDetailsData } = this.state;
         if (isAll) {
             const rows = this.buildRows(activeReports, kbaDetailsData, {}, '');
             this.setState({ rows, filters: {}, searchValue: '' });
@@ -354,8 +353,9 @@ class InventoryRuleList extends Component {
 
         return <Fragment>
             {inventoryReportFetchStatus === 'pending' ||
-                (inventoryReportFetchStatus === 'fulfilled' && hideResultsSatelliteManaged) ?
-                <React.Fragment></React.Fragment>
+                (inventoryReportFetchStatus === 'fulfilled' && hideResultsSatelliteManaged) ||
+                entity.insights_id === null ?
+                <Fragment />
                 :
                 <PrimaryToolbar
                     actionsConfig={{ actions }}
@@ -369,7 +369,7 @@ class InventoryRuleList extends Component {
                             isDisabled={selectedAnsibleRules.length === 0}
                             dataProvider={() => this.processRemediation(selectedAnsibleRules)}
                             onRemediationCreated={result => addNotification(result.getNotification())} >
-                            {AnsibeTowerIcon && <AnsibeTowerIcon size='sm' color={global_BackgroundColor_100.value} />} Remediate
+                            {AnsibeTowerIcon && <AnsibeTowerIcon size='sm' className='ins-c-background__default' />} Remediate
                         </RemediationButton>
                     </ToolbarItem>
                 </PrimaryToolbar>
@@ -403,13 +403,33 @@ class InventoryRuleList extends Component {
                                     text={`This filter criteria matches no rules. Try changing your filter settings.`} />
                             }
                         </Fragment>
-                        :
-                        <Card>
+                        : entity.insights_id !== null ? <Card>
                             <CardBody>
-                                <MessageState icon={CheckIcon} iconStyle={{ color: global_success_color_200.value }} size='md'
+                                <MessageState icon={CheckIcon} iconClass='ins-c-insights__check' size='md'
                                     title='No rule hits' text={`No known rules affect this system`} />
                             </CardBody>
                         </Card>
+                            : <MessageState
+                                iconClass='chartSpikeIconColor'
+                                icon={ChartSpikeIcon}
+                                title='Get started with Red Hat Insights'
+                                text={<Bullseye>
+                                    <Stack gutter="md">
+                                        <StackItem>
+                                            1. Install the client on the RHEL system.
+                                            <ClipboardCopy>yum install insights-client</ClipboardCopy>
+                                        </StackItem>
+                                        <StackItem>
+                                            2. Register the system to Red Hat Insights.
+                                            <ClipboardCopy>insights-client --register</ClipboardCopy>
+                                        </StackItem>
+                                    </Stack>
+                                </Bullseye>}>
+                                <Button component="a" href="https://access.redhat.com/products/red-hat-insights#getstarted"
+                                    target="_blank" variant="primary">
+                                    Getting started documentation
+                                </Button>
+                            </MessageState>
                     ))
             }
             {inventoryReportFetchStatus === 'failed' && entity &&

--- a/packages/inventory-insights/src/MessageState.js
+++ b/packages/inventory-insights/src/MessageState.js
@@ -1,7 +1,8 @@
-import React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
-import PropTypes from 'prop-types';
+
 import { CubesIcon } from '@patternfly/react-icons';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const MessageState = ({ children, icon, iconClass, iconStyle, size, text, title, variant }) => (
     <EmptyState variant={variant}>
@@ -31,7 +32,7 @@ MessageState.defaultProps = {
     icon: CubesIcon,
     title: '',
     variant: EmptyStateVariant.full,
-    size: ''
+    size: 'md'
 };
 
 export default MessageState;

--- a/packages/inventory-insights/src/insights.scss
+++ b/packages/inventory-insights/src/insights.scss
@@ -95,3 +95,23 @@
         height: 1.25rem; 
     }
 }
+
+.chartSpikeIconColor  {
+    color: var(--pf-global--primary-color--100);
+}
+
+.pf-c-clipboard-copy__group-copy {
+    background-color: var(--pf-global--BackgroundColor--100);
+}
+
+.pf-l-stack {
+    color: var(--pf-c-empty-state__body--Color);
+}
+  
+.ins-c-insights__check {
+    color: var(--pf-global--success-color--200);
+}
+
+.ins-c-background__default {
+    color: var(--pf-global--BackgroundColor--100);
+}


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4063

so previously, if a system didn't have insights installed, n yah viewed it in inventory, we'd say no rule hits, which is technically incorrect, as the system hasn't been scanned, have an "install insights" call to action

#### looks like this! (ignore that it's on the rules tab)
<img width="1309" alt="Screen Shot 2020-01-17 at 1 53 54 PM" src="https://user-images.githubusercontent.com/6640236/72638995-ad7cb280-3932-11ea-9af7-f55fa7128fdf.png">
