### PR TITLE
Add updates to support subscription watch wizard steps.

### DIFF
--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    TextContent,
+    Text,
+    TextVariants,
+    TextList,
+    TextListItem,
+    ClipboardCopy,
+    ClipboardCopyVariant
+} from '@patternfly/react-core';
+
+
+export const IAMRoleDescription = () => (<TextContent>
+    <Text component={ TextVariants.p }>
+To delegate account access, create an IAM role to associate with your IAM policy.
+    </Text>
+    <TextList>
+        <TextListItem>From the AWS Identity access management console, create a new role.</TextListItem>
+        <TextListItem>Select another AWS account from the list of trusted entities and paste the following value into the Account ID field:</TextListItem>
+        <ClipboardCopy className="pf-u-m-sm-on-sm" isReadOnly>
+        372779871274
+        </ClipboardCopy>
+        <TextListItem>Attach the permissions policy that you just created.</TextListItem>
+        <TextListItem>Complete the process to create your new role.</TextListItem>
+    </TextList>
+</TextContent>);
+
+export const IAMPolicyDescription = ({ formOptions }) => {
+
+    return (<TextContent>
+        <Text component={ TextVariants.p }>
+To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy.
+        </Text>
+        <TextList>
+            <TextListItem>
+                Sign in to the <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html" rel="noopener noreferrer" target="_blank">
+                    AWS Identity Access Management* (IAM) console</a>.
+            </TextListItem>
+            <TextListItem>Create a new policy, pasting the following content into the JSON text box.</TextListItem>
+            <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
+                {JSON.stringify({
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Sid": "VisualEditor0",
+                        "Effect": "Allow",
+                        "Action": [
+                            "ec2:DescribeInstances",
+                            "ec2:DescribeImages",
+                            "ec2:DescribeSnapshots",
+                            "ec2:ModifySnapshotAttribute",
+                            "ec2:DescribeSnapshotAttribute",
+                            "ec2:CopyImage",
+                            "ec2:CreateTags",
+                            "ec2:DescribeRegions",
+                            "cloudtrail:CreateTrail",
+                            "cloudtrail:UpdateTrail",
+                            "cloudtrail:PutEventSelectors",
+                            "cloudtrail:DescribeTrails",
+                            "cloudtrail:StartLogging",
+                            "cloudtrail:StopLogging"
+                        ],
+                        "Resource": "*"
+                    }]
+                }, null, 2)}
+            </ClipboardCopy>
+            <TextListItem>Complete the process to create your new policy.</TextListItem>
+        </TextList>
+        <Text component={ TextVariants.p }>
+            <b>Do not close your browser.</b> You will need to be logged in to the IAM console to compute the next step.
+        </Text>
+    </TextContent>);
+};
+
+IAMPolicyDescription.propTypes = {
+    formOptions: PropTypes.shape({
+        getState: PropTypes.func.isRequired
+    }).isRequired
+};
+
+
+export const ArnDescription = () => (<TextContent>
+    <Text component={ TextVariants.p }>
+To enable account access, capture the ARN associated with the role you just created.
+    </Text>
+    <TextList>
+        <TextListItem>From the Roles tab, select the role you just created.</TextListItem>
+        <TextListItem>From the Summary screen, copy the role ARN and paste it in the ARN field:</TextListItem>
+    </TextList>
+</TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -10,7 +10,6 @@ import {
     ClipboardCopyVariant
 } from '@patternfly/react-core';
 
-
 export const IAMRoleDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
 To delegate account access, create an IAM role to associate with your IAM policy.
@@ -26,58 +25,48 @@ To delegate account access, create an IAM role to associate with your IAM policy
     </TextList>
 </TextContent>);
 
