### PR TITLE
Kba row attribute ensures response of all queried node_id

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -95,10 +95,17 @@ class InventoryRuleList extends Component {
 
     fetchKbaDetails = async (reportsData) => {
         const { filters, searchValue, rows } = this.state;
-        const kbaIds = reportsData.map(report => report.rule.node_id).filter(x => x).join(` OR `);
+        const kbaIds = reportsData.map(({ rule }) => rule.node_id).filter(x => x);
         try {
-            const kbaDetailsFetch = (await API.get(`https://access.redhat.com/hydra/rest/search/kcs?q=id:(${kbaIds})&fl=view_uri,id,publishedTitle`,
-                {}, { credentials: 'include' })).data.response.docs;
+            const kbaDetailsFetch = (await API.get(
+                `https://access.redhat.com/hydra/rest/search/kcs?q=id:(${
+                    kbaIds.join(` OR `)
+                })&fl=view_uri,id,publishedTitle&rows=${
+                    kbaIds.length
+                }`,
+                {},
+                { credentials: 'include' }
+            )).data.response.docs;
             this.setState({
                 kbaDetailsData: kbaDetailsFetch,
                 rows: this.buildRows(reportsData, kbaDetailsFetch, filters, rows, true, searchValue)


### PR DESCRIPTION
oughta fix https://projects.engineering.redhat.com/browse/RHCLOUD-4927

#### we request 23 rows, receive 23 rows
<img width="1440" alt="Screen Shot 2020-04-15 at 11 11 26 AM" src="https://user-images.githubusercontent.com/6640236/79354072-eb757c80-7f09-11ea-8357-10303984e4db.png">
