### PR TITLE
Fix missing react-intl provider by using custom one, if required

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Wrapper } from 'react';
 import propTypes from 'prop-types';
 import SystemPolicyCards from './SystemPolicyCards';
 import SystemRulesTable from './SystemRulesTable';
@@ -10,6 +10,7 @@ import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
 import { columns } from './defaultColumns';
 import './compliance.scss';
 import { ErrorCard } from './PresentationalComponents';
+import { IntlProvider } from 'react-intl';
 
 const COMPLIANCE_API_ROOT = '/api/compliance';
 
@@ -137,4 +138,11 @@ SystemQuery.defaultProps = {
     loading: true
 };
 
-export default SystemDetails;
+const WrappedSystemDetails = ({ customItnl, intlProps, ...props }) => {
+    const IntlWrapper = customItnl ? IntlProvider : Wrapper;
+    return <IntlWrapper { ...customItnl && intlProps } >
+        <SystemDetails { ...props } />
+    </IntlWrapper>;
+};
+
+export default WrappedSystemDetails;

--- a/packages/inventory-compliance/src/SystemPolicyCard.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FormattedRelative } from 'react-intl';
+import React, { Wrapper } from 'react';
+import { FormattedRelative, FormattedRelativeTime } from 'react-intl';
 import { CheckCircleIcon, ExclamationCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import Truncate from 'react-truncate';
 
@@ -57,6 +57,7 @@ class SystemPolicyCard extends React.Component {
         const { policy, benchmark, rulesPassed, rulesFailed, compliant, lastScanned, score } = this.state.policy;
         const { refIdTruncated, cardTitle } = this.state;
         const passedPercentage = this.fixedPercentage(score);
+        const FormattedRelativeCmp = FormattedRelativeTime || FormattedRelative || Wrapper;
 
         return (
             <Card>
@@ -98,7 +99,7 @@ class SystemPolicyCard extends React.Component {
                         </Text>
                     </div>
                     <Text className='margin-bottom-none' component={ TextVariants.small }>
-                      Last scanned: <FormattedRelative value={ Date.parse(lastScanned) } />
+                      Last scanned: <FormattedRelativeCmp value={ Date.parse(lastScanned) } />
                     </Text>
                 </CardBody>
             </Card>


### PR DESCRIPTION
If parent component does not have intl provider it would fail with missing provider, this PR fixes such issue by allowing custom provider prop to be passed and this component will create new intl provider. Also `FormattedRelative` has been deprecated so try using newer component instead called `FormattedRelativeTime` if no such component is found fallback to `FormattedRelative` and if neither that is found use `Wrapper` this way we won't crash the UI for the cost of missing relaive time ticker. Also might want to consider using `DateFormat` it does not require intl provider to present and works the same as this component (but for the cause of hot fixing this issue, let's go with the fallbacks).