### PR TITLE
PDF renderer table column header to support customization 

### DIFF
--- a/packages/pdf-generator/src/components/Table.js
+++ b/packages/pdf-generator/src/components/Table.js
@@ -29,13 +29,14 @@ const Table = ({
                 justifyContent: 'flex-start',
                 ...headerStyles
             }}>
-                {header.map((cell, key) => <Text key={ key } style={{
-                    ...appliedStyles.secondTitle,
-                    ...appliedStyles.compactCellPadding,
-                    flex: 1
-                }}>
-                    {cell}
-                </Text>)}
+                {header.map((cell, key) => (
+                    (typeof cell === 'string' || cell instanceof String) ? <Text key={ key } style={{
+                        ...appliedStyles.secondTitle,
+                        ...appliedStyles.compactCellPadding,
+                        flex: 1
+                    }}>
+                        {cell}
+                    </Text> : cell))}
             </View>
         }
         <View style={{


### PR DESCRIPTION
while we are able to render a pdf with custom table cell styles (per rows), the headers remain unchangeable, SO if you wanted to have a column that was 200px wide, header wouldn't support that, table looks super wonky n outta place

this pr recreates the magic of the row for the header, if Imma send you something that isn't a string, show it in it's entirety 💝

related to https://github.com/RedHatInsights/insights-advisor-frontend/pull/680