### PR TITLE
Display the request-id in the error window

### DIFF
--- a/packages/notifications/src/Notification.js
+++ b/packages/notifications/src/Notification.js
@@ -38,7 +38,7 @@ class Notification extends Component {
     }
 
     render() {
-        const { description, dismissable, onDismiss, dismissDelay, title, sentryId, ...rest } = this.props;
+        const { description, dismissable, onDismiss, dismissDelay, title, sentryId, requestId, ...rest } = this.props;
         return (
             <Alert
                 className="notification-item"
@@ -62,6 +62,11 @@ class Notification extends Component {
                         <Text component={ TextVariants.small }>Tracking Id: { sentryId }</Text>
                     </TextContent>
                 }
+                {
+                    requestId && <TextContent>
+                        <Text component={ TextVariants.small }>Request Id: { requestId }</Text>
+                    </TextContent>
+                }
             </Alert>
         );
     }
@@ -75,6 +80,7 @@ Notification.propTypes = {
     title: PropTypes.string.isRequired,
     description: PropTypes.node,
     dismissDelay: PropTypes.number,
+    requestId: PropTypes.string,
     sentryId: PropTypes.string
 };
 

--- a/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
+++ b/packages/notifications/src/__snapshots__/NotificationPortal.test.js.snap
@@ -264,6 +264,7 @@ exports[`Notification portal should render notifications given as direct props 1
                   "children": Array [
                     "Some meaningfull description",
                     undefined,
+                    undefined,
                   ],
                   "className": "notification-item",
                   "id": "0",
@@ -788,6 +789,7 @@ exports[`Notification portal should render notifications given as direct props o
                   "children": Array [
                     "Some meaningfull description",
                     undefined,
+                    undefined,
                   ],
                   "className": "notification-item",
                   "id": "Direct notification",
@@ -1166,6 +1168,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
                   </AlertActionCloseButton>,
                   "children": Array [
                     "Some meaningfull description",
+                    undefined,
                     undefined,
                   ],
                   "className": "notification-item",

--- a/packages/utils/src/interceptors.js
+++ b/packages/utils/src/interceptors.js
@@ -42,8 +42,10 @@ export function interceptor500(error) {
 
 export function errorInterceptor(err) {
     if (!axios.isCancel(err)) {
+        let requestId;
         try {
             const errObject = { ...err };
+            requestId = errObject.response.config.headers['x-rh-insights-request-id'];
             if (errObject.response && errObject.response.data) {
                 throw errObject.response.data;
             }
@@ -53,6 +55,7 @@ export function errorInterceptor(err) {
         catch (customError) {
             const sentryId = Sentry.captureException(customError);
             customError.sentryId = sentryId;
+            customError.requestId = requestId;
             throw customError;
         }
     }


### PR DESCRIPTION
- Added request id (header "x-rh-insights-request-id") displaying in error window for every call coming.
- Updated tests

@karelhala 