### PR TITLE
Remove constant column numbers from SystemRulesTable

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import propTypes from 'prop-types';
-import routerParams from '@redhat-cloud-services/frontend-components-utilities/files/RouterParams';
 import SystemPolicyCards from './SystemPolicyCards';
 import SystemRulesTable from './SystemRulesTable';
 import { Query } from 'react-apollo';

--- a/packages/inventory-compliance/src/RulesComplianceFilter.js
+++ b/packages/inventory-compliance/src/RulesComplianceFilter.js
@@ -26,7 +26,7 @@ class RulesComplianceFilter extends React.Component {
             ]
         });
 
-        if (props.availablePolicies.length > 1) {
+        if (props.availablePolicies && props.availablePolicies.length > 1) {
             filterCategories.push({
                 type: 'checkbox', title: 'Policy', urlParam: 'policy',
                 values: props.availablePolicies.map(policy => ({

--- a/packages/inventory-compliance/src/RulesComplianceFilter.js
+++ b/packages/inventory-compliance/src/RulesComplianceFilter.js
@@ -7,34 +7,39 @@ import { HIGH_SEVERITY, MEDIUM_SEVERITY, LOW_SEVERITY } from './Constants';
 class RulesComplianceFilter extends React.Component {
     constructor(props) {
         super(props);
+        const filterCategories = [];
+        if (props.showPassFailFilter) {
+            filterCategories.push({
+                type: 'radio', title: 'Passed', urlParam: 'hidePassed', values: [
+                    { label: 'Show all rules', value: false },
+                    { label: 'Hide passed rules', value: true }
+                ]
+            });
+        }
+
+        filterCategories.push({
+            type: 'checkbox', title: 'Severity', urlParam: 'severity', values: [
+                { label: HIGH_SEVERITY, value: 'high' },
+                { label: MEDIUM_SEVERITY, value: 'medium' },
+                { label: LOW_SEVERITY, value: 'low' },
+                { label: 'Unknown', value: 'unknown' }
+            ]
+        });
+
+        if (props.availablePolicies.length > 1) {
+            filterCategories.push({
+                type: 'checkbox', title: 'Policy', urlParam: 'policy',
+                values: props.availablePolicies.map(policy => ({
+                    label: policy.name, value: policy.name
+                }))
+            });
+        }
+
         this.state = {
             hidePassed: props.hidePassed,
             severity: props.severity,
             policy: props.policy,
-            filterCategories: [
-                {
-                    type: 'radio', title: 'Passed', urlParam: 'hidePassed', values: [
-                        { label: 'Show all rules', value: false },
-                        { label: 'Hide passed rules', value: true }
-                    ]
-                },
-                {
-                    type: 'checkbox', title: 'Severity', urlParam: 'severity', values: [
-                        { label: HIGH_SEVERITY, value: 'high' },
-                        { label: MEDIUM_SEVERITY, value: 'medium' },
-                        { label: LOW_SEVERITY, value: 'low' },
-                        { label: 'Unknown', value: 'unknown' }
-                    ]
-                },
-                ...props.availablePolicies.length > 1 ? [
-                    {
-                        type: 'checkbox', title: 'Policy', urlParam: 'policy',
-                        values: props.availablePolicies.map(policy => ({
-                            label: policy.name, value: policy.name
-                        }))
-                    }
-                ] : []
-            ]
+            filterCategories
         };
     };
 
@@ -85,6 +90,7 @@ class RulesComplianceFilter extends React.Component {
 RulesComplianceFilter.propTypes = {
     updateFilter: propTypes.func,
     hidePassed: propTypes.bool,
+    showPassFailFilter: propTypes.bool,
     severity: propTypes.array,
     availablePolicies: propTypes.array,
     policy: propTypes.array
@@ -92,6 +98,7 @@ RulesComplianceFilter.propTypes = {
 
 RulesComplianceFilter.defaultProps = {
     hidePassed: false,
+    showPassFailFilter: true,
     severity: [],
     policy: [],
     updateFilter: () => {}

--- a/packages/inventory-compliance/src/RulesComplianceFilter.test.js
+++ b/packages/inventory-compliance/src/RulesComplianceFilter.test.js
@@ -28,6 +28,19 @@ describe('RulesComplianceFilter component', () => {
         );
         wrapper.instance();
         expect(wrapper.state('filterCategories').length).toEqual(2);
+        expect(wrapper.state('filterCategories')[0].title).toEqual('Passed');
+        expect(wrapper.state('filterCategories')[1].title).toEqual('Severity');
+    });
+
+    it('should not display the "Passed" filter if disabled', () => {
+        const wrapper = shallow(
+            <RulesComplianceFilter
+                showPassFailFilter={ false }
+            />
+        );
+        wrapper.instance();
+        expect(wrapper.state('filterCategories').length).toEqual(1);
+        expect(wrapper.state('filterCategories')[0].title).toEqual('Severity');
     });
 
     it('should allow to add and remove filters', () => {

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -92,15 +92,13 @@ class SystemRulesTable extends React.Component {
                 columnIndices.REMEDIATIONS_COLUMN = index;
             }
         });
-        return this.setState({
-            columnIndices
-        });
+        return columnIndices;
     }
 
     componentDidMount = () => {
-        this.setColumnIndices().then(() => {
-            this.setInitialCurrentRows();
-        });
+        this.setState({
+            columnIndices: this.setColumnIndices()
+        }, this.setInitialCurrentRows);
     }
 
     componentDidUpdate = (prevProps) => {
@@ -397,6 +395,8 @@ class SystemRulesTable extends React.Component {
     }
 
     filterBy = (attribute, rows, column) => {
+        if (column === undefined) { return rows; }
+
         const filteredRows = [];
         rows.forEach((row, i) => {
             if (this.isParent(row) && String(row.cells[column].original).toLowerCase().match(
@@ -423,8 +423,8 @@ class SystemRulesTable extends React.Component {
             searchTerm = lowerString(searchTerm);
             rows.forEach((row, i) => {
                 const titleMatches = this.isParent(row) && lowerString(row.cells[columnIndices.TITLE_COLUMN].original).match(searchTerm);
-                const identifierMatches = !this.isParent(row) && lowerString(row.cells[0].originalIdentifier).match(searchTerm);
-                const referencesMatch = !this.isParent(row) && lowerString(row.cells[0].originalReferences).match(searchTerm);
+                const identifierMatches = !this.isParent(row) && lowerString(row.cells[columnIndices.TITLE_COLUMN].originalIdentifier).match(searchTerm);
+                const referencesMatch = !this.isParent(row) && lowerString(row.cells[columnIndices.TITLE_COLUMN].originalReferences).match(searchTerm);
 
                 if (titleMatches || identifierMatches || referencesMatch) {
                     let parent = this.isParent(row) ? row : rows[i - 1];
@@ -500,7 +500,7 @@ class SystemRulesTable extends React.Component {
     }
 
     render() {
-        const { hidePassed, sortBy, rows, currentRows, columns, page, itemsPerPage } = this.state;
+        const { columnIndices, hidePassed, sortBy, rows, currentRows, columns, page, itemsPerPage } = this.state;
         const { remediationsEnabled, system, loading, profileRules } = this.props;
 
         if (loading) {
@@ -528,6 +528,7 @@ class SystemRulesTable extends React.Component {
                                 <InputGroup>
                                     <RulesComplianceFilter
                                         hidePassed={hidePassed}
+                                        showPassFailFilter={ (columnIndices && columnIndices.COMPLIANT_COLUMN !== undefined) || false }
                                         availablePolicies={ profileRules.map(profile => profile.profile) }
                                         updateFilter={ this.updateFilter } />
                                     <SimpleTableFilter buttonTitle={ null }

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -289,15 +289,6 @@ class SystemRulesTable extends React.Component {
             ];
         })).filter(row => row); // Need to remove undefined (duplicate) rows
 
-        rows.forEach((row) => {
-            if (this.isParent(row)) {
-                row.cells[POLICY_COLUMN] = {
-                    title: profiles[row.cells[TITLE_COLUMN].original].name,
-                    original: profiles[row.cells[TITLE_COLUMN].original].name
-                };
-            }
-        });
-
         for (let [ key, value ] of Object.entries(profiles)) {
             profiles[key] = value.refId;
         }

--- a/packages/inventory-compliance/src/SystemRulesTable.test.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.test.js
@@ -7,6 +7,7 @@ import { TITLE_COLUMN } from './Constants';
 import { remediationsResponse, system, profileRules } from './Fixtures';
 import { columns } from './defaultColumns';
 import debounce from 'lodash/debounce';
+import { ANSIBLE_ICON } from './Constants';
 
 jest.mock('lodash/debounce');
 debounce.mockImplementation(fn => fn);
@@ -216,5 +217,28 @@ describe('SystemRulesTable component', () => {
                 expect(row.parent).toEqual(i - 1);
             }
         });
+    });
+
+    it('should be able to filter when columns do not contain Passed or Policy', async () => {
+        const wrapper = shallow(
+            <SystemRulesTable
+                profileRules={ profileRules }
+                loading={ false }
+                system={ system }
+                itemsPerPage={ 50 }
+                columns={ [
+                    { title: 'Rule' },
+                    { title: 'Policy' },
+                    { title: 'Severity' },
+                    { title: 'Passed' },
+                    { title: <React.Fragment>{ ANSIBLE_ICON } Ansible</React.Fragment>, original: 'Ansible' }
+                ] }
+            />
+        );
+        const instance = wrapper.instance();
+        await instance.setInitialCurrentRows();
+        await instance.setState({ page: 3 });
+        await instance.updateFilter(wrapper.state('hidePassed'), [ 'low' ], []);
+        expect(wrapper.state('currentRows').length / 2).toEqual(2);
     });
 });

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -22,6 +22,7 @@ exports[`SystemRulesTable component should render 1`] = `
             hidePassed={false}
             policy={Array []}
             severity={Array []}
+            showPassFailFilter={true}
             updateFilter={[Function]}
           />
           <SimpleFilter
@@ -1638,6 +1639,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
             hidePassed={false}
             policy={Array []}
             severity={Array []}
+            showPassFailFilter={true}
             updateFilter={[Function]}
           />
           <SimpleFilter


### PR DESCRIPTION
This PR is meant to remove the constants we use to set the column numbers, and provide those through a prop. The problem with using constants is that it's not flexible enough when we want to use the table in other places and add/remove columns - the search/filtering is completely reliant on these constants and it won't work in these cases.