### PR TITLE
Replace Button with AlertActionCloseButton in notifications.

### DIFF
--- a/packages/notifications/src/Notification.js
+++ b/packages/notifications/src/Notification.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Alert, Button, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Alert, TextContent, Text, TextVariants, AlertActionCloseButton } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import './notifications.scss';
@@ -45,13 +45,13 @@ class Notification extends Component {
                 title={ title && title.replace(/<\/?[^>]+(>|$)/g, '') }
                 { ...rest }
                 action={ dismissable ?
-                    <Button
+                    <AlertActionCloseButton
                         aria-label="close-notification"
                         variant="plain"
                         onClick={ this.handleDismiss }
                     >
                         <CloseIcon/>
-                    </Button> : null
+                    </AlertActionCloseButton> : null
                 }
                 onMouseEnter={this.clearDismissTimeout}
                 onMouseLeave={this.setDismissTimeout}

--- a/packages/notifications/src/__snapshots__/Notification.test.js.snap
+++ b/packages/notifications/src/__snapshots__/Notification.test.js.snap
@@ -59,7 +59,7 @@ exports[`Notification component should render correctly with HTML title 1`] = `
 exports[`Notification component should render correctly with dismiss button 1`] = `
 <Component
   action={
-    <Unknown
+    <AlertActionCloseButton
       aria-label="close-notification"
       onClick={[Function]}
       variant="plain"
@@ -70,7 +70,7 @@ exports[`Notification component should render correctly with dismiss button 1`] 
         size="sm"
         title={null}
       />
-    </Unknown>
+    </AlertActionCloseButton>
   }
   className="notification-item"
   id="Foo"

--- a/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
+++ b/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
@@ -120,9 +120,7 @@ exports[`Notification portal should render notifications given as direct props 1
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -130,12 +128,12 @@ exports[`Notification portal should render notifications given as direct props 1
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -189,9 +187,7 @@ exports[`Notification portal should render notifications given as direct props 1
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -199,12 +195,12 @@ exports[`Notification portal should render notifications given as direct props 1
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -229,7 +225,7 @@ exports[`Notification portal should render notifications given as direct props 1
         >
           <Component
             action={
-              <Unknown
+              <AlertActionCloseButton
                 aria-label="close-notification"
                 onClick={[Function]}
                 variant="plain"
@@ -240,7 +236,7 @@ exports[`Notification portal should render notifications given as direct props 1
                   size="sm"
                   title={null}
                 />
-              </Unknown>
+              </AlertActionCloseButton>
             }
             className="notification-item"
             id="0"
@@ -253,7 +249,7 @@ exports[`Notification portal should render notifications given as direct props 1
               component={[Function]}
               componentProps={
                 Object {
-                  "action": <Unknown
+                  "action": <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -264,7 +260,7 @@ exports[`Notification portal should render notifications given as direct props 1
                       size="sm"
                       title={null}
                     />
-                  </Unknown>,
+                  </AlertActionCloseButton>,
                   "children": Array [
                     "Some meaningfull description",
                     undefined,
@@ -281,7 +277,7 @@ exports[`Notification portal should render notifications given as direct props 1
             >
               <Alert
                 action={
-                  <Unknown
+                  <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -292,7 +288,7 @@ exports[`Notification portal should render notifications given as direct props 1
                       size="sm"
                       title={null}
                     />
-                  </Unknown>
+                  </AlertActionCloseButton>
                 }
                 className="notification-item"
                 id="0"
@@ -366,91 +362,91 @@ exports[`Notification portal should render notifications given as direct props 1
                   <div
                     className="pf-c-alert__action"
                   >
-                    <Component
+                    <AlertActionCloseButton
                       aria-label="close-notification"
                       onClick={[Function]}
                       title="Notification title"
                       variant="plain"
                       variantLabel="Success alert:"
                     >
-                      <ComponentWithOuia
-                        component={[Function]}
-                        componentProps={
-                          Object {
-                            "aria-label": "close-notification",
-                            "children": <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
-                            />,
-                            "onClick": [Function],
-                            "title": "Notification title",
-                            "variant": "plain",
-                            "variantLabel": "Success alert:",
-                          }
-                        }
-                        consumerContext={
-                          Object {
-                            "isOuia": false,
-                            "ouiaId": null,
-                          }
-                        }
+                      <Component
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
                       >
-                        <Button
-                          aria-label="close-notification"
-                          onClick={[Function]}
-                          ouiaContext={
+                        <ComponentWithOuia
+                          component={[Function]}
+                          componentProps={
+                            Object {
+                              "aria-label": "close-notification",
+                              "children": <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
+                              />,
+                              "onClick": [Function],
+                              "variant": "plain",
+                            }
+                          }
+                          consumerContext={
                             Object {
                               "isOuia": false,
                               "ouiaId": null,
                             }
                           }
-                          title="Notification title"
-                          variant="plain"
-                          variantLabel="Success alert:"
                         >
-                          <button
-                            aria-disabled={null}
+                          <Button
                             aria-label="close-notification"
-                            className="pf-c-button pf-m-plain"
-                            disabled={false}
                             onClick={[Function]}
-                            tabIndex={null}
-                            title="Notification title"
-                            type="button"
-                            variantLabel="Success alert:"
+                            ouiaContext={
+                              Object {
+                                "isOuia": false,
+                                "ouiaId": null,
+                              }
+                            }
+                            variant="plain"
                           >
-                            <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
+                            <button
+                              aria-disabled={null}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              disabled={false}
+                              onClick={[Function]}
+                              tabIndex={null}
+                              type="button"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  Object {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 64 731 1024"
-                                width="1em"
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
                               >
-                                <path
-                                  d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                                  transform="rotate(180 0 512) scale(-1 1)"
-                                />
-                              </svg>
-                            </CloseIcon>
-                          </button>
-                        </Button>
-                      </ComponentWithOuia>
-                    </Component>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                    transform=""
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </Button>
+                        </ComponentWithOuia>
+                      </Component>
+                    </AlertActionCloseButton>
                   </div>
                 </div>
               </Alert>
@@ -583,9 +579,7 @@ exports[`Notification portal should render notifications given as direct props o
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -593,12 +587,12 @@ exports[`Notification portal should render notifications given as direct props o
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -652,9 +646,7 @@ exports[`Notification portal should render notifications given as direct props o
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -662,12 +654,12 @@ exports[`Notification portal should render notifications given as direct props o
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -721,9 +713,7 @@ exports[`Notification portal should render notifications given as direct props o
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -731,12 +721,12 @@ exports[`Notification portal should render notifications given as direct props o
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -761,7 +751,7 @@ exports[`Notification portal should render notifications given as direct props o
         >
           <Component
             action={
-              <Unknown
+              <AlertActionCloseButton
                 aria-label="close-notification"
                 onClick={[Function]}
                 variant="plain"
@@ -772,7 +762,7 @@ exports[`Notification portal should render notifications given as direct props o
                   size="sm"
                   title={null}
                 />
-              </Unknown>
+              </AlertActionCloseButton>
             }
             className="notification-item"
             id="Direct notification"
@@ -785,7 +775,7 @@ exports[`Notification portal should render notifications given as direct props o
               component={[Function]}
               componentProps={
                 Object {
-                  "action": <Unknown
+                  "action": <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -796,7 +786,7 @@ exports[`Notification portal should render notifications given as direct props o
                       size="sm"
                       title={null}
                     />
-                  </Unknown>,
+                  </AlertActionCloseButton>,
                   "children": Array [
                     "Some meaningfull description",
                     undefined,
@@ -813,7 +803,7 @@ exports[`Notification portal should render notifications given as direct props o
             >
               <Alert
                 action={
-                  <Unknown
+                  <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -824,7 +814,7 @@ exports[`Notification portal should render notifications given as direct props o
                       size="sm"
                       title={null}
                     />
-                  </Unknown>
+                  </AlertActionCloseButton>
                 }
                 className="notification-item"
                 id="Direct notification"
@@ -898,91 +888,91 @@ exports[`Notification portal should render notifications given as direct props o
                   <div
                     className="pf-c-alert__action"
                   >
-                    <Component
+                    <AlertActionCloseButton
                       aria-label="close-notification"
                       onClick={[Function]}
                       title="Notification title"
                       variant="plain"
                       variantLabel="Success alert:"
                     >
-                      <ComponentWithOuia
-                        component={[Function]}
-                        componentProps={
-                          Object {
-                            "aria-label": "close-notification",
-                            "children": <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
-                            />,
-                            "onClick": [Function],
-                            "title": "Notification title",
-                            "variant": "plain",
-                            "variantLabel": "Success alert:",
-                          }
-                        }
-                        consumerContext={
-                          Object {
-                            "isOuia": false,
-                            "ouiaId": null,
-                          }
-                        }
+                      <Component
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
                       >
-                        <Button
-                          aria-label="close-notification"
-                          onClick={[Function]}
-                          ouiaContext={
+                        <ComponentWithOuia
+                          component={[Function]}
+                          componentProps={
+                            Object {
+                              "aria-label": "close-notification",
+                              "children": <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
+                              />,
+                              "onClick": [Function],
+                              "variant": "plain",
+                            }
+                          }
+                          consumerContext={
                             Object {
                               "isOuia": false,
                               "ouiaId": null,
                             }
                           }
-                          title="Notification title"
-                          variant="plain"
-                          variantLabel="Success alert:"
                         >
-                          <button
-                            aria-disabled={null}
+                          <Button
                             aria-label="close-notification"
-                            className="pf-c-button pf-m-plain"
-                            disabled={false}
                             onClick={[Function]}
-                            tabIndex={null}
-                            title="Notification title"
-                            type="button"
-                            variantLabel="Success alert:"
+                            ouiaContext={
+                              Object {
+                                "isOuia": false,
+                                "ouiaId": null,
+                              }
+                            }
+                            variant="plain"
                           >
-                            <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
+                            <button
+                              aria-disabled={null}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              disabled={false}
+                              onClick={[Function]}
+                              tabIndex={null}
+                              type="button"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  Object {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 64 731 1024"
-                                width="1em"
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
                               >
-                                <path
-                                  d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                                  transform="rotate(180 0 512) scale(-1 1)"
-                                />
-                              </svg>
-                            </CloseIcon>
-                          </button>
-                        </Button>
-                      </ComponentWithOuia>
-                    </Component>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                    transform=""
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </Button>
+                        </ComponentWithOuia>
+                      </Component>
+                    </AlertActionCloseButton>
                   </div>
                 </div>
               </Alert>
@@ -1104,9 +1094,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
                 <button
                   aria-label="close-notification"
                   class="pf-c-button pf-m-plain"
-                  title="Notification title"
                   type="button"
-                  variantlabel="Success alert:"
                 >
                   <svg
                     aria-hidden="true"
@@ -1114,12 +1102,12 @@ exports[`Notification portal should render notifications given from store 1`] = 
                     height="1em"
                     role="img"
                     style="vertical-align: -0.125em;"
-                    viewBox="0 64 731 1024"
+                    viewBox="0 0 352 512"
                     width="1em"
                   >
                     <path
-                      d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                      transform="rotate(180 0 512) scale(-1 1)"
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                      transform=""
                     />
                   </svg>
                 </button>
@@ -1144,7 +1132,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
         >
           <Component
             action={
-              <Unknown
+              <AlertActionCloseButton
                 aria-label="close-notification"
                 onClick={[Function]}
                 variant="plain"
@@ -1155,7 +1143,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
                   size="sm"
                   title={null}
                 />
-              </Unknown>
+              </AlertActionCloseButton>
             }
             className="notification-item"
             id="0"
@@ -1168,7 +1156,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
               component={[Function]}
               componentProps={
                 Object {
-                  "action": <Unknown
+                  "action": <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -1179,7 +1167,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
                       size="sm"
                       title={null}
                     />
-                  </Unknown>,
+                  </AlertActionCloseButton>,
                   "children": Array [
                     "Some meaningfull description",
                     undefined,
@@ -1196,7 +1184,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
             >
               <Alert
                 action={
-                  <Unknown
+                  <AlertActionCloseButton
                     aria-label="close-notification"
                     onClick={[Function]}
                     variant="plain"
@@ -1207,7 +1195,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
                       size="sm"
                       title={null}
                     />
-                  </Unknown>
+                  </AlertActionCloseButton>
                 }
                 className="notification-item"
                 id="0"
@@ -1281,91 +1269,91 @@ exports[`Notification portal should render notifications given from store 1`] = 
                   <div
                     className="pf-c-alert__action"
                   >
-                    <Component
+                    <AlertActionCloseButton
                       aria-label="close-notification"
                       onClick={[Function]}
                       title="Notification title"
                       variant="plain"
                       variantLabel="Success alert:"
                     >
-                      <ComponentWithOuia
-                        component={[Function]}
-                        componentProps={
-                          Object {
-                            "aria-label": "close-notification",
-                            "children": <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
-                            />,
-                            "onClick": [Function],
-                            "title": "Notification title",
-                            "variant": "plain",
-                            "variantLabel": "Success alert:",
-                          }
-                        }
-                        consumerContext={
-                          Object {
-                            "isOuia": false,
-                            "ouiaId": null,
-                          }
-                        }
+                      <Component
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
                       >
-                        <Button
-                          aria-label="close-notification"
-                          onClick={[Function]}
-                          ouiaContext={
+                        <ComponentWithOuia
+                          component={[Function]}
+                          componentProps={
+                            Object {
+                              "aria-label": "close-notification",
+                              "children": <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
+                              />,
+                              "onClick": [Function],
+                              "variant": "plain",
+                            }
+                          }
+                          consumerContext={
                             Object {
                               "isOuia": false,
                               "ouiaId": null,
                             }
                           }
-                          title="Notification title"
-                          variant="plain"
-                          variantLabel="Success alert:"
                         >
-                          <button
-                            aria-disabled={null}
+                          <Button
                             aria-label="close-notification"
-                            className="pf-c-button pf-m-plain"
-                            disabled={false}
                             onClick={[Function]}
-                            tabIndex={null}
-                            title="Notification title"
-                            type="button"
-                            variantLabel="Success alert:"
+                            ouiaContext={
+                              Object {
+                                "isOuia": false,
+                                "ouiaId": null,
+                              }
+                            }
+                            variant="plain"
                           >
-                            <CloseIcon
-                              color="currentColor"
-                              noVerticalAlign={false}
-                              size="sm"
-                              title={null}
+                            <button
+                              aria-disabled={null}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              disabled={false}
+                              onClick={[Function]}
+                              tabIndex={null}
+                              type="button"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-labelledby={null}
-                                fill="currentColor"
-                                height="1em"
-                                role="img"
-                                style={
-                                  Object {
-                                    "verticalAlign": "-0.125em",
-                                  }
-                                }
-                                viewBox="0 64 731 1024"
-                                width="1em"
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
                               >
-                                <path
-                                  d="M96.464 804.571c-4.816-0.064-9.12-1.963-12.912-5.733l-77.815-77.815c-3.769-3.794-5.669-8.096-5.735-12.91-0.032-4.839 1.815-9.113 5.543-12.823l616.603-616.606c3.71-3.714 7.986-5.577 12.823-5.541 4.834 0.039 9.138 1.957 12.91 5.73l77.817 77.819c3.769 3.769 5.691 8.066 5.73 12.912 0.037 4.839-1.829 9.106-5.538 12.825l-616.606 616.599c-3.717 3.73-7.986 5.575-12.821 5.541zM622.144 799.031l-616.603-616.601c-3.726-3.717-5.577-7.989-5.536-12.827 0.059-4.843 1.959-9.143 5.728-12.914l77.817-77.817c3.792-3.774 8.096-5.691 12.91-5.728 4.837-0.039 9.106 1.824 12.821 5.536l616.599 616.608c3.717 3.712 5.579 7.989 5.543 12.823-0.041 4.814-1.959 9.118-5.728 12.91l-77.824 77.808c-3.767 3.778-8.073 5.678-12.907 5.744-4.834 0.034-9.104-1.815-12.818-5.541z"
-                                  transform="rotate(180 0 512) scale(-1 1)"
-                                />
-                              </svg>
-                            </CloseIcon>
-                          </button>
-                        </Button>
-                      </ComponentWithOuia>
-                    </Component>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                    transform=""
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </Button>
+                        </ComponentWithOuia>
+                      </Component>
+                    </AlertActionCloseButton>
                   </div>
                 </div>
               </Alert>


### PR DESCRIPTION
After PF update, alerts are now throwing an error:
```
VM34414 backend.js:6 Warning: React does not recognize the `variantLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `variantlabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in button (created by Button)
    in Button (created by Context.Consumer)
    in ComponentWithOuia (created by Context.Consumer)
    in Unknown (created by Notification)
    in div (created by Alert)
    in div (created by Alert)
    in Alert (created by Context.Consumer)
```

That is caused by PF cloning the action element and thus basically enforcing a certain type of component used for the close action.