### PR TITLE
RHICOMPL-572 - Prevent rule overflow in Compliance Rules table

### DIFF
--- a/packages/inventory-compliance/src/PresentationalComponents/RuleTitle.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/RuleTitle.js
@@ -1,23 +1,16 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import {
-    Stack,
-    StackItem,
     Text,
     TextVariants,
     TextContent
 } from '@patternfly/react-core';
 
 const RuleTitle = ({ title, identifier }) => (
-    <Stack>
-        <StackItem>{ title }</StackItem>
-        { identifier &&
-            <StackItem>
-                <TextContent>
-                    <Text component={ TextVariants.small }>{ identifier.label }</Text>
-                </TextContent>
-            </StackItem> || '' }
-    </Stack>
+    <TextContent>
+        { title }
+        { identifier && <Text component={ TextVariants.small }>{ identifier.label }</Text> || '' }
+    </TextContent>
 );
 
 RuleTitle.propTypes = {


### PR DESCRIPTION
The Stack Patternfly component is display: flex and therefore it's
height is set as 0. This makes it impossible for the Table component to
understand how tall is each of the rows.

Instead, I'm switching the rows to use a simple TextContent component
which the Table can effortlessly use to figure out the correct height.

Before, note the overlapping identifiers on the 'removexattr' rows:  
![Screenshot from 2020-06-02 14-01-13](https://user-images.githubusercontent.com/598891/83517929-0c098e00-a4da-11ea-9d3f-0b9b8d0fcdf4.png)

After, note how each row text is vertically centered too: 
![Screenshot from 2020-06-02 14-00-03](https://user-images.githubusercontent.com/598891/83517935-0ca22480-a4da-11ea-9d16-c4cb661a7bb0.png)
