### PR TITLE
Remove ToolTip from TotalRisk column of Inventory-Insights

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -168,11 +168,7 @@ class InventoryRuleList extends Component {
                         },
                         {
                             title: <div className='pf-m-center' key={key} style={{ verticalAlign: 'top' }}>
-                                <Tooltip key={key} position={TooltipPosition.bottom} content={<span>The <strong>likelihood</strong> that this will be
-                                a problem is {LIKELIHOOD_LABEL[rule.likelihood]}. The <strong>impact</strong> of the problem would be
-                                &nbsp;{IMPACT_LABEL[rule.impact.impact]} if it occurred.</span>}>
-                                    <Battery label={RISK_TO_STRING[rule.total_risk]} severity={rule.total_risk} />
-                                </Tooltip>
+                                <Battery label={RISK_TO_STRING[rule.total_risk]} severity={rule.total_risk} />
                             </div >
                         },
                         {


### PR DESCRIPTION
This PR is in response to RHCLOUD 5247 (page 1 of the attached doc). It removes the ToolTip from the TotalRisk column of the inventory-insights table.

Before:
![Screen Shot 2020-04-28 at 1 23 57 PM](https://user-images.githubusercontent.com/4829473/80517768-8bdc8f80-8953-11ea-8b41-c6b324fbc900.png)

After:
![Screen Shot 2020-04-28 at 1 23 07 PM](https://user-images.githubusercontent.com/4829473/80517759-8a12cc00-8953-11ea-9f92-f74249a72544.png)