### PR TITLE
Use direct imports for PDF generator and do not lock react-dom version

### DIFF
--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -34,8 +34,8 @@
         "@patternfly/react-styles": "^3.6.26",
         "@patternfly/react-tokens": "^2.7.25",
         "@react-pdf/renderer": "^1.6.8",
-        "react": "16.12.0",
-        "react-dom": "16.12.0",
+        "react": "^16.12.0",
+        "react-dom": "^16.12.0",
         "rgb-hex": "^3.0.0"
     },
     "devDependencies": {

--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -34,8 +34,8 @@
         "@patternfly/react-styles": "^3.6.26",
         "@patternfly/react-tokens": "^2.7.25",
         "@react-pdf/renderer": "^1.6.8",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0",
+        "react": "16.12.0",
+        "react-dom": "16.12.0",
         "rgb-hex": "^3.0.0"
     },
     "devDependencies": {

--- a/packages/pdf-generator/src/components/Battery.js
+++ b/packages/pdf-generator/src/components/Battery.js
@@ -7,7 +7,7 @@ import {
     View
 } from '@react-pdf/renderer';
 // eslint-disable-next-line camelcase
-import { global_icon_Color_light } from '@patternfly/react-tokens';
+import global_icon_Color_light from '@patternfly/react-tokens/dist/js/global_icon_Color_light';
 
 import styles from '../utils/styles';
 

--- a/packages/pdf-generator/src/components/Table.js
+++ b/packages/pdf-generator/src/components/Table.js
@@ -2,7 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Text } from '@react-pdf/renderer';
-import { global_BorderColor_200, global_BorderColor_300 } from '@patternfly/react-tokens';
+import global_BorderColor_300 from '@patternfly/react-tokens/dist/js/global_BorderColor_300';
+import global_BorderColor_200 from '@patternfly/react-tokens/dist/js/global_BorderColor_200';
 import { styleProps } from '../utils/propTypes';
 import styles from '../utils/styles';
 

--- a/packages/pdf-generator/src/utils/styles.js
+++ b/packages/pdf-generator/src/utils/styles.js
@@ -1,17 +1,15 @@
 /* eslint-disable camelcase */
 import { StyleSheet, Font } from '@react-pdf/renderer';
-import {
-    chart_color_red_100,
-    global_Color_dark_100,
-    global_Color_dark_200,
-    global_Color_light_300,
-    chart_global_warning_Color_100,
-    chart_global_warning_Color_200,
-    chart_global_Fill_Color_700,
-    c_table_m_compact_cell_PaddingLeft,
-    c_table_m_compact_cell_PaddingBottom,
-    c_table_m_compact_cell_PaddingTop
-} from '@patternfly/react-tokens';
+import c_table_m_compact_cell_PaddingTop from '@patternfly/react-tokens/dist/js/c_table_m_compact_cell_PaddingTop';
+import c_table_m_compact_cell_PaddingBottom from '@patternfly/react-tokens/dist/js/c_table_m_compact_cell_PaddingBottom';
+import c_table_m_compact_cell_PaddingLeft from '@patternfly/react-tokens/dist/js/c_table_m_compact_cell_PaddingLeft';
+import chart_global_Fill_Color_700 from '@patternfly/react-tokens/dist/js/chart_global_Fill_Color_700';
+import chart_global_warning_Color_200 from '@patternfly/react-tokens/dist/js/chart_global_warning_Color_200';
+import chart_global_warning_Color_100 from '@patternfly/react-tokens/dist/js/chart_global_warning_Color_100';
+import global_Color_light_300 from '@patternfly/react-tokens/dist/js/global_Color_light_300';
+import global_Color_dark_200 from '@patternfly/react-tokens/dist/js/global_Color_dark_200';
+import global_Color_dark_100 from '@patternfly/react-tokens/dist/js/global_Color_dark_100';
+import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
 import { fontTypes, generateFonts, redhatFont } from './fonts';
 
 Font.register({ family: 'Overpass', fonts: generateFonts(fontTypes) });


### PR DESCRIPTION
When importing PDF generator, it adds 1.7 MB of redundant dependencies. This PR uses direct imports for PF react-tokens (removes about 800 KB) and uses caret version of react-dom (removes about 900 KB).