### PR TITLE
Fix systems count per issue on Compliance

### DIFF
--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -21,7 +21,8 @@ class ComplianceRemediationButton extends React.Component {
         return issues.filter((issue, index) => {
             const originalIssueIndex = issueIds.indexOf(issue.id);
             return (originalIssueIndex === index) ? true :
-                (issues[originalIssueIndex].systems = issues[originalIssueIndex].systems.concat(issue.systems)) && false;
+                (issues[originalIssueIndex].systems = Array.from(new Set(
+                    issues[originalIssueIndex].systems.concat(issue.systems)))) && false;
         });
     }
 


### PR DESCRIPTION
If you have a system with multiple policies and the failed rules are the
same in multiple policies, the systems count in the Remediations column
will be counted wrong, because the same system is listed multiple times.

This shouldn't change any functionality, just the step of the
remediations wizard where it shows the systems count.