### PR TITLE
Import DataToolbarItem from dist/js/experimental

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { Pagination, PaginationVariant, DataToolbarItem } from '@patternfly/react-core';
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { DataToolbarItem } from '@patternfly/react-core/dist/js/experimental';
 import { CheckIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { TableToolbar, PrimaryToolbar } from '@redhat-cloud-services/frontend-components';


### PR DESCRIPTION
The `DataToolbarItem` import has to be from '@patternfly/react-core/dist/js/experimental' as in `PrimaryToolbar`[1]

Strangely this import works when `npm linking` the `@redhat-cloud-services/frontend-components-inventory-compliance` package into `compliance-frontend`.

[1] https://github.com/RedHatInsights/frontend-components/blob/master/packages/components/src/Components/PrimaryToolbar/PrimaryToolbar.js#L1