### PR TITLE
Fix notifications babel config for direct imports

### DIFF
--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -52,6 +52,10 @@ Since our components require a bit more setting up, we are recommending using `b
 Change your babel config to be javascript config `babel.config.js` so you can use JS functions to properly transform your imports
 
 ```JS
+notificationsMapper = {
+    addNotification: 'actions',
+    removeNotification: 'actions',
+};
 module.exports = {
     presets: [
         // your presets go here
@@ -63,8 +67,8 @@ module.exports = {
             {
               '@redhat-cloud-services/frontend-components-notifications': {
                 transform: (importName) =>
-                  `@redhat-cloud-services/frontend-components-notifications/cjs/${importName}`,
-                preventFullImport: true
+                  `@redhat-cloud-services/frontend-components-notifications/cjs/${notificationsMapper[importName] || importName}`,
+                preventFullImport: true,
               }
             },
             'frontend-notifications'

--- a/packages/notifications/src/redux/reducers/notifications.js
+++ b/packages/notifications/src/redux/reducers/notifications.js
@@ -26,4 +26,5 @@ export const notificationsReducers = {
     [CLEAR_NOTIFICATIONS]: clearNotifications
 };
 
-export default applyReducerHash(notificationsReducers, defaultState);
+export const notifications = applyReducerHash(notificationsReducers, defaultState);
+export default notifications;


### PR DESCRIPTION
Many parts of the documentation suggests importing the `addNotification` action directly.

However, that didn't work with the babel-plugin-transform-imports configuration offered in the README file.
This commit fixes the documented configuration to allow direct import of `addNotification` and `removeNotification`.

cc: @karelhala 