### PR TITLE
Minimize inv-insights bundle size

### DIFF
--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Rules detail page for RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/inventory-insights/src/Constants.js
+++ b/packages/inventory-insights/src/Constants.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Battery } from '@redhat-cloud-services/frontend-components';
+import { Battery } from '@redhat-cloud-services/frontend-components/components/Battery';
 import React from 'react';
 
 export const BASE_FETCH_URL = '/api/insights/v1/';

--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -1,21 +1,32 @@
 /* eslint-disable camelcase */
 import './insights.scss';
 
-import { CheckCircleIcon, CheckIcon, ExternalLinkAltIcon, PficonSatelliteIcon, TimesCircleIcon } from '@patternfly/react-icons';
-import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
-import ChartSpikeIcon from '@patternfly/react-icons/dist/js/icons/chartSpike-icon';
 import { BASE_FETCH_URL, FILTER_CATEGORIES as FC } from './Constants';
-import { Battery, PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
-import { Bullseye, Button, Card, CardBody, ClipboardCopy, Stack, StackItem, ToolbarItem } from '@patternfly/react-core';
 import React, { Component, Fragment } from 'react';
 import { SortByDirection, Table, TableBody, TableHeader, cellWidth, sortable } from '@patternfly/react-table';
+import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
 import { flatten, sortBy } from 'lodash';
 
+import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
+import { Battery } from '@redhat-cloud-services/frontend-components/components/Battery';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye/Bullseye';
+import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
+import { Card } from '@patternfly/react-core/dist/js/components/Card/Card';
+import { CardBody } from '@patternfly/react-core/dist/js/components/Card/CardBody';
+import ChartSpikeIcon from '@patternfly/react-icons/dist/js/icons/chartSpike-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import { ClipboardCopy } from '@patternfly/react-core/dist/js/components/ClipboardCopy/ClipboardCopy';
+import ExternalLinkAltIcon  from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { List } from 'react-content-loader';
 import MessageState from './MessageState';
+import PficonSatelliteIcon  from '@patternfly/react-icons/dist/js/icons/pficon-satellite-icon';
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/components/PrimaryToolbar';
 import PropTypes from 'prop-types';
 import RemediationButton from '@redhat-cloud-services/frontend-components-remediations/RemediationButton';
 import ReportDetails from './ReportDetails';
+import TimesCircleIcon  from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import { ToolbarItem } from '@patternfly/react-core/dist/js/layouts/Toolbar/ToolbarItem';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import connect from 'react-redux/es/connect/connect';
 import moment from 'moment';

--- a/packages/inventory-insights/src/MessageState.js
+++ b/packages/inventory-insights/src/MessageState.js
@@ -1,8 +1,11 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyState';
 
-import { CubesIcon } from '@patternfly/react-icons';
+import  CubesIcon  from '@patternfly/react-icons/dist/js/icons/cubes-icon';
+import { EmptyStateBody } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyStateBody';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyStateIcon';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 
 const MessageState = ({ children, icon, iconClass, iconStyle, size, text, title, variant }) => (
     <EmptyState variant={variant}>

--- a/packages/inventory-insights/src/ReportDetails.js
+++ b/packages/inventory-insights/src/ReportDetails.js
@@ -1,11 +1,18 @@
 import '@redhat-cloud-services/frontend-components/components/Section.css';
 import './insights.scss';
 
-import { BullseyeIcon, ExternalLinkAltIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
-import { Card, CardBody, CardHeader, Stack, StackItem } from '@patternfly/react-core';
-import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/components/Skeleton';
+import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
 
+import BullseyeIcon from '@patternfly/react-icons/dist/js/icons/bullseye-icon';
+import { Card } from '@patternfly/react-core/dist/js/components/Card/Card';
+import { CardBody } from '@patternfly/react-core/dist/js/components/Card/CardBody';
+import { CardHeader } from '@patternfly/react-core/dist/js/components/Card/CardHeader';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
+import LightbulbIcon from '@patternfly/react-icons/dist/js/icons/lightbulb-icon';
 import React from 'react';
+import ThumbsUpIcon from '@patternfly/react-icons/dist/js/icons/thumbs-up-icon';
 import classNames from 'classnames';
 import doT from 'dot';
 import marked from 'marked';


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-4490


#### before
<img width="851" alt="Screen Shot 2020-02-12 at 10 18 49 AM" src="https://user-images.githubusercontent.com/6640236/74348822-4b706b00-4d81-11ea-922c-65cdf33e3608.png">

#### after? 
<img width="545" alt="Screen Shot 2020-02-12 at 10 06 22 AM" src="https://user-images.githubusercontent.com/6640236/74348840-51fee280-4d81-11ea-9d86-3de2849762c2.png">
