### PR TITLE
Fix fail when authentication does not have validate attribute

### DIFF
--- a/packages/sources/src/sourceFormRenderer/components/Authentication.js
+++ b/packages/sources/src/sourceFormRenderer/components/Authentication.js
@@ -9,7 +9,7 @@ const Authentication = (rest) => {
 
     const { authentication } = formOptions.getState().values;
 
-    const doNotRequirePassword = rest.validate.filter(({ type }) => type !== validatorTypes.REQUIRED);
+    const doNotRequirePassword = rest.validate && rest.validate.filter(({ type }) => type !== validatorTypes.REQUIRED);
 
     const componentProps = {
         ...rest,

--- a/packages/sources/src/tests/sourceFormRenderer/authentication.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/authentication.test.js
@@ -39,6 +39,51 @@ describe('Authentication test', () => {
         };
     });
 
+    it('renders with no validation', () => {
+        schema = {
+            fields: [{
+                component: 'authentication',
+                name: 'authentication.password',
+                isRequired: true
+            }]
+        };
+
+        const wrapper = mount(<SourcesFormRenderer
+            {...initialProps}
+            schema={schema}
+            initialValues={{
+                authentication: {
+                    id: 'someid'
+                }
+            }}
+        />);
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+    });
+
+    it('renders with func validation', () => {
+        schema = {
+            fields: [{
+                component: 'authentication',
+                name: 'authentication.password',
+                isRequired: true,
+                validate: [ () => undefined ]
+            }]
+        };
+
+        const wrapper = mount(<SourcesFormRenderer
+            {...initialProps}
+            schema={schema}
+            initialValues={{
+                authentication: {
+                    id: 'someid'
+                }
+            }}
+        />);
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+    });
+
     it('renders not editing', () => {
         const wrapper = mount(<SourcesFormRenderer
             {...initialProps}


### PR DESCRIPTION
When authentication has empty validate, the UI fails :panda_face: (however, authentication should be always required :man_shrugging: )