### PR TITLE
Fix broken empty state link to docs

### DIFF
--- a/packages/inventory-compliance/src/ComplianceEmptyState.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.js
@@ -33,8 +33,8 @@ const ComplianceEmptyState = ({ title, mainButton }) => (
             { mainButton }
             <EmptyStateSecondaryActions>
                 <Button variant='link' component='a' target='_blank' rel='noopener noreferrer'
-                    href={ `https://access.redhat.com/documentation/en-us/red_hat_insights/ \
-                          2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index` } >
+                    href={ `https://access.redhat.com/documentation/en-us/red_hat_insights/` +
+                           `2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index` } >
                     Learn about OpenSCAP and Compliance
                 </Button>
             </EmptyStateSecondaryActions>

--- a/packages/inventory-compliance/src/__snapshots__/ComplianceEmptyState.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/ComplianceEmptyState.test.js.snap
@@ -39,7 +39,7 @@ exports[`ComplianceEmptyState expect to render without error 1`] = `
     <EmptyStateSecondaryActions>
       <Component
         component="a"
-        href="https://access.redhat.com/documentation/en-us/red_hat_insights/                           2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
         rel="noopener noreferrer"
         target="_blank"
         variant="link"


### PR DESCRIPTION
It was going to `https://access.redhat.com/documentation/en-us/red_hat_insights/%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%202020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index`. I guess `\` in a JS string includes all the additional space.

Signed-off-by: Andrew Kofink <akofink@redhat.com>