### PR TITLE
Export ComplianceRemediationButton and make minor changes

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -123,15 +123,17 @@ class SystemDetails extends Component {
     }
 
     render() {
-        const { match: { params: { inventoryId } }, hidePassed, client } = this.props;
+        const { inventoryId, hidePassed, client } = this.props;
+        console.log(inventoryId);
         return (
             <ApolloProvider client={ client }>
                 <Query query={ QUERY } variables={ { systemId: inventoryId } }>
-                    { ({ data, error, loading }) => (
-                        error ?
+                    { ({ data, error, loading }) => {
+                        console.log(data, error, inventoryId);
+                        return error ?
                             this.renderError(error) :
                             <SystemQuery hidePassed={ hidePassed } data={ data } error={ error } loading={ loading } />
-                    ) }
+                    } }
                 </Query>
             </ApolloProvider>
         );
@@ -139,11 +141,7 @@ class SystemDetails extends Component {
 }
 
 SystemDetails.propTypes = {
-    match: propTypes.shape({
-        params: propTypes.shape({
-            inventoryId: propTypes.string
-        })
-    }),
+    inventoryId: propTypes.string,
     columns: propTypes.shape([
         {
             title: propTypes.oneOfType([ propTypes.string, propTypes.object ]).isRequired,
@@ -156,9 +154,6 @@ SystemDetails.propTypes = {
 };
 
 SystemDetails.defaultProps = {
-    match: {
-        params: {}
-    },
     client: new ApolloClient({
         link: new HttpLink({
             uri: COMPLIANCE_API_ROOT + '/graphql',
@@ -187,4 +182,4 @@ SystemQuery.defaultProps = {
     loading: true
 };
 
-export default routerParams(SystemDetails);
+export default SystemDetails;

--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -124,16 +124,15 @@ class SystemDetails extends Component {
 
     render() {
         const { inventoryId, hidePassed, client } = this.props;
-        console.log(inventoryId);
+
         return (
             <ApolloProvider client={ client }>
                 <Query query={ QUERY } variables={ { systemId: inventoryId } }>
-                    { ({ data, error, loading }) => {
-                        console.log(data, error, inventoryId);
-                        return error ?
+                    { ({ data, error, loading }) => (
+                        error ?
                             this.renderError(error) :
                             <SystemQuery hidePassed={ hidePassed } data={ data } error={ error } loading={ loading } />
-                    } }
+                    ) }
                 </Query>
             </ApolloProvider>
         );

--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -8,10 +8,6 @@ import { AnsibeTowerIcon } from '@patternfly/react-icons';
 import { global_BackgroundColor_100 as globalBackgroundColor100 } from '@patternfly/react-tokens';
 
 class ComplianceRemediationButton extends React.Component {
-    constructor(props) {
-        super(props);
-    }
-
     formatRule = ({ title, refId }, profile, system) => ({
         id: `ssg:rhel7|${profile}|${refId}`,
         description: title,
@@ -44,10 +40,10 @@ class ComplianceRemediationButton extends React.Component {
         const result = { systems: [], issues: [] };
         allSystems.forEach(async (system) => {
             result.systems.push(system.id);
-            if (selectedRules) {
+            if (selectedRules.length !== 0) {
                 result.issues.push(this.rulesWithRemediations(selectedRules, system.id));
             } else {
-                result.issues.push(this.rulesWithRemediations(system.rule_objects_failed, system.id));
+                result.issues.push(this.rulesWithRemediations(system.ruleObjectsFailed, system.id));
             }
         });
 
@@ -57,15 +53,18 @@ class ComplianceRemediationButton extends React.Component {
         });
     }
 
+    noRemediationAvailable = () => {
+        const { allSystems } = this.props;
+        return !allSystems.some((system) => system.ruleObjectsFailed.some((rule) => rule.remediationAvailable));
+    }
+
     render() {
         const { addNotification, allSystems, selectedRules } = this.props;
 
         return (
             <React.Fragment>
                 <RemediationButton
-                    isDisabled={ (allSystems.length === 0 || allSystems[0].rule_objects_failed.length === 0) &&
-                        selectedRules.length === 0
-                    }
+                    isDisabled={ this.noRemediationAvailable() }
                     onRemediationCreated={ result => addNotification(result.getNotification()) }
                     dataProvider={ this.dataProvider }
                 >

--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -54,12 +54,12 @@ class ComplianceRemediationButton extends React.Component {
     }
 
     noRemediationAvailable = () => {
-        const { allSystems } = this.props;
-        return !allSystems.some((system) => system.ruleObjectsFailed.some((rule) => rule.remediationAvailable));
+        const { allSystems, selectedRules } = this.props;
+        return selectedRules.length === 0 && !allSystems.some((system) => system.ruleObjectsFailed.some((rule) => rule.remediationAvailable));
     }
 
     render() {
-        const { addNotification, allSystems, selectedRules } = this.props;
+        const { addNotification } = this.props;
 
         return (
             <React.Fragment>

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -530,7 +530,7 @@ class SystemRulesTable extends React.Component {
                             { remediationsEnabled &&
                                 <LevelItem>
                                     <ComplianceRemediationButton
-                                        allSystems={ [{ id: system.id, rule_objects_failed: [] }] }
+                                        allSystems={ [{ id: system.id, ruleObjectsFailed: [] }] }
                                         selectedRules={ this.selectedRules() } />
                                 </LevelItem>
                             }

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -45,7 +45,7 @@ exports[`SystemRulesTable component should render 1`] = `
             Array [
               Object {
                 "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
-                "rule_objects_failed": Array [],
+                "ruleObjectsFailed": Array [],
               },
             ]
           }

--- a/packages/inventory-compliance/src/index.js
+++ b/packages/inventory-compliance/src/index.js
@@ -1,2 +1,3 @@
 export { default as default } from './Compliance';
 export { default as SystemRulesTable } from './SystemRulesTable';
+export { default as ComplianceRemediationButton } from './ComplianceRemediationButton';


### PR DESCRIPTION
We'll use this ComplianceRemediationButton instead of writting yet another one in compliance-frontend. This exports the component and adds changes to make this possible.