### PR TITLE
Use sentence case for reboot label

### DIFF
--- a/packages/components/src/Components/Reboot/Reboot.js
+++ b/packages/components/src/Components/Reboot/Reboot.js
@@ -18,7 +18,7 @@ const Reboot = ({ red, className, ...props }) => {
     return (
         <span className={ rebootIconClasses } { ...props }>
             <RebootingIcon/>
-            <span>Reboot Required</span>
+            <span>Reboot required</span>
         </span>
     );
 };

--- a/packages/components/src/Components/Reboot/__snapshots__/Reboot.test.js.snap
+++ b/packages/components/src/Components/Reboot/__snapshots__/Reboot.test.js.snap
@@ -11,7 +11,7 @@ exports[`Reboot component should render correctly 1`] = `
     title={null}
   />
   <span>
-    Reboot Required
+    Reboot required
   </span>
 </span>
 `;
@@ -27,7 +27,7 @@ exports[`Reboot component should render correctly with red 1`] = `
     title={null}
   />
   <span>
-    Reboot Required
+    Reboot required
   </span>
 </span>
 `;


### PR DESCRIPTION
instead of  `Reboot Required` display sentence case `Reboot required`