### PR TITLE
Fix boolean to bool in ConditionalFilter propTypes

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -106,7 +106,7 @@ const TextInputProps = {
 };
 
 ConditionalFilter.propTypes = {
-    hideLabel: PropTypes.boolean,
+    hideLabel: PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.shape({
         id: PropTypes.string,
         label: PropTypes.node,


### PR DESCRIPTION
Fixes

```
Warning: Failed prop type: ConditionalFilter: prop type `hideLabel` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
    in ConditionalFilter (created by PrimaryToolbar)
    in PrimaryToolbar (created by SourcesPage)
    in section (created by Section)
```