### PR TITLE
Fire only refresh when user changes pagination and refresh is set

### DIFF
--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -52,6 +52,7 @@ class InventoryTable extends Component {
             } }>
                 <EntityTableToolbar
                     { ...props }
+                    onRefresh={onRefresh}
                     totalItems={ total || (items && items.length) }
                     hasItems={ Boolean(items) }
                     filters={ filters }

--- a/packages/inventory/src/Pagination.js
+++ b/packages/inventory/src/Pagination.js
@@ -63,7 +63,7 @@ class ContextFooterPagination extends Component {
                         itemCount={ total }
                         page={ statePage || page }
                         perPage={ perPage }
-                        direction={ direction }
+                        dropDirection={ direction }
                         onSetPage={ this.onSetPage }
                         onPerPageSelect={ this.onPerPageSelect }
                     />

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -95,3 +95,15 @@ export function reduceFilters(filters) {
         tagFilters: {}
     });
 }
+
+export const mergeTableProps = (stateProps, dispatchProps, ownProps) => ({
+    ...stateProps,
+    ...dispatchProps,
+    ...ownProps,
+    ...ownProps.onRefresh && {
+        onRefresh: (...props) => {
+            dispatchProps.onRefresh(...props);
+            ownProps.onRefresh(...props);
+        }
+    }
+});


### PR DESCRIPTION
When consumer passes `onRefresh` to inventory use it directly instead of `onRefreshData`. We rely on the consumer to refresh the data, if the data remains the same as previously they have to fire `onRefreshData`.

Also when using `onRefresh` fire loading so the inv table shows loading state.