### PR TITLE
RHICOMPL-6508 - Include os_release in response

### DIFF
--- a/packages/inventory/src/api/index.js
+++ b/packages/inventory/src/api/index.js
@@ -83,6 +83,11 @@ export function getEntities(items, {
         ...defaultFilters,
         registeredWithFilter: []
     }) : defaultFilters;
+
+    const fields = 'fields[canonical_facts]=insights_id,rhel_machine_id,subscription_manager_id,satellite_id,bios_uuid,ip_addresses,fqdn,mac_addresses,external_id' +
+        '&&fields[host]=ansible_host,facts,reporter,stale_timestamp,stale_warning_timestamp,culled_timestamp,created,updated' +
+        '&&fields[system_profile]=arch,os_release';
+
     if (hasItems && items.length > 0) {
         return hosts.apiHostGetHostById(items, undefined, perPage, page, undefined, undefined, { cancelToken: controller && controller.token })
         .then((data) => showTags ? mapTags(data) : data)
@@ -108,7 +113,8 @@ export function getEntities(items, {
             staleFilter,
             constructTags(tagFilters),
             registeredWithFilter,
-            { cancelToken: controller && controller.token }
+            { cancelToken: controller && controller.token },
+            fields
         )
         .then((data) => showTags ? mapTags(data, { orderBy, orderDirection }) : data)
         .then(({ results = [], ...data } = {}) => ({


### PR DESCRIPTION
:warning: Depends on https://github.com/RedHatInsights/insights-host-inventory/pull/659 being merged, released and a new client being built in https://github.com/RedHatInsights/javascript-clients :skull_and_crossbones: DO NOT MERGE YET

This follows the addition of sparse_fieldset to the inventory API. Since
so many fields were included by default, we have to request them now in
order not to break the "frontend API", as we want the entities store to
remain the same after this change + the system_field os_release and
arch.