### PR TITLE
[RFR] Add Label to Battery in Insights-Inventory

### DIFF
--- a/packages/inventory-insights/src/Constants.js
+++ b/packages/inventory-insights/src/Constants.js
@@ -20,3 +20,10 @@ export const FILTER_CATEGORIES = {
         ]
     }
 };
+
+export const RISK_TO_STRING = {
+    1: 'Low',
+    2: 'Moderate',
+    3: 'Important',
+    4: 'Critical'
+};

--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import './insights.scss';
 
-import { BASE_FETCH_URL, FILTER_CATEGORIES as FC } from './Constants';
+import { BASE_FETCH_URL, FILTER_CATEGORIES as FC, RISK_TO_STRING } from './Constants';
 import React, { Component, Fragment } from 'react';
 import { SortByDirection, Table, TableBody, TableHeader, cellWidth, sortable } from '@patternfly/react-table';
 import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
@@ -161,8 +161,7 @@ class InventoryRuleList extends Component {
                         {
                             title: <div className='pf-m-center' key={key} style={{ verticalAlign: 'top' }}>
                                 <Battery
-                                    label='Total risk'
-                                    labelHidden
+                                    label={RISK_TO_STRING[rule.total_risk]}
                                     severity={rule.total_risk}
                                 />
                             </div>


### PR DESCRIPTION
@AllenBW This is in response to RHCLOUD-5246 on page 2 of the google doc. We're adding the label to the battery icon.