### PR TITLE
Include mergeMessages helper function to utils package

### DIFF
--- a/packages/utils/config/rollup.config.js
+++ b/packages/utils/config/rollup.config.js
@@ -26,7 +26,8 @@ const entryMapper = {
     debounce: './src/debounce.js',
     inventoryDependencies: './src/inventoryDependencies.js',
     RBAC: './src/RBAC.js',
-    RBACHook: './src/RBACHook.js'
+    RBACHook: './src/RBACHook.js',
+    mergeMessages: './src/mergeMessages.js'
 };
 
 const commonjsOptions = {


### PR DESCRIPTION
We forgot to export `mergeMessages` helper function in new bundler. This PR fixes such issue.