### PR TITLE
Fixed total risk icon align and fixed markdown code word wrap

### DIFF
--- a/packages/rule-components/src/ReportDetails/Markdown.js
+++ b/packages/rule-components/src/ReportDetails/Markdown.js
@@ -35,7 +35,7 @@ const Markdown = ({ template, definitions }) => {
         const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
         const compiledMd = marked(sanitizeHtml(compiledDot, sanitizeOptions));
 
-        return <div dangerouslySetInnerHTML={{
+        return <div className="ins-c-rule__markdown" dangerouslySetInnerHTML={{
             __html: compiledMd
             .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
             .replace(/<a>/gim, `<a rel="noopener noreferrer" target="_blank">`)

--- a/packages/rule-components/src/ReportDetails/RiskDescription.js
+++ b/packages/rule-components/src/ReportDetails/RiskDescription.js
@@ -8,7 +8,7 @@ const RiskDescription = ({ riskValue, riskMeta, showDescription }) => {
 
     return (
         <div className="ins-c-rule__risk-description">
-            <div className={ `ins-c-rule__battery ins-c-rule__severity-level-${ riskValue }` }>
+            <div className={ `ins-c-rule__battery battery ins-c-rule__severity-level-${ riskValue }` }>
                 <IconComponent label={ label } severity={ riskValue }/>
             </div>
             {

--- a/packages/rule-components/src/ReportDetails/index.scss
+++ b/packages/rule-components/src/ReportDetails/index.scss
@@ -65,15 +65,6 @@
     font-size: 28px;
   }
 
-  // align label vertically
-  .ins-c-rule__battery {
-    line-height: 2;
-    display: flex;
-
-    i {
-      margin-right: 5px;
-    }
-  }
   ol {
       @include rem('margin-top', 10px);
       @include rem('margin-left', 15px);
@@ -102,5 +93,9 @@
   .ins-c-rule__modal-content {
     margin-top: 24px;
   }
+}
+
+.ins-c-rule__markdown code {
+  white-space: pre-wrap;
 }
 

--- a/packages/rule-components/src/RuleTable/index.scss
+++ b/packages/rule-components/src/RuleTable/index.scss
@@ -29,5 +29,8 @@
         }
 
     }
+    div.battery {
+        display: block;
+    }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3332176/82807755-b5bc9f80-9e88-11ea-93da-56c791bffb83.png)
![image](https://user-images.githubusercontent.com/3332176/82807805-cbca6000-9e88-11ea-8422-59fbe56794ca.png)

@karelhala please, take a look.