### PR TITLE
If no kba article, hide kba section (gated off node_id param)

### DIFF
--- a/packages/inventory-insights/src/ReportDetails.js
+++ b/packages/inventory-insights/src/ReportDetails.js
@@ -86,21 +86,19 @@ const ReportDetails = ({ report, kbaDetail, kbaLoading }) => {
                         </CardBody>
                     </Card>
                 </StackItem>
-                <StackItem>
+                {rule.node_id && <StackItem>
                     <Card className='ins-m-card__flat'>
                         <CardHeader>
                             <LightbulbIcon /><strong> Related Knowledgebase article </strong>
                         </CardHeader>
                         <CardBody>
-                            {kbaDetail && kbaDetail.view_uri ?
-                                <a rel="noopener noreferrer" target="_blank" href={`${kbaDetail.view_uri}`}>
-                                    {kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article` } <ExternalLinkAltIcon />
-                                </a>
-                                : kbaLoading ? <Skeleton size={SkeletonSize.sm} />
-                                    : <React.Fragment>No related Knowledgebase article.</React.Fragment>}
+                            {kbaLoading ? <Skeleton size={SkeletonSize.sm} />
+                                : <a rel="noopener noreferrer" target="_blank" href={`${kbaDetail.view_uri}`}>
+                                    {kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`} <ExternalLinkAltIcon />
+                                </a>}
                         </CardBody>
                     </Card>
-                </StackItem>
+                </StackItem>}
                 {rule.more_info && <StackItem>
                     <Card className='ins-m-card__flat'>
                         <CardHeader>


### PR DESCRIPTION
fixes https://projects.engineering.redhat.com/browse/RHCLOUD-6584

Now that all the kba api funkiness is sorted out, if yah have ah node id, we know we'll have an article, which makes this ask real simple to fulfill

#### looks like this!
<img width="1319" alt="Screen Shot 2020-06-05 at 8 41 53 AM" src="https://user-images.githubusercontent.com/6640236/83877759-18bff900-a709-11ea-9e3f-2f02d16baac5.png">
<img width="1319" alt="Screen Shot 2020-06-05 at 8 41 33 AM" src="https://user-images.githubusercontent.com/6640236/83877764-19588f80-a709-11ea-89ca-db14ae5261be.png">
