### PR TITLE
Do not show empty policy cards

### DIFF
--- a/packages/inventory-compliance/src/SystemPolicyCards.js
+++ b/packages/inventory-compliance/src/SystemPolicyCards.js
@@ -6,7 +6,8 @@ import { Instagram } from 'react-content-loader';
 
 class SystemPolicyCards extends React.Component {
     systemPolicyCards() {
-        return this.props.policies.map(
+        const { policies } = this.props;
+        return policies.filter((policy) => (policy.rulesFailed + policy.rulesPassed) > 0).map(
             (policy, i) =>
                 <GridItem sm={ 12 } md={ 12 } lg={ 6 } xl={ 4 } key={ i }>
                     <SystemPolicyCard policy={ policy } />

--- a/packages/inventory-compliance/src/SystemPolicyCards.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCards.test.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import SystemPolicyCards from './SystemPolicyCards';
 import { IntlProvider } from 'react-intl';
-import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+jest.mock('react-content-loader', () => ({
+    Instagram: 'Instagram'
+}));
 
 describe('SystemPolicyCards component', () => {
     const policies = [{
@@ -21,20 +25,20 @@ describe('SystemPolicyCards component', () => {
     }];
 
     it('should render loading state', () => {
-        const component = renderer.create(
+        const wrappper = mount(
             <IntlProvider locale={ navigator.language }>
                 <SystemPolicyCards policies={ policies } loading={ true } />
             </IntlProvider>
         );
-        expect(component.toJSON()).toMatchSnapshot();
+        expect(toJson(wrappper)).toMatchSnapshot();
     });
 
     it('should render real table', () => {
-        const component = renderer.create(
+        const wrappper = mount(
             <IntlProvider locale={ navigator.language }>
                 <SystemPolicyCards policies={ policies } loading={ false } />
             </IntlProvider>
         );
-        expect(component.toJSON()).toMatchSnapshot();
+        expect(toJson(wrappper)).toMatchSnapshot();
     });
 });

--- a/packages/inventory-compliance/src/SystemPolicyCards.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCards.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import SystemPolicyCards from './SystemPolicyCards';
 import { IntlProvider } from 'react-intl';
+import renderer from 'react-test-renderer';
 
 describe('SystemPolicyCards component', () => {
     const policies = [{
@@ -12,23 +11,30 @@ describe('SystemPolicyCards component', () => {
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
         compliant: false
+    }, {
+        rulesPassed: 0,
+        rulesFailed: 0,
+        lastScanned: null,
+        refId: 'xccdf_org.ssgproject.content_profile_pci-dss2',
+        name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2',
+        compliant: false
     }];
 
     it('should render loading state', () => {
-        const wrapper = shallow(
+        const component = renderer.create(
             <IntlProvider locale={ navigator.language }>
                 <SystemPolicyCards policies={ policies } loading={ true } />
             </IntlProvider>
         );
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(component.toJSON()).toMatchSnapshot();
     });
 
     it('should render real table', () => {
-        const wrapper = shallow(
+        const component = renderer.create(
             <IntlProvider locale={ navigator.language }>
                 <SystemPolicyCards policies={ policies } loading={ false } />
             </IntlProvider>
         );
-        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(component.toJSON()).toMatchSnapshot();
     });
 });

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -1,602 +1,569 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SystemPolicyCards component should render loading state 1`] = `
-<div
-  className="pf-l-grid pf-m-gutter"
+<IntlProvider
+  locale="en-US"
 >
-  <div
-    className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
+  <SystemPolicyCards
+    loading={true}
+    policies={
+      Array [
+        Object {
+          "compliant": false,
+          "lastScanned": "2019-03-06T06:20:13Z",
+          "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+          "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
+          "rulesFailed": 10,
+          "rulesPassed": 30,
+        },
+        Object {
+          "compliant": false,
+          "lastScanned": null,
+          "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2",
+          "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
+          "rulesFailed": 0,
+          "rulesPassed": 0,
+        },
+      ]
+    }
   >
-    <article
-      className="pf-c-card"
+    <Grid
+      gutter="md"
     >
       <div
-        className="pf-c-card__body"
+        className="pf-l-grid pf-m-gutter"
       >
-        <div
-          className="pf-c-content margin-bottom-md"
-        >
-          <small
-            className="margin-bottom-none"
-            data-pf-content={true}
-          >
-            External policy
-          </small>
-          <h4
-            className="margin-bottom-top-none"
-            data-pf-content={true}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            <span
-              width={0}
-            >
-              <span />
-              <span>
-                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
-              </span>
-              <span
-                style={
-                  Object {
-                    "left": 0,
-                    "position": "fixed",
-                    "top": 0,
-                    "visibility": "hidden",
-                  }
-                }
-              >
-                …
-              </span>
-            </span>
-          </h4>
-        </div>
-        <div
-          className="margin-bottom-md"
+        <GridItem
+          key="0"
+          lg={6}
+          md={12}
+          sm={12}
+          xl={4}
         >
           <div
-            className="ins-c-policy-card ins-m-noncompliant"
+            className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
           >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
+            <SystemPolicyCard
+              policy={
                 Object {
-                  "verticalAlign": "-0.125em",
+                  "compliant": false,
+                  "lastScanned": "2019-03-06T06:20:13Z",
+                  "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
+                  "rulesFailed": 10,
+                  "rulesPassed": 30,
                 }
               }
-              viewBox="0 0 512 512"
-              width="1em"
             >
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                transform=""
-              />
-            </svg>
-             Noncompliant
+              <Card>
+                <article
+                  className="pf-c-card"
+                >
+                  <CardBody>
+                    <div
+                      className="pf-c-card__body"
+                    >
+                      <TextContent
+                        className="margin-bottom-md"
+                      >
+                        <div
+                          className="pf-c-content margin-bottom-md"
+                        >
+                          <Text
+                            className="margin-bottom-none"
+                            component="small"
+                          >
+                            <small
+                              className="margin-bottom-none"
+                              data-pf-content={true}
+                            >
+                              External policy
+                            </small>
+                          </Text>
+                          <Text
+                            className="margin-bottom-top-none"
+                            component="h4"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                          >
+                            <h4
+                              className="margin-bottom-top-none"
+                              data-pf-content={true}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <Truncate
+                                ellipsis="…"
+                                lines={1}
+                                trimWhitespace={false}
+                                width={0}
+                              >
+                                <span
+                                  width={0}
+                                >
+                                  <span />
+                                  <span>
+                                    PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "left": 0,
+                                        "position": "fixed",
+                                        "top": 0,
+                                        "visibility": "hidden",
+                                      }
+                                    }
+                                  >
+                                    …
+                                  </span>
+                                </span>
+                              </Truncate>
+                            </h4>
+                          </Text>
+                        </div>
+                      </TextContent>
+                      <div
+                        className="margin-bottom-md"
+                      >
+                        <div
+                          className="ins-c-policy-card ins-m-noncompliant"
+                        >
+                          <ExclamationCircleIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                            title={null}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 512 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                transform=""
+                              />
+                            </svg>
+                          </ExclamationCircleIcon>
+                           Noncompliant
+                        </div>
+                        <Text
+                          component="small"
+                        >
+                          <small
+                            className=""
+                            data-pf-content={true}
+                          >
+                            30
+                             of 
+                            40
+                             rules passed (
+                            75%
+                            )
+                          </small>
+                        </Text>
+                      </div>
+                      <div
+                        className="margin-bottom-md"
+                      >
+                        <Text
+                          className="wrap-break-word"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          <p
+                            className="wrap-break-word"
+                            data-pf-content={true}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                          >
+                            Profile 
+                            <br />
+                            <Truncate
+                              ellipsis="…"
+                              lines={1}
+                              trimWhitespace={false}
+                              width={0}
+                            >
+                              <span
+                                width={0}
+                              >
+                                <span />
+                                <span>
+                                  xccdf_org.ssgproject.content_profile_pci-dss
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "left": 0,
+                                      "position": "fixed",
+                                      "top": 0,
+                                      "visibility": "hidden",
+                                    }
+                                  }
+                                >
+                                  …
+                                </span>
+                              </span>
+                            </Truncate>
+                          </p>
+                        </Text>
+                      </div>
+                      <Text
+                        className="margin-bottom-none"
+                        component="small"
+                      >
+                        <small
+                          className="margin-bottom-none"
+                          data-pf-content={true}
+                        >
+                          Last scanned: 
+                          <FormattedRelative
+                            updateInterval={10000}
+                            value={1551853213000}
+                          >
+                            <span>
+                              11 months ago
+                            </span>
+                          </FormattedRelative>
+                        </small>
+                      </Text>
+                    </div>
+                  </CardBody>
+                </article>
+              </Card>
+            </SystemPolicyCard>
           </div>
-          <small
-            className=""
-            data-pf-content={true}
+        </GridItem>
+        <GridItem
+          key="0"
+          span={4}
+        >
+          <div
+            className="pf-l-grid__item pf-m-4-col"
           >
-            30
-             of 
-            40
-             rules passed (
-            75%
-            )
-          </small>
-        </div>
-        <div
-          className="margin-bottom-md"
+            <Card>
+              <article
+                className="pf-c-card"
+              >
+                <CardBody>
+                  <div
+                    className="pf-c-card__body"
+                  >
+                    <Instagram />
+                  </div>
+                </CardBody>
+              </article>
+            </Card>
+          </div>
+        </GridItem>
+        <GridItem
+          key="1"
+          span={4}
         >
-          <p
-            className="wrap-break-word"
-            data-pf-content={true}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
+          <div
+            className="pf-l-grid__item pf-m-4-col"
           >
-            Profile 
-            <br />
-            <span
-              width={0}
-            >
-              <span />
-              <span>
-                xccdf_org.ssgproject.content_profile_pci-dss
-              </span>
-              <span
-                style={
-                  Object {
-                    "left": 0,
-                    "position": "fixed",
-                    "top": 0,
-                    "visibility": "hidden",
-                  }
-                }
+            <Card>
+              <article
+                className="pf-c-card"
               >
-                …
-              </span>
-            </span>
-          </p>
-        </div>
-        <small
-          className="margin-bottom-none"
-          data-pf-content={true}
+                <CardBody>
+                  <div
+                    className="pf-c-card__body"
+                  >
+                    <Instagram />
+                  </div>
+                </CardBody>
+              </article>
+            </Card>
+          </div>
+        </GridItem>
+        <GridItem
+          key="2"
+          span={4}
         >
-          Last scanned: 
-          <span>
-            11 months ago
-          </span>
-        </small>
+          <div
+            className="pf-l-grid__item pf-m-4-col"
+          >
+            <Card>
+              <article
+                className="pf-c-card"
+              >
+                <CardBody>
+                  <div
+                    className="pf-c-card__body"
+                  >
+                    <Instagram />
+                  </div>
+                </CardBody>
+              </article>
+            </Card>
+          </div>
+        </GridItem>
       </div>
-    </article>
-  </div>
-  <div
-    className="pf-l-grid__item pf-m-4-col"
-  >
-    <article
-      className="pf-c-card"
-    >
-      <div
-        className="pf-c-card__body"
-      >
-        <svg
-          aria-labelledby="Loading interface..."
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 400 480"
-        >
-          <title>
-            Loading interface...
-          </title>
-          <rect
-            clipPath="url(#6sy3go9waes)"
-            height={480}
-            style={
-              Object {
-                "fill": "url(#ah7zx0ex2q5)",
-              }
-            }
-            width={400}
-            x="0"
-            y="0"
-          />
-          <defs>
-            <clipPath
-              id="6sy3go9waes"
-            >
-              <circle
-                cx="30"
-                cy="30"
-                r="30"
-              />
-              <rect
-                height="13"
-                rx="4"
-                ry="4"
-                width="100"
-                x="75"
-                y="13"
-              />
-              <rect
-                height="8"
-                rx="4"
-                ry="4"
-                width="50"
-                x="75"
-                y="37"
-              />
-              <rect
-                height="400"
-                rx="5"
-                ry="5"
-                width="400"
-                x="0"
-                y="70"
-              />
-            </clipPath>
-            <linearGradient
-              id="ah7zx0ex2q5"
-            >
-              <stop
-                offset="0%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-3; 1"
-                />
-              </stop>
-              <stop
-                offset="50%"
-                stopColor="#e0e0e0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-2; 2"
-                />
-              </stop>
-              <stop
-                offset="100%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-1; 3"
-                />
-              </stop>
-            </linearGradient>
-          </defs>
-        </svg>
-      </div>
-    </article>
-  </div>
-  <div
-    className="pf-l-grid__item pf-m-4-col"
-  >
-    <article
-      className="pf-c-card"
-    >
-      <div
-        className="pf-c-card__body"
-      >
-        <svg
-          aria-labelledby="Loading interface..."
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 400 480"
-        >
-          <title>
-            Loading interface...
-          </title>
-          <rect
-            clipPath="url(#3eyu80fnaov)"
-            height={480}
-            style={
-              Object {
-                "fill": "url(#7hrdli9rrif)",
-              }
-            }
-            width={400}
-            x="0"
-            y="0"
-          />
-          <defs>
-            <clipPath
-              id="3eyu80fnaov"
-            >
-              <circle
-                cx="30"
-                cy="30"
-                r="30"
-              />
-              <rect
-                height="13"
-                rx="4"
-                ry="4"
-                width="100"
-                x="75"
-                y="13"
-              />
-              <rect
-                height="8"
-                rx="4"
-                ry="4"
-                width="50"
-                x="75"
-                y="37"
-              />
-              <rect
-                height="400"
-                rx="5"
-                ry="5"
-                width="400"
-                x="0"
-                y="70"
-              />
-            </clipPath>
-            <linearGradient
-              id="7hrdli9rrif"
-            >
-              <stop
-                offset="0%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-3; 1"
-                />
-              </stop>
-              <stop
-                offset="50%"
-                stopColor="#e0e0e0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-2; 2"
-                />
-              </stop>
-              <stop
-                offset="100%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-1; 3"
-                />
-              </stop>
-            </linearGradient>
-          </defs>
-        </svg>
-      </div>
-    </article>
-  </div>
-  <div
-    className="pf-l-grid__item pf-m-4-col"
-  >
-    <article
-      className="pf-c-card"
-    >
-      <div
-        className="pf-c-card__body"
-      >
-        <svg
-          aria-labelledby="Loading interface..."
-          preserveAspectRatio="xMidYMid meet"
-          role="img"
-          viewBox="0 0 400 480"
-        >
-          <title>
-            Loading interface...
-          </title>
-          <rect
-            clipPath="url(#96f82mrno1j)"
-            height={480}
-            style={
-              Object {
-                "fill": "url(#zwd571hx0di)",
-              }
-            }
-            width={400}
-            x="0"
-            y="0"
-          />
-          <defs>
-            <clipPath
-              id="96f82mrno1j"
-            >
-              <circle
-                cx="30"
-                cy="30"
-                r="30"
-              />
-              <rect
-                height="13"
-                rx="4"
-                ry="4"
-                width="100"
-                x="75"
-                y="13"
-              />
-              <rect
-                height="8"
-                rx="4"
-                ry="4"
-                width="50"
-                x="75"
-                y="37"
-              />
-              <rect
-                height="400"
-                rx="5"
-                ry="5"
-                width="400"
-                x="0"
-                y="70"
-              />
-            </clipPath>
-            <linearGradient
-              id="zwd571hx0di"
-            >
-              <stop
-                offset="0%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-3; 1"
-                />
-              </stop>
-              <stop
-                offset="50%"
-                stopColor="#e0e0e0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-2; 2"
-                />
-              </stop>
-              <stop
-                offset="100%"
-                stopColor="#f0f0f0"
-                stopOpacity={1}
-              >
-                <animate
-                  attributeName="offset"
-                  dur="2s"
-                  repeatCount="indefinite"
-                  values="-1; 3"
-                />
-              </stop>
-            </linearGradient>
-          </defs>
-        </svg>
-      </div>
-    </article>
-  </div>
-</div>
+    </Grid>
+  </SystemPolicyCards>
+</IntlProvider>
 `;
 
 exports[`SystemPolicyCards component should render real table 1`] = `
-<div
-  className="pf-l-grid pf-m-gutter"
+<IntlProvider
+  locale="en-US"
 >
-  <div
-    className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
+  <SystemPolicyCards
+    loading={false}
+    policies={
+      Array [
+        Object {
+          "compliant": false,
+          "lastScanned": "2019-03-06T06:20:13Z",
+          "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+          "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
+          "rulesFailed": 10,
+          "rulesPassed": 30,
+        },
+        Object {
+          "compliant": false,
+          "lastScanned": null,
+          "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2",
+          "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
+          "rulesFailed": 0,
+          "rulesPassed": 0,
+        },
+      ]
+    }
   >
-    <article
-      className="pf-c-card"
+    <Grid
+      gutter="md"
     >
       <div
-        className="pf-c-card__body"
+        className="pf-l-grid pf-m-gutter"
       >
-        <div
-          className="pf-c-content margin-bottom-md"
-        >
-          <small
-            className="margin-bottom-none"
-            data-pf-content={true}
-          >
-            External policy
-          </small>
-          <h4
-            className="margin-bottom-top-none"
-            data-pf-content={true}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            <span
-              width={0}
-            >
-              <span />
-              <span>
-                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
-              </span>
-              <span
-                style={
-                  Object {
-                    "left": 0,
-                    "position": "fixed",
-                    "top": 0,
-                    "visibility": "hidden",
-                  }
-                }
-              >
-                …
-              </span>
-            </span>
-          </h4>
-        </div>
-        <div
-          className="margin-bottom-md"
+        <GridItem
+          key="0"
+          lg={6}
+          md={12}
+          sm={12}
+          xl={4}
         >
           <div
-            className="ins-c-policy-card ins-m-noncompliant"
+            className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
           >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
+            <SystemPolicyCard
+              policy={
                 Object {
-                  "verticalAlign": "-0.125em",
+                  "compliant": false,
+                  "lastScanned": "2019-03-06T06:20:13Z",
+                  "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
+                  "rulesFailed": 10,
+                  "rulesPassed": 30,
                 }
               }
-              viewBox="0 0 512 512"
-              width="1em"
             >
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                transform=""
-              />
-            </svg>
-             Noncompliant
+              <Card>
+                <article
+                  className="pf-c-card"
+                >
+                  <CardBody>
+                    <div
+                      className="pf-c-card__body"
+                    >
+                      <TextContent
+                        className="margin-bottom-md"
+                      >
+                        <div
+                          className="pf-c-content margin-bottom-md"
+                        >
+                          <Text
+                            className="margin-bottom-none"
+                            component="small"
+                          >
+                            <small
+                              className="margin-bottom-none"
+                              data-pf-content={true}
+                            >
+                              External policy
+                            </small>
+                          </Text>
+                          <Text
+                            className="margin-bottom-top-none"
+                            component="h4"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                          >
+                            <h4
+                              className="margin-bottom-top-none"
+                              data-pf-content={true}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              <Truncate
+                                ellipsis="…"
+                                lines={1}
+                                trimWhitespace={false}
+                                width={0}
+                              >
+                                <span
+                                  width={0}
+                                >
+                                  <span />
+                                  <span>
+                                    PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "left": 0,
+                                        "position": "fixed",
+                                        "top": 0,
+                                        "visibility": "hidden",
+                                      }
+                                    }
+                                  >
+                                    …
+                                  </span>
+                                </span>
+                              </Truncate>
+                            </h4>
+                          </Text>
+                        </div>
+                      </TextContent>
+                      <div
+                        className="margin-bottom-md"
+                      >
+                        <div
+                          className="ins-c-policy-card ins-m-noncompliant"
+                        >
+                          <ExclamationCircleIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                            title={null}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 512 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                transform=""
+                              />
+                            </svg>
+                          </ExclamationCircleIcon>
+                           Noncompliant
+                        </div>
+                        <Text
+                          component="small"
+                        >
+                          <small
+                            className=""
+                            data-pf-content={true}
+                          >
+                            30
+                             of 
+                            40
+                             rules passed (
+                            75%
+                            )
+                          </small>
+                        </Text>
+                      </div>
+                      <div
+                        className="margin-bottom-md"
+                      >
+                        <Text
+                          className="wrap-break-word"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          <p
+                            className="wrap-break-word"
+                            data-pf-content={true}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                          >
+                            Profile 
+                            <br />
+                            <Truncate
+                              ellipsis="…"
+                              lines={1}
+                              trimWhitespace={false}
+                              width={0}
+                            >
+                              <span
+                                width={0}
+                              >
+                                <span />
+                                <span>
+                                  xccdf_org.ssgproject.content_profile_pci-dss
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "left": 0,
+                                      "position": "fixed",
+                                      "top": 0,
+                                      "visibility": "hidden",
+                                    }
+                                  }
+                                >
+                                  …
+                                </span>
+                              </span>
+                            </Truncate>
+                          </p>
+                        </Text>
+                      </div>
+                      <Text
+                        className="margin-bottom-none"
+                        component="small"
+                      >
+                        <small
+                          className="margin-bottom-none"
+                          data-pf-content={true}
+                        >
+                          Last scanned: 
+                          <FormattedRelative
+                            updateInterval={10000}
+                            value={1551853213000}
+                          >
+                            <span>
+                              11 months ago
+                            </span>
+                          </FormattedRelative>
+                        </small>
+                      </Text>
+                    </div>
+                  </CardBody>
+                </article>
+              </Card>
+            </SystemPolicyCard>
           </div>
-          <small
-            className=""
-            data-pf-content={true}
-          >
-            30
-             of 
-            40
-             rules passed (
-            75%
-            )
-          </small>
-        </div>
-        <div
-          className="margin-bottom-md"
-        >
-          <p
-            className="wrap-break-word"
-            data-pf-content={true}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-          >
-            Profile 
-            <br />
-            <span
-              width={0}
-            >
-              <span />
-              <span>
-                xccdf_org.ssgproject.content_profile_pci-dss
-              </span>
-              <span
-                style={
-                  Object {
-                    "left": 0,
-                    "position": "fixed",
-                    "top": 0,
-                    "visibility": "hidden",
-                  }
-                }
-              >
-                …
-              </span>
-            </span>
-          </p>
-        </div>
-        <small
-          className="margin-bottom-none"
-          data-pf-content={true}
-        >
-          Last scanned: 
-          <span>
-            11 months ago
-          </span>
-        </small>
+        </GridItem>
       </div>
-    </article>
-  </div>
-</div>
+    </Grid>
+  </SystemPolicyCards>
+</IntlProvider>
 `;

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -1,37 +1,602 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SystemPolicyCards component should render loading state 1`] = `
-<SystemPolicyCards
-  loading={true}
-  policies={
-    Array [
-      Object {
-        "compliant": false,
-        "lastScanned": "2019-03-06T06:20:13Z",
-        "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
-        "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
-        "rulesFailed": 10,
-        "rulesPassed": 30,
-      },
-    ]
-  }
-/>
+<div
+  className="pf-l-grid pf-m-gutter"
+>
+  <div
+    className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
+  >
+    <article
+      className="pf-c-card"
+    >
+      <div
+        className="pf-c-card__body"
+      >
+        <div
+          className="pf-c-content margin-bottom-md"
+        >
+          <small
+            className="margin-bottom-none"
+            data-pf-content={true}
+          >
+            External policy
+          </small>
+          <h4
+            className="margin-bottom-top-none"
+            data-pf-content={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span
+              width={0}
+            >
+              <span />
+              <span>
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+              </span>
+              <span
+                style={
+                  Object {
+                    "left": 0,
+                    "position": "fixed",
+                    "top": 0,
+                    "visibility": "hidden",
+                  }
+                }
+              >
+                …
+              </span>
+            </span>
+          </h4>
+        </div>
+        <div
+          className="margin-bottom-md"
+        >
+          <div
+            className="ins-c-policy-card ins-m-noncompliant"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                transform=""
+              />
+            </svg>
+             Noncompliant
+          </div>
+          <small
+            className=""
+            data-pf-content={true}
+          >
+            30
+             of 
+            40
+             rules passed (
+            75%
+            )
+          </small>
+        </div>
+        <div
+          className="margin-bottom-md"
+        >
+          <p
+            className="wrap-break-word"
+            data-pf-content={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            Profile 
+            <br />
+            <span
+              width={0}
+            >
+              <span />
+              <span>
+                xccdf_org.ssgproject.content_profile_pci-dss
+              </span>
+              <span
+                style={
+                  Object {
+                    "left": 0,
+                    "position": "fixed",
+                    "top": 0,
+                    "visibility": "hidden",
+                  }
+                }
+              >
+                …
+              </span>
+            </span>
+          </p>
+        </div>
+        <small
+          className="margin-bottom-none"
+          data-pf-content={true}
+        >
+          Last scanned: 
+          <span>
+            11 months ago
+          </span>
+        </small>
+      </div>
+    </article>
+  </div>
+  <div
+    className="pf-l-grid__item pf-m-4-col"
+  >
+    <article
+      className="pf-c-card"
+    >
+      <div
+        className="pf-c-card__body"
+      >
+        <svg
+          aria-labelledby="Loading interface..."
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          viewBox="0 0 400 480"
+        >
+          <title>
+            Loading interface...
+          </title>
+          <rect
+            clipPath="url(#6sy3go9waes)"
+            height={480}
+            style={
+              Object {
+                "fill": "url(#ah7zx0ex2q5)",
+              }
+            }
+            width={400}
+            x="0"
+            y="0"
+          />
+          <defs>
+            <clipPath
+              id="6sy3go9waes"
+            >
+              <circle
+                cx="30"
+                cy="30"
+                r="30"
+              />
+              <rect
+                height="13"
+                rx="4"
+                ry="4"
+                width="100"
+                x="75"
+                y="13"
+              />
+              <rect
+                height="8"
+                rx="4"
+                ry="4"
+                width="50"
+                x="75"
+                y="37"
+              />
+              <rect
+                height="400"
+                rx="5"
+                ry="5"
+                width="400"
+                x="0"
+                y="70"
+              />
+            </clipPath>
+            <linearGradient
+              id="ah7zx0ex2q5"
+            >
+              <stop
+                offset="0%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-3; 1"
+                />
+              </stop>
+              <stop
+                offset="50%"
+                stopColor="#e0e0e0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-2; 2"
+                />
+              </stop>
+              <stop
+                offset="100%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-1; 3"
+                />
+              </stop>
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+    </article>
+  </div>
+  <div
+    className="pf-l-grid__item pf-m-4-col"
+  >
+    <article
+      className="pf-c-card"
+    >
+      <div
+        className="pf-c-card__body"
+      >
+        <svg
+          aria-labelledby="Loading interface..."
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          viewBox="0 0 400 480"
+        >
+          <title>
+            Loading interface...
+          </title>
+          <rect
+            clipPath="url(#3eyu80fnaov)"
+            height={480}
+            style={
+              Object {
+                "fill": "url(#7hrdli9rrif)",
+              }
+            }
+            width={400}
+            x="0"
+            y="0"
+          />
+          <defs>
+            <clipPath
+              id="3eyu80fnaov"
+            >
+              <circle
+                cx="30"
+                cy="30"
+                r="30"
+              />
+              <rect
+                height="13"
+                rx="4"
+                ry="4"
+                width="100"
+                x="75"
+                y="13"
+              />
+              <rect
+                height="8"
+                rx="4"
+                ry="4"
+                width="50"
+                x="75"
+                y="37"
+              />
+              <rect
+                height="400"
+                rx="5"
+                ry="5"
+                width="400"
+                x="0"
+                y="70"
+              />
+            </clipPath>
+            <linearGradient
+              id="7hrdli9rrif"
+            >
+              <stop
+                offset="0%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-3; 1"
+                />
+              </stop>
+              <stop
+                offset="50%"
+                stopColor="#e0e0e0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-2; 2"
+                />
+              </stop>
+              <stop
+                offset="100%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-1; 3"
+                />
+              </stop>
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+    </article>
+  </div>
+  <div
+    className="pf-l-grid__item pf-m-4-col"
+  >
+    <article
+      className="pf-c-card"
+    >
+      <div
+        className="pf-c-card__body"
+      >
+        <svg
+          aria-labelledby="Loading interface..."
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          viewBox="0 0 400 480"
+        >
+          <title>
+            Loading interface...
+          </title>
+          <rect
+            clipPath="url(#96f82mrno1j)"
+            height={480}
+            style={
+              Object {
+                "fill": "url(#zwd571hx0di)",
+              }
+            }
+            width={400}
+            x="0"
+            y="0"
+          />
+          <defs>
+            <clipPath
+              id="96f82mrno1j"
+            >
+              <circle
+                cx="30"
+                cy="30"
+                r="30"
+              />
+              <rect
+                height="13"
+                rx="4"
+                ry="4"
+                width="100"
+                x="75"
+                y="13"
+              />
+              <rect
+                height="8"
+                rx="4"
+                ry="4"
+                width="50"
+                x="75"
+                y="37"
+              />
+              <rect
+                height="400"
+                rx="5"
+                ry="5"
+                width="400"
+                x="0"
+                y="70"
+              />
+            </clipPath>
+            <linearGradient
+              id="zwd571hx0di"
+            >
+              <stop
+                offset="0%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-3; 1"
+                />
+              </stop>
+              <stop
+                offset="50%"
+                stopColor="#e0e0e0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-2; 2"
+                />
+              </stop>
+              <stop
+                offset="100%"
+                stopColor="#f0f0f0"
+                stopOpacity={1}
+              >
+                <animate
+                  attributeName="offset"
+                  dur="2s"
+                  repeatCount="indefinite"
+                  values="-1; 3"
+                />
+              </stop>
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+    </article>
+  </div>
+</div>
 `;
 
 exports[`SystemPolicyCards component should render real table 1`] = `
-<SystemPolicyCards
-  loading={false}
-  policies={
-    Array [
-      Object {
-        "compliant": false,
-        "lastScanned": "2019-03-06T06:20:13Z",
-        "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
-        "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
-        "rulesFailed": 10,
-        "rulesPassed": 30,
-      },
-    ]
-  }
-/>
+<div
+  className="pf-l-grid pf-m-gutter"
+>
+  <div
+    className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-6-col-on-lg pf-m-4-col-on-xl"
+  >
+    <article
+      className="pf-c-card"
+    >
+      <div
+        className="pf-c-card__body"
+      >
+        <div
+          className="pf-c-content margin-bottom-md"
+        >
+          <small
+            className="margin-bottom-none"
+            data-pf-content={true}
+          >
+            External policy
+          </small>
+          <h4
+            className="margin-bottom-top-none"
+            data-pf-content={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <span
+              width={0}
+            >
+              <span />
+              <span>
+                PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7
+              </span>
+              <span
+                style={
+                  Object {
+                    "left": 0,
+                    "position": "fixed",
+                    "top": 0,
+                    "visibility": "hidden",
+                  }
+                }
+              >
+                …
+              </span>
+            </span>
+          </h4>
+        </div>
+        <div
+          className="margin-bottom-md"
+        >
+          <div
+            className="ins-c-policy-card ins-m-noncompliant"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                transform=""
+              />
+            </svg>
+             Noncompliant
+          </div>
+          <small
+            className=""
+            data-pf-content={true}
+          >
+            30
+             of 
+            40
+             rules passed (
+            75%
+            )
+          </small>
+        </div>
+        <div
+          className="margin-bottom-md"
+        >
+          <p
+            className="wrap-break-word"
+            data-pf-content={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            Profile 
+            <br />
+            <span
+              width={0}
+            >
+              <span />
+              <span>
+                xccdf_org.ssgproject.content_profile_pci-dss
+              </span>
+              <span
+                style={
+                  Object {
+                    "left": 0,
+                    "position": "fixed",
+                    "top": 0,
+                    "visibility": "hidden",
+                  }
+                }
+              >
+                …
+              </span>
+            </span>
+          </p>
+        </div>
+        <small
+          className="margin-bottom-none"
+          data-pf-content={true}
+        >
+          Last scanned: 
+          <span>
+            11 months ago
+          </span>
+        </small>
+      </div>
+    </article>
+  </div>
+</div>
 `;


### PR DESCRIPTION
This PR is meant to fix the problem with the new `Create Policies` feature in CI. If you assign a policy to a host, it will show up on the SystemDetails page. However it does not make sense to show such policies until they have at least one scan with results.

![Screenshot from 2020-01-24 08-33-36](https://user-images.githubusercontent.com/598891/73052021-63408780-3e84-11ea-9761-0f35b3a665fe.png)

Notice the NaN policies:

![Screenshot from 2020-01-24 08-37-37](https://user-images.githubusercontent.com/598891/73052196-cf22f000-3e84-11ea-9790-5e87b8808bb9.png)
