### PR TITLE
Allow hiding active filter label for ConditionalFilter component

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -56,7 +56,7 @@ class ConditionalFilter extends Component {
                                         toggle={
                                             <DropdownToggle
                                                 onToggle={ this.dropdownToggle }
-                                                className={ hideLabel ? 'no__label' : '' } >
+                                                className={ hideLabel ? 'ins-c-conditional-filter__no-label' : '' } >
                                                 <FilterIcon size="sm" />
                                                 { !hideLabel &&
                                                     <span className="ins-c-conditional-filter__value-selector">

--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -24,7 +24,7 @@ class ConditionalFilter extends Component {
     }
 
     render() {
-        const { items, value, id, onChange, placeholder, ...props } = this.props;
+        const { items, value, id, onChange, placeholder, hideLabel, ...props } = this.props;
         const { isOpen, stateValue } = this.state;
         const currentValue = onChange ? value : stateValue;
         const activeItem = items && items.length && (
@@ -54,11 +54,15 @@ class ConditionalFilter extends Component {
                                         onSelect={ () => this.dropdownToggle(false) }
                                         isOpen={ isOpen }
                                         toggle={
-                                            <DropdownToggle onToggle={ this.dropdownToggle }>
+                                            <DropdownToggle
+                                                onToggle={ this.dropdownToggle }
+                                                className={ hideLabel ? 'no__label' : '' } >
                                                 <FilterIcon size="sm" />
-                                                <span className="ins-c-conditional-filter__value-selector">
-                                                    { activeItem && activeItem.label }
-                                                </span>
+                                                { !hideLabel &&
+                                                    <span className="ins-c-conditional-filter__value-selector">
+                                                        { activeItem && activeItem.label }
+                                                    </span>
+                                                }
                                             </DropdownToggle>
                                         }
                                         dropdownItems={
@@ -102,6 +106,7 @@ const TextInputProps = {
 };
 
 ConditionalFilter.propTypes = {
+    hideLabel: PropTypes.boolean,
     items: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string,
         label: PropTypes.node,
@@ -133,6 +138,7 @@ ConditionalFilter.propTypes = {
 
 ConditionalFilter.defaultProps = {
     value: '',
-    items: []
+    items: [],
+    hideLabel: false,
 };
 export default ConditionalFilter;

--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -139,6 +139,6 @@ ConditionalFilter.propTypes = {
 ConditionalFilter.defaultProps = {
     value: '',
     items: [],
-    hideLabel: false,
+    hideLabel: false
 };
 export default ConditionalFilter;

--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.test.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.test.js
@@ -71,6 +71,11 @@ describe('ConditionalFilter', () => {
             const wrappper = shallow(<ConditionalFilter items={[ config[0] ]} />);
             expect(toJson(wrappper)).toMatchSnapshot();
         });
+
+        it('should render correctly with with the active label hidden', () => {
+            const wrappper = shallow(<ConditionalFilter hideLabel={ true } items={ config } />);
+            expect(toJson(wrappper)).toMatchSnapshot();
+        });
     });
 
     describe('API', () => {

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
@@ -612,7 +612,7 @@ exports[`ConditionalFilter render should render correctly with with the active l
         onSelect={[Function]}
         toggle={
           <DropdownToggle
-            className="no__label"
+            className="ins-c-conditional-filter__no-label"
             onToggle={[Function]}
           >
             <FilterIcon

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
@@ -67,6 +67,7 @@ exports[`ConditionalFilter render should render correctly Checkbox with value ch
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -166,6 +167,7 @@ exports[`ConditionalFilter render should render correctly No value with value un
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -248,6 +250,7 @@ exports[`ConditionalFilter render should render correctly Radio filter with valu
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -343,6 +346,7 @@ exports[`ConditionalFilter render should render correctly Simple text 1 with val
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -425,6 +429,7 @@ exports[`ConditionalFilter render should render correctly Simple text 2 with val
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -507,6 +512,7 @@ exports[`ConditionalFilter render should render correctly with config 1`] = `
         onSelect={[Function]}
         toggle={
           <DropdownToggle
+            className=""
             onToggle={[Function]}
           >
             <FilterIcon
@@ -548,6 +554,83 @@ exports[`ConditionalFilter render should render correctly with one filter 1`] = 
       <Text
         onSubmit={[Function]}
         placeholder="Filter by simple text 1"
+        value=""
+      />
+    </SplitItem>
+  </Split>
+</Fragment>
+`;
+
+exports[`ConditionalFilter render should render correctly with with the active label hidden 1`] = `
+<Fragment>
+  <Split
+    className="ins-c-conditional-filter"
+  >
+    <SplitItem>
+      <Dropdown
+        className="ins-c-conditional-filter__group"
+        dropdownItems={
+          Array [
+            <DropdownItem
+              component="button"
+              isHovered={false}
+              onClick={[Function]}
+            >
+              Simple text 1
+            </DropdownItem>,
+            <DropdownItem
+              component="button"
+              isHovered={false}
+              onClick={[Function]}
+            >
+              Simple text 2
+            </DropdownItem>,
+            <DropdownItem
+              component="button"
+              isHovered={false}
+              onClick={[Function]}
+            >
+              Checkbox
+            </DropdownItem>,
+            <DropdownItem
+              component="button"
+              isHovered={false}
+              onClick={[Function]}
+            >
+              Radio filter
+            </DropdownItem>,
+            <DropdownItem
+              component="button"
+              isHovered={true}
+              onClick={[Function]}
+            >
+              No value
+            </DropdownItem>,
+          ]
+        }
+        isOpen={false}
+        onSelect={[Function]}
+        toggle={
+          <DropdownToggle
+            className="no__label"
+            onToggle={[Function]}
+          >
+            <FilterIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+              title={null}
+            />
+          </DropdownToggle>
+        }
+      />
+    </SplitItem>
+    <SplitItem
+      isFilled={true}
+    >
+      <Text
+        onSubmit={[Function]}
+        placeholder="Filter by no value"
         value=""
       />
     </SplitItem>

--- a/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
@@ -5,12 +5,20 @@
         @include rem('max-width', 150px);
     }
 
-    .ins-c-conditional-filter__group .pf-c-dropdown__toggle-text {
-        width: 102px;
-        text-align: left;
+    .ins-c-conditional-filter__group {
+        .pf-c-dropdown__toggle-text {
+            width: 102px;
+            text-align: left;
 
-        & > svg {
-            margin-right: var(--pf-global--spacer--xs);
+            & > svg {
+                margin-right: var(--pf-global--spacer--xs);
+            }
+        }
+
+        &.no__label {
+            .pf-c-dropdown__toggle-text {
+                width: auto;
+            }
         }
     }
 

--- a/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
@@ -15,10 +15,8 @@
             }
         }
 
-        &.no__label {
-            .pf-c-dropdown__toggle-text {
-                width: auto;
-            }
+        &.ins-c-conditional-filter__no-label .pf-c-dropdown__toggle-text  {
+            width: auto;
         }
     }
 

--- a/packages/components/src/Components/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
+++ b/packages/components/src/Components/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
@@ -137,6 +137,7 @@ exports[`PrimaryToolbar should render with data full config 1`] = `
         className="ins-c-primary-toolbar__filter"
       >
         <ConditionalFilter
+          hideLabel={false}
           items={
             Array [
               Object {
@@ -325,6 +326,7 @@ exports[`PrimaryToolbar should render with data only - filterConfig 1`] = `
         className="ins-c-primary-toolbar__filter"
       >
         <ConditionalFilter
+          hideLabel={false}
           items={
             Array [
               Object {
@@ -386,6 +388,7 @@ exports[`PrimaryToolbar should render wrong actionsConfig 1`] = `
         className="ins-c-primary-toolbar__filter"
       >
         <ConditionalFilter
+          hideLabel={false}
           items={
             Array [
               Object {


### PR DESCRIPTION
This adds a `hideLabel` prop for the ConditionalFilter to allow hiding the label of the current active filter.

![Screenshot 2020-02-18 at 18 54 27](https://user-images.githubusercontent.com/7757/74763441-1e8bee80-5280-11ea-90d9-fb73f33ba26c.png)

While still showing the labels for the dropdown items available: 

![Screenshot 2020-02-18 at 18 56 18](https://user-images.githubusercontent.com/7757/74763594-61e65d00-5280-11ea-95f0-51383578e8df.png)
