### PR TITLE
Remove seconds for exact date format

### DIFF
--- a/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
+++ b/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
@@ -10,7 +10,7 @@ exports[`DateFormat component DateFormat renders with date integer 1`] = `
     content={
       <div>
         
-        01 Jan 1970 00:00:00 UTC
+        01 Jan 1970 00:00 UTC
       </div>
     }
     distance={15}
@@ -47,7 +47,7 @@ exports[`DateFormat component DateFormat renders with date integer 1`] = `
 
 exports[`DateFormat component DateFormat renders with date integer 2`] = `
 <Fragment>
-  01 Jan 1970 00:00:00 UTC
+  01 Jan 1970 00:00 UTC
 </Fragment>
 `;
 
@@ -67,7 +67,7 @@ exports[`DateFormat component DateFormat renders with date object 1`] = `
     content={
       <div>
         
-        31 Dec 2019 00:00:00 UTC
+        31 Dec 2019 00:00 UTC
       </div>
     }
     distance={15}
@@ -112,7 +112,7 @@ exports[`DateFormat component DateFormat renders with date string 1`] = `
     content={
       <div>
         
-        31 Dec 2019 00:00:00 UTC
+        31 Dec 2019 00:00 UTC
       </div>
     }
     distance={15}

--- a/packages/components/src/Components/DateFormat/helper.js
+++ b/packages/components/src/Components/DateFormat/helper.js
@@ -18,7 +18,7 @@ const relativeTimeTable = [
     { rightBound: minute, description: () => 'Just now' }
 ];
 
-const exact = (value) => value.toUTCString().split(',')[1].slice(0, -4).trim();
+const exact = (value) => value.toUTCString().split(',')[1].slice(0, -7).trim();
 
 export const addTooltip = (date, element, extraTitle = '') => (
     <Tooltip
@@ -29,7 +29,7 @@ export const addTooltip = (date, element, extraTitle = '') => (
 
 export const dateStringByType = (type) => ({
     exact: date => exact(date) + ' UTC',
-    onlyDate: date => exact(date).slice(0, -9),
+    onlyDate: date => exact(date).slice(0, -6),
     relative: date => relativeTimeTable.reduce((acc, i) => (i.rightBound > Date.now() - date ? i.description(Date.now() - date) : acc), exact(date)),
     invalid: () => 'Invalid Date'
 })[type];

--- a/packages/components/src/Components/DateFormat/helper.test.js
+++ b/packages/components/src/Components/DateFormat/helper.test.js
@@ -27,7 +27,7 @@ describe('dateStringByType component', () => {
     });
 
     it('Exact datetime matches', () => {
-        expect(dateStringByType('exact')(date)).toEqual('31 Dec 2019 00:00:00 UTC');
+        expect(dateStringByType('exact')(date)).toEqual('31 Dec 2019 00:00 UTC');
     });
 
     it('OnlyDate date matches', () => {


### PR DESCRIPTION
According to https://www.patternfly.org/v4/design-guidelines/content/grammar-and-terminology#date-and-time there shouldn't be displayed seconds  when displaying datetime.