### PR TITLE
Remove 'external policy' and add SSG version

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -40,6 +40,9 @@ query System($systemId: String!){
             rulesPassed
             lastScanned
             score
+            benchmark {
+                version
+            }
             rules {
                 title
                 severity

--- a/packages/inventory-compliance/src/SystemPolicyCard.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.js
@@ -53,7 +53,7 @@ class SystemPolicyCard extends React.Component {
     }
 
     render() {
-        const { rulesPassed, rulesFailed, compliant, lastScanned, score } = this.state.policy;
+        const { benchmark, rulesPassed, rulesFailed, compliant, lastScanned, score } = this.state.policy;
         const { refIdTruncated, cardTitle } = this.state;
         const passedPercentage = this.fixedPercentage(score);
 
@@ -61,7 +61,6 @@ class SystemPolicyCard extends React.Component {
             <Card>
                 <CardBody>
                     <TextContent className='margin-bottom-md'>
-                        <Text className='margin-bottom-none' component={ TextVariants.small }>External policy</Text>
                         <Text className='margin-bottom-top-none'
                             component={ TextVariants.h4 }
                             onMouseEnter={ this.onTitleMouseover }
@@ -85,6 +84,8 @@ class SystemPolicyCard extends React.Component {
                         >
                             Profile <br/>
                             { refIdTruncated }
+                            <br/>
+                            SSG { benchmark.version }
                         </Text>
                     </div>
                     <Text className='margin-bottom-none' component={ TextVariants.small }>

--- a/packages/inventory-compliance/src/SystemPolicyCard.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.test.js
@@ -15,7 +15,10 @@ describe('SystemPolicyCard component', () => {
             lastScanned: currentTime.toISOString(),
             refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
             name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
-            compliant: false
+            compliant: false,
+            benchmark: {
+                version: '0.1.45'
+            }
         };
         const wrapper = render(
             <IntlProvider locale={ navigator.language }>

--- a/packages/inventory-compliance/src/SystemPolicyCards.test.js
+++ b/packages/inventory-compliance/src/SystemPolicyCards.test.js
@@ -15,7 +15,10 @@ describe('SystemPolicyCards component', () => {
         lastScanned: '2019-03-06T06:20:13Z',
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
-        compliant: false
+        compliant: false,
+        benchmark: {
+            version: '0.1.45'
+        }
     }, {
         rulesPassed: 0,
         rulesFailed: 0,
@@ -23,7 +26,10 @@ describe('SystemPolicyCards component', () => {
         lastScanned: null,
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss2',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2',
-        compliant: false
+        compliant: false,
+        benchmark: {
+            version: '0.1.45'
+        }
     }];
 
     it('should render loading state', () => {

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
@@ -10,12 +10,6 @@ exports[`SystemPolicyCard component should render 1`] = `
     <div
       class="pf-c-content margin-bottom-md"
     >
-      <small
-        class="margin-bottom-none"
-        data-pf-content="true"
-      >
-        External policy
-      </small>
       <h4
         class="margin-bottom-top-none"
         data-pf-content="true"
@@ -86,6 +80,8 @@ exports[`SystemPolicyCard component should render 1`] = `
             …
           </span>
         </span>
+        <br />
+        SSG 0.1.45
       </p>
     </div>
     <small

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -9,6 +9,9 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
     policies={
       Array [
         Object {
+          "benchmark": Object {
+            "version": "0.1.45",
+          },
           "compliant": false,
           "lastScanned": "2019-03-06T06:20:13Z",
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -18,6 +21,9 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
           "score": 75,
         },
         Object {
+          "benchmark": Object {
+            "version": "0.1.45",
+          },
           "compliant": false,
           "lastScanned": null,
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2",
@@ -48,6 +54,9 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
             <SystemPolicyCard
               policy={
                 Object {
+                  "benchmark": Object {
+                    "version": "0.1.45",
+                  },
                   "compliant": false,
                   "lastScanned": "2019-03-06T06:20:13Z",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -72,17 +81,6 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
                         <div
                           className="pf-c-content margin-bottom-md"
                         >
-                          <Text
-                            className="margin-bottom-none"
-                            component="small"
-                          >
-                            <small
-                              className="margin-bottom-none"
-                              data-pf-content={true}
-                            >
-                              External policy
-                            </small>
-                          </Text>
                           <Text
                             className="margin-bottom-top-none"
                             component="h4"
@@ -219,6 +217,9 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
                                 </span>
                               </span>
                             </Truncate>
+                            <br />
+                            SSG 
+                            0.1.45
                           </p>
                         </Text>
                       </div>
@@ -329,6 +330,9 @@ exports[`SystemPolicyCards component should render real table 1`] = `
     policies={
       Array [
         Object {
+          "benchmark": Object {
+            "version": "0.1.45",
+          },
           "compliant": false,
           "lastScanned": "2019-03-06T06:20:13Z",
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -338,6 +342,9 @@ exports[`SystemPolicyCards component should render real table 1`] = `
           "score": 75,
         },
         Object {
+          "benchmark": Object {
+            "version": "0.1.45",
+          },
           "compliant": false,
           "lastScanned": null,
           "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7 2",
@@ -368,6 +375,9 @@ exports[`SystemPolicyCards component should render real table 1`] = `
             <SystemPolicyCard
               policy={
                 Object {
+                  "benchmark": Object {
+                    "version": "0.1.45",
+                  },
                   "compliant": false,
                   "lastScanned": "2019-03-06T06:20:13Z",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
@@ -392,17 +402,6 @@ exports[`SystemPolicyCards component should render real table 1`] = `
                         <div
                           className="pf-c-content margin-bottom-md"
                         >
-                          <Text
-                            className="margin-bottom-none"
-                            component="small"
-                          >
-                            <small
-                              className="margin-bottom-none"
-                              data-pf-content={true}
-                            >
-                              External policy
-                            </small>
-                          </Text>
                           <Text
                             className="margin-bottom-top-none"
                             component="h4"
@@ -539,6 +538,9 @@ exports[`SystemPolicyCards component should render real table 1`] = `
                                 </span>
                               </span>
                             </Truncate>
+                            <br />
+                            SSG 
+                            0.1.45
                           </p>
                         </Text>
                       </div>


### PR DESCRIPTION
![Screenshot from 2020-04-15 19-52-25](https://user-images.githubusercontent.com/598891/79372263-053cb100-7f56-11ea-90cb-19cc914ac684.png)

Perhaps we could still show whether the Policy is external or not, but I'm not sure what to show if the policy is *not* external - if I remove the text altogether then cards for External Policies are slightly bigger