### PR TITLE
Lock DFF version to 2.4.8 due to PF changes.

### DIFF
--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -27,15 +27,15 @@
         "awesome-debounce-promise": "^2.1.0"
     },
     "devDependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^2.1.8",
-        "@data-driven-forms/react-form-renderer": "^2.1.8",
+        "@data-driven-forms/pf4-component-mapper": "2.4.8",
+        "@data-driven-forms/react-form-renderer": "2.4.8",
         "@patternfly/react-core": "^3.153.13",
         "@patternfly/react-icons": "^3.14.39"
     },
     "peerDependencies": {
         "react": "^16.12.0",
-        "@data-driven-forms/pf4-component-mapper": "^2.1.8",
-        "@data-driven-forms/react-form-renderer": "^2.1.8",
+        "@data-driven-forms/pf4-component-mapper": "2.4.8",
+        "@data-driven-forms/react-form-renderer": "2.4.8",
         "lodash": "^4.17.15"
     }
 }


### PR DESCRIPTION
Data driven form released 2.5.0 version which supports PF4v4

We have to lock it until FCE officially releases PF4v4 support to prevent test failures.