### PR TITLE
Use solid error icon in wizard

### DIFF
--- a/packages/sources/src/addSourceWizard/steps/ErroredStep.js
+++ b/packages/sources/src/addSourceWizard/steps/ErroredStep.js
@@ -13,11 +13,11 @@ import {
     Text,
     TextVariants
 } from '@patternfly/react-core';
-import { ErrorCircleOIcon } from '@patternfly/react-icons';
+import { TimesCircleIcon } from '@patternfly/react-icons';
 
 const ErroredStep = ({ onClose, onRetry, returnButtonTitle, message }) => <div className="pf-l-bullseye">
     <EmptyState variant={ EmptyStateVariant.full }>
-        <EmptyStateIcon icon={ ErrorCircleOIcon } color="var(--pf-global--danger-color--100)" />
+        <EmptyStateIcon icon={ TimesCircleIcon } color="var(--pf-global--danger-color--100)" />
         <Title headingLevel="h5" size="lg">
       Configuration unsuccessful
         </Title>


### PR DESCRIPTION
Because the success icon is solid, the error should be solid too.

**Before**

![image](https://user-images.githubusercontent.com/32869456/77067099-b21e1f80-69e4-11ea-84f9-c11faa7ad707.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/77067116-b8ac9700-69e4-11ea-88e5-9480bf16feed.png)