### PR TITLE
Removing the large loading Skeleton for actions

### DIFF
--- a/packages/inventory/src/EntityTableToolbar.js
+++ b/packages/inventory/src/EntityTableToolbar.js
@@ -254,7 +254,7 @@ class ContextEntityTableToolbar extends Component {
                 }
             }}
             { ...this.isFilterSelected() && { activeFiltersConfig: this.constructFilters() } }
-            actionsConfig={ loaded ? actionsConfig : <Skeleton size={SkeletonSize.lg} /> }
+            actionsConfig={ loaded ? actionsConfig : null }
             pagination={loaded ? {
                 page,
                 itemCount: total,


### PR DESCRIPTION
The large Skeleton on loading breaks the layout of the Toolbar, as illustrated in this example:

![Screenshot 2020-02-19 at 07 33 39](https://user-images.githubusercontent.com/7757/74808459-2fbe1500-52eb-11ea-9d08-1370ca276edf.png)

Removing the `Skeleton` fixes the issue:

![Screenshot 2020-02-19 at 07 37 01](https://user-images.githubusercontent.com/7757/74808613-875c8080-52eb-11ea-9a4b-af606505cc7b.png)

And without an action/export config set:

![Screenshot 2020-02-19 at 07 35 21](https://user-images.githubusercontent.com/7757/74808642-96dbc980-52eb-11ea-8639-1acba152300c.png)