-export const IAMPolicyDescription = ({ formOptions }) => {
-
-    return (<TextContent>
-        <Text component={ TextVariants.p }>
+export const IAMPolicyDescription = () =>  (<TextContent>
+    <Text component={ TextVariants.p }>
 To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy.
-        </Text>
-        <TextList>
-            <TextListItem>
+    </Text>
+    <TextList>
+        <TextListItem>
                 Sign in to the <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html" rel="noopener noreferrer" target="_blank">
                     AWS Identity Access Management* (IAM) console</a>.
-            </TextListItem>
-            <TextListItem>Create a new policy, pasting the following content into the JSON text box.</TextListItem>
-            <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
-                {JSON.stringify({
-                    "Version": "2012-10-17",
-                    "Statement": [{
-                        "Sid": "VisualEditor0",
-                        "Effect": "Allow",
-                        "Action": [
-                            "ec2:DescribeInstances",
-                            "ec2:DescribeImages",
-                            "ec2:DescribeSnapshots",
-                            "ec2:ModifySnapshotAttribute",
-                            "ec2:DescribeSnapshotAttribute",
-                            "ec2:CopyImage",
-                            "ec2:CreateTags",
-                            "ec2:DescribeRegions",
-                            "cloudtrail:CreateTrail",
-                            "cloudtrail:UpdateTrail",
-                            "cloudtrail:PutEventSelectors",
-                            "cloudtrail:DescribeTrails",
-                            "cloudtrail:StartLogging",
-                            "cloudtrail:StopLogging"
-                        ],
-                        "Resource": "*"
-                    }]
-                }, null, 2)}
-            </ClipboardCopy>
-            <TextListItem>Complete the process to create your new policy.</TextListItem>
-        </TextList>
-        <Text component={ TextVariants.p }>
-            <b>Do not close your browser.</b> You will need to be logged in to the IAM console to compute the next step.
-        </Text>
-    </TextContent>);
-};
-
-IAMPolicyDescription.propTypes = {
-    formOptions: PropTypes.shape({
-        getState: PropTypes.func.isRequired
-    }).isRequired
-};
-
+        </TextListItem>
+        <TextListItem>Create a new policy, pasting the following content into the JSON text box.</TextListItem>
+        <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
+            {JSON.stringify({
+                Version: '2012-10-17',
+                Statement: [{
+                    Sid: 'VisualEditor0',
+                    Effect: 'Allow',
+                    Action: [
+                        'ec2:DescribeInstances',
+                        'ec2:DescribeImages',
+                        'ec2:DescribeSnapshots',
+                        'ec2:ModifySnapshotAttribute',
+                        'ec2:DescribeSnapshotAttribute',
+                        'ec2:CopyImage',
+                        'ec2:CreateTags',
+                        'ec2:DescribeRegions',
+                        'cloudtrail:CreateTrail',
+                        'cloudtrail:UpdateTrail',
+                        'cloudtrail:PutEventSelectors',
+                        'cloudtrail:DescribeTrails',
+                        'cloudtrail:StartLogging',
+                        'cloudtrail:StopLogging'
+                    ],
+                    Resource: '*'
+                }]
+            }, null, 2)}
+        </ClipboardCopy>
+        <TextListItem>Complete the process to create your new policy.</TextListItem>
+    </TextList>
+    <Text component={ TextVariants.p }>
+        <b>Do not close your browser.</b> You will need to be logged in to the IAM console to compute the next step.
+    </Text>
+</TextContent>);
 
 export const ArnDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -7,10 +7,13 @@ import * as OpenshiftToken from './hardcodedComponents/openshift/token';
 import * as AwsSecret from './hardcodedComponents/aws/access_key';
 import * as AwsArn from './hardcodedComponents/aws/arn';
 
+import * as SWAwsArn from './hardcodedComponents/aws/subscriptionWatch';
+
 import * as CMOpenshift from  './hardcodedComponents/openshift/costManagement';
 import * as CMAzure from './hardcodedComponents/azure/costManagement';
 
 export const COST_MANAGEMENT_APP_NAME = '/insights/platform/cost-management';
