### PR TITLE
Ignore errors in findSource request in name validator

### DIFF
--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -7,14 +7,23 @@ import { findSource } from '../api';
 import { schemaBuilder } from './schemaBuilder';
 import { WIZARD_DESCRIPTION, WIZARD_TITLE } from '../utilities/stringConstants';
 import ValidatorReset from './ValidatorReset';
+import { handleError } from '../api/handleError';
 
-export const asyncValidator = (value, sourceId = undefined) => findSource(value).then(({ data: { sources } }) => {
-    if (sources.find(({ id }) => id !== sourceId)) {
+export const asyncValidator = async (value, sourceId = undefined) => {
+    let response;
+    try {
+        response = await findSource(value);
+    } catch (error) {
+        console.error(handleError(error));
+        return undefined;
+    }
+
+    if (response.data.sources.find(({ id }) => id !== sourceId)) {
         throw 'Name has already been taken';
     }
 
     return undefined;
-});
+};
 
 let firstValidation = true;
 export const setFirstValidated = (bool) => firstValidation = bool;

--- a/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
+++ b/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
@@ -42,6 +42,20 @@ describe('asyncNameValidator', () => {
         expect(msg).toEqual(undefined);
     });
 
+    it('returns nothing when the request fails', async () => {
+        const consoleTmp = console.error;
+        console.error = jest.fn();
+
+        actions.findSource = jest.fn(() => Promise.reject('Some error'));
+
+        const msg = await asyncValidator('a1');
+
+        expect(msg).toEqual(undefined);
+        expect(console.error).toHaveBeenCalledWith('Some error');
+
+        console.error = consoleTmp;
+    });
+
     describe('wrapper', () => {
         beforeEach(() => {
             setFirstValidated(true);


### PR DESCRIPTION
- we can safely ignore API errors, because the API itself is checking the name when a source is created - users won't be allowed to create sources with duplicated names.