### PR TITLE
RHICOMPL-646 - Sync empty states in Reports/SCAP policies

### DIFF
--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -40,6 +40,7 @@
         "@redhat-cloud-services/frontend-components-notifications": "*",
         "@redhat-cloud-services/frontend-components-remediations": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
+        "@apollo/react-hooks": "^3.1.5",
         "apollo-boost": "^0.1.23",
         "graphql-tag": "^2.10.0",
         "react-apollo": "^2.3.3",

--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -8,13 +8,8 @@ import gql from 'graphql-tag';
 import { ApolloProvider } from 'react-apollo';
 import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
 import { columns } from './defaultColumns';
-import {
-    Card,
-    CardBody,
-    CardHeader
-} from '@patternfly/react-core';
-import { NotEqualIcon } from '@patternfly/react-icons';
 import './compliance.scss';
+import { ErrorCard } from './PresentationalComponents';
 
 const COMPLIANCE_API_ROOT = '/api/compliance';
 
@@ -79,15 +74,8 @@ class SystemDetails extends Component {
     renderError = (error) => {
         const errorMsg = `Oops! Error loading System data: ${error}`;
         return (error.networkError && error.networkError.statusCode === 404) ?
-            <ComplianceEmptyState title='No policies are reporting' /> :
-            <Card className="ins-error-card">
-                <CardHeader>
-                    <NotEqualIcon />
-                </CardHeader>
-                <CardBody>
-                    <div>{ errorMsg }</div>
-                </CardBody>
-            </Card>;
+            <ComplianceEmptyState title='No policies are reporting for this system' /> :
+            <ErrorCard message={errorMsg} />;
     }
 
     render() {

--- a/packages/inventory-compliance/src/ComplianceEmptyState.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
 import {
     Title,
     TextContent,
@@ -11,9 +12,36 @@ import {
     EmptyStateIcon
 } from '@patternfly/react-core';
 import { CloudSecurityIcon } from '@patternfly/react-icons';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+import { Spinner } from '@redhat-cloud-services/frontend-components';
+import { ErrorCard } from './PresentationalComponents';
+const COMPLIANCE_API_ROOT = '/api/compliance';
 
-const ComplianceEmptyState = ({ title, mainButton }) => (
-    <Bullseye>
+const QUERY = gql`
+{
+    profiles(search: "external = false") {
+        totalCount
+    }
+}
+`;
+
+const ComplianceEmptyState = ({ title, mainButton, client }) => {
+    let { data, error, loading } = useQuery(QUERY, { fetchPolicy: 'network-only', client: client });
+
+    if (loading) { return <Spinner/>; }
+
+    if (error) {
+        const errorMsg = `Oops! Error loading System data: ${error}`;
+        return <ErrorCard message={errorMsg} />;
+    }
+
+    const policiesCount = data.profiles.totalCount;
+
+    const policyWord = policiesCount > 1 ? 'policies' : 'policy';
+    const haveWord = policiesCount > 1 ? 'have' : 'has';
+
+    return <Bullseye>
         <EmptyState>
             <EmptyStateIcon style={{ fontWeight: '500', color: 'var(--pf-global--primary-color--100)' }}
                 size="xl" title="Compliance" icon={CloudSecurityIcon} />
@@ -21,6 +49,11 @@ const ComplianceEmptyState = ({ title, mainButton }) => (
             <Title size="lg">{ title }</Title>
             <br/>
             <EmptyStateBody>
+                { policiesCount > 0 ?
+                    <TextContent>
+                        <a href='insights/compliance/scappolicies'>{policiesCount} {policyWord}</a> {haveWord} been created but {haveWord} no reports.
+                    </TextContent> :
+                    '' }
                 <TextContent>
                     The Compliance service uses SCAP policies to track your organization&#39;s adherence to
                     compliance requirements.
@@ -39,12 +72,13 @@ const ComplianceEmptyState = ({ title, mainButton }) => (
                 </Button>
             </EmptyStateSecondaryActions>
         </EmptyState>
-    </Bullseye>
-);
+    </Bullseye>;
+};
 
 ComplianceEmptyState.propTypes = {
     title: propTypes.string,
-    mainButton: propTypes.object
+    mainButton: propTypes.object,
+    client: propTypes.object
 };
 
 ComplianceEmptyState.defaultProps = {
@@ -54,7 +88,14 @@ ComplianceEmptyState.defaultProps = {
         component="a"
         href="/insights/compliance/scappolicies">
         Create new policy
-    </Button>
+    </Button>,
+    client: new ApolloClient({
+        link: new HttpLink({
+            uri: COMPLIANCE_API_ROOT + '/graphql',
+            credentials: 'include'
+        }),
+        cache: new InMemoryCache()
+    })
 };
 
 export default ComplianceEmptyState;

--- a/packages/inventory-compliance/src/ComplianceEmptyState.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.js
@@ -49,11 +49,10 @@ const ComplianceEmptyState = ({ title, mainButton, client }) => {
             <Title size="lg">{ title }</Title>
             <br/>
             <EmptyStateBody>
-                { policiesCount > 0 ?
+                { policiesCount > 0 &&
                     <TextContent>
                         <a href='insights/compliance/scappolicies'>{policiesCount} {policyWord}</a> {haveWord} been created but {haveWord} no reports.
-                    </TextContent> :
-                    '' }
+                    </TextContent> }
                 <TextContent>
                     The Compliance service uses SCAP policies to track your organization&#39;s adherence to
                     compliance requirements.

--- a/packages/inventory-compliance/src/ComplianceEmptyState.test.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.test.js
@@ -2,9 +2,37 @@ import React from 'react';
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';
 import ComplianceEmptyState from './ComplianceEmptyState';
+import { useQuery } from '@apollo/react-hooks';
+jest.mock('@apollo/react-hooks');
+jest.mock('apollo-boost');
 
 describe('ComplianceEmptyState', () => {
-    it('expect to render without error', () => {
+    it('expect to render without error if no policies exist', () => {
+        useQuery.mockImplementation(() => ({
+            data: { profiles: { totalCount: 0 } }, error: false, loading: false
+        }));
+        const wrapper = shallow(
+            <ComplianceEmptyState />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render different message if one policy exists', () => {
+        useQuery.mockImplementation(() => ({
+            data: { profiles: { totalCount: 1 } }, error: false, loading: false
+        }));
+        const wrapper = shallow(
+            <ComplianceEmptyState />
+        );
+
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('expect to render different message if many policies exist', () => {
+        useQuery.mockImplementation(() => ({
+            data: { profiles: { totalCount: 2 } }, error: false, loading: false
+        }));
         const wrapper = shallow(
             <ComplianceEmptyState />
         );

--- a/packages/inventory-compliance/src/ComplianceEmptyState.test.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.test.js
@@ -9,10 +9,10 @@ jest.mock('apollo-boost');
 describe('ComplianceEmptyState', () => {
     it('expect to render without error if no policies exist', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 0 } }, error: false, loading: false
+            data: { profiles: { totalCount: 0 } }, error: undefined, loading: false
         }));
         const wrapper = shallow(
-            <ComplianceEmptyState />
+            <ComplianceEmptyState client={{}}/>
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -20,10 +20,10 @@ describe('ComplianceEmptyState', () => {
 
     it('expect to render different message if one policy exists', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 1 } }, error: false, loading: false
+            data: { profiles: { totalCount: 1 } }, error: undefined, loading: false
         }));
         const wrapper = shallow(
-            <ComplianceEmptyState />
+            <ComplianceEmptyState client={{}}/>
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -31,10 +31,10 @@ describe('ComplianceEmptyState', () => {
 
     it('expect to render different message if many policies exist', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 2 } }, error: false, loading: false
+            data: { profiles: { totalCount: 2 } }, error: undefined, loading: false
         }));
         const wrapper = shallow(
-            <ComplianceEmptyState />
+            <ComplianceEmptyState client={{}}/>
         );
 
         expect(toJson(wrapper)).toMatchSnapshot();

--- a/packages/inventory-compliance/src/ComplianceEmptyState.test.js
+++ b/packages/inventory-compliance/src/ComplianceEmptyState.test.js
@@ -9,7 +9,7 @@ jest.mock('apollo-boost');
 describe('ComplianceEmptyState', () => {
     it('expect to render without error if no policies exist', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 0 } }, error: undefined, loading: false
+            data: { profiles: { totalCount: 0 } }, error: undefined, loading: undefined
         }));
         const wrapper = shallow(
             <ComplianceEmptyState client={{}}/>
@@ -20,7 +20,7 @@ describe('ComplianceEmptyState', () => {
 
     it('expect to render different message if one policy exists', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 1 } }, error: undefined, loading: false
+            data: { profiles: { totalCount: 1 } }, error: undefined, loading: undefined
         }));
         const wrapper = shallow(
             <ComplianceEmptyState client={{}}/>
@@ -31,7 +31,7 @@ describe('ComplianceEmptyState', () => {
 
     it('expect to render different message if many policies exist', () => {
         useQuery.mockImplementation(() => ({
-            data: { profiles: { totalCount: 2 } }, error: undefined, loading: false
+            data: { profiles: { totalCount: 2 } }, error: undefined, loading: undefined
         }));
         const wrapper = shallow(
             <ComplianceEmptyState client={{}}/>

--- a/packages/inventory-compliance/src/PresentationalComponents/ErrorCard.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/ErrorCard.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import {
+    Card,
+    CardHeader,
+    CardBody
+} from '@patternfly/react-core';
+import { NotEqualIcon } from '@patternfly/react-icons';
+
+const ErrorCard = ({ errorMsg }) => (
+    <Card className="ins-error-card">
+        <CardHeader>
+            <NotEqualIcon />
+        </CardHeader>
+        <CardBody>
+            <div>{ errorMsg }</div>
+        </CardBody>
+    </Card>
+);
+
+ErrorCard.propTypes = {
+    errorMsg: propTypes.string
+};
+
+export default ErrorCard;

--- a/packages/inventory-compliance/src/PresentationalComponents/index.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/index.js
@@ -3,3 +3,4 @@ export { default as RuleChildRow } from './RuleChildRow';
 export { default as RuleTitle } from './RuleTitle';
 export { default as RuleLoadingTable } from './RuleLoadingTable';
 export { default as EmptyRows } from './EmptyRows';
+export { default as ErrorCard } from './ErrorCard';

--- a/packages/inventory-compliance/src/__snapshots__/ComplianceEmptyState.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/ComplianceEmptyState.test.js.snap
@@ -1,6 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ComplianceEmptyState expect to render without error 1`] = `
+exports[`ComplianceEmptyState expect to render different message if many policies exist 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+      size="xl"
+      style={
+        Object {
+          "color": "var(--pf-global--primary-color--100)",
+          "fontWeight": "500",
+        }
+      }
+      title="Compliance"
+    />
+    <br />
+    <Title
+      size="lg"
+    >
+      No policies
+    </Title>
+    <br />
+    <EmptyStateBody>
+      <TextContent>
+        <a
+          href="insights/compliance/scappolicies"
+        >
+          2
+           
+          policies
+        </a>
+         
+        have
+         been created but 
+        have
+         no reports.
+      </TextContent>
+      <TextContent>
+        The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
+      </TextContent>
+      <TextContent>
+        Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
+      </TextContent>
+    </EmptyStateBody>
+    <Component
+      component="a"
+      href="/insights/compliance/scappolicies"
+      variant="primary"
+    >
+      Create new policy
+    </Component>
+    <EmptyStateSecondaryActions>
+      <Component
+        component="a"
+        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+        rel="noopener noreferrer"
+        target="_blank"
+        variant="link"
+      >
+        Learn about OpenSCAP and Compliance
+      </Component>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`ComplianceEmptyState expect to render different message if one policy exists 1`] = `
+<Bullseye>
+  <EmptyState>
+    <EmptyStateIcon
+      icon={[Function]}
+      size="xl"
+      style={
+        Object {
+          "color": "var(--pf-global--primary-color--100)",
+          "fontWeight": "500",
+        }
+      }
+      title="Compliance"
+    />
+    <br />
+    <Title
+      size="lg"
+    >
+      No policies
+    </Title>
+    <br />
+    <EmptyStateBody>
+      <TextContent>
+        <a
+          href="insights/compliance/scappolicies"
+        >
+          1
+           
+          policy
+        </a>
+         
+        has
+         been created but 
+        has
+         no reports.
+      </TextContent>
+      <TextContent>
+        The Compliance service uses SCAP policies to track your organization's adherence to compliance requirements.
+      </TextContent>
+      <TextContent>
+        Get started by adding a policy, or read documentation about how to connect OpenSCAP to the Compliance service.
+      </TextContent>
+    </EmptyStateBody>
+    <Component
+      component="a"
+      href="/insights/compliance/scappolicies"
+      variant="primary"
+    >
+      Create new policy
+    </Component>
+    <EmptyStateSecondaryActions>
+      <Component
+        component="a"
+        href="https://access.redhat.com/documentation/en-us/red_hat_insights/2020-04/html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index"
+        rel="noopener noreferrer"
+        target="_blank"
+        variant="link"
+      >
+        Learn about OpenSCAP and Compliance
+      </Component>
+    </EmptyStateSecondaryActions>
+  </EmptyState>
+</Bullseye>
+`;
+
+exports[`ComplianceEmptyState expect to render without error if no policies exist 1`] = `
 <Bullseye>
   <EmptyState>
     <EmptyStateIcon


### PR DESCRIPTION
The empty state should also give some info to the user about existing
policies, as the current message is a bit confusing. This shows how many
policies exist (but are not reporting) if any - if there are no policies, it just shows the same message as before.

![Screenshot from 2020-06-02 09-58-31](https://user-images.githubusercontent.com/598891/83497734-2ed87a00-a4bb-11ea-9bf7-f41e0d9cd7a8.png)
![Screenshot from 2020-06-02 09-57-31](https://user-images.githubusercontent.com/598891/83497738-2f711080-a4bb-11ea-8394-20efc9808828.png)
![Screenshot from 2020-06-02 09-51-29](https://user-images.githubusercontent.com/598891/83497740-3009a700-a4bb-11ea-92c2-f31d50557b50.png)
![Screenshot from 2020-06-02 09-51-19](https://user-images.githubusercontent.com/598891/83497741-3009a700-a4bb-11ea-8dbc-c5f85b5d1628.png)
![Screenshot from 2020-06-02 09-51-09](https://user-images.githubusercontent.com/598891/83497743-30a23d80-a4bb-11ea-967d-0dda94341cfc.png)
