### PR TITLE
Stop extracting css to files and inject them with component mount.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16343,54 +16343,6 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
-    "mini-css-extract-plugin": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
-      "integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -24824,16 +24776,6 @@
           "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
           "dev": true
         }
-      }
-    },
-    "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
-      "dev": true,
-      "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
       }
     },
     "webpack-visualizer-plugin": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
         "jest-fetch-mock": "^2.1.2",
         "lerna": "^3.13.4",
         "lodash-webpack-plugin": "^0.11.5",
-        "mini-css-extract-plugin": "^0.4.2",
         "mkdirp": "^0.5.1",
         "node-sass": "^4.13.1",
         "react-content-loader": "^3.4.1",

--- a/packages/charts/config/webpack.config.js
+++ b/packages/charts/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals, entries } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -27,15 +26,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/charts/config/webpack.plugins.js
+++ b/packages/charts/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new (require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: 'dist/[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -33,5 +33,8 @@
         "c3": "^0.6.7",
         "classnames": "^2.2.5",
         "d3": "^5.7.0"
+    },
+    "devDependencies": {
+        "style-loader": "^1.1.3"
     }
 }

--- a/packages/components/config/webpack.config.js
+++ b/packages/components/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals, entries } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -27,15 +26,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/components/config/webpack.plugins.js
+++ b/packages/components/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -25,21 +20,12 @@ const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({
     shorthands: true
 });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = {
     buildPlugins: (env) => ({
         plugins: [
             WriteFileWebpackPlugin,
             LodashWebpackPlugin,
-            ExtractCssWebpackPlugin,
-            ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+            ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
         ]
     })
 };

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,7 +28,6 @@
         "html-webpack-plugin": "^3.2.0",
         "koa-connect": "^2.0.1",
         "lodash-webpack-plugin": "^0.11.5",
