### PR TITLE
Cancel notification dismiss timeout on mouseEnter

### DIFF
--- a/packages/notifications/src/Notification.js
+++ b/packages/notifications/src/Notification.js
@@ -14,19 +14,27 @@ class Notification extends Component {
     constructor(props) {
         super(props);
         this.handleDismiss = this.handleDismiss.bind(this);
-        if (!props.dismissable) {
-            this.dismissTimeout = setTimeout(() => this.handleDismiss(), props.dismissDelay);
-        }
+        this.setDismissTimeout();
     }
 
-    handleDismiss() {
+    handleDismiss = () => {
         this.props.onDismiss(this.props.id);
     }
 
-    componentWillUnmount() {
+    setDismissTimeout = () => {
+        if (!this.props.dismissable) {
+            this.dismissTimeout = setTimeout(() => this.handleDismiss(), this.props.dismissDelay);
+        }
+    }
+
+    clearDismissTimeout = () => {
         if (this.dismissTimeout) {
             clearTimeout(this.dismissTimeout);
         }
+    }
+
+    componentWillUnmount() {
+        this.clearDismissTimeout();
     }
 
     render() {
@@ -45,6 +53,8 @@ class Notification extends Component {
                         <CloseIcon/>
                     </Button> : null
                 }
+                onMouseEnter={this.clearDismissTimeout}
+                onMouseLeave={this.setDismissTimeout}
             >
                 { (typeof description === 'string') ? description.replace(/<\/?[^>]+(>|$)/g, '') : description }
                 {

--- a/packages/notifications/src/Notification.test.js
+++ b/packages/notifications/src/Notification.test.js
@@ -80,4 +80,26 @@ describe('Notification component', () => {
         wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } dismissable description={ undefined }/>);
         expect(timeoutSpy).not.toHaveBeenCalled();
     });
+
+    it('should clear timeout on notification mouse enter', () => {
+        const timeoutSpy = jest.spyOn(global, 'clearTimeout');
+        let wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } description={ undefined }/>);
+        wrapper.find('.pf-c-alert').simulate('mouseEnter');
+        expect(timeoutSpy).toHaveBeenCalledTimes(1);
+        timeoutSpy.mockRestore();
+
+        wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } dismissable description={ undefined }/>);
+        expect(timeoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('should set timeout on notification mouse leave', () => {
+        const timeoutSpy = jest.spyOn(global, 'setTimeout');
+        let wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } description={ undefined }/>);
+        wrapper.find('.pf-c-alert').simulate('mouseLeave');
+        expect(timeoutSpy).toHaveBeenCalledTimes(2);
+        timeoutSpy.mockRestore();
+
+        wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } dismissable description={ undefined }/>);
+        expect(timeoutSpy).not.toHaveBeenCalled();
+    });
 });

