### PR TITLE
Add NotAuthorized component to handle 403s

### DIFF
--- a/packages/components/src/Components/NotAuthorized/NotAuthorized.js
+++ b/packages/components/src/Components/NotAuthorized/NotAuthorized.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateVariant,
+    EmptyStateIcon,
+    EmptyStateBody
+} from '@patternfly/react-core';
+
+import { LockIcon } from '@patternfly/react-icons';
+
+import './NotAuthorized.scss';
+
+const NotAuthorized = ({ serviceName }) => {
+    return (
+        <React.Fragment>
+            <EmptyState variant={ EmptyStateVariant.full } className='ins-c-not-authorized'>
+                <EmptyStateIcon icon={ LockIcon } />
+                <Title headingLevel="h5" size="lg"> You do not have access to { serviceName }</Title>
+                <EmptyStateBody>
+                    Contact your organization administrator(s) for more information.
+                </EmptyStateBody>
+                {
+                    document.referrer ?
+                        <Button variant="primary" onClick={ () => history.back() }>Return to previous page</Button> :
+                        <Button variant="primary" component="a" href=".">Go to landing page</Button>
+                }
+            </EmptyState>
+        </React.Fragment>
+    );
+};
+
+NotAuthorized.propTypes = {
+    serviceName: PropTypes.node
+};
+
+export default NotAuthorized;

--- a/packages/components/src/Components/NotAuthorized/NotAuthorized.scss
+++ b/packages/components/src/Components/NotAuthorized/NotAuthorized.scss
@@ -1,0 +1,7 @@
+.ins-c-not-authorized {
+    .pf-c-title {
+        max-width: 540px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+}

--- a/packages/components/src/Components/NotAuthorized/NotAuthorized.test.js
+++ b/packages/components/src/Components/NotAuthorized/NotAuthorized.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import NotAuthorized from './NotAuthorized';
+
+describe('NotAuthorized component', () => {
+    it('should render', () => {
+        const wrapper = shallow(<NotAuthorized serviceName='Foo' />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/packages/components/src/Components/NotAuthorized/__snapshots__/NotAuthorized.test.js.snap
+++ b/packages/components/src/Components/NotAuthorized/__snapshots__/NotAuthorized.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotAuthorized component should render 1`] = `
+<Fragment>
+  <EmptyState
+    className="ins-c-not-authorized"
+    variant="full"
+  >
+    <EmptyStateIcon
+      icon={[Function]}
+    />
+    <Title
+      headingLevel="h5"
+      size="lg"
+    >
+       You do not have access to 
+      Foo
+    </Title>
+    <EmptyStateBody>
+      Contact your organization administrator(s) for more information.
+    </EmptyStateBody>
+    <Component
+      component="a"
+      href="."
+      variant="primary"
+    >
+      Go to landing page
+    </Component>
+  </EmptyState>
+</Fragment>
+`;

--- a/packages/components/src/Components/NotAuthorized/index.js
+++ b/packages/components/src/Components/NotAuthorized/index.js
@@ -1,0 +1,2 @@
+export { default as NotAuthorized } from './NotAuthorized';
+import './NotAuthorized.scss';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -23,6 +23,7 @@ export * from './Components/EmptyTable';
 export * from './Components/Spinner';
 export * from './Components/Filters';
 export * from './Components/InvalidObject';
+export * from './Components/NotAuthorized';
 export * from './Components/FilterChips';
 export * from './Components/BulkSelect';
 export * from './Components/ConditionalFilter';


### PR DESCRIPTION
Stolen (and modified a bit) directly from https://github.com/RedHatInsights/insights-rbac-ui/blob/master/src/presentational-components/states/DeniedState.js

Signed-off-by: Andrew Kofink <akofink@redhat.com>