### PR TITLE
remove excess padding from toolbar items

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
+++ b/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
@@ -67,11 +67,3 @@
         }
     }
 }
-
-@media only screen and (max-width: 1795px) {
-    .ins-c-primary-toolbar {
-        .pf-c-data-toolbar__item {
-            padding-bottom: var(--pf-global--spacer--sm);
-        }
-    }
-}


### PR DESCRIPTION
looking at: https://www.patternfly.org/v4/documentation/react/demos/filtertabledemo/basic, there isn't any spacing under the toolbar elements