--- a/packages/notifications/src/Notification.test.js
+++ b/packages/notifications/src/Notification.test.js
@@ -87,9 +87,6 @@ describe('Notification component', () => {
         wrapper.find('.pf-c-alert').simulate('mouseEnter');
         expect(timeoutSpy).toHaveBeenCalledTimes(1);
         timeoutSpy.mockRestore();
-
-        wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } dismissable description={ undefined }/>);
-        expect(timeoutSpy).not.toHaveBeenCalled();
     });
 
     it('should set timeout on notification mouse leave', () => {
@@ -98,8 +95,5 @@ describe('Notification component', () => {
         wrapper.find('.pf-c-alert').simulate('mouseLeave');
         expect(timeoutSpy).toHaveBeenCalledTimes(2);
         timeoutSpy.mockRestore();
-
-        wrapper = mount(<Notification dismissDelay={ 100 } { ...initialProps } dismissable description={ undefined }/>);
-        expect(timeoutSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/notifications/src/__snapshots__/Notification.test.js.snap
+++ b/packages/notifications/src/__snapshots__/Notification.test.js.snap
@@ -5,6 +5,8 @@ exports[`Notification component pagination should render correctly 1`] = `
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 >
@@ -17,6 +19,8 @@ exports[`Notification component should render correctly 1`] = `
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 >
@@ -29,6 +33,8 @@ exports[`Notification component should render correctly with HTML description 1`
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 >
@@ -41,6 +47,8 @@ exports[`Notification component should render correctly with HTML title 1`] = `
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Some textanother"
   variant="success"
 >
@@ -66,6 +74,8 @@ exports[`Notification component should render correctly with dismiss button 1`] 
   }
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 />
@@ -76,6 +86,8 @@ exports[`Notification component should render correctly with sentryId 1`] = `
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 >
@@ -96,6 +108,8 @@ exports[`Notification component should render correctly withouth description 1`]
   action={null}
   className="notification-item"
   id="Foo"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   title="Bar"
   variant="success"
 />

--- a/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
+++ b/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
@@ -244,6 +244,8 @@ exports[`Notification portal should render notifications given as direct props 1
             }
             className="notification-item"
             id="0"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             title="Notification title"
             variant="success"
           >
@@ -269,6 +271,8 @@ exports[`Notification portal should render notifications given as direct props 1
                   ],
                   "className": "notification-item",
                   "id": "0",
+                  "onMouseEnter": [Function],
+                  "onMouseLeave": [Function],
                   "title": "Notification title",
                   "variant": "success",
                 }
@@ -292,6 +296,8 @@ exports[`Notification portal should render notifications given as direct props 1
                 }
                 className="notification-item"
                 id="0"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 ouiaContext={
                   Object {
                     "isOuia": false,
@@ -305,6 +311,8 @@ exports[`Notification portal should render notifications given as direct props 1
                   aria-label="Success Alert"
                   className="pf-c-alert pf-m-success notification-item"
                   id="0"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <AlertIcon
                     variant="success"
@@ -768,6 +776,8 @@ exports[`Notification portal should render notifications given as direct props o
             }
             className="notification-item"
             id="Direct notification"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             title="Notification title"
             variant="success"
           >
@@ -793,6 +803,8 @@ exports[`Notification portal should render notifications given as direct props o
                   ],
                   "className": "notification-item",
                   "id": "Direct notification",
+                  "onMouseEnter": [Function],
+                  "onMouseLeave": [Function],
                   "title": "Notification title",
                   "variant": "success",
                 }
@@ -816,6 +828,8 @@ exports[`Notification portal should render notifications given as direct props o
                 }
                 className="notification-item"
                 id="Direct notification"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 ouiaContext={
                   Object {
                     "isOuia": false,
@@ -829,6 +843,8 @@ exports[`Notification portal should render notifications given as direct props o
                   aria-label="Success Alert"
                   className="pf-c-alert pf-m-success notification-item"
                   id="Direct notification"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <AlertIcon
                     variant="success"
@@ -1143,6 +1159,8 @@ exports[`Notification portal should render notifications given from store 1`] = 
             }
             className="notification-item"
             id="0"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             title="Notification title"
             variant="success"
           >
@@ -1168,6 +1186,8 @@ exports[`Notification portal should render notifications given from store 1`] = 
                   ],
                   "className": "notification-item",
                   "id": "0",
+                  "onMouseEnter": [Function],
+                  "onMouseLeave": [Function],
                   "title": "Notification title",
                   "variant": "success",
                 }
@@ -1191,6 +1211,8 @@ exports[`Notification portal should render notifications given from store 1`] = 
                 }
                 className="notification-item"
                 id="0"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 ouiaContext={
                   Object {
                     "isOuia": false,
@@ -1204,6 +1226,8 @@ exports[`Notification portal should render notifications given from store 1`] = 
                   aria-label="Success Alert"
                   className="pf-c-alert pf-m-success notification-item"
                   id="0"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
                   <AlertIcon
                     variant="success"


### PR DESCRIPTION
New state:

On not-dismissable notification mouseEnter:
- clear default dismiss timeout

On not-dismissable notification mouseLeave:
- set new dismiss timeout

![002](https://user-images.githubusercontent.com/50696716/73860708-3dc85c00-483c-11ea-8c59-cad3288bcc83.png)

& tests
