### PR TITLE
Fixed missing file extension in babel config.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -94,7 +94,7 @@ module.exports = {
             'transform-imports',
             {
                 '@patternfly/react-icons': {
-                    transform: (importName, matches) => `@patternfly/react-icons/dist/js/icons/${importName.split(/(?=[A-Z])/).join('-').toLowerCase()}`,
+                    transform: (importName, matches) => `@patternfly/react-icons/dist/js/icons/${importName.split(/(?=[A-Z])/).join('-').toLowerCase()}.js`,
                     preventFullImport: true
                 }
             },
@@ -103,7 +103,7 @@ module.exports = {
             'transform-imports',
             {
                 '@redhat-cloud-services/frontend-components': {
-                    transform: (importName, matches) => `@redhat-cloud-services/frontend-components/components/cjs/${frontendComponentsMappe[importName] || importName}`,
+                    transform: (importName, matches) => `@redhat-cloud-services/frontend-components/components/cjs/${frontendComponentsMappe[importName] || importName}.js`,
                     preventFullImport: true,
                     skipDefaultConversion: true
                 }


### PR DESCRIPTION
The missing file extension can cause issues when resolving external dependencies. Files might not get imported and the module is undefined.

@karelhala this will probably require a new release of all packages. Is there a label for that?

cc @rvsia 