### PR TITLE
Correct selector to hide conditional filter label

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/Components/ConditionalFilter/conditional-filter.scss
@@ -15,7 +15,7 @@
             }
         }
 
-        &.ins-c-conditional-filter__no-label .pf-c-dropdown__toggle-text  {
+        .ins-c-conditional-filter__no-label .pf-c-dropdown__toggle-text  {
             width: auto;
         }
     }


### PR DESCRIPTION
A follow up to https://github.com/RedHatInsights/frontend-components/pull/367

When renaming and realigning the selector, I must have forgotten to rebuild the package or chrome for testing.