### PR TITLE
Shield tooltip doesn't overflow viewport

### DIFF
--- a/packages/components/src/Components/Shield/Shield.js
+++ b/packages/components/src/Components/Shield/Shield.js
@@ -20,7 +20,7 @@ const Shield = ({ impact, hasLabel, hasTooltip, size }) => {
     return (
         <span>
             {hasTooltip ?
-                <Tooltip content={<div>{attributes.message}</div>} position={'bottom'}>
+                <Tooltip content={<div>{attributes.message}</div>} position={'bottom'} boundary={'viewport'}>
                     {body}
                 </Tooltip>
                 : body}

--- a/packages/components/src/Components/Shield/__snapshots__/Shield.test.js.snap
+++ b/packages/components/src/Components/Shield/__snapshots__/Shield.test.js.snap
@@ -21,7 +21,7 @@ exports[`Shield component should render where impact value is 1 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -73,7 +73,7 @@ exports[`Shield component should render where impact value is 2 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -125,7 +125,7 @@ exports[`Shield component should render where impact value is 3 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -177,7 +177,7 @@ exports[`Shield component should render where impact value is 4 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -229,7 +229,7 @@ exports[`Shield component should render where impact value is Critical 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -281,7 +281,7 @@ exports[`Shield component should render where impact value is Low 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -333,7 +333,7 @@ exports[`Shield component should render where impact value is NonExist 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={<div />}
     distance={15}
@@ -381,7 +381,7 @@ exports[`Shield component should render where impact value is empty string 1`] =
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={<div />}
     distance={15}
@@ -429,7 +429,7 @@ exports[`Shield component should render where impact value is undefined 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={<div />}
     distance={15}
@@ -477,7 +477,7 @@ exports[`Shield component should render with label 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={
       <div>
@@ -530,7 +530,7 @@ exports[`Shield component should render without props 1`] = `
   <Tooltip
     appendTo={[Function]}
     aria="describedby"
-    boundary="window"
+    boundary="viewport"
     className=""
     content={<div />}
     distance={15}


### PR DESCRIPTION
Shield tooltip would overflow the viewport, which caused additional scrollbar to appear and twitch table to the left.
Fixes https://projects.engineering.redhat.com/browse/VMAAS-1059 .