+export const CLOUD_METER_APP_NAME = '/insights/platform/cloud-meter';
 
 const arnField = {
     placeholder: 'arn:aws:iam:123456789:role/CostManagement',
@@ -18,6 +21,22 @@ const arnField = {
     validate: [{
         type: validatorTypes.REQUIRED
     },  {
+        type: validatorTypes.PATTERN_VALIDATOR,
+        pattern: /^arn:aws:.*/,
+        message: 'ARN must start with arn:aws:'
+    }, {
+        type: validatorTypes.MIN_LENGTH,
+        threshold: 10,
+        message: 'ARN should have at least 10 characters'
+    }]
+};
+
+const subsWatchArnField = {
+    placeholder: 'arn:aws:iam:123456789:role/SubscriptionWatch',
+    isRequired: true,
+    validate: [{
+        type: validatorTypes.REQUIRED
+    }, {
         type: validatorTypes.PATTERN_VALIDATOR,
         pattern: /^arn:aws:.*/,
         message: 'ARN must start with arn:aws:'
@@ -381,6 +400,50 @@ export default {
                             Content: AwsArn.ArnDescription
                         }]
                     }]
+                }
+            },
+            'cloud-meter-arn': {
+                [CLOUD_METER_APP_NAME]: {
+                    skipSelection: true,
+                    'authentication.password': subsWatchArnField,
+                    additionalSteps: [{
+                        title: 'Create IAM policy',
+                        name: 'iam-policy',
+                        nextStep: 'subs-iam-role',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'iam-policy-description',
+                            component: 'description',
+                            Content: SWAwsArn.IAMPolicyDescription
+                        }]
+                    }, {
+                        title: 'Create IAM role',
+                        stepKey: 'subs-iam-role',
+                        name: 'subs-iam-role',
+                        nextStep: 'subs-arn',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'iam-role-description',
+                            component: 'description',
+                            Content: SWAwsArn.IAMRoleDescription
+                        }]
+                    }, {
+                        title: 'Enter ARN',
+                        stepKey: 'subs-arn',
+                        name: 'cloud-meter-arn',
+                        substepOf: 'Enable account access',
+                        fields: [{
+                            name: 'arn-description',
+                            component: 'description',
+                            Content: SWAwsArn.ArnDescription
+                        }, {
+                            component: componentTypes.TEXT_FIELD,
+                            name: 'authentication.password',
+                            label: 'ARN',
+                            isRequired: true
+                        }]
+                    }
+                    ]
                 }
             }
         },

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import {
+    TextContent,
+    Text,
+    TextList,
+    TextListItem,
+    ClipboardCopy
+} from '@patternfly/react-core';
+
+import * as SubsAwsArn from '../../../addSourceWizard/hardcodedComponents/aws/subscriptionWatch';
+
+describe('AWS-ARN hardcoded schemas', () => {
+    it('ARN DESCRIPTION is rendered correctly', () => {
+        const wrapper = mount(<SubsAwsArn.ArnDescription />);
+
+        expect(wrapper.find(TextContent)).toHaveLength(1);
+        expect(wrapper.find(Text)).toHaveLength(1);
+        expect(wrapper.find(TextList)).toHaveLength(1);
+        expect(wrapper.find(TextListItem)).toHaveLength(2);
+    });
+
+    it('IAM POLICY is rendered correctly', () => {
+        const wrapper = mount(<SubsAwsArn.IAMPolicyDescription />);
+
+        expect(wrapper.find(TextContent)).toHaveLength(1);
+        expect(wrapper.find(Text)).toHaveLength(2);
+        expect(wrapper.find(TextList)).toHaveLength(1);
+        expect(wrapper.find(TextListItem)).toHaveLength(3);
+        expect(wrapper.find(ClipboardCopy)).toHaveLength(1);
+    });
+
+    it('IAM ROLE is rendered correctly', () => {
+        const CM_ID = '372779871274';
+        const wrapper = mount(<SubsAwsArn.IAMRoleDescription />);
+
+        expect(wrapper.find(TextContent)).toHaveLength(1);
+        expect(wrapper.find(Text)).toHaveLength(1);
+        expect(wrapper.find(TextList)).toHaveLength(1);
+        expect(wrapper.find(TextListItem)).toHaveLength(4);
+        expect(wrapper.find(ClipboardCopy)).toHaveLength(1);
+        expect(wrapper.find(ClipboardCopy).html().includes(CM_ID)).toEqual(true);
+    });
+});


### PR DESCRIPTION
* Add wizard steps for Amazon with cloud-meter-arn auth
* Added descriptive text for IAM policy, IAM role, and ARN steps.


![SubsWatch_Sources](https://user-images.githubusercontent.com/29379759/75456921-2830e880-5949-11ea-9761-82687a063ee5.gif)