### PR TITLE
Apply all filters when fetching all tags

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -23,11 +23,17 @@ class Group extends Component {
         });
     };
 
-    componentDidUpdate({ selected: prevSelected }) {
-        const { selected } = this.props;
+    componentDidUpdate({ selected: prevSelected, filterBy: prevFilterBy }) {
+        const { selected, filterBy } = this.props;
         if (!isEqual(prevSelected, selected)) {
             this.setState({
                 selected
+            });
+        }
+
+        if (filterBy !== undefined && prevFilterBy !== filterBy) {
+            this.setState({
+                filterBy
             });
         }
     }
@@ -280,6 +286,7 @@ Group.propTypes = {
         type: PropTypes.oneOf(Object.values(groupType)),
         items: itemsProps
     })),
+    filterBy: PropTypes.string,
     items: itemsProps,
     isFilterable: PropTypes.bool,
     onFilter: PropTypes.func
@@ -287,6 +294,7 @@ Group.propTypes = {
 
 Group.defaultProps = {
     selected: {},
+    filterBy: '',
     onChange: () => undefined,
     groups: [],
     isFilterable: false

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Group - component render should render correctly 1`] = `
 <Fragment>
   <Text
+    filterBy=""
     groups={Array []}
     isFilterable={false}
     onChange={[Function]}

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
-        "@redhat-cloud-services/host-inventory-client": "1.0.60",
+        "@redhat-cloud-services/host-inventory-client": "1.0.61",
         "axios": "^0.19.0"
     }
 }

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
-        "@redhat-cloud-services/host-inventory-client": "1.0.56",
+        "@redhat-cloud-services/host-inventory-client": "1.0.60",
         "axios": "^0.19.0"
     }
 }

--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -141,14 +141,19 @@ export function getTags(systemId, search, { pagination } = { pagination: {} }) {
 }
 
 export function getAllTags(search, { filters, pagination } = { pagination: {} }) {
-    const { tagFilters } = filters ? filters.reduce(filtersReducer, {}) : {};
+    const {
+        tagFilters,
+        staleFilter,
+        registeredWithFilter
+    } = filters ? filters.reduce(filtersReducer, defaultFilters) : defaultFilters;
     return tags.apiTagGetTags(
         tagFilters ? constructTags(tagFilters) : undefined,
         undefined,
         undefined,
         (pagination && pagination.perPage) || 10,
         (pagination && pagination.page) || 1,
-        undefined,
-        search
+        pagination === undefined ? staleFilter : undefined,
+        search,
+        pagination === undefined ? registeredWithFilter : undefined,
     );
 }

--- a/packages/inventory/src/constants.js
+++ b/packages/inventory/src/constants.js
@@ -143,7 +143,7 @@ export const mergeTableProps = (stateProps, dispatchProps, ownProps) => ({
     }
 });
 
-export const tagsFilterBuilder = (onFilter, onChange, selected, loaded, tags, items = [], loader) => ({
+export const tagsFilterBuilder = (onFilter, filterBy, onChange, selected, loaded, tags, items = [], loader) => ({
     label: 'Tags',
     value: 'tags',
     type: 'group',
@@ -151,6 +151,7 @@ export const tagsFilterBuilder = (onFilter, onChange, selected, loaded, tags, it
     filterValues: {
         className: 'ins-c-inventory__tags-filter',
         onFilter,
+        filterBy,
         onChange: (_e, newSelection, group, item, groupKey, itemKey) => {
             if (item.meta) {
                 const isSelected = newSelection[groupKey][itemKey];


### PR DESCRIPTION
* Allow passing filterBy paramter to Group filter (to show active filter if it changed from outside)
* When fetching inventory data refresh tags as well, this will apply newly selected filters to all tags
* When manipulating with filters clear previous search value for fetching all tags
* When feching all tags apply filters only if no pagination is given, when in modal selection mode you will get all tags regardless on staleness etc.

![animation](https://user-images.githubusercontent.com/3439771/79722131-cc993080-82e3-11ea-84c0-ab5591e1e277.gif)