-        "mini-css-extract-plugin": "^0.6.0",
         "node-sass": "^4.12.0",
         "sass-loader": "^7.1.0",
         "source-map-loader": "^0.2.4",

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -1,6 +1,5 @@
 const history = require('connect-history-api-fallback');
 const convert = require('koa-connect');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = ({
     port,
@@ -46,15 +45,7 @@ module.exports = ({
                 exclude: /(node_modules)/i
             }, {
                 test: /\.s?[ac]ss$/,
-                use: [
-                    process.env.NODE_ENV === 'production' ? 'style-loader' : MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader'
-                    },
-                    {
-                        loader: 'sass-loader'
-                    }
-                ]
+                use: [ 'style-loader', 'css-loader', 'sass-loader' ]
             }, {
                 test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
                 use: [{

--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -13,10 +13,6 @@ const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({
     paths: true,
     shorthands: true
 });
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: 'css/[name].css',
-    filename: 'css/[name].css'
-});
 const CleanWebpackPlugin = new(require('clean-webpack-plugin'))();
 const WebpackHotModuleReplacement = new HotModuleReplacementPlugin();
 
@@ -45,7 +41,6 @@ module.exports = ({
         WriteFileWebpackPlugin,
         SourceMapsPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
         CleanWebpackPlugin,
         HtmlWebpackPlugin,
         HtmlReplaceWebpackPlugin,

--- a/packages/config/src/plugins.test.js
+++ b/packages/config/src/plugins.test.js
@@ -1,13 +1,13 @@
 import plugins from './plugins';
 
-const HTML_WEBPACK = 5;
-const REPLACE = 6;
+const HTML_WEBPACK = 4;
+const REPLACE = 5;
 
 describe('plugins generations, no option', () => {
     const enabledPlugins = plugins();
 
     it('should generate plugins', () => {
-        expect(enabledPlugins.length).toBe(8);
+        expect(enabledPlugins.length).toBe(7);
     });
 
     it('should generate correct template path for HtmlWebpackPlugin', () => {

--- a/packages/demo/webpack.config.js
+++ b/packages/demo/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
 module.exports = (env) => ({
@@ -11,7 +10,7 @@ module.exports = (env) => ({
         index: './src/index.js'
     },
     output: {
-        filename: '[name].js',
+        filename: '[name].js'
     },
     module: {
         rules: [{
@@ -20,15 +19,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{
@@ -40,14 +31,10 @@ module.exports = (env) => ({
         }]
     },
     plugins: [
-        new (require('write-file-webpack-plugin'))(),
-        new (require('webpack').HotModuleReplacementPlugin)(),
-        new MiniCssExtractPlugin({
-            chunkFilename: '[name].css',
-            filename: '[id].css'
-        }),
-        new (require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true }),
-        new (require('html-webpack-plugin'))({
+        new(require('write-file-webpack-plugin'))(),
+        new(require('webpack').HotModuleReplacementPlugin)(),
+        new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true }),
+        new(require('html-webpack-plugin'))({
             title: 'Playground',
             template: path.resolve(__dirname, './src/index.html')
         })

--- a/packages/inventory-compliance/config/webpack.config.js
+++ b/packages/inventory-compliance/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -26,15 +25,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/inventory-compliance/config/webpack.plugins.js
+++ b/packages/inventory-compliance/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/inventory-general-info/config/webpack.config.js
+++ b/packages/inventory-general-info/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -27,15 +26,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/inventory-general-info/config/webpack.plugins.js
+++ b/packages/inventory-general-info/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/inventory-insights/config/webpack.config.js
+++ b/packages/inventory-insights/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -26,15 +25,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/inventory-insights/config/webpack.plugins.js
+++ b/packages/inventory-insights/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/inventory/config/webpack.config.js
+++ b/packages/inventory/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -29,15 +28,7 @@ module.exports = (env) => ({
             }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/inventory/config/webpack.plugins.js
+++ b/packages/inventory/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/notifications/config/webpack.config.js
+++ b/packages/notifications/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -26,15 +25,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/notifications/config/webpack.plugins.js
+++ b/packages/notifications/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -30,5 +30,8 @@
     },
     "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "*"
+    },
+    "devDependencies": {
+        "style-loader": "^1.1.3"
     }
 }

--- a/packages/remediations/config/webpack.config.js
+++ b/packages/remediations/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -28,15 +27,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/remediations/config/webpack.plugins.js
+++ b/packages/remediations/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/sources/config/webpack.config.js
+++ b/packages/sources/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -26,15 +25,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/sources/config/webpack.plugins.js
+++ b/packages/sources/config/webpack.plugins.js
@@ -2,8 +2,6 @@
  * Plugins used by webpack bundler
  */
 const webpack = require('webpack');
-const path = require('path');
-
 /**
  * Writes bundles to distribution folder.
  *
@@ -21,14 +19,6 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
 /**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
-/**
  * Makes build-time env vars available to the client-side as constants
  */
 const envPlugin = new webpack.DefinePlugin({
@@ -40,7 +30,6 @@ module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
         envPlugin,
         ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]

--- a/packages/translations/config/webpack.config.js
+++ b/packages/translations/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -27,15 +26,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/translations/config/webpack.plugins.js
+++ b/packages/translations/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,19 +14,10 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };

--- a/packages/utils/config/webpack.config.js
+++ b/packages/utils/config/webpack.config.js
@@ -1,4 +1,3 @@
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { resolve } = require('path');
 const { buildPlugins } = require('./webpack.plugins.js');
 
@@ -34,15 +33,7 @@ module.exports = (env) => ({
             use: [{ loader: 'source-map-loader' }, { loader: 'babel-loader' }]
         }, {
             test: /\.s?[ac]ss$/,
-            use: [
-                MiniCssExtractPlugin.loader,
-                {
-                    loader: 'css-loader'
-                },
-                {
-                    loader: 'sass-loader'
-                }
-            ]
+            use: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }, {
             test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
             use: [{

--- a/packages/utils/config/webpack.plugins.js
+++ b/packages/utils/config/webpack.plugins.js
@@ -1,9 +1,4 @@
 /**
- * Plugins used by webpack bundler
- */
-const path = require('path');
-
-/**
  * Writes bundles to distribution folder.
  *
  * @type {var}
@@ -19,16 +14,7 @@ const HotModuleReplacementPlugin = new(require('webpack').HotModuleReplacementPl
  */
 const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: true, flattening: true, placeholders: true, paths: true });
 
-/**
- * Writes final css to file
- */
-const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
-});
-
 const CopyFilesWebpackPlugin = new(require('copy-webpack-plugin'))([
-    { from: 'src/**/*.scss', to: 'files/Utilities', flatten: true },
     { from: 'src/mergeMessages.js', to: 'files/mergeMessages.js' }
 ]);
 
@@ -36,8 +22,7 @@ module.exports = { buildPlugins: (env) => ({
     plugins: [
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
-        ExtractCssWebpackPlugin,
         CopyFilesWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };


### PR DESCRIPTION
Styles are now injected into the DOM only when the component is actually used. For instance if somebody is using only `Section`  component before they would get every CSS rule from every component. Now they will only get the `Section` specific CSS rules.

There is a breaking change. No stylesheets will be generated so if somebody is importing any CSS files from these libraries have to remove these imports from the codebase.

Styles are still working. Tested in the demo and also in Catalog APP.
![Screenshot from 2020-02-18 09-54-57](https://user-images.githubusercontent.com/22619452/74721612-f4164300-5237-11ea-8894-dd07b29d4d40.png)
