### PR TITLE
Update empty state content width

### DIFF
--- a/packages/sources/src/styles/emptyState.scss
+++ b/packages/sources/src/styles/emptyState.scss
@@ -1,5 +1,9 @@
 .ins-c-sources__empty-state {
     width: 75%;
+
+    .pf-c-empty-state__content {
+        width: 100%;
+    }
 }
 
 .ins-c-sources__progress {


### PR DESCRIPTION
- PF4.4 introduces new div element that is not 100% width so it breaks how the empty state looks