### PR TITLE
Add Tooltip to Inventory-Insights added column

### DIFF
--- a/packages/components/src/Components/DateFormat/DateFormat.js
+++ b/packages/components/src/Components/DateFormat/DateFormat.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { dateByType } from './helper';
 
-export default function DateFormat({ date, type = 'relative', extraTitle }) {
+export default function DateFormat({ date, type = 'relative', extraTitle, tooltipProps = {} }) {
     const dateObj = date instanceof Date ? date : new Date(date);
     const dateType = dateObj.toString() === 'Invalid Date' ? 'invalid' : type;
     return (
         <React.Fragment>
-            {dateByType(dateType, extraTitle)(dateObj)}
+            {dateByType(dateType, tooltipProps, extraTitle)(dateObj)}
         </React.Fragment>
     );
 }
@@ -15,5 +15,8 @@ export default function DateFormat({ date, type = 'relative', extraTitle }) {
 DateFormat.propTypes = {
     date: PropTypes.oneOfType([ PropTypes.instanceOf(Date), PropTypes.string, PropTypes.number ]),
     type: PropTypes.oneOf([ 'exact', 'onlyDate', 'relative' ]),
-    extraTitle: PropTypes.string
+    extraTitle: PropTypes.string,
+    tooltipProps: PropTypes.shape({
+        [PropTypes.string]: PropTypes.oneOfType([ PropTypes.number, PropTypes.string ])
+    })
 };

--- a/packages/components/src/Components/DateFormat/helper.js
+++ b/packages/components/src/Components/DateFormat/helper.js
@@ -20,8 +20,9 @@ const relativeTimeTable = [
 
 const exact = (value) => value.toUTCString().split(',')[1].slice(0, -7).trim();
 
-export const addTooltip = (date, element, extraTitle = '') => (
+export const addTooltip = (date, element, tooltipProps, extraTitle = '') => (
     <Tooltip
+        {...tooltipProps}
         content={<div>{extraTitle}{date}</div>}
     >
         {element}
@@ -34,9 +35,11 @@ export const dateStringByType = (type) => ({
     invalid: () => 'Invalid date'
 })[type];
 
-export const dateByType = (type, extraTitle) => ({
+export const dateByType = (type, tooltipProps, extraTitle) => ({
     exact: date => dateStringByType(type)(date),
     onlyDate: date => dateStringByType(type)(date),
-    relative: date => addTooltip(dateStringByType('exact')(date), <span>{dateStringByType(type)(date)}</span>, extraTitle),
+    relative: date => addTooltip(
+        dateStringByType('exact')(date), <span>{dateStringByType(type)(date)}</span>, tooltipProps, extraTitle
+    ),
     invalid: () => 'Invalid date'
 })[type];

--- a/packages/inventory-insights/package.json
+++ b/packages/inventory-insights/package.json
@@ -36,7 +36,6 @@
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "dot": "1.1.3",
         "marked": "0.7.0",
-        "moment": "2.24.0",
         "sanitize-html": "^1.20.1"
     }
 }

--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -19,6 +19,7 @@ import ChartSpikeIcon from '@patternfly/react-icons/dist/js/icons/chartSpike-ico
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import { ClipboardCopy } from '@patternfly/react-core/dist/js/components/ClipboardCopy/ClipboardCopy';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/components/DateFormat';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { List } from 'react-content-loader';
 import MessageState from './MessageState';
@@ -31,7 +32,6 @@ import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-
 import { ToolbarItem } from '@patternfly/react-core/dist/js/layouts/Toolbar/ToolbarItem';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import connect from 'react-redux/es/connect/connect';
-import moment from 'moment';
 
 class InventoryRuleList extends Component {
     state = {
@@ -163,7 +163,7 @@ class InventoryRuleList extends Component {
                         { title: <div> {rule.description}</div> },
                         {
                             title: <div key={key}>
-                                {moment(rule.publish_date).fromNow()}
+                                <DateFormat date={rule.publish_date} type='relative' tooltipProps={{ position: TooltipPosition.bottom }}/>
                             </div>
                         },
                         {


### PR DESCRIPTION
This PR is in response to RHCLOUD 5247 (page 2 of the attached doc). It adds a tooltip to the Inventory table over the `added` column showing the time in raw UTC.

Before:
![Screen Shot 2020-04-27 at 1 53 38 PM](https://user-images.githubusercontent.com/4829473/80404113-b284c280-888e-11ea-8937-6a13cf3b5508.png)

After:
![Screen Shot 2020-04-27 at 1 54 56 PM](https://user-images.githubusercontent.com/4829473/80404120-b6b0e000-888e-11ea-8c4b-89a2ee1081f5.png)