### PR TITLE
Dont hide first item in Primary toolbar

### DIFF
--- a/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
+++ b/packages/components/src/Components/PrimaryToolbar/primary-toolbar.scss
@@ -1,6 +1,6 @@
 .ins-c-primary-toolbar {
     padding: var(--pf-global--spacer--md);
-    .pf-c-data-toolbar__item {
+    .pf-c-toolbar__item {
             &.ins-c-primary-toolbar__first-action {
                 display: initial;
             }


### PR DESCRIPTION
`pf-c-data-toolbar__item` was replaced with `pf-c-toolbar__item`This was causing hiding first item in the `<PrimaryToolbar>`