### PR TITLE
Use break-word in notification styles.

### DIFF
--- a/packages/notifications/src/notifications.scss
+++ b/packages/notifications/src/notifications.scss
@@ -22,5 +22,5 @@
 .notification-item {
   position: relative;
   margin: 10px;
-  word-break: break-all;
+  word-break: break-word;
 }


### PR DESCRIPTION
`break-word` is slightly more friendly to long words than `break-all`. When text is about to overflow, instead of just breaking any word, it will first try to put the word on a new line and not break it in the middle. Word will still break if it's longer than the whole row.

```
break-all:
I have a sentence withaverylongwordthatshou\n
ldoverflow
word-break:
I have a sentence\n
withaverylongwordthatshouldoverflow
```

It should prevent issues like this:
<img width="1399" alt="sharing_error" src="https://user-images.githubusercontent.com/22619452/76859565-e0232880-6859-11ea-97f6-a7598ac1c2bc.png">
