### PR TITLE
Run afterSubmit immediately after source creating

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -53,8 +53,8 @@ import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sour
 |Prop|Type|Default|Description|
 |----|:--:|:-----:|----------:|
 |isOpen|bool|`false`|You need to control yourselves if the wizard is open or not. (Not needed for the button version)|
-|afterSuccess|function|`null`|This function will be executed after closing the wizard successful finish step. In Sources-UI this method is used for updating the list of sources.|
-|onClose|function|`null`|This function will be executed after closing the wizard. Eg. set isOpen to false. In case of closing wizard before submitting, form values are passed as the first argument.|
+|afterSuccess|function|`null`|This function will be executed after successful creation of a source. In Sources-UI this method is used for updating the list of sources.|
+|onClose|function|`null`|This function will be executed after closing the wizard. Eg. set isOpen to false. In case of closing wizard before submitting, form values are passed as the first argument. If source has been successfully created, the source is passed as the second argument.|
 |successfulMessage|node|`'Your source has been successfully added.'`|A message shown on the last page of the wizard. Can be customized when accessing from different app (eg. 'Source was added to Cost Management')|
 |sourceTypes|array|`null`|SourceTypes array. This prop can be used on pages, which have already loaded the source types, so there is no need to load them in this component.|
 |applicationTypes|array|`null`|applicationTypes array. This prop can be used on pages, which have already loaded the application types, so there is no need to load them in this component.|

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -27,6 +27,7 @@ class AddSourceWizard extends React.Component {
     onSubmit = (formValues, sourceTypes) => {
         this.setOnSubmitState(formValues);
         return doCreateSource(formValues, sourceTypes).then((data) => {
+            this.props.afterSuccess(data);
             this.setState({ isFinished: true, createdSource: data });
         })
         .catch((error) => {
@@ -35,11 +36,8 @@ class AddSourceWizard extends React.Component {
     }
 
     afterSubmit = () => {
-        const { afterSuccess, onClose } = this.props;
-
-        onClose();
+        this.props.onClose(undefined, this.state.createdSource);
         this.setState({ ...initialValues });
-        afterSuccess(this.state.createdSource);
     }
 
     onRetry = () => this.setState({


### PR DESCRIPTION
`afterSubmit` props is now executed immediately after the submit request, so all data are being loaded in the background. If user needs, he can still use `onClose` and check for the second argument, if he needs some specific action after closing the wizard.

![sourcesinbackground](https://user-images.githubusercontent.com/32869456/74741421-0787d500-525d-11ea-9f84-7dc77f01f9a5.gif)

Notice that the loading of sources is started after the source is created.