### PR TITLE
Left Align Remediations Wizard

### DIFF
--- a/packages/components/src/Components/Wizard/Wizard.js
+++ b/packages/components/src/Components/Wizard/Wizard.js
@@ -50,12 +50,6 @@ class Wizard extends Component {
         );
 
         const renderModalActions =  [
-            <Button key="cancel" action="cancel" variant="secondary" onClick={ () => this.handleOnClose(false) }>
-            Cancel
-            </Button>,
-            // Conditionally render 'previous' button if not on first page
-            this.state.currentStep !== 0 &&
-                <Button key="back" action="back" variant="secondary" onClick={ this.handlePreviousModalStep }> Back </Button>,
             // Conditionally render 'confirm' button if on last page
             this.state.currentStep < this.props.content.length - 1
                 ? <Button
@@ -73,7 +67,13 @@ class Wizard extends Component {
                     isDisabled={ !isValidated }
                     onClick={ () => this.handleOnClose(true) }>
                     { confirmAction }
-                </Button>
+                </Button>,
+            // Conditionally render 'previous' button if not on first page
+            this.state.currentStep !== 0 &&
+                <Button key="back" action="back" variant="secondary" onClick={ this.handlePreviousModalStep }> Back </Button>,
+            <Button key="cancel" action="cancel" variant="secondary" onClick={ () => this.handleOnClose(false) }>
+                Cancel
+            </Button>
         ];
 
         return (

--- a/packages/components/src/Components/Wizard/__snapshots__/Wizard.test.js.snap
+++ b/packages/components/src/Components/Wizard/__snapshots__/Wizard.test.js.snap
@@ -5,20 +5,20 @@ exports[`Wizard component should render correctly default 1`] = `
   actions={
     Array [
       <Unknown
-        action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Unknown>,
-      false,
-      <Unknown
         action="next"
         isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Next
+      </Unknown>,
+      false,
+      <Unknown
+        action="cancel"
+        onClick={[Function]}
+        variant="secondary"
+      >
+        Cancel
       </Unknown>,
     ]
   }
@@ -73,20 +73,20 @@ exports[`Wizard component should render correctly large 1`] = `
   actions={
     Array [
       <Unknown
-        action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Unknown>,
-      false,
-      <Unknown
         action="next"
         isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Next
+      </Unknown>,
+      false,
+      <Unknown
+        action="cancel"
+        onClick={[Function]}
+        variant="secondary"
+      >
+        Cancel
       </Unknown>,
     ]
   }
@@ -141,20 +141,20 @@ exports[`Wizard component should render correctly one page 1`] = `
   actions={
     Array [
       <Unknown
-        action="cancel"
-        onClick={[Function]}
-        variant="secondary"
-      >
-        Cancel
-      </Unknown>,
-      false,
-      <Unknown
         action="confirm"
         isDisabled={false}
         onClick={[Function]}
         variant="primary"
       >
         Confirm
+      </Unknown>,
+      false,
+      <Unknown
+        action="cancel"
+        onClick={[Function]}
+        variant="secondary"
+      >
+        Cancel
       </Unknown>,
     ]
   }

--- a/packages/remediations/src/RemediationWizard.js
+++ b/packages/remediations/src/RemediationWizard.js
@@ -318,6 +318,7 @@ class RemediationWizard extends Component {
                 className='ins-c-remediation-modal'
                 onClose = { this.closeWizard }
                 isOpen= { this.state.open !== false }
+                isFooterLeftAligned
                 content = { steps }
                 confirmAction={ this.state.isNewSwitch ? 'Create' : 'Save' }
             />


### PR DESCRIPTION
@AllenBW This PR is in response to RHCLOUD-5247 (page 2 of the attached doc). This change makes the footer of the Wizard appear on the left-hand side. This _should_ be the only change that is necessary for this to function, however, I haven't been able to correctly setup a local chrome env in order to throughly test. The wizard is loaded through the `chrome.experimental` window var.