### PR TITLE
Updates css class from .pf-c-data-toolbar__item to .pf-c-toolbar__item

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
+++ b/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
@@ -1,6 +1,6 @@
 .ins-c-primary-toolbar {
     padding: var(--pf-global--spacer--md);
-    .pf-c-data-toolbar__item {
+    .pf-c-toolbar__item {
             &.ins-c-primary-toolbar__first-action {
                 display: initial;
             }
@@ -37,7 +37,7 @@
     .ins-c-primary-toolbar {
         padding: var(--pf-global--spacer--sm);
 
-        .pf-c-data-toolbar__item {
+        .pf-c-toolbar__item {
             &.ins-c-primary-toolbar__first-action {
                 display: none;
             }


### PR DESCRIPTION
 primary-toolbar.scss

 DataToolbar was renamed to Toolbar, and the related css classes too

Note that the data-toolbar is used also in: but i didn't touch anything because I think that someone is working there.

https://github.com/RedHatInsights/frontend-components/blob/41d66f3227e582a081af5f445dbdea3f97fe5160/packages/inventory/src/InventoryList.scss#L12-L13


Before:
 - Desktop
![Screenshot_2020-06-11_15-10-59](https://user-images.githubusercontent.com/3845764/84439897-acf4f900-abfe-11ea-8dcf-ce94929196b8.png)
 - Mobile
![Screenshot_2020-06-11_15-13-43](https://user-images.githubusercontent.com/3845764/84439893-abc3cc00-abfe-11ea-91d5-8375ac41ee22.png)

After:
 - Desktop
![Screenshot_2020-06-11_16-16-47](https://user-images.githubusercontent.com/3845764/84440080-00ffdd80-abff-11ea-8cd1-674af18840e7.png)

 - Mobile

![Screenshot_2020-06-11_16-17-04](https://user-images.githubusercontent.com/3845764/84440090-065d2800-abff-11ea-9773-96dc1b6d67c1.png)
