### PR TITLE
Sometimes primary toolbar placeholders need to be capitalized...

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -33,6 +33,7 @@ class ConditionalFilter extends Component {
         );
         const onChangeCallback = onChange || this.onChange;
         const ActiveComponent = activeItem && (typeMapper[activeItem.type] || typeMapper.text);
+        const capitalize = (string) => string[0].toUpperCase() + string.substring(1);
         return (
             <Fragment>
                 {
@@ -60,7 +61,7 @@ class ConditionalFilter extends Component {
                                                 <FilterIcon size="sm" />
                                                 { !hideLabel &&
                                                     <span className="ins-c-conditional-filter__value-selector">
-                                                        { activeItem && activeItem.label }
+                                                        { activeItem && capitalize(activeItem.label) }
                                                     </span>
                                                 }
                                             </DropdownToggle>
@@ -72,7 +73,7 @@ class ConditionalFilter extends Component {
                                                 onClick={ e => onChangeCallback(e, item.value || key, item) }
                                                 isHovered={ activeItem.label === item.label }
                                             >
-                                                { item.label }
+                                                { capitalize(item.label) }
                                             </DropdownItem>)
                                         }
                                     />
@@ -84,7 +85,7 @@ class ConditionalFilter extends Component {
                                         {
                                         ...activeItem.type !== conditionalFilterType.custom &&
                                             {
-                                                placeholder: placeholder || activeItem.placeholder || `Filter by ${activeItem.label.toLowerCase()}`,
+                                                placeholder: placeholder || activeItem.placeholder || `Filter by ${activeItem.label}`,
                                                 id: (activeItem.filterValues && activeItem.filterValues.id) || currentValue
                                             }
                                         }

--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.test.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.test.js
@@ -5,45 +5,45 @@ import toJson from 'enzyme-to-json';
 
 const config = [{
     id: 'some',
-    label: 'Simple text 1',
+    label: 'simple text 1',
     value: 'simple-text-1'
 }, {
-    label: 'Simple text 2',
+    label: 'simple text 2',
     value: 'simple-text-2',
     type: 'text',
     filterValues: {
         value: 'some-value blaa'
     }
 }, {
-    label: 'Checkbox',
+    label: 'checkbox',
     value: 'checkbox-filter',
     type: 'checkbox',
     filterValues: {
         items: [{
-            label: <div>Custom value</div>,
+            label: <div>custom value</div>,
             value: 'some-value'
         }, {
-            label: 'Another',
+            label: 'another',
             value: 'another-value'
         }, {
-            label: 'No value'
+            label: 'no value'
         }]
     }
 }, {
-    label: 'Radio filter',
+    label: 'radio filter',
     value: 'radio-filter',
     type: 'radio',
     filterValues: {
         items: [{
-            label: <div>Custom value</div>,
+            label: <div>custom value</div>,
             value: 'some-value'
         }, {
-            label: 'Another',
+            label: 'another',
             value: 'another-value'
         }]
     }
 }, {
-    label: 'No value',
+    label: 'no value',
     type: 'text'
 }];
 

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
@@ -16,7 +16,7 @@ exports[`ConditionalFilter render should render correctly 1`] = `
 </Fragment>
 `;
 
-exports[`ConditionalFilter render should render correctly Checkbox with value checkbox-filter 1`] = `
+exports[`ConditionalFilter render should render correctly checkbox with value checkbox-filter 1`] = `
 <Fragment>
   <Split
     className="ins-c-conditional-filter"
@@ -94,16 +94,16 @@ exports[`ConditionalFilter render should render correctly Checkbox with value ch
           Array [
             Object {
               "label": <div>
-                Custom value
+                custom value
               </div>,
               "value": "some-value",
             },
             Object {
-              "label": "Another",
+              "label": "another",
               "value": "another-value",
             },
             Object {
-              "label": "No value",
+              "label": "no value",
             },
           ]
         }
@@ -116,7 +116,7 @@ exports[`ConditionalFilter render should render correctly Checkbox with value ch
 </Fragment>
 `;
 
-exports[`ConditionalFilter render should render correctly No value with value undefined 1`] = `
+exports[`ConditionalFilter render should render correctly no value with value undefined 1`] = `
 <Fragment>
   <Split
     className="ins-c-conditional-filter"
@@ -199,7 +199,7 @@ exports[`ConditionalFilter render should render correctly No value with value un
 </Fragment>
 `;
 
-exports[`ConditionalFilter render should render correctly Radio filter with value radio-filter 1`] = `
+exports[`ConditionalFilter render should render correctly radio filter with value radio-filter 1`] = `
 <Fragment>
   <Split
     className="ins-c-conditional-filter"
@@ -277,12 +277,12 @@ exports[`ConditionalFilter render should render correctly Radio filter with valu
           Array [
             Object {
               "label": <div>
-                Custom value
+                custom value
               </div>,
               "value": "some-value",
             },
             Object {
-              "label": "Another",
+              "label": "another",
               "value": "another-value",
             },
           ]
@@ -295,7 +295,7 @@ exports[`ConditionalFilter render should render correctly Radio filter with valu
 </Fragment>
 `;
 
-exports[`ConditionalFilter render should render correctly Simple text 1 with value simple-text-1 1`] = `
+exports[`ConditionalFilter render should render correctly simple text 1 with value simple-text-1 1`] = `
 <Fragment>
   <Split
     className="ins-c-conditional-filter"
@@ -378,7 +378,7 @@ exports[`ConditionalFilter render should render correctly Simple text 1 with val
 </Fragment>
 `;
 
-exports[`ConditionalFilter render should render correctly Simple text 2 with value simple-text-2 1`] = `
+exports[`ConditionalFilter render should render correctly simple text 2 with value simple-text-2 1`] = `
 <Fragment>
   <Split
     className="ins-c-conditional-filter"


### PR DESCRIPTION
So now, we'll capitalize the labels, but for the filter placeholder to be sentence case, the label will have to be lowercase, BUT this will allow a label of say `Ansible`to remain `Ansible` n make everyone happy

fixes https://projects.engineering.redhat.com/browse/RHCLOUD-5702