### PR TITLE
Add missing authtype for cloud meter arn

### DIFF
--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -428,6 +428,12 @@ export default {
                             name: 'iam-policy-description',
                             component: 'description',
                             Content: SWAwsArn.IAMPolicyDescription
+                        }, {
+                            component: componentTypes.TEXT_FIELD,
+                            name: 'authentication.authtype',
+                            hideField: true,
+                            initialValue: 'cloud-meter-arn',
+                            initializeOnMount: true
                         }]
                     }, {
                         title: 'Create IAM role',


### PR DESCRIPTION
Subscription Watch arn was missing `authtype` value.

cc @chambridge 