### PR TITLE
CSS tweaks for the pdf generator

### DIFF
--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -112,7 +112,8 @@ class Chart extends Component {
                     { width: 'auto', flex: 1 }
                 }
                 rowsStyle={{
-                    justifyContent: 'flex-start'
+                    justifyContent: 'flex-start',
+                    ...appliedStyles.compactCellPadding
                 }}
                 rows={[
                     [ 'Legend' ],
@@ -124,7 +125,7 @@ class Chart extends Component {
                                 width: 15,
                                 height: 10
                             }}
-                            paint={({ path }) => path(CircleIconConfig.svgPath).scale(0.012).fill(colors[key])}
+                            paint={({ path }) => path(CircleIconConfig.svgPath).scale(0.014).fill(colors[key])}
                         />,
                         <Text key={`${key}-text`}>
                             {x} {y}

--- a/packages/pdf-generator/src/components/Table.js
+++ b/packages/pdf-generator/src/components/Table.js
@@ -24,11 +24,13 @@ const Table = ({
         {
             withHeader && <View style={{
                 ...appliedStyles.flexRow,
+                ...appliedStyles.compactCellPadding,
                 justifyContent: 'flex-start',
                 ...headerStyles
             }}>
                 {header.map((cell, key) => <Text key={ key } style={{
                     ...appliedStyles.secondTitle,
+                    ...appliedStyles.compactCellPadding,
                     flex: 1
                 }}>
                     {cell}
@@ -47,12 +49,14 @@ const Table = ({
                 (!withHeader ? [ header, ...cells ] : cells).map((row, key) => (
                     <View key={key} style={{
                         ...appliedStyles.flexRow,
+                        ...appliedStyles.compactCellPadding,
                         ...key % 2 && { backgroundColor: global_BorderColor_300.value },
                         ...rowsStyle
                     }}>
                         { row.map((cell, cellKey) => (
                             (typeof cell === 'string' || cell instanceof String) ? <Text key={cellKey} style={{
                                 ...appliedStyles.text,
+                                ...appliedStyles.compactCellPadding,
                                 flex: 1
                             }}>
                                 { cell }

--- a/packages/pdf-generator/src/utils/styles.js
+++ b/packages/pdf-generator/src/utils/styles.js
@@ -3,11 +3,14 @@ import { StyleSheet, Font } from '@react-pdf/renderer';
 import {
     chart_color_red_100,
     global_Color_dark_100,
-    chart_global_warning_Color_100,
-    global_disabled_color_100,
+    global_Color_dark_200,
     global_Color_light_300,
+    chart_global_warning_Color_100,
     chart_global_warning_Color_200,
-    global_Color_dark_200
+    chart_global_Fill_Color_700,
+    c_table_m_compact_cell_PaddingLeft,
+    c_table_m_compact_cell_PaddingBottom,
+    c_table_m_compact_cell_PaddingTop
 } from '@patternfly/react-tokens';
 import { fontTypes, generateFonts, redhatFont } from './fonts';
 
@@ -24,7 +27,8 @@ export default (style = {}) => StyleSheet.create({
         fontWeight: 500,
         fontFamily: 'RedHatText',
         height: '100%',
-        padding: '20 50'
+        padding: '20 50',
+        lineHeight: 1.5
     },
     displayFont: {
         fontFamily: 'RedHatDisplay'
@@ -65,7 +69,7 @@ export default (style = {}) => StyleSheet.create({
     secondTitle: {
         fontWeight: 700,
         fontSize: 9,
-        color: global_disabled_color_100.value
+        color: chart_global_Fill_Color_700.value
     },
     thirdTitle: {
         fontSize: 9,
@@ -91,5 +95,10 @@ export default (style = {}) => StyleSheet.create({
     },
     defaultColor: {
         color: global_Color_light_300.value
+    },
+    compactCellPadding: {
+        paddingLeft: c_table_m_compact_cell_PaddingLeft.value,
+        paddingBottom: c_table_m_compact_cell_PaddingBottom.value,
+        paddingTop: c_table_m_compact_cell_PaddingTop.value
     }
 });


### PR DESCRIPTION
CSS tweaks 

before: 
[0929e309-5b03-4da1-82af-06d46753ad7e (1).pdf](https://github.com/RedHatInsights/frontend-components/files/4205549/0929e309-5b03-4da1-82af-06d46753ad7e.1.pdf)

after: 
[fa969d78-83aa-4e5b-b26e-76e3b20c7902.pdf](https://github.com/RedHatInsights/frontend-components/files/4205609/fa969d78-83aa-4e5b-b26e-76e3b20c7902.pdf)


