### PR TITLE
Use score from backend in SystemPolicyCard

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -39,6 +39,7 @@ query System($systemId: String!){
             rulesFailed
             rulesPassed
             lastScanned
+            score
             rules {
                 title
                 severity

--- a/packages/inventory-compliance/src/SystemPolicyCard.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.js
@@ -52,9 +52,9 @@ class SystemPolicyCard extends React.Component {
     }
 
     render() {
-        const { rulesPassed, rulesFailed, compliant, lastScanned } = this.state.policy;
+        const { rulesPassed, rulesFailed, compliant, lastScanned, score } = this.state.policy;
         const { refIdTruncated, cardTitle } = this.state;
-        const passedPercentage = this.fixedPercentage(100 * (rulesPassed / (rulesPassed + rulesFailed)));
+        const passedPercentage = this.fixedPercentage(score);
 
         return (
             <Card>
@@ -100,6 +100,7 @@ SystemPolicyCard.propTypes = {
     policy: PropTypes.shape({
         rulesPassed: PropTypes.number,
         rulesFailed: PropTypes.number,
+        score: PropTypes.number,
         lastScanned: PropTypes.string,
         refId: PropTypes.string,
         name: PropTypes.string,

--- a/packages/inventory-compliance/src/SystemPolicyCard.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.test.js
@@ -11,6 +11,7 @@ describe('SystemPolicyCard component', () => {
         const policy = {
             rulesPassed: 30,
             rulesFailed: 10,
+            score: 75,
             lastScanned: currentTime.toISOString(),
             refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
             name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',

--- a/packages/inventory-compliance/src/SystemPolicyCards.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCards.test.js
@@ -11,6 +11,7 @@ describe('SystemPolicyCards component', () => {
     const policies = [{
         rulesPassed: 30,
         rulesFailed: 10,
+        score: 75,
         lastScanned: '2019-03-06T06:20:13Z',
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
@@ -18,6 +19,7 @@ describe('SystemPolicyCards component', () => {
     }, {
         rulesPassed: 0,
         rulesFailed: 0,
+        score: 0,
         lastScanned: null,
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss2',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2',

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -15,6 +15,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
           "rulesFailed": 10,
           "rulesPassed": 30,
+          "score": 75,
         },
         Object {
           "compliant": false,
@@ -23,6 +24,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
           "rulesFailed": 0,
           "rulesPassed": 0,
+          "score": 0,
         },
       ]
     }
@@ -52,6 +54,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rulesFailed": 10,
                   "rulesPassed": 30,
+                  "score": 75,
                 }
               }
             >
@@ -332,6 +335,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
           "rulesFailed": 10,
           "rulesPassed": 30,
+          "score": 75,
         },
         Object {
           "compliant": false,
@@ -340,6 +344,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
           "refId": "xccdf_org.ssgproject.content_profile_pci-dss2",
           "rulesFailed": 0,
           "rulesPassed": 0,
+          "score": 0,
         },
       ]
     }
@@ -369,6 +374,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rulesFailed": 10,
                   "rulesPassed": 30,
+                  "score": 75,
                 }
               }
             >


### PR DESCRIPTION
This should be the last place where score was still being calculated from passed/failed rules.

We are for sure going to get bugs reported against this now that the math isn't so simple to figure out. Check out what looks like a discrepancy between the score and pass/fail rule count.

```
18 of 51 rules passed (78%)
43 of 141 rules passed (63%)
```

![image](https://user-images.githubusercontent.com/761923/78272270-4a370100-74db-11ea-87ef-7bb379a1615d.png)

I'm not sure why I needed to update snapshots not related to what I changed, but they were failing. Any guidance would be appreciated.

Signed-off-by: Andrew Kofink <akofink@redhat.com>