### PR TITLE
Align battery SVG

### DIFF
--- a/packages/components/src/Components/Battery/battery.scss
+++ b/packages/components/src/Components/Battery/battery.scss
@@ -10,6 +10,7 @@ i.ins-battery {
   line-height: 0;
   svg {
     position: relative;
+    top: var(--pf-global--spacer--sm);
     @include setBatteryFont;
   }
 }


### PR DESCRIPTION
This is a PR in response to RHCLOUD-5244 (page one of attached google doc). This code moves the battery svg inline with its label. See below.

Before:
![Screen Shot 2020-04-13 at 12 20 27 PM](https://user-images.githubusercontent.com/4829473/79138099-ea194800-7d81-11ea-84c6-491a59b94e4c.png)

After:
![Screen Shot 2020-04-13 at 12 18 56 PM](https://user-images.githubusercontent.com/4829473/79138111-eeddfc00-7d81-11ea-9870-154c65f546e8.png)
