### PR TITLE
Allows `actionsConfig` to be a React Element

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.js
@@ -80,19 +80,18 @@ class PrimaryToolbar extends Component {
                         </DataToolbarGroup>
                     }
                     {
-                        (
-                            (actionsConfig && actionsConfig.actions && actionsConfig.actions.length > 0) ||
-                            sortByConfig ||
-                            exportConfig
-                        ) && (
-                            React.isValidElement(actionsConfig) ?
-                                actionsConfig :
+                        React.isValidElement(actionsConfig) ? actionsConfig :
+                            (
+                                (actionsConfig && actionsConfig.actions && actionsConfig.actions.length > 0) ||
+                                sortByConfig ||
+                                exportConfig
+                            ) && (
                                 <Actions
                                     {...actionsConfig || {}}
                                     exportConfig={exportConfig}
                                     overflowActions={overflowActions}
                                 />
-                        )
+                            )
                     }
                     {
                         sortByConfig &&


### PR DESCRIPTION
 - I saw some checkings for React.isValidElement, but it was
   unreachable because previous checks test for
   actionsConfig.actions. Moved code a bit to test if it is a
   ReactElement before the other checks