### PR TITLE
When editing authentication do not show empty password

### DIFF
--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -32,6 +32,10 @@ export const createItem = (formField, values, stepKeys) => {
         value = value ? 'Yes' : 'No';
     }
 
+    if (!value && formField.name === 'authentication.password' && get(values, 'authentication.id')) {
+        value = '●●●●●●●●●●●●';
+    }
+
     return ({ label: formField['aria-label'] || formField.label,  value: value || '-' });
 };
 

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -322,6 +322,27 @@ describe('SourceWizardSummary component', () => {
             });
         });
 
+        it('authentication editing', () => {
+            field = {
+                label: 'Label 1',
+                name: 'authentication.password',
+                stepKey: 'in'
+            };
+
+            values = {
+                authentication: {
+                    id: 'someid'
+                }
+            };
+
+            availableStepKeys = [ 'in' ];
+
+            expect(createItem(field, values, availableStepKeys)).toEqual({
+                label: 'Label 1',
+                value: '●●●●●●●●●●●●'
+            });
+        });
+
         it('hidden conditional field', () => {
             field = {
                 label: 'Label 1',


### PR DESCRIPTION
When adding application using existing authentication, users do not have to enter password and the value is not stored in the form state. In these cases, the summary was showing `-`, now it shows `Not edited`

Before
![image](https://user-images.githubusercontent.com/32869456/78887720-a90ef400-7a60-11ea-88e2-193ad5ad59a1.png)


After
![image](https://user-images.githubusercontent.com/32869456/78887566-63eac200-7a60-11ea-8819-ec4fb11e85a2.png)

