### PR TITLE
Allow custom titles in TagModal

### DIFF
--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -45,6 +45,7 @@ export default class TagModal extends React.Component {
     render() {
         const {
             className,
+            title,
             systemName,
             toggleModal,
             isOpen,
@@ -67,7 +68,7 @@ export default class TagModal extends React.Component {
                 {...props}
                 className={classNames('ins-c-tag-modal', className)}
                 isOpen={isOpen}
-                title={`Tags for ${systemName}`}
+                title={title || `Tags for ${systemName}`}
                 onClose={toggleModal}
                 {...onApply && {
                     actions: [
@@ -171,6 +172,7 @@ export default class TagModal extends React.Component {
 
 TagModal.propTypes = {
     loaded: PropTypes.bool,
+    title: PropTypes.string,
     systemName: PropTypes.string,
     isOpen: PropTypes.bool,
     toggleModal: PropTypes.func,


### PR DESCRIPTION
@AllenBW This PR is in response to RHCLOUD-6738. It allows for the specification of a custom title to the TagModal component. If no title is specified it will default to `Tags for ${systemName}`. This change is necessary to meet the specifications laid out by https://marvelapp.com/4e20f90/screen/69662590