### PR TITLE
Explicitly declare ul market style cuz sometimes its lost

### DIFF
--- a/packages/inventory-insights/src/insights.scss
+++ b/packages/inventory-insights/src/insights.scss
@@ -62,7 +62,7 @@
 
     .pf-c-list {
         @include rem('margin', 5px 0);
-        list-style: var(--pf-c-list--ul--ListStyle);
+        list-style: 'disc';
         padding-left: var(--pf-global--spacer--lg);
     }
 


### PR DESCRIPTION
it looks correct now
<img width="1653" alt="Screen Shot 2020-05-05 at 7 50 10 AM" src="https://user-images.githubusercontent.com/6640236/81063106-39e0c000-8ea5-11ea-8bbd-b6da701f2878.png">
