### PR TITLE
Pass isDisabled prop to DropdownToggle

### DIFF
--- a/packages/components/src/Components/DownloadButton/DownloadButton.js
+++ b/packages/components/src/Components/DownloadButton/DownloadButton.js
@@ -32,6 +32,7 @@ class DownloadButton extends Component {
                     <DropdownToggle
                         iconComponent={null}
                         onToggle={ this.onToggle }
+                        isDisabled={isDisabled}
                     >
                         <ExportIcon size="sm" />
                     </DropdownToggle>

--- a/packages/components/src/Components/DownloadButton/__snapshots__/DownloadButton.test.js.snap
+++ b/packages/components/src/Components/DownloadButton/__snapshots__/DownloadButton.test.js.snap
@@ -640,6 +640,7 @@ exports[`DownloadButton component should render disabled 1`] = `
   toggle={
     <DropdownToggle
       iconComponent={null}
+      isDisabled={true}
       onToggle={[Function]}
     >
       <ExportIcon


### PR DESCRIPTION
For consistency in the primarytoolbar, pass the prop `isDisabled` to `DropdownToggle`  
The `kebabToggle` is disabled 
before
![Screenshot from 2020-05-29 12-11-00](https://user-images.githubusercontent.com/3369346/83248656-b796a380-a1a5-11ea-9c59-f40a91f1edf5.png)

after
![Screenshot from 2020-05-29 12-11-40](https://user-images.githubusercontent.com/3369346/83248671-be251b00-a1a5-11ea-972a-ddfa56f00644.png)
