### PR TITLE
Add popover for long values in wizard summary

### DIFF
--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -4,6 +4,7 @@ import { TextContent, TextListItem, TextListItemVariants, TextListVariants, Text
 import get from 'lodash/get';
 import hardcodedSchemas from '../../addSourceWizard/hardcodedSchemas';
 import { injectAuthFieldsInfo, injectEndpointFieldsInfo } from '../../addSourceWizard/schemaBuilder';
+import ValuePopover from './ValuePopover';
 
 export const createItem = (formField, values, stepKeys) => {
     let value = get(values, formField.name);
@@ -83,7 +84,13 @@ const SourceWizardSummary = ({ sourceTypes, formOptions, applicationTypes, showA
     const valuesList = valuesInfo.map(({ label, value }) => (
         <React.Fragment key={ `${label}--${value}` }>
             <TextListItem component={ TextListItemVariants.dt }>{ label }</TextListItem>
-            <TextListItem component={ TextListItemVariants.dd }>{ value }</TextListItem>
+            <TextListItem component={ TextListItemVariants.dd }>
+                { value.toString().length > 150 ?
+                    <ValuePopover label={label} value={value} />
+                    :
+                    value
+                }
+            </TextListItem>
         </React.Fragment>
     ));
 

--- a/packages/sources/src/sourceFormRenderer/components/ValuePopover.js
+++ b/packages/sources/src/sourceFormRenderer/components/ValuePopover.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Popover } from '@patternfly/react-core';
+
+const ValuePopover = ({ label, value }) => (
+    <Popover
+        headerContent={label}
+        bodyContent={value}
+        position="top"
+        maxWidth="80%"
+    >
+        <Button variant="link" isInline className="ins-c-sources__wizard--summary-buttonss">Show more</Button>
+    </Popover>
+);
+
+ValuePopover.propTypes = {
+    label: PropTypes.node,
+    value: PropTypes.node
+};
+
+export default ValuePopover;

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -6,6 +6,7 @@ import { TextListItem } from '@patternfly/react-core';
 import SourceWizardSummary, { createItem } from '../../../sourceFormRenderer/components/SourceWizardSummary';
 import applicationTypes from '../../helpers/applicationTypes';
 import sourceTypes from '../../helpers/sourceTypes';
+import ValuePopover from '../../../sourceFormRenderer/components/ValuePopover';
 
 describe('SourceWizardSummary component', () => {
     describe('should render correctly', () => {
@@ -188,6 +189,28 @@ describe('SourceWizardSummary component', () => {
 
             const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions } />);
             expect(wrapper.contains('OpenShift Container Platform')).toEqual(true);
+        });
+
+        it('contains too long text', () => {
+            const randomLongText = new Array(500).fill(1).map(() => String.fromCharCode(Math.random() * (122 - 97) + 97)).join('');
+
+            formOptions = {
+                getState: () => ({
+                    values: {
+                        source: {
+                            name: 'openshift'
+                        },
+                        source_type: 'openshift',
+                        endpoint: {
+                            certificate_authority: randomLongText,
+                            verify_ssl: true
+                        }
+                    }
+                })
+            };
+
+            const wrapper = shallow(<SourceWizardSummary { ...initialProps } formOptions={ formOptions } />);
+            expect(wrapper.find(ValuePopover).props().value).toEqual(randomLongText);
         });
     });
 

--- a/packages/sources/src/tests/sourceFormRenderer/components/valuePopover.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/valuePopover.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Popover, Button } from '@patternfly/react-core';
+import ValuePopover from '../../../sourceFormRenderer/components/ValuePopover';
+
+describe('ValuePopover', () => {
+    it('renders correctly', () => {
+        const wrapper = mount(<ValuePopover
+            label="Some label"
+            value="Some value"
+        />);
+
+        expect(wrapper.find(Popover).props().bodyContent).toEqual('Some value');
+        expect(wrapper.find(Popover).props().headerContent).toEqual('Some label');
+        expect(wrapper.find(Button)).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
When some value is longer than 150 chars (approx. line and half) it is wrapped in popover.

![image](https://user-images.githubusercontent.com/32869456/77062294-e5a87c00-69db-11ea-8379-0b841ab293b2.png)

The position of popover is broken, please see https://github.com/patternfly/patternfly-react/issues/3930