### PR TITLE
Add authentication component

### DIFF
--- a/packages/sources/src/sourceFormRenderer/components/Authentication.js
+++ b/packages/sources/src/sourceFormRenderer/components/Authentication.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+import { formFieldsMapper } from '@data-driven-forms/pf4-component-mapper';
+
+const Authentication = ({ FieldProvider, formOptions, ...rest }) => {
+    const { authentication } = formOptions.getState().values;
+
+    const doNotRequirePassword = (...args) => !args[0] ? '' : rest.validate(...args);
+
+    const componentProps = {
+        ...rest,
+        component: formFieldsMapper[componentTypes.TEXT_FIELD],
+        ...(authentication && authentication.id ? {
+            isRequired: false,
+            helperText: `Changing this resets your current ${rest.label}.`,
+            validate: doNotRequirePassword
+        } : {})
+    };
+
+    return (
+        <FieldProvider { ...componentProps } />
+    );
+};
+
+export default Authentication;

--- a/packages/sources/src/sourceFormRenderer/index.js
+++ b/packages/sources/src/sourceFormRenderer/index.js
@@ -7,12 +7,14 @@ import SourceWizardSummary from './components/SourceWizardSummary';
 import Description from './components/Description';
 import CardSelect from './components/CardSelect';
 import AuthSelect from './components/AuthSelect';
+import Authentication from './components/Authentication';
 
 export const mapperExtension = {
     'auth-select': AuthSelect,
     description: Description,
     'card-select': CardSelect,
-    summary: SourceWizardSummary
+    summary: SourceWizardSummary,
+    authentication: Authentication
 };
 
 const SourcesFormRenderer = props => (

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
@@ -169,7 +169,7 @@ describe('schema builder', () => {
             ];
 
             expect(injectAuthFieldsInfo(fields, 'nonsense', 'nonsense', 'generic', disablePassword)).toEqual([
-                { name: 'authentication.password', validate: [{ type: 'cosi' }], isRequired: false, helperText: expect.any(String) },
+                { ...passwordField, component: 'authentication' },
                 unchangedField
             ]);
         });
@@ -283,13 +283,14 @@ describe('schema builder', () => {
         let expectedSchema;
         const APPEND_ENDPOINT_FIELDS = [ true ];
         const EMPTY_APPEND_ENDPOINT = [ ];
-        const NOT_EDITING = false;
 
         describe('createGenericAuthTypeSelection', () => {
             it('generate single selection', () => {
                 const fields = [
                     ...OPENSHIFT_TYPE.schema.authentication[0].fields.filter(({ stepKey }) => !stepKey)
-                    .map((field) => expect.objectContaining(field)),
+                    .map((field) => expect.objectContaining(field.name === 'authentication.password' ?
+                        { ...field, component: 'authentication' } : field
+                    )),
                     createEndpointFlagger(false)
                 ];
 
@@ -301,7 +302,7 @@ describe('schema builder', () => {
                     nextStep: 'summary'
                 });
 
-                expect(createGenericAuthTypeSelection(OPENSHIFT_TYPE, APPEND_ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createGenericAuthTypeSelection(OPENSHIFT_TYPE, APPEND_ENDPOINT_FIELDS)).toEqual(expectedSchema);
             });
 
             it('generate single selection with endpoint', () => {
@@ -313,7 +314,7 @@ describe('schema builder', () => {
                     nextStep: `${OPENSHIFT_TYPE.name}-endpoint`
                 });
 
-                expect(createGenericAuthTypeSelection(OPENSHIFT_TYPE, EMPTY_APPEND_ENDPOINT, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createGenericAuthTypeSelection(OPENSHIFT_TYPE, EMPTY_APPEND_ENDPOINT)).toEqual(expectedSchema);
             });
 
             it('generate multiple selection', () => {
@@ -337,7 +338,7 @@ describe('schema builder', () => {
                     }
                 });
 
-                expect(createGenericAuthTypeSelection(AMAZON_TYPE, APPEND_ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createGenericAuthTypeSelection(AMAZON_TYPE, APPEND_ENDPOINT_FIELDS)).toEqual(expectedSchema);
             });
         });
 
@@ -357,7 +358,7 @@ describe('schema builder', () => {
                     nextStep: 'summary'
                 });
 
-                expect(createSpecificAuthTypeSelection(AZURE_TYPE, TOPOLOGY_INV_APP, APPEND_ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createSpecificAuthTypeSelection(AZURE_TYPE, TOPOLOGY_INV_APP, APPEND_ENDPOINT_FIELDS)).toEqual(expectedSchema);
             });
 
             it('generate single selection with endpoints', () => {
@@ -372,7 +373,7 @@ describe('schema builder', () => {
                     nextStep: `${AZURE_TYPE.name}-endpoint`
                 });
 
-                expect(createSpecificAuthTypeSelection(AZURE_TYPE, TOPOLOGY_INV_APP, EMPTY_APPEND_ENDPOINT, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createSpecificAuthTypeSelection(AZURE_TYPE, TOPOLOGY_INV_APP, EMPTY_APPEND_ENDPOINT)).toEqual(expectedSchema);
             });
 
             it('generate with custom steps', () => {
@@ -389,7 +390,7 @@ describe('schema builder', () => {
                     nextStep: firstAdditionalStep.nextStep
                 });
 
-                expect(createSpecificAuthTypeSelection(AMAZON_TYPE, COST_MANAGEMENT_APP, APPEND_ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+                expect(createSpecificAuthTypeSelection(AMAZON_TYPE, COST_MANAGEMENT_APP, APPEND_ENDPOINT_FIELDS)).toEqual(expectedSchema);
             });
         });
     });


### PR DESCRIPTION
Because of changes in Sources UI, authentication has to be set to edit mode dynamically, not in the schema.

So, when `authentication { id }` is set, the wizard is in 'edit' mode.

Required validator has to be removed, but because we cannot longer change the schema, the validate function is wrapped.