### PR TITLE
Make sources translatable

### DIFF
--- a/packages/sources/.gitignore
+++ b/packages/sources/.gitignore
@@ -2,3 +2,4 @@
 /index.css
 /esm
 /cjs
+translations

--- a/packages/sources/config/rollup.config.js
+++ b/packages/sources/config/rollup.config.js
@@ -55,7 +55,7 @@ const plugins = [
 export default rollupConfig(
     external(externalDeps(
         { ...dependencies, ...peerDependencies, ...devDependencies },
-        [ '@patternfly', '@redhat-cloud-services',  '@data-driven-forms', 'lodash' ]
+        [ '@patternfly', '@redhat-cloud-services',  '@data-driven-forms', 'lodash', 'react-intl' ]
     )),
     plugins,
     {
@@ -63,7 +63,8 @@ export default rollupConfig(
         '@data-driven-forms/pf4-component-mapper': '@data-driven-forms/pf4-component-mapper',
         '@data-driven-forms/react-form-renderer': '@data-driven-forms/react-form-renderer',
         '@redhat-cloud-services/frontend-components-utilities': '@redhat-cloud-services/frontend-components-utilities',
-        lodash: 'lodash'
+        lodash: 'lodash',
+        'react-intl': 'react-intl'
     },
     name,
     [{

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -9,7 +9,8 @@
     },
     "scripts": {
         "build": "rollup -c ./config/rollup.config.js --environment NODE_ENV:production",
-        "start": "rollup -c ./config/rollup.config.js -w"
+        "start": "rollup -c ./config/rollup.config.js -w",
+        "extract:messages": "npx @formatjs/cli extract 'src/**/*.{js,jsx}' --out-file ./translations/messages.json"
     },
     "repository": {
         "type": "git",

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -30,12 +30,14 @@
         "@data-driven-forms/pf4-component-mapper": "^2.5.0",
         "@data-driven-forms/react-form-renderer": "^2.5.0",
         "@patternfly/react-core": "^4.18.5",
-        "@patternfly/react-icons": "^4.3.5"
+        "@patternfly/react-icons": "^4.3.5",
+        "react-intl": "^5.0.2"
     },
     "peerDependencies": {
         "react": "^16.12.0",
         "@data-driven-forms/pf4-component-mapper": "^2.5.0",
         "@data-driven-forms/react-form-renderer": "^2.5.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.15",
+        "react-intl": "^5.0.2"
     }
 }

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -28,16 +28,16 @@
         "awesome-debounce-promise": "^2.1.0"
     },
     "devDependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^2.5.0",
-        "@data-driven-forms/react-form-renderer": "^2.5.0",
+        "@data-driven-forms/pf4-component-mapper": "^2.6.7",
+        "@data-driven-forms/react-form-renderer": "^2.6.7",
         "@patternfly/react-core": "^4.18.5",
         "@patternfly/react-icons": "^4.3.5",
         "react-intl": "^5.0.2"
     },
     "peerDependencies": {
         "react": "^16.12.0",
-        "@data-driven-forms/pf4-component-mapper": "^2.5.0",
-        "@data-driven-forms/react-form-renderer": "^2.5.0",
+        "@data-driven-forms/pf4-component-mapper": "^2.6.7",
+        "@data-driven-forms/react-form-renderer": "^2.6.7",
         "lodash": "^4.17.15",
         "react-intl": "^5.0.2"
     }

--- a/packages/sources/src/addSourceWizard/CloseModal.js
+++ b/packages/sources/src/addSourceWizard/CloseModal.js
@@ -2,34 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, TextContent, Text, TextVariants } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { useIntl, FormattedMessage } from 'react-intl';
 
-const CloseModal = ({ onExit, onStay, isOpen, title, exitTitle, stayTitle, description }) => (
-    <Modal
-        variant="small"
-        title={title}
-        aria-label="Close add source wizard"
-        header={
-            <TextContent>
-                <ExclamationTriangleIcon size="lg" className="ins-c-source__warning-icon" />
-                <Text component={TextVariants.h1}>
-                    {title}
-                </Text>
-            </TextContent>
-        }
-        isOpen={isOpen}
-        onClose={onStay}
-        actions={[
-            <Button key="confirm" variant="primary" id="on-exit-button" onClick={onExit}>
-                {exitTitle}
-            </Button>,
-            <Button key="cancel" variant="link" id="on-stay-button" onClick={onStay}>
-                {stayTitle}
-            </Button>
-        ]}
-    >
-        {description}
-    </Modal>
-);
+const CloseModal = ({ onExit, onStay, isOpen, title, exitTitle, stayTitle, description }) => {
+    const intl = useIntl();
+
+    return (
+        <Modal
+            variant="small"
+            title={title}
+            aria-label={intl.formatMessage({ id: 'wizard.closeAriaLabel', defaultMessage: 'Close add source wizard' })}
+            header={
+                <TextContent>
+                    <ExclamationTriangleIcon size="lg" className="ins-c-source__warning-icon" />
+                    <Text component={TextVariants.h1}>
+                        {title}
+                    </Text>
+                </TextContent>
+            }
+            isOpen={isOpen}
+            onClose={onStay}
+            actions={[
+                <Button key="confirm" variant="primary" id="on-exit-button" onClick={onExit}>
+                    {exitTitle}
+                </Button>,
+                <Button key="cancel" variant="link" id="on-stay-button" onClick={onStay}>
+                    {stayTitle}
+                </Button>
+            ]}
+        >
+            {description}
+        </Modal>
+    );};
 
 CloseModal.propTypes = {
     onExit: PropTypes.func.isRequired,
@@ -42,10 +46,10 @@ CloseModal.propTypes = {
 };
 
 CloseModal.defaultProps = {
-    title: 'Exit source creation?',
-    exitTitle: 'Exit',
-    stayTitle: 'Stay',
-    description: 'All inputs will be discarded.'
+    title: <FormattedMessage id="wizard.closeTitle" defaultMessage="Exit source creation?"/>,
+    exitTitle: <FormattedMessage id="wizard.exitText" defaultMessage="Exit"/>,
+    stayTitle: <FormattedMessage id="wizard.stayText" defaultMessage="Stay"/>,
+    description: <FormattedMessage id="wizard.closeWarning" defaultMessage="All inputs will be discarded."/>
 };
 
 export default CloseModal;

--- a/packages/sources/src/addSourceWizard/FinalWizard.js
+++ b/packages/sources/src/addSourceWizard/FinalWizard.js
@@ -67,7 +67,7 @@ FinalWizard.propTypes = {
     returnButtonTitle: PropTypes.node.isRequired,
     errorMessage: PropTypes.node,
     progressStep: PropTypes.number.isRequired,
-    progressTexts: PropTypes.arrayOf(PropTypes.string).isRequired
+    progressTexts: PropTypes.arrayOf(PropTypes.node).isRequired
 };
 
 export default FinalWizard;

--- a/packages/sources/src/addSourceWizard/FinalWizard.js
+++ b/packages/sources/src/addSourceWizard/FinalWizard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Wizard } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 import FinishedStep from './steps/FinishedStep';
 import ErroredStep from './steps/ErroredStep';
@@ -46,7 +47,7 @@ const FinalWizard = ({
                         progressTexts={progressTexts}
                     />
                     : <LoadingStep
-                        customText='Source is being created'
+                        customText={<FormattedMessage id="wizard.loadingText" defaultMessage="Source is being created"/>}
                         progressStep={progressStep}
                         progressTexts={progressTexts}
                     />,

--- a/packages/sources/src/addSourceWizard/SSLFormLabel.js
+++ b/packages/sources/src/addSourceWizard/SSLFormLabel.js
@@ -1,23 +1,29 @@
 import React from 'react';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 const SSLFormLabel = () => (
     <React.Fragment>
-        SSL Certificate&nbsp;
+        <FormattedMessage id="wizard.SslCertificate" defaultMessage="SSL Certificate" />&nbsp;
         <Popover
             aria-label="Help text"
             maxWidth="50%"
             bodyContent={
                 <TextContent>
                     <Text component={ TextVariants.p }>
-                            You can obtain your OpenShift Container Platform provider’s CA
-                            certificate for all endpoints (default, metrics, alerts) from
-                        <b>/etc/origin/master/ca.crt</b>.
+                        <FormattedMessage
+                            id="wizard.YouCanObtainYourOpenshiftContainerPlatformProviderSCaCertificateForAllEndpointsDefaultMetricsAlertsFrom"
+                            // eslint-disable-next-line max-len
+                            defaultMessage="You can obtain your OpenShift Container Platform provider’s CA certificate for all endpoints (default, metrics, alerts) from {cmd}."
+                            values={{ cmd: <b>/etc/origin/master/ca.crt</b> }}
+                        />
                     </Text>
                     <Text component={ TextVariants.p }>
-                            Paste the output (a block of text starting with --BEGIN CERTIFICATE--)
-                            into the Trusted CA Certificates field.
+                        <FormattedMessage
+                            id="wizard.PasteTheOutputABlockOfTextStartingWithBeginCertificateIntoTheTrustedCaCertificatesField"
+                            defaultMessage="Paste the output (a block of text starting with --BEGIN CERTIFICATE--) into the Trusted CA Certificates field."
+                        />
                     </Text>
                 </TextContent>
             }

--- a/packages/sources/src/addSourceWizard/SourceAddModal.js
+++ b/packages/sources/src/addSourceWizard/SourceAddModal.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { Wizard } from '@patternfly/react-core';
+import { useIntl } from 'react-intl';
 
 import SourcesFormRenderer from '../sourceFormRenderer/index';
 import createSchema from './SourceAddSchema';
@@ -15,12 +16,12 @@ const initialValues = {
     isLoading: true
 };
 
-const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection }) => {
+const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection, intl }) => {
     switch (type) {
         case 'loaded':
             return {
                 ...state,
-                schema: createSchema(sourceTypes.filter(type => type.schema), applicationTypes.filter(filterApps), disableAppSelection, container),
+                schema: createSchema(sourceTypes.filter(type => type.schema), applicationTypes.filter(filterApps), disableAppSelection, container, intl),
                 isLoading: false,
                 sourceTypes
             };
@@ -39,6 +40,7 @@ const SourceAddModal = ({
     const [{ schema, sourceTypes: stateSourceTypes, isLoading }, dispatch ] = useReducer(reducer, initialValues);
     const isMounted = useRef(false);
     const container = useRef(document.createElement('div'));
+    const intl = useIntl();
 
     useEffect(() => {
         isMounted.current = true;
@@ -62,7 +64,8 @@ const SourceAddModal = ({
                     sourceTypes: sourceTypes || sourceTypesOut.sourceTypes,
                     applicationTypes: applicationTypes || applicationTypesOut.applicationTypes,
                     disableAppSelection,
-                    container: container.current
+                    container: container.current,
+                    intl
                 });
             }
         });

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -56,7 +56,7 @@ const compileAllSourcesComboOptions = (sourceTypes) => (
 
 const compileAllApplicationComboOptions = (applicationTypes) => (
     [
-        { label: <FormattedMessage id="wizard.None" defaultMessage="None" /> },
+        { label: <FormattedMessage id="wizard.None" defaultMessage="None" />, key: 'none' },
         ...applicationTypes.sort((a, b) => a.display_name.localeCompare(b.display_name)).map(t => ({
             value: t.id,
             label: t.display_name

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
@@ -9,7 +10,11 @@ import { WIZARD_DESCRIPTION, WIZARD_TITLE } from '../utilities/stringConstants';
 import ValidatorReset from './ValidatorReset';
 import { handleError } from '../api/handleError';
 
-export const asyncValidator = async (value, sourceId = undefined) => {
+export const asyncValidator = async (value, sourceId = undefined, intl) => {
+    if (!value) {
+        return undefined;
+    }
+
     let response;
     try {
         response = await findSource(value);
@@ -19,7 +24,7 @@ export const asyncValidator = async (value, sourceId = undefined) => {
     }
 
     if (response.data.sources.find(({ id }) => id !== sourceId)) {
-        throw 'Name has already been taken';
+        throw intl.formatMessage({ defaultMessage: 'Name has already been taken', id: 'wizard.nameTaken' });
     }
 
     return undefined;
@@ -31,10 +36,10 @@ export const getFirstValidated = () => firstValidation;
 
 export const asyncValidatorDebounced = debouncePromise(asyncValidator);
 
-export const asyncValidatorDebouncedWrapper = () => {
+export const asyncValidatorDebouncedWrapper = (intl) => {
     if (getFirstValidated()) {
         setFirstValidated(false);
-        return (value, id) => value ? asyncValidator(value, id) : 'Required';
+        return (value, id) => asyncValidator(value, id, intl);
     }
 
     return asyncValidatorDebounced;
@@ -51,7 +56,7 @@ const compileAllSourcesComboOptions = (sourceTypes) => (
 
 const compileAllApplicationComboOptions = (applicationTypes) => (
     [
-        { label: 'None' },
+        { label: <FormattedMessage id="wizard.None" defaultMessage="None" /> },
         ...applicationTypes.sort((a, b) => a.display_name.localeCompare(b.display_name)).map(t => ({
             value: t.id,
             label: t.display_name
@@ -102,27 +107,30 @@ export const nextStep = ({ values: { application, source_type } }) => {
     return resultedStep;
 };
 
-const typesStep = (sourceTypes, applicationTypes, disableAppSelection) => ({
-    title: 'Choose application and source type',
+const typesStep = (sourceTypes, applicationTypes, disableAppSelection, intl) => ({
+    title: <FormattedMessage id="wizard.ChooseApplicationAndSourceType" defaultMessage="Choose application and source type" />,
     name: 'types_step',
     nextStep,
     fields: [
         {
             component: 'enhanced-select',
             name: 'application.application_type_id',
-            label: 'A. Select your application',
+            label: <FormattedMessage id="wizard.ASelectYourApplication" defaultMessage="A. Select your application" />,
             // eslint-disable-next-line react/display-name
             options: compileAllApplicationComboOptions(applicationTypes),
             mutator: appMutator(applicationTypes),
-            description: 'Selecting an application will limit the available source types. You can assign an application to your source now or after adding your source.',
+            description: <FormattedMessage
+                id="wizard.SelectingAnApplicationWillLimitTheAvailableSourceTypesYouCanAssignAnApplicationToYourSourceNowOrAfterAddingYourSource"
+                defaultMessage="Selecting an application will limit the available source types. You can assign an application to your source now or after adding your source."
+            />,
             isDisabled: disableAppSelection,
-            placeholder: 'Choose application'
+            placeholder: intl.formatMessage({ id: 'wizard.chooseApp', defaultMessage: 'Choose application' })
         },
         {
             component: 'card-select',
             name: 'source_type',
             isRequired: true,
-            label: 'B. Select your source type',
+            label: <FormattedMessage id="wizard.BSelectYourSourceType" defaultMessage="B. Select your source type" />,
             iconMapper: iconMapper(sourceTypes),
             validate: [{
                 type: validatorTypes.REQUIRED
@@ -141,14 +149,17 @@ const typesStep = (sourceTypes, applicationTypes, disableAppSelection) => ({
 export const NameDescription = () => (
     <TextContent key='step1'>
         <Text component={ TextVariants.p }>
-To import data for an application, you need to connect to a data source.
-Enter a name, then proceed to select your application and source type.
+            <FormattedMessage
+                id="wizard.ToImportDataForAnApplicationYouNeedToConnectToADataSourceEnterANameThenProceedToSelectYourApplicationAndSourceType"
+                // eslint-disable-next-line max-len
+                defaultMessage="To import data for an application, you need to connect to a data source. Enter a name, then proceed to select your application and source type."
+            />
         </Text>
     </TextContent>
 );
 
-const nameStep = () => ({
-    title: 'Enter source name',
+const nameStep = (intl) => ({
+    title: <FormattedMessage id="wizard.EnterSourceName" defaultMessage="Enter source name" />,
     name: 'name_step',
     nextStep: 'types_step',
     fields: [
@@ -161,11 +172,11 @@ const nameStep = () => ({
             component: componentTypes.TEXT_FIELD,
             name: 'source.name',
             type: 'text',
-            label: 'Name',
+            label: <FormattedMessage id="wizard.Name" defaultMessage="Name" />,
             placeholder: 'Source_1',
             isRequired: true,
             validate: [
-                (value) => asyncValidatorDebouncedWrapper()(value),
+                (value) => asyncValidatorDebouncedWrapper(intl)(value, undefined, intl),
                 { type: validatorTypes.REQUIRED }
             ]
         }
@@ -175,7 +186,10 @@ const nameStep = () => ({
 export const SummaryDescription = () => (
     <TextContent>
         <Text component={ TextVariants.p }>
-            Review the information below and click Add to add your source. Use the Back button to make changes.
+            <FormattedMessage
+                id="wizard.ReviewTheInformationBelowAndClickAddToAddYourSourceUseTheBackButtonToMakeChanges"
+                defaultMessage="Review the information below and click Add to add your source. Use the Back button to make changes."
+            />
         </Text>
     </TextContent>
 );
@@ -194,10 +208,10 @@ const summaryStep = (sourceTypes, applicationTypes) => ({
             applicationTypes
         }],
     name: 'summary',
-    title: 'Review details'
+    title: <FormattedMessage id="wizard.ReviewDetails" defaultMessage="Review details" />
 });
 
-export default (sourceTypes, applicationTypes, disableAppSelection, container) => {
+export default (sourceTypes, applicationTypes, disableAppSelection, container, intl) => {
     setFirstValidated(true);
 
     return ({
@@ -208,14 +222,17 @@ export default (sourceTypes, applicationTypes, disableAppSelection, container) =
             inModal: true,
             description: WIZARD_DESCRIPTION,
             buttonLabels: {
-                submit: 'Add'
+                submit: <FormattedMessage id="sources.addButton" defaultMessage="Add" />,
+                back: <FormattedMessage id="wizard.Back" defaultMessage="Back" />,
+                cancel: <FormattedMessage id="wizard.Cancel" defaultMessage="Cancel" />,
+                next: <FormattedMessage id="wizard.Next" defaultMessage="Next" />
             },
             container,
             showTitles: true,
             crossroads: [ 'application.application_type_id', 'source_type', 'auth_select' ],
             fields: [
-                nameStep(),
-                typesStep(sourceTypes, applicationTypes, disableAppSelection),
+                nameStep(intl),
+                typesStep(sourceTypes, applicationTypes, disableAppSelection, intl),
                 ...schemaBuilder(sourceTypes, applicationTypes),
                 summaryStep(sourceTypes, applicationTypes)
             ]

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -39,7 +39,7 @@ export const asyncValidatorDebounced = debouncePromise(asyncValidator);
 export const asyncValidatorDebouncedWrapper = (intl) => {
     if (getFirstValidated()) {
         setFirstValidated(false);
-        return (value, id) => asyncValidator(value, id, intl);
+        return (value, id) => value ? asyncValidator(value, id, intl) : undefined;
     }
 
     return asyncValidatorDebounced;

--- a/packages/sources/src/addSourceWizard/createProgressText.js
+++ b/packages/sources/src/addSourceWizard/createProgressText.js
@@ -1,29 +1,50 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
 const createProgressText = (formData) => {
     let progressTexts = [];
     let step = 1;
 
     const authAndApp = formData.endpoint && formData.application && formData.application.application_type_id;
 
-    progressTexts.push('Step 1: sending source data');
+    progressTexts.push(<FormattedMessage id="wizard.StepSendingSourceData" defaultMessage="Step 1: sending source data" />);
     if (authAndApp) {
-        progressTexts.push(`Step ${++step}: sending endpoint and application data`);
+        step++;
+        progressTexts.push(<FormattedMessage
+            id="wizard.StepStepSendingEndpointAndApplicationData"
+            defaultMessage="Step {step}: sending endpoint and application data"
+            values={{ step }} />
+        );
     } else if ((formData.endpoint) && !(formData.application && formData.application.application_type_id)) {
-        progressTexts.push(`Step ${++step}: sending endpoint data`);
+        step++;
+        progressTexts.push(<FormattedMessage id="wizard.StepStepSendingEndpointData" defaultMessage="Step {step}: sending endpoint data" values={{ step }} />);
     } else if (!(formData.endpoint) && (formData.application && formData.application.application_type_id)) {
-        progressTexts.push(`Step ${++step}: sending application data`);
+        step++;
+        progressTexts.push(<FormattedMessage id="wizard.StepStepSendingApplicationData" defaultMessage="Step {step}: sending application data" values={{ step }} />);
     }
 
     if (formData.endpoint) {
-        progressTexts.push(`Step ${++step}: sending authentication data`);
+        step++;
+        progressTexts.push(<FormattedMessage id="wizard.StepStepSendingAuthenticationData" defaultMessage="Step {step}: sending authentication data" values={{ step }} />);
     }
 
     if (formData.credentials || formData.billing_source) {
-        progressTexts.push(`Step ${++step}: sending cost management data and connecting authentication and application`);
+        step++;
+        progressTexts.push(<FormattedMessage
+            id="wizard.StepStepSendingCostManagementDataAndConnectingAuthenticationAndApplication"
+            defaultMessage="Step {step}: sending cost management data and connecting authentication and application"
+            values={{ step }}
+        />);
     } else if (authAndApp) {
-        progressTexts.push(`Step ${++step}: connecting authentication and application`);
+        step++;
+        progressTexts.push(<FormattedMessage
+            id="wizard.StepStepConnectingAuthenticationAndApplication"
+            defaultMessage="Step {step}: connecting authentication and application"
+            values={{ step }}
+        />);
     }
 
-    progressTexts.push('Completed');
+    progressTexts.push(<FormattedMessage id="wizard.Completed" defaultMessage="Completed" />);
 
     return progressTexts;
 };

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/access_key.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/access_key.js
@@ -1,23 +1,22 @@
+/* eslint-disable max-len */
 import React from 'react';
 import { Popover, TextContent, Text, TextVariants } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { FormattedMessage } from 'react-intl';
 
 export const DescriptionSummary = () => (<TextContent>
     <Text component={ TextVariants.p }>
-Create an access key in your AWS user account and enter the details below.
+        <FormattedMessage id="wizard.CreateAnAccessKeyInYourAwsUserAccountAndEnterTheDetailsBelow" defaultMessage="Create an access key in your AWS user account and enter the details below." />
     </Text>
     <Text component={ TextVariants.p }>
-For sufficient access and security, Red Hat recommends using
-    the Power user identity and access management (IAM) policy for your AWS user account.&nbsp;
+        <FormattedMessage id="wizard.ForSufficientAccessAndSecurityRedHatRecommendsUsingThePowerUserIdentityAndAccessManagementIamPolicyForYourAwsUserAccount" defaultMessage="For sufficient access and security, Red Hat recommends using the Power user identity and access management (IAM) policy for your AWS user account. " />
         <Popover
             aria-label="Help text"
             position="bottom"
             bodyContent={
                 <React.Fragment>
                     <Text component={ TextVariants.p }>
-                        The Power user policy allows the user full access to API functionality and AWS services for user administration.
-Create an access key in the Security Credentials area of your AWS user account.
-When adding your AWS account as a source, the access key ID and secret access key act as your user ID and password.
+                        <FormattedMessage id="wizard.ThePowerUserPolicyAllowsTheUserFullAccessToApiFunctionalityAndAwsServicesForUserAdministrationCreateAnAccessKeyInTheSecurityCredentialsAreaOfYourAwsUserAccountWhenAddingYourAwsAccountAsASourceTheAccessKeyIdAndSecretAccessKeyActAsYourUserIdAndPassword" defaultMessage="The Power user policy allows the user full access to API functionality and AWS services for user administration. Create an access key in the Security Credentials area of your AWS user account. When adding your AWS account as a source, the access key ID and secret access key act as your user ID and password." />
                     </Text>
                 </React.Fragment>
             }

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import {
     TextContent,
@@ -12,44 +13,48 @@ import {
 } from '@patternfly/react-core';
 import { HCCM_DOCS_PREFIX } from '../../../utilities/stringConstants';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
+import { FormattedMessage } from 'react-intl';
 
 const CREATE_S3_BUCKET = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_adding_sources_cost#creating_an_aws_s3_bucket`;
 const ENABLE_AWS_ACCOUNT = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_adding_sources_cost#enabling_aws_account_access`;
 
 export const UsageDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-To collect and store the information needed for cost management, you need to set up an Amazon S3 bucket
-    for cost and usage reports. <Text component={TextVariants.a} href={CREATE_S3_BUCKET} rel="noopener noreferrer" target="_blank">Learn more</Text>
+        <FormattedMessage
+            id="wizard.ToCollectAndStoreTheInformationNeededForCostManagementYouNeedToSetUpAnAmazonSBucketForCostAndUsageReports"
+            defaultMessage="To collect and store the information needed for cost management, you need to set up an Amazon S3 bucket for cost and usage reports. {link}"
+            values={{ link: <Text component={TextVariants.a} href={CREATE_S3_BUCKET} rel="noopener noreferrer" target="_blank"><FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" /></Text> }}
+        />
     </Text>
     <TextList component={TextListVariants.ol}>
-        <TextListItem>Specify or create an Amazon S3 bucket for your account.</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.SpecifyOrCreateAnAmazonSBucketForYourAccount" defaultMessage="Specify or create an Amazon S3 bucket for your account." /></TextListItem>
         <TextListItem>
-Create a cost and usage report using the following values:
+            <FormattedMessage id="wizard.CreateACostAndUsageReportUsingTheFollowingValues" defaultMessage="Create a cost and usage report using the following values:" />
             <TextList>
-                <TextListItem>Report name: koku</TextListItem>
-                <TextListItem>Time unit: hourly</TextListItem>
-                <TextListItem>Include: Resource IDs</TextListItem>
-                <TextListItem>Enable support for: RedShift, QuickSight and disable support for Athena</TextListItem>
-                <TextListItem>Report path prefix: (leave blank)</TextListItem>
-                <TextListItem>Compression type: GZIP</TextListItem>
+                <TextListItem><FormattedMessage id="wizard.ReportNameKoku" defaultMessage="Report name: koku" /></TextListItem>
+                <TextListItem><FormattedMessage id="wizard.TimeUnitHourly" defaultMessage="Time unit: hourly" /></TextListItem>
+                <TextListItem><FormattedMessage id="wizard.IncludeResourceIds" defaultMessage="Include: Resource IDs" /></TextListItem>
+                <TextListItem><FormattedMessage id="wizard.EnableSupportForRedshiftQuicksightAndDisableSupportForAthena" defaultMessage="Enable support for: RedShift, QuickSight and disable support for Athena" /></TextListItem>
+                <TextListItem><FormattedMessage id="wizard.ReportPathPrefixLeaveBlank" defaultMessage="Report path prefix: (leave blank)" /></TextListItem>
+                <TextListItem><FormattedMessage id="wizard.CompressionTypeGzip" defaultMessage="Compression type: GZIP" /></TextListItem>
             </TextList>
         </TextListItem>
-        <TextListItem>Enter the name of the Amazon S3 bucket you just created below:</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.EnterTheNameOfTheAmazonSBucketYouJustCreatedBelow" defaultMessage="Enter the name of the Amazon S3 bucket you just created below:" /></TextListItem>
     </TextList>
 </TextContent>);
 
 export const IAMRoleDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-To delegate account access, create an IAM role to associate with your IAM policy.
+        <FormattedMessage id="wizard.ToDelegateAccountAccessCreateAnIamRoleToAssociateWithYourIamPolicy" defaultMessage="To delegate account access, create an IAM role to associate with your IAM policy." />
     </Text>
     <TextList>
-        <TextListItem>From the AWS Identity access management console, create a new role.</TextListItem>
-        <TextListItem>Select another AWS account from the list of trusted entities and paste the following value into the Account ID field:</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.FromTheAwsIdentityAccessManagementConsoleCreateANewRole" defaultMessage="From the AWS Identity access management console, create a new role." /></TextListItem>
+        <TextListItem><FormattedMessage id="wizard.SelectAnotherAwsAccountFromTheListOfTrustedEntitiesAndPasteTheFollowingValueIntoTheAccountIdField" defaultMessage="Select another AWS account from the list of trusted entities and paste the following value into the Account ID field:" /></TextListItem>
         <ClipboardCopy className="pf-u-m-sm-on-sm" isReadOnly>
         589173575009
         </ClipboardCopy>
-        <TextListItem>Attach the permissions policy that you just created.</TextListItem>
-        <TextListItem>Complete the process to create your new role.</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.AttachThePermissionsPolicyThatYouJustCreated" defaultMessage="Attach the permissions policy that you just created." /></TextListItem>
+        <TextListItem><FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewRole" defaultMessage="Complete the process to create your new role." /></TextListItem>
     </TextList>
 </TextContent>);
 
@@ -60,21 +65,23 @@ export const IAMPolicyDescription = () => {
 
     if (!s3Bucket) {
         return (<Text component={ TextVariants.p }>
-            Something went wrong, you are missing bucket value.
+            <FormattedMessage id="wizard.SomethingWentWrongYouAreMissingBucketValue" defaultMessage="Something went wrong, you are missing bucket value." />
         </Text>);
     }
 
     return (<TextContent>
         <Text component={ TextVariants.p }>
-To grant permissions to the cost management report you just configured,
-create an AWS Identity and Access Management (IAM) policy.&nbsp;
-            <Text component={TextVariants.a} href={ENABLE_AWS_ACCOUNT} rel="noopener noreferrer" target="_blank">Learn more</Text>
+            <FormattedMessage
+                id="wizard.ToGrantPermissionsToTheCostManagementReportYouJustConfiguredCreateAnAwsIdentityAndAccessManagementIamPolicy"
+                defaultMessage="To grant permissions to the cost management report you just configured, create an AWS Identity and Access Management (IAM) policy. {link}"
+                values={{ link: <Text component={TextVariants.a} href={ENABLE_AWS_ACCOUNT} rel="noopener noreferrer" target="_blank"><FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" /></Text> }}
+            />
         </Text>
         <TextList component={TextListVariants.ol}>
             <TextListItem component={TextListItemVariants.li}>
-                Sign in to the AWS Identity and Access Management (IAM) console.
+                <FormattedMessage id="wizard.SignInToTheAwsIdentityAndAccessManagementIamConsole" defaultMessage="Sign in to the AWS Identity and Access Management (IAM) console." />
             </TextListItem>
-            <TextListItem component={TextListItemVariants.li}>Create a new policy, pasting the following content into the JSON text box.</TextListItem>
+            <TextListItem component={TextListItemVariants.li}><FormattedMessage id="wizard.CreateANewPolicyPastingTheFollowingContentIntoTheJsonTextBox" defaultMessage="Create a new policy, pasting the following content into the JSON text box." /></TextListItem>
             <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
                 {JSON.stringify({
                     Version: '2012-10-17',
@@ -107,30 +114,44 @@ create an AWS Identity and Access Management (IAM) policy.&nbsp;
                     ]
                 }, null, 2)}
             </ClipboardCopy>
-            <TextListItem component={TextListItemVariants.li}>Complete the process to create your new policy.</TextListItem>
+            <TextListItem component={TextListItemVariants.li}><FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewPolicy" defaultMessage="Complete the process to create your new policy." /></TextListItem>
         </TextList>
         <Text component={ TextVariants.p }>
-            <b>Do not close your browser.</b> You will need to be logged in to the IAM console to complete the next step.
+            <FormattedMessage
+                id="wizard.BDoNotCloseYourBrowserBYouWillNeedToBeLoggedInToTheIamConsoleToCompleteTheNextStep"
+                defaultMessage="{bold} You will need to be logged in to the IAM console to complete the next step."
+                values={{ bold: <b><FormattedMessage id="wizard.DoNotCloseYourBrowser" defaultMessage="Do not close your browser." /></b> }}
+            />
         </Text>
     </TextContent>);
 };
 
 export const TagsDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-    To use tags to organize your AWS resources in the cost management application, activate your tags in AWS to allow them to be imported automatically.
+        <FormattedMessage id="wizard.ToUseTagsToOrganizeYourAwsResourcesInTheCostManagementApplicationActivateYourTagsInAwsToAllowThemToBeImportedAutomatically" defaultMessage="To use tags to organize your AWS resources in the cost management application, activate your tags in AWS to allow them to be imported automatically." />
     </Text>
     <TextList component={TextListVariants.ol}>
-        <TextListItem>In the AWS Billing and Cost Management console, open the Cost Allocation Tags section.</TextListItem>
-        <TextListItem>Select the tags you want to use in the cost management application, and click Activate.</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.InTheAwsBillingAndCostManagementConsoleOpenTheCostAllocationTagsSection" defaultMessage="In the AWS Billing and Cost Management console, open the Cost Allocation Tags section." /></TextListItem>
+        <TextListItem><FormattedMessage id="wizard.SelectTheTagsYouWantToUseInTheCostManagementApplicationAndClickActivate" defaultMessage="Select the tags you want to use in the cost management application, and click Activate." /></TextListItem>
     </TextList>
 </TextContent>);
 
 export const ArnDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-To enable account access, capture the ARN associated with the role you just created.
+        <FormattedMessage
+            id="wizard.ToEnableAccountAccessCaptureTheArnAssociatedWithTheRoleYouJustCreated"
+            defaultMessage="To enable account access, capture the ARN associated with the role you just created."
+        />
     </Text>
     <TextList>
-        <TextListItem>From the Roles tab, select the role you just created.</TextListItem>
-        <TextListItem>From the Summary screen, copy the role ARN and paste it in the ARN field:</TextListItem>
+        <TextListItem>
+            <FormattedMessage id="wizard.FromTheRolesTabSelectTheRoleYouJustCreated" defaultMessage="From the Roles tab, select the role you just created." />
+        </TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.FromTheSummaryScreenCopyTheRoleArnAndPasteItInTheArnField"
+                defaultMessage="From the Summary screen, copy the role ARN and paste it in the ARN field:"
+            />
+        </TextListItem>
     </TextList>
 </TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -8,32 +8,68 @@ import {
     ClipboardCopy,
     ClipboardCopyVariant
 } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 export const IAMRoleDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-To delegate account access, create an IAM role to associate with your IAM policy.
+        <FormattedMessage
+            id="wizard.ToDelegateAccountAccessCreateAnIamRoleToAssociateWithYourIamPolicy"
+            defaultMessage="To delegate account access, create an IAM role to associate with your IAM policy."
+        />
     </Text>
     <TextList>
-        <TextListItem>From the AWS Identity access management console, create a new role.</TextListItem>
-        <TextListItem>Select another AWS account from the list of trusted entities and paste the following value into the Account ID field:</TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.FromTheAwsIdentityAccessManagementConsoleCreateANewRole"
+                defaultMessage="From the AWS Identity access management console, create a new role."
+            />
+        </TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.SelectAnotherAwsAccountFromTheListOfTrustedEntitiesAndPasteTheFollowingValueIntoTheAccountIdField"
+                defaultMessage="Select another AWS account from the list of trusted entities and paste the following value into the Account ID field:"
+            />
+        </TextListItem>
         <ClipboardCopy className="pf-u-m-sm-on-sm" isReadOnly>
         372779871274
         </ClipboardCopy>
-        <TextListItem>Attach the permissions policy that you just created.</TextListItem>
-        <TextListItem>Complete the process to create your new role.</TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.AttachThePermissionsPolicyThatYouJustCreated"
+                defaultMessage="Attach the permissions policy that you just created."
+            />
+        </TextListItem>
+        <TextListItem><FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewRole" defaultMessage="Complete the process to create your new role." /></TextListItem>
     </TextList>
 </TextContent>);
 
 export const IAMPolicyDescription = () =>  (<TextContent>
     <Text component={ TextVariants.p }>
-To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy.
+        <FormattedMessage
+            id="wizard.ToGrantPermissionsToObtainSubscriptionDataCreateAnAwsIdentityAccessManagementIamPolicy"
+            defaultMessage="To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy."
+        />
     </Text>
     <TextList>
         <TextListItem>
-                Sign in to the <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html" rel="noopener noreferrer" target="_blank">
-                    AWS Identity Access Management* (IAM) console</a>.
+            <FormattedMessage
+                id="wizard.SignInToThe"
+                defaultMessage="Sign in to the {link}."
+                values={{ link: <a
+                    href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html"
+                    rel="noopener noreferrer"
+                    target="_blank">
+                    <FormattedMessage id="wizard.AwsIdentityAccessManagementIamConsole" defaultMessage="AWS Identity Access Management* (IAM) console" />
+                </a>
+                }}
+            />
         </TextListItem>
-        <TextListItem>Create a new policy, pasting the following content into the JSON text box.</TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.CreateANewPolicyPastingTheFollowingContentIntoTheJsonTextBox"
+                defaultMessage="Create a new policy, pasting the following content into the JSON text box."
+            />
+        </TextListItem>
         <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
             {JSON.stringify({
                 Version: '2012-10-17',
@@ -60,19 +96,36 @@ To grant permissions to obtain subscription data, create an AWS identity access 
                 }]
             }, null, 2)}
         </ClipboardCopy>
-        <TextListItem>Complete the process to create your new policy.</TextListItem>
+        <TextListItem><FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewPolicy" defaultMessage="Complete the process to create your new policy." /></TextListItem>
     </TextList>
     <Text component={ TextVariants.p }>
-        <b>Do not close your browser.</b> You will need to be logged in to the IAM console to compute the next step.
+        <FormattedMessage
+            id="wizard.BDoNotCloseYourBrowserBYouWillNeedToBeLoggedInToTheIamConsoleToComputeTheNextStep"
+            defaultMessage="{bold} You will need to be logged in to the IAM console to compute the next step."
+            values={{ bold: <b><FormattedMessage id="wizard.DoNotCloseYourBrowser" defaultMessage="Do not close your browser." /></b> }}
+        />
     </Text>
 </TextContent>);
 
 export const ArnDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
-To enable account access, capture the ARN associated with the role you just created.
+        <FormattedMessage
+            id="wizard.ToEnableAccountAccessCaptureTheArnAssociatedWithTheRoleYouJustCreated"
+            defaultMessage="To enable account access, capture the ARN associated with the role you just created."
+        />
     </Text>
     <TextList>
-        <TextListItem>From the Roles tab, select the role you just created.</TextListItem>
-        <TextListItem>From the Summary screen, copy the role ARN and paste it in the ARN field:</TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.FromTheRolesTabSelectTheRoleYouJustCreated"
+                defaultMessage="From the Roles tab, select the role you just created."
+            />
+        </TextListItem>
+        <TextListItem>
+            <FormattedMessage
+                id="wizard.FromTheSummaryScreenCopyTheRoleArnAndPasteItInTheArnField"
+                defaultMessage="From the Summary screen, copy the role ARN and paste it in the ARN field:"
+            />
+        </TextListItem>
     </TextList>
 </TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/azure/costManagement.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/azure/costManagement.js
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { HCCM_DOCS_PREFIX } from '../../../utilities/stringConstants';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
+import { FormattedMessage } from 'react-intl';
 
 const CREATE_AZURE_STORAGE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_adding_sources_cost#creating_an_azure_storage_account`;
 const AZURE_CREDS_URL = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_adding_sources_cost#configuring_an_azure_service_principal`;
@@ -19,11 +20,25 @@ const RECURRING_TASK_URL = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_m
 export const ConfigureResourceGroupAndStorageAccount = () => (
     <TextContent>
         <Text component={TextVariants.p}>
-            Red Hat recommends creating a dedicated resource group and storage account in Azure to collect cost data and metrics for cost management.&nbsp;
-            <Text rel="noopener noreferrer" target="_blank" component={TextVariants.a} href={CREATE_AZURE_STORAGE}>Learn more</Text>
+            <FormattedMessage
+                id="wizard.RedHatRecommendsCreatingADedicatedResourceGroupAndStorageAccountInAzureToCollectCostDataAndMetricsForCostManagementLink"
+                // eslint-disable-next-line max-len
+                defaultMessage="Red Hat recommends creating a dedicated resource group and storage account in Azure to collect cost data and metrics for cost management. {link}"
+                values={{ link: <Text
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    component={TextVariants.a}
+                    href={CREATE_AZURE_STORAGE}>
+                    <FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" />
+                </Text>
+                }}
+            />
         </Text>
         <Text component={TextVariants.p}>
-            After configuring a resource group and storage account in the Azure portal, enter the following:
+            <FormattedMessage
+                id="wizard.AfterConfiguringAResourceGroupAndStorageAccountInTheAzurePortalEnterTheFollowing"
+                defaultMessage="After configuring a resource group and storage account in the Azure portal, enter the following:"
+            />
         </Text>
     </TextContent>
 );
@@ -32,7 +47,10 @@ export const SubscriptionID = () => {
     return (
         <TextContent>
             <Text component={TextVariants.p}>
-            Run the following command in Cloud Shell to obtain your Subscription ID and enter it below:
+                <FormattedMessage
+                    id="wizard.RunTheFollowingCommandInCloudShellToObtainYourSubscriptionIdAndEnterItBelow"
+                    defaultMessage="Run the following command in Cloud Shell to obtain your Subscription ID and enter it below:"
+                />
             </Text>
             <ClipboardCopy>{`az account show --query "{ subscription_id: id }"`}</ClipboardCopy>
         </TextContent>
@@ -42,12 +60,21 @@ export const SubscriptionID = () => {
 export const ConfigureRolesDescription = () => (
     <TextContent>
         <Text component={TextVariants.p}>
-            Red Hat recommends configuring dedicated credentials to grant Cost Management read-only access to Azure cost data.&nbsp;&nbsp;
-            <Text rel="noopener noreferrer" target="_blank" component={TextVariants.a} href={AZURE_CREDS_URL}>Learn more</Text>
+            <FormattedMessage
+                id="wizard.RedHatRecommendsConfiguringDedicatedCredentialsToGrantCostManagementReadOnlyAccessToAzureCostDataLink"
+                defaultMessage="Red Hat recommends configuring dedicated credentials to grant Cost Management read-only access to Azure cost data.  {link}"
+                values={{ link: <Text rel="noopener noreferrer" target="_blank" component={TextVariants.a} href={AZURE_CREDS_URL}>
+                    <FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" />
+                </Text>
+                }}
+            />
         </Text>
         <Text component={TextVariants.p}>
-            Run the following command in Cloud Shell to create a Cost Management Storage Account Contributor role.
-            From the output enter the values in the fields below:
+            <FormattedMessage
+                id="wizard.RunTheFollowingCommandInCloudShellToCreateACostManagementStorageAccountContributorRoleFromTheOutputEnterTheValuesInTheFieldsBelow"
+                // eslint-disable-next-line max-len
+                defaultMessage="Run the following command in Cloud Shell to create a Cost Management Storage Account Contributor role. From the output enter the values in the fields below:"
+            />
         </Text>
         <ClipboardCopy>{
             `az ad sp create-for-rbac -n "CostManagement" --role "Storage Account Contributor" --query '{"tenant": tenant, "client_id": appId, "secret": password}'`
@@ -61,7 +88,10 @@ export const ReaderRoleDescription = () => {
     return (
         <TextContent>
             <Text component={TextVariants.p}>
-            Run the following command in Cloud Shell to create a Cost Management Reader role:
+                <FormattedMessage
+                    id="wizard.RunTheFollowingCommandInCloudShellToCreateACostManagementReaderRole"
+                    defaultMessage="Run the following command in Cloud Shell to create a Cost Management Reader role:"
+                />
             </Text>
             <ClipboardCopy>{
                 `az role assignment create --role "Cost Management Reader" --assignee http://CostManagement --subscription ${credentials.subscription_id}`
@@ -72,34 +102,44 @@ export const ReaderRoleDescription = () => {
 export const ExportSchedule = () => (
     <TextContent>
         <Text component={TextVariants.p}>
-            Create a recurring task to export cost data to your Azure storage account,
-                where cost management will retrieve the data.&nbsp;&nbsp;
-            <Text rel="noopener noreferrer" target="_blank" component={TextVariants.a} href={RECURRING_TASK_URL}>Learn more</Text>
+            <FormattedMessage
+                id="wizard.CreateARecurringTaskToExportCostDataToYourAzureStorageAccountWhereCostManagementWillRetrieveTheDataLink"
+                defaultMessage="Create a recurring task to export cost data to your Azure storage account, where cost management will retrieve the data.  {link}"
+                values={{ link: <Text
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    component={TextVariants.a}
+                    href={RECURRING_TASK_URL}>
+                    <FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" />
+                </Text> }}
+            />
         </Text>
         <TextContent className='list-align-left'>
             <TextList component={TextListVariants.ol}>
                 <TextListItem component={TextListItemVariants.li}>
-                    From the Azure portal, add a new export.
+                    <FormattedMessage id="wizard.FromTheAzurePortalAddANewExport" defaultMessage="From the Azure portal, add a new export." />
                 </TextListItem>
                 <TextListItem component={TextListItemVariants.li}>
-                    Provide a name for the container and directory path, and
-                        specify the below settings to create the daily export.
-                            Leave all other options as the default.
+                    <FormattedMessage
+                        id="wizard.ProvideANameForTheContainerAndDirectoryPathAndSpecifyTheBelowSettingsToCreateTheDailyExportLeaveAllOtherOptionsAsTheDefault"
+                        // eslint-disable-next-line max-len
+                        defaultMessage="Provide a name for the container and directory path, and specify the below settings to create the daily export. Leave all other options as the default."
+                    />
                 </TextListItem>
             </TextList>
         </TextContent>
         <TextList className='export-table' component={TextListVariants.dl}>
             <TextListItem component={TextListItemVariants.dt}>
-                <Text component={TextVariants.b}>Export type</Text>
+                <Text component={TextVariants.b}><FormattedMessage id="wizard.ExportType" defaultMessage="Export type" /></Text>
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-                Daily export for billing-period-to-date costs
+                <FormattedMessage id="wizard.DailyExportForBillingPeriodToDateCosts" defaultMessage="Daily export for billing-period-to-date costs" />
             </TextListItem>
             <TextListItem component={TextListItemVariants.dt}>
-                <Text component={TextVariants.b}>Storage account name</Text>
+                <Text component={TextVariants.b}><FormattedMessage id="wizard.StorageAccountName" defaultMessage="Storage account name" /></Text>
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-                Storage account name created earlier
+                <FormattedMessage id="wizard.StorageAccountNameCreatedEarlier" defaultMessage="Storage account name created earlier" />
             </TextListItem>
         </TextList>
     </TextContent>

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/costManagement.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/costManagement.js
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
 import { TextContent, Text, TextVariants, TextListItem, TextList } from '@patternfly/react-core';
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { HCCM_DOCS_PREFIX } from '../../../utilities/stringConstants';
 
 const INSTALL_PREREQUISITE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_adding_sources_cost#installing_ocp_prerequisites`;
@@ -7,18 +9,31 @@ const INSTALL_PREREQUISITE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost
 export const ConfigureCostOperator = () => (
     <TextContent>
         <Text component={TextVariants.p}>
-            The Cost Management Operator collects the data required for Cost Management.&nbsp;
-            This is supported for clusters that are OpenShift Container Platform version 4.3 or later.&nbsp;
-            <Text component={TextVariants.a} href={INSTALL_PREREQUISITE} target="_blank" rel="noopener noreferrer">Learn more</Text>
+            <FormattedMessage
+                id="wizard.TheCostManagementOperatorCollectsTheDataRequiredForCostManagementThisIsSupportedForClustersThatAreOpenshiftContainerPlatformVersionOrLaterMore"
+                defaultMessage="The Cost Management Operator collects the data required for Cost Management. This is supported for clusters that are OpenShift Container Platform version 4.3 or later. {more}"
+                values={{ more: <Text
+                    component={TextVariants.a}
+                    href={INSTALL_PREREQUISITE}
+                    target="_blank"
+                    rel="noopener noreferrer"><FormattedMessage id="wizard.LearnMore" defaultMessage="Learn more" /></Text>
+                }}
+            />
         </Text>
         <TextContent className='list-align-left'>
             <TextList component='ol'>
                 <TextListItem component='li'>
-                    Install the Cost Management Operator from OperatorHub on your cluster (search
-                    for <i>cost management</i> ).
+                    <FormattedMessage
+                        id="wizard.InstallTheCostManagementOperatorFromOperatorhubOnYourClusterSearchForICostManagementI"
+                        defaultMessage="Install the Cost Management Operator from OperatorHub on your cluster (search for {cost})."
+                        values={{ cost: <i><FormattedMessage id="wizard.CostManagement" defaultMessage="cost management" /></i> }}
+                    />
                 </TextListItem>
                 <TextListItem component='li'>
-                    When configuration is complete, enter the cluster identifier below. The cluster identifier can be found in the cluster&apos;s Help &gt; About screen.
+                    <FormattedMessage
+                        id="wizard.WhenConfigurationIsCompleteEnterTheClusterIdentifierBelowTheClusterIdentifierCanBeFoundInTheClusterAposSHelpGtAboutScreen"
+                        defaultMessage="When configuration is complete, enter the cluster identifier below. The cluster identifier can be found in the cluster's Help > About screen."
+                    />
                 </TextListItem>
             </TextList>
         </TextContent>

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/endpoint.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/endpoint.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 export const EndpointDesc = () => (<TextContent>
     <Text component={ TextVariants.p }>
-        Provide the OpenShift Container Platform URL and SSL certificate.
+        <FormattedMessage
+            id="wizard.ProvideTheOpenshiftContainerPlatformUrlAndSslCertificate"
+            defaultMessage="Provide the OpenShift Container Platform URL and SSL certificate."
+        />
     </Text>
 </TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/token.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/openshift/token.js
@@ -1,24 +1,41 @@
 import React from 'react';
 import { TextContent, TextList, TextListItem, Text, TextVariants, ClipboardCopy } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 export const DescriptionSummary = () => (<TextContent key='1'>
     <Text component={ TextVariants.p }>
-    An OpenShift Container Platform login token is required to communicate with the application.
+        <FormattedMessage
+            id="wizard.AnOpenshiftContainerPlatformLoginTokenIsRequiredToCommunicateWithTheApplication"
+            defaultMessage="An OpenShift Container Platform login token is required to communicate with the application."
+        />
     </Text>
     <Text component={ TextVariants.p }>
-        To collect data from a Red Hat OpenShift Container Platform source:
+        <FormattedMessage
+            id="wizard.ToCollectDataFromARedHatOpenshiftContainerPlatformSource"
+            defaultMessage="To collect data from a Red Hat OpenShift Container Platform source:"
+        />
     </Text>
     <TextList component='ul'>
         <TextListItem component='li' key='1'>
-                Log in to the Red Hat OpenShift Container Platform cluster with an account
-                    that has access to the namespace
+            <FormattedMessage
+                id="wizard.LogInToTheRedHatOpenshiftContainerPlatformClusterWithAnAccountThatHasAccessToTheNamespace"
+                defaultMessage="Log in to the Red Hat OpenShift Container Platform cluster with an account that has access to the namespace"
+            />
         </TextListItem>
         <TextListItem component='li' key='2'>
-                Run the following command to obtain your login token:
+            <FormattedMessage
+                id="wizard.RunTheFollowingCommandToObtainYourLoginToken"
+                defaultMessage="Run the following command to obtain your login token:"
+            />
         </TextListItem>
-        <ClipboardCopy className="pf-u-mb-md" isReadOnly># oc sa get-token -n management-infra management-admin</ClipboardCopy>
+        <ClipboardCopy className="pf-u-mb-md" isReadOnly>
+            <FormattedMessage id="wizard.OcSaGetTokenNManagementInfraManagementAdmin" defaultMessage="# oc sa get-token -n management-infra management-admin" />
+        </ClipboardCopy>
         <TextListItem component='li' key='3'>
-                Copy the token and paste it in the Token field:
+            <FormattedMessage
+                id="wizard.CopyTheTokenAndPasteItInTheTokenField"
+                defaultMessage="Copy the token and paste it in the Token field:"
+            />
         </TextListItem>
     </TextList>
 </TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedComponents/tower/catalog.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/tower/catalog.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 export const AuthDescription = () => (<TextContent>
     <Text component={TextVariants.p} className="pf-u-mb-l">
-    Provide Ansible Tower service account user credentials to ensure
-    optimized availability of resources to Catalog Administrators.
+        <FormattedMessage
+            id="wizard.ProvideAnsibleTowerServiceAccountUserCredentialsToEnsureOptimizedAvailabilityOfResourcesToCatalogAdministrators"
+            defaultMessage="Provide Ansible Tower service account user credentials to ensure optimized availability of resources to Catalog Administrators."
+        />
     </Text>
     <Text component={TextVariants.p} className="ins-c-sources__wizard--all-required-text">
-    All fields are required.
+        <FormattedMessage
+            id="wizard.AllFieldsAreRequired" defaultMessage="All fields are required."
+        />
     </Text>
 </TextContent>);
 
 export const EndpointDescription = () => (<TextContent>
     <Text component={TextVariants.p} className="pf-u-mb-l">
-Enter the hostname of the Ansible Tower instance you want to connect to.
+        <FormattedMessage
+            id="wizard.EnterTheHostnameOfTheAnsibleTowerInstanceYouWantToConnectTo"
+            defaultMessage="Enter the hostname of the Ansible Tower instance you want to connect to."
+        />
     </Text>
 </TextContent>);

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { FormHelperText } from '@patternfly/react-core';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
@@ -521,10 +522,12 @@ export default {
                             },
                             { type: validatorTypes.URL }
                         ],
-                        helperText: <FormattedMessage
-                            id="wizard.ForExampleHttpsMyansibleinstanceExampleComOrHttps"
-                            defaultMessage="For example, https://myansibleinstance.example.com/ or https://127.0.0.1/"
-                        />,
+                        helperText: <FormHelperText isHidden={false}>
+                            <FormattedMessage
+                                id="wizard.ForExampleHttpsMyansibleinstanceExampleComOrHttps"
+                                defaultMessage="For example, https://myansibleinstance.example.com/ or https://127.0.0.1/"
+                            />
+                        </FormHelperText>,
                         label: <FormattedMessage id="wizard.Hostname" defaultMessage="Hostname" />
                     },
                     'endpoint.certificate_authority': {

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -77,7 +77,7 @@ export default {
                     skipSelection: true,
                     skipEndpoint: true,
                     'source.source_ref': {
-                        label: <FormattedMessage id="wizard.clusterId" defaultMessage="Cluster Indetifier"/>,
+                        label: <FormattedMessage id="wizard.clusterId" defaultMessage="Cluster Identifier"/>,
                         isRequired: true,
                         component: componentTypes.TEXT_FIELD,
                         validate: [{
@@ -364,7 +364,7 @@ export default {
                         title: <FormattedMessage id="wizard.IamPolicyTitle" defaultMessage="Create IAM policy" />,
                         name: 'iam-policy',
                         nextStep: 'iam-role',
-                        substepOf: 'Enable account access',
+                        substepOf: { name: 'eaa', title: <FormattedMessage id="wizard.EnableAccountAccess" defaultMessage="Enable account access" /> },
                         fields: [{
                             name: 'iam-policy-description',
                             component: 'description',
@@ -374,7 +374,7 @@ export default {
                         title: <FormattedMessage id="wizard.IamRoleStepTitle" defaultMessage="Create IAM role" />,
                         name: 'iam-role',
                         nextStep: 'arn',
-                        substepOf: 'Enable account access',
+                        substepOf: 'eaa',
                         fields: [{
                             name: 'iam-role-description',
                             component: 'description',
@@ -383,7 +383,7 @@ export default {
                     }, {
                         title: <FormattedMessage id="wizard.EnterArn" defaultMessage="Enter ARN" />,
                         name: 'arn',
-                        substepOf: 'Enable account access',
+                        substepOf: 'eaa',
                         fields: [{
                             name: 'arn-description',
                             component: 'description',
@@ -399,7 +399,7 @@ export default {
                     additionalSteps: [{
                         title: <FormattedMessage id="wizard.CreateIamPolicy" defaultMessage="Create IAM policy" />,
                         nextStep: 'subs-iam-role',
-                        substepOf: 'Enable account access',
+                        substepOf: { name: 'eaa', title: <FormattedMessage id="wizard.EnableAccountAccess" defaultMessage="Enable account access" /> },
                         fields: [{
                             name: 'iam-policy-description',
                             component: 'description',
@@ -415,7 +415,7 @@ export default {
                         title: <FormattedMessage id="wizard.CreateIamRole" defaultMessage="Create IAM role" />,
                         name: 'subs-iam-role',
                         nextStep: 'subs-arn',
-                        substepOf: 'Enable account access',
+                        substepOf: 'eaa',
                         fields: [{
                             name: 'iam-role-description',
                             component: 'description',
@@ -424,7 +424,7 @@ export default {
                     }, {
                         title: <FormattedMessage id="wizard.EnterArn" defaultMessage="Enter ARN" />,
                         name: 'subs-arn',
-                        substepOf: 'Enable account access',
+                        substepOf: 'eaa',
                         fields: [{
                             name: 'arn-description',
                             component: 'description',

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 import SSLFormLabel from './SSLFormLabel';
@@ -19,6 +21,9 @@ export const COST_MANAGEMENT_APP_NAME = '/insights/platform/cost-management';
 export const CLOUD_METER_APP_NAME = '/insights/platform/cloud-meter';
 export const CATALOG_APP = '/insights/platform/catalog';
 
+const arnMessagePattern = <FormattedMessage id="wizard.arnPattern" defaultMessage="ARN must start with arn:aws:"/>;
+const arnMessageLength = <FormattedMessage id="wizard.arnLength" defaultMessage="ARN should have at least 10 characters"/>;
+
 const arnField = {
     placeholder: 'arn:aws:iam:123456789:role/CostManagement',
     isRequired: true,
@@ -27,11 +32,11 @@ const arnField = {
     },  {
         type: validatorTypes.PATTERN,
         pattern: /^arn:aws:.*/,
-        message: 'ARN must start with arn:aws:'
+        message: arnMessagePattern
     }, {
         type: validatorTypes.MIN_LENGTH,
         threshold: 10,
-        message: 'ARN should have at least 10 characters'
+        message: arnMessageLength
     }]
 };
 
@@ -43,13 +48,13 @@ const subsWatchArnField = {
     }, {
         type: validatorTypes.PATTERN,
         pattern: /^arn:aws:.*/,
-        message: 'ARN must start with arn:aws:'
+        message: arnMessagePattern
     }, {
         type: validatorTypes.MIN_LENGTH,
         threshold: 10,
-        message: 'ARN should have at least 10 characters'
+        message: arnMessageLength
     }],
-    label: 'ARN'
+    label: <FormattedMessage id="wizard.Arn" defaultMessage="ARN" />
 };
 
 export default {
@@ -71,7 +76,7 @@ export default {
                     skipSelection: true,
                     skipEndpoint: true,
                     'source.source_ref': {
-                        label: 'Cluster Identifier',
+                        label: <FormattedMessage id="wizard.clusterId" defaultMessage="Cluster Indetifier"/>,
                         isRequired: true,
                         component: componentTypes.TEXT_FIELD,
                         validate: [{
@@ -79,11 +84,14 @@ export default {
                         }, {
                             type: validatorTypes.PATTERN,
                             pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                            message: 'Cluster ID must start with alphanumeric character and can contain underscore and hyphen'
+                            message: <FormattedMessage
+                                id="wizard.clusterIdPattern"
+                                defaultMessage="Cluster ID must start with alphanumeric character and can contain underscore and hyphen"
+                            />
                         }]
                     },
                     additionalSteps: [{
-                        title: 'Configure Cost Management Operator',
+                        title: <FormattedMessage id="wizard.ConfigureCostManagementOperator" defaultMessage="Configure Cost Management Operator" />,
                         fields: [{
                             component: 'description',
                             name: 'description-summary',
@@ -107,7 +115,7 @@ export default {
                 isRequired: true,
                 validate: [
                     { type: validatorTypes.REQUIRED },
-                    { type: validatorTypes.URL, message: 'The URL is not formatted correctly.' }
+                    { type: validatorTypes.URL, message: <FormattedMessage id="wizard.urlPatternMessage" defaultMessage="The URL is not formatted correctly."/> }
                 ]
             },
             'endpoint.certificate_authority': {
@@ -133,7 +141,10 @@ export default {
                         }, {
                             type: validatorTypes.PATTERN,
                             pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                            message: 'Subscription ID must start with alphanumeric character and can contain underscore and hyphen'
+                            message: <FormattedMessage
+                                id="wizard.subidPattern"
+                                defaultMessage="Subscription ID must start with alphanumeric character and can contain underscore and hyphen"
+                            />
                         }],
                         isRequired: true
                     },
@@ -144,7 +155,10 @@ export default {
                         }, {
                             type: validatorTypes.PATTERN,
                             pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                            message: 'Resource group must start with alphanumeric character and can contain underscore and hyphen'
+                            message: <FormattedMessage
+                                id="wizard.resourceGroupPattern"
+                                defaultMessage="Resource group must start with alphanumeric character and can contain underscore and hyphen"
+                            />
                         }],
                         isRequired: true
                     },
@@ -155,7 +169,10 @@ export default {
                         }, {
                             type: validatorTypes.PATTERN,
                             pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                            message: 'Storage account must start with alphanumeric character and can contain underscore and hyphen'
+                            message: <FormattedMessage
+                                id="wizard.storageAccountPattern"
+                                defaultMessage="Storage account must start with alphanumeric character and can contain underscore and hyphen"
+                            />
                         }],
                         isRequired: true
                     },
@@ -165,24 +182,24 @@ export default {
                         validate: [{
                             type: validatorTypes.REQUIRED
                         }],
-                        label: 'Client secret'
+                        label: <FormattedMessage id="wizard.clientSecret" defaultMessage="Client secret"/>
                     },
                     'authentication.username': {
                         isRequired: true,
                         validate: [{
                             type: validatorTypes.REQUIRED
                         }],
-                        label: 'Client (Application) ID'
+                        label: <FormattedMessage id="wizard.clientAppId" defaultMessage="Client (Application) ID" />
                     },
                     'authentication.extra.azure.tenant_id': {
                         isRequired: true,
-                        label: 'Tenant (Directory) ID',
+                        label: <FormattedMessage id="wizard.tenantDirId" defaultMessage="Tenant (Directory) ID" />,
                         validate: [{
                             type: validatorTypes.REQUIRED
                         }]
                     },
                     additionalSteps: [{
-                        title: 'Configure resource group and storage account',
+                        title: <FormattedMessage id="wizard.azureSubStepId" defaultMessage="Configure resource group and storage account" />,
                         nextStep: 'azure-sub-id',
                         fields: [{
                             component: componentTypes.TEXT_FIELD,
@@ -197,14 +214,14 @@ export default {
                         }, {
                             name: 'billing_source.data_source.resource_group',
                             component: componentTypes.TEXT_FIELD,
-                            label: 'Resource group name'
+                            label: <FormattedMessage id="wizard.resourceGroupName" defaultMessage="Resource group name" />
                         }, {
                             name: 'billing_source.data_source.storage_account',
                             component: componentTypes.TEXT_FIELD,
-                            label: 'Storage account name'
+                            label: <FormattedMessage id="wizard.storageAccountName" defaultMessage="Storage account name" />
                         }]
                     }, {
-                        title: 'Enter subscription ID',
+                        title: <FormattedMessage id="wizard.SubItTitle" defaultMessage="Enter subscription ID" />,
                         name: 'azure-sub-id',
                         nextStep: 'configure-roles',
                         fields: [{
@@ -214,10 +231,10 @@ export default {
                         }, {
                             name: 'credentials.subscription_id',
                             component: componentTypes.TEXT_FIELD,
-                            label: 'Subscription ID'
+                            label: <FormattedMessage id="wizard.SubIdID" defaultMessage="Subscription ID" />
                         }]
                     }, {
-                        title: 'Configure roles',
+                        title: <FormattedMessage id="wizard.ConfigureRoles" defaultMessage="Configure roles" />,
                         name: 'configure-roles',
                         nextStep: 'export-schedule',
                         fields: [{
@@ -239,7 +256,7 @@ export default {
                             Content: CMAzure.ReaderRoleDescription
                         }]
                     }, {
-                        title: 'Create daily export',
+                        title: <FormattedMessage id="wizard.DailyExport" defaultMessage="Create daily export" />,
                         name: 'export-schedule',
                         fields: [{
                             name: 'export-schedule-description',
@@ -256,13 +273,13 @@ export default {
             access_key_secret_key: {
                 generic: {
                     'authentication.username': {
-                        label: 'Access key ID',
+                        label: <FormattedMessage id="wizard.AccessKeyId" defaultMessage="Access key ID" />,
                         placeholder: 'AKIAIOSFODNN7EXAMPLE',
                         isRequired: true,
                         validate: [{ type: validatorTypes.REQUIRED }]
                     },
                     'authentication.password': {
-                        label: 'Secret access key',
+                        label: <FormattedMessage id="wizard.SecretAccessKey" defaultMessage="Secret access key" />,
                         placeholder: 'wJairXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
                         isRequired: true,
                         validate: [{ type: validatorTypes.REQUIRED }],
@@ -271,7 +288,7 @@ export default {
                     skipSelection: true,
                     onlyHiddenFields: true,
                     additionalSteps: [{
-                        title: 'Configure account access',
+                        title: <FormattedMessage id="wizard.ConfigureAccountAccess" defaultMessage="Configure account access" />,
                         fields: [{
                             component: 'description',
                             name: 'description-summary',
@@ -307,12 +324,15 @@ export default {
                         }, {
                             type: validatorTypes.PATTERN,
                             pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
-                            message: 'S3 bucket name must start with alphanumeric character and can contain underscore and hyphen'
+                            message: <FormattedMessage
+                                id="wizard.S3BucketPattern"
+                                defaultMessage="S3 bucket name must start with alphanumeric character and can contain underscore and hyphen"
+                            />
                         }],
                         isRequired: true
                     },
                     additionalSteps: [{
-                        title: 'Configure cost and usage reporting',
+                        title: <FormattedMessage id="wizard.usageDescriptionTitle" defaultMessage="Configure cost and usage reporting" />,
                         nextStep: 'tags',
                         fields: [{
                             name: 'usage-description',
@@ -321,7 +341,7 @@ export default {
                         },  {
                             name: 'billing_source.bucket',
                             component: componentTypes.TEXT_FIELD,
-                            label: 'S3 bucket name'
+                            label: <FormattedMessage id="wizard.S3Label" defaultMessage="S3 bucket name" />
                         }, {
                             component: componentTypes.TEXT_FIELD,
                             name: 'authentication.authtype',
@@ -330,7 +350,7 @@ export default {
                             initializeOnMount: true
                         }]
                     }, {
-                        title: 'Activate cost allocation tags',
+                        title: <FormattedMessage id="wizard.TagsStepTitle" defaultMessage="Activate cost allocation tags" />,
                         name: 'tags',
                         nextStep: 'iam-policy',
                         fields: [{
@@ -340,7 +360,7 @@ export default {
                         }]
                     },
                     {
-                        title: 'Create IAM policy',
+                        title: <FormattedMessage id="wizard.IamPolicyTitle" defaultMessage="Create IAM policy" />,
                         name: 'iam-policy',
                         nextStep: 'iam-role',
                         substepOf: 'Enable account access',
@@ -350,7 +370,7 @@ export default {
                             Content: AwsArn.IAMPolicyDescription
                         }]
                     }, {
-                        title: 'Create IAM role',
+                        title: <FormattedMessage id="wizard.IamRoleStepTitle" defaultMessage="Create IAM role" />,
                         name: 'iam-role',
                         nextStep: 'arn',
                         substepOf: 'Enable account access',
@@ -360,7 +380,7 @@ export default {
                             Content: AwsArn.IAMRoleDescription
                         }]
                     }, {
-                        title: 'Enter ARN',
+                        title: <FormattedMessage id="wizard.EnterArn" defaultMessage="Enter ARN" />,
                         name: 'arn',
                         substepOf: 'Enable account access',
                         fields: [{
@@ -376,7 +396,7 @@ export default {
                     skipSelection: true,
                     'authentication.password': subsWatchArnField,
                     additionalSteps: [{
-                        title: 'Create IAM policy',
+                        title: <FormattedMessage id="wizard.CreateIamPolicy" defaultMessage="Create IAM policy" />,
                         nextStep: 'subs-iam-role',
                         substepOf: 'Enable account access',
                         fields: [{
@@ -391,7 +411,7 @@ export default {
                             initializeOnMount: true
                         }]
                     }, {
-                        title: 'Create IAM role',
+                        title: <FormattedMessage id="wizard.CreateIamRole" defaultMessage="Create IAM role" />,
                         name: 'subs-iam-role',
                         nextStep: 'subs-arn',
                         substepOf: 'Enable account access',
@@ -401,7 +421,7 @@ export default {
                             Content: SWAwsArn.IAMRoleDescription
                         }]
                     }, {
-                        title: 'Enter ARN',
+                        title: <FormattedMessage id="wizard.EnterArn" defaultMessage="Enter ARN" />,
                         name: 'subs-arn',
                         substepOf: 'Enable account access',
                         fields: [{
@@ -425,13 +445,13 @@ export default {
             receptor_node: {
                 generic: {
                     'source.source_ref': {
-                        label: 'Satellite ID',
+                        label: <FormattedMessage id="wizard.SatelliteId" defaultMessage="Satellite ID" />,
                         isRequired: true,
                         validate: [{ type: validatorTypes.REQUIRED }],
                         component: componentTypes.TEXT_FIELD
                     },
                     'endpoint.receptor_node': {
-                        label: 'Receptor ID',
+                        label: <FormattedMessage id="wizard.ReceptorId" defaultMessage="Receptor ID" />,
                         isRequired: true,
                         validate: [{ type: validatorTypes.REQUIRED }],
                         component: componentTypes.TEXT_FIELD
@@ -440,7 +460,7 @@ export default {
                     onlyHiddenFields: true,
                     customSteps: true,
                     additionalSteps: [{
-                        title: 'Configure receptor node credentials',
+                        title: <FormattedMessage id="wizard.ConfigureReceptorNodeCredentials" defaultMessage="Configure receptor node credentials" />,
                         nextStep: 'summary',
                         fields: [{
                             name: 'source.source_ref'
@@ -482,13 +502,13 @@ export default {
                     'authentication.username': {
                         isRequired: false,
                         validate: [{ type: validatorTypes.REQUIRED }],
-                        label: 'Username'
+                        label: <FormattedMessage id="wizard.Username" defaultMessage="Username" />
                     },
                     'authentication.password': {
                         type: 'password',
                         isRequired: false,
                         validate: [{ type: validatorTypes.REQUIRED }],
-                        label: 'Password'
+                        label: <FormattedMessage id="wizard.Password" defaultMessage="Password" />
                     },
                     url: {
                         isRequired: true,
@@ -496,24 +516,27 @@ export default {
                             { type: validatorTypes.REQUIRED },
                             {
                                 type: validatorTypes.PATTERN,
-                                message: 'URL must start with https:// or http://',
+                                message: <FormattedMessage id="wizard.UrlMustStartWithHttpsOrHttp" defaultMessage="URL must start with https:// or http://" />,
                                 pattern: /^https{0,1}:\/\//
                             },
                             { type: validatorTypes.URL }
                         ],
-                        helperText: 'For example, https://myansibleinstance.example.com/ or https://127.0.0.1/',
-                        label: 'Hostname'
+                        helperText: <FormattedMessage
+                            id="wizard.ForExampleHttpsMyansibleinstanceExampleComOrHttps"
+                            defaultMessage="For example, https://myansibleinstance.example.com/ or https://127.0.0.1/"
+                        />,
+                        label: <FormattedMessage id="wizard.Hostname" defaultMessage="Hostname" />
                     },
                     'endpoint.certificate_authority': {
-                        label: 'Certificate authority'
+                        label: <FormattedMessage id="wizard.CertificateAuthority" defaultMessage="Certificate authority" />
                     },
                     'endpoint.verify_ssl': {
                         initialValue: false,
-                        label: 'Verify SSL'
+                        label: <FormattedMessage id="wizard.VerifySsl" defaultMessage="Verify SSL" />
                     },
                     additionalSteps: [{
                         nextStep: 'catalog-ansible-tower',
-                        title: 'Configure Ansible Tower endpoint',
+                        title: <FormattedMessage id="wizard.ConfigureAnsibleTowerEndpoint" defaultMessage="Configure Ansible Tower endpoint" />,
                         fields: [{
                             name: 'ansible-tower-desc',
                             component: 'description',
@@ -536,7 +559,7 @@ export default {
                             condition: { is: true, when: 'endpoint.verify_ssl' }
                         }]
                     }, {
-                        title: 'Configure credentials',
+                        title: <FormattedMessage id="wizard.ConfigureCredentials" defaultMessage="Configure credentials" />,
                         name: 'catalog-ansible-tower',
                         fields: [{
                             component: componentTypes.TEXT_FIELD,
@@ -564,10 +587,10 @@ export default {
                 isRequired: true,
                 validate: [{ type: validatorTypes.REQUIRED }],
                 placeholder: 'https://',
-                label: 'Hostname'
+                label: <FormattedMessage id="wizard.Hostname" defaultMessage="Hostname" />
             },
             'endpoint.certificate_authority': {
-                label: 'Certificate authority'
+                label: <FormattedMessage id="wizard.CertificateAuthority" defaultMessage="Certificate authority" />
             },
             'endpoint.verify_ssl': {
                 initialValue: false

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -10,6 +10,7 @@ import { doCreateSource } from '../api/createSource';
 import { WIZARD_TITLE } from '../utilities/stringConstants';
 import createProgressText from './createProgressText';
 import CloseModal from './CloseModal';
+import { FormattedMessage } from 'react-intl';
 
 const prepareInitialValues = (initialValues) => ({
     isSubmitted: false,
@@ -162,9 +163,9 @@ AddSourceWizard.propTypes = {
 };
 
 AddSourceWizard.defaultProps = {
-    successfulMessage: 'Your source has been successfully added.',
+    successfulMessage: <FormattedMessage id="wizard.successfulMessage" defaultMessage="Your source has been successfully added." />,
     initialValues: {},
-    returnButtonTitle: 'Go back to sources'
+    returnButtonTitle: <FormattedMessage id="wizard.goBackToSources" defaultMessage="Go back to sources" />
 };
 
 const AddSourceButton = (props) => {

--- a/packages/sources/src/addSourceWizard/schemaBuilder.js
+++ b/packages/sources/src/addSourceWizard/schemaBuilder.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 import hardcodedSchemas from './hardcodedSchemas';
@@ -133,7 +135,11 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
 
         return ({
             name: type.name,
-            title: `Configure ${acronymMapper(type.product_name)} credentials`,
+            title: <FormattedMessage
+                id="wizard.ConfigureAcronymmapperTypeProductNameCredentials"
+                defaultMessage="Configure {title} credentials"
+                values={{ title: acronymMapper(type.product_name) }}
+            />,
             fields,
             nextStep: {
                 when: 'auth_select',
@@ -169,7 +175,11 @@ export const createGenericAuthTypeSelection = (type, endpointFields, disableAuth
 
         return ({
             name: type.name,
-            title: `Configure ${acronymMapper(type.product_name)} - ${auth.name} credentials`,
+            title: <FormattedMessage
+                id="wizard.ConfigureAcronymmapperTypeProductNameAuthNameCredentials"
+                defaultMessage="Configure {title} - {name} credentials"
+                values={{ title: acronymMapper(type.product_name), name: auth.name }}
+            />,
             fields: [
                 ...fields,
                 ...getAdditionalAuthFields(type.name, auth.type),
@@ -241,7 +251,7 @@ export const createSpecificAuthTypeSelection = (type, appType, endpointFields, d
 
         return ({
             name: `${type.name}-${appType.id}`,
-            title: 'Choose authentication type',
+            title: <FormattedMessage id="wizard.ChooseAuthenticationType" defaultMessage="Choose authentication type" />,
             fields,
             nextStep: {
                 when: 'auth_select',
@@ -295,7 +305,11 @@ export const createSpecificAuthTypeSelection = (type, appType, endpointFields, d
 
         return ({
             name: `${type.name}-${appType.id}`,
-            title: `Configure ${auth.name} credentials`,
+            title: <FormattedMessage
+                id="wizard.ConfigureAuthNameCredentials"
+                defaultMessage="Configure {name} credentials"
+                title={{ name: auth.name }}
+            />,
             fields: [
                 ...fields,
                 ...getAdditionalAuthFields(type.name, auth.type, appName),

--- a/packages/sources/src/addSourceWizard/steps/ErroredStep.js
+++ b/packages/sources/src/addSourceWizard/steps/ErroredStep.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import {
     EmptyStateBody,
@@ -71,9 +72,9 @@ ErroredStep.propTypes = {
 };
 
 ErroredStep.defaultProps = {
-    title: 'Configuration unsuccessful',
-    customText: 'Your source has not been successfully added:',
-    retryText: 'Retry'
+    title: <FormattedMessage id="wizard.unsuccConfiguration" defaultMessage="Configuration unsuccessful"/>,
+    customText: <FormattedMessage id="wizard.errorText" defaultMessage="Your source has not been successfully added:"/>,
+    retryText: <FormattedMessage id="wizard.retryText" defaultMessage="Retry"/>
 };
 
 export default ErroredStep;

--- a/packages/sources/src/addSourceWizard/steps/ErroredStep.js
+++ b/packages/sources/src/addSourceWizard/steps/ErroredStep.js
@@ -45,6 +45,7 @@ const ErroredStep = ({
                     label={progressTexts[progressStep]}
                     valueText={progressTexts[progressStep]}
                     variant='danger'
+                    id="errored-step-progress-bar"
                 />
                 <TextContent>
                     <Text variant={TextVariants.p}>{customText}</Text>
@@ -65,7 +66,7 @@ ErroredStep.propTypes = {
     returnButtonTitle: PropTypes.node.isRequired,
     message: PropTypes.node,
     progressStep: PropTypes.number.isRequired,
-    progressTexts: PropTypes.arrayOf(PropTypes.string).isRequired,
+    progressTexts: PropTypes.arrayOf(PropTypes.node).isRequired,
     title: PropTypes.node,
     customText: PropTypes.node,
     retryText: PropTypes.node

--- a/packages/sources/src/addSourceWizard/steps/FinishedStep.js
+++ b/packages/sources/src/addSourceWizard/steps/FinishedStep.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import {
     EmptyStateBody,
@@ -74,8 +75,8 @@ FinishedStep.propTypes = {
 };
 
 FinishedStep.defaultProps = {
-    title: 'Configuration successful',
-    linkText: 'Take me to sources'
+    title: <FormattedMessage id="wizard.succConfiguration" defaultMessage="Configuration successful"/>,
+    linkText: <FormattedMessage id="wizard.toSources" defaultMessage="Take me to sources"/>
 };
 
 export default FinishedStep;

--- a/packages/sources/src/addSourceWizard/steps/FinishedStep.js
+++ b/packages/sources/src/addSourceWizard/steps/FinishedStep.js
@@ -42,6 +42,7 @@ const FinishedStep = ({
                     label={progressTexts[progressStep]}
                     valueText={progressTexts[progressStep]}
                     variant="success"
+                    id="finished-progress-bar"
                 />
                 { successfulMessage }
             </EmptyStateBody>
@@ -68,7 +69,7 @@ FinishedStep.propTypes = {
     hideSourcesButton: PropTypes.bool,
     returnButtonTitle: PropTypes.node.isRequired,
     progressStep: PropTypes.number.isRequired,
-    progressTexts: PropTypes.arrayOf(PropTypes.string).isRequired,
+    progressTexts: PropTypes.arrayOf(PropTypes.node).isRequired,
     title: PropTypes.node,
     linkText: PropTypes.node,
     secondaryActions: PropTypes.node

--- a/packages/sources/src/addSourceWizard/steps/LoadingStep.js
+++ b/packages/sources/src/addSourceWizard/steps/LoadingStep.js
@@ -27,6 +27,7 @@ const LoadingStep = ({ onClose, customText, progressStep, progressTexts, cancelT
                         label={progressTexts[progressStep]}
                         valueText={progressTexts[progressStep]}
                         className="pf-u-mb-0 ins-c-sources__progress"
+                        id="loading-progress-bar"
                     />
                     : customText
                 }
@@ -43,7 +44,7 @@ LoadingStep.propTypes = {
     onClose: PropTypes.func,
     customText: PropTypes.node,
     progressStep: PropTypes.number,
-    progressTexts: PropTypes.arrayOf(PropTypes.string),
+    progressTexts: PropTypes.arrayOf(PropTypes.node),
     cancelTitle: PropTypes.node
 };
 

--- a/packages/sources/src/addSourceWizard/steps/LoadingStep.js
+++ b/packages/sources/src/addSourceWizard/steps/LoadingStep.js
@@ -11,6 +11,7 @@ import {
     Progress,
     EmptyStateIcon
 } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 const LoadingStep = ({ onClose, customText, progressStep, progressTexts, cancelTitle }) => (
     <Bullseye>
@@ -40,15 +41,15 @@ const LoadingStep = ({ onClose, customText, progressStep, progressTexts, cancelT
 
 LoadingStep.propTypes = {
     onClose: PropTypes.func,
-    customText: PropTypes.string,
+    customText: PropTypes.node,
     progressStep: PropTypes.number,
     progressTexts: PropTypes.arrayOf(PropTypes.string),
     cancelTitle: PropTypes.node
 };
 
 LoadingStep.defaultProps = {
-    customText: 'Loading, please wait.',
-    cancelTitle: 'Cancel'
+    customText: <FormattedMessage id="wizard.loadingText" defaultMessage="Loading, please wait."/>,
+    cancelTitle: <FormattedMessage id="wizard.cancelText" defaultMessage="Cancel"/>
 };
 
 export default LoadingStep;

--- a/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/AuthSelect.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Radio, FormHelperText } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-field-api';
+import { FormattedMessage } from 'react-intl';
 
 const AuthRadio = (props) => {
     const { label, input, authName, supportedAuthTypes, disableAuthType } = useFieldApi(props);
@@ -25,7 +26,7 @@ const AuthRadio = (props) => {
                 isDisabled={isDisabled}
             />
             {disableAuthType && !isSelected && <FormHelperText isHidden={false} className="pf-m-disabled">
-                You cannot change the authtype, when editing.
+                <FormattedMessage id="wizard.YouCannotChangeTheAuthtypeWhenEditing" defaultMessage="You cannot change the authtype, when editing." />
             </FormHelperText>}
         </React.Fragment>
     );

--- a/packages/sources/src/sourceFormRenderer/components/Authentication.js
+++ b/packages/sources/src/sourceFormRenderer/components/Authentication.js
@@ -3,6 +3,7 @@ import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/comp
 import componentMapper from '@data-driven-forms/pf4-component-mapper/dist/cjs/component-mapper';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
+import { FormattedMessage } from 'react-intl';
 
 const Authentication = (rest) => {
     const formOptions = useFormApi();
@@ -15,7 +16,11 @@ const Authentication = (rest) => {
         ...rest,
         ...(authentication && authentication.id ? {
             isRequired: false,
-            helperText: `Changing this resets your current ${rest.label}.`,
+            helperText: <FormattedMessage
+                id="wizard.ChangingThisResetsYourCurrentRestLabel"
+                defaultMessage="Changing this resets your current {label}."
+                values={{ label: rest.label }}
+            />,
             validate: doNotRequirePassword
         } : {})
     };

--- a/packages/sources/src/sourceFormRenderer/components/Authentication.js
+++ b/packages/sources/src/sourceFormRenderer/components/Authentication.js
@@ -4,6 +4,7 @@ import componentMapper from '@data-driven-forms/pf4-component-mapper/dist/cjs/co
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 import { FormattedMessage } from 'react-intl';
+import { FormHelperText } from '@patternfly/react-core';
 
 const Authentication = (rest) => {
     const formOptions = useFormApi();
@@ -16,11 +17,13 @@ const Authentication = (rest) => {
         ...rest,
         ...(authentication && authentication.id ? {
             isRequired: false,
-            helperText: <FormattedMessage
-                id="wizard.ChangingThisResetsYourCurrentRestLabel"
-                defaultMessage="Changing this resets your current {label}."
-                values={{ label: rest.label }}
-            />,
+            helperText: <FormHelperText isHidden={false}>
+                <FormattedMessage
+                    id="wizard.ChangingThisResetsYourCurrentRestLabel"
+                    defaultMessage="Changing this resets your current {label}."
+                    values={{ label: rest.label }}
+                />
+            </FormHelperText>,
             validate: doNotRequirePassword
         } : {})
     };

--- a/packages/sources/src/sourceFormRenderer/components/CardSelect.js
+++ b/packages/sources/src/sourceFormRenderer/components/CardSelect.js
@@ -95,10 +95,10 @@ const CardSelect = (originalProps) => {
 CardSelect.propTypes = {
     multi: PropTypes.bool,
     isMulti: PropTypes.bool,
-    label: PropTypes.string,
+    label: PropTypes.node,
     isRequired: PropTypes.bool,
-    helperText: PropTypes.string,
-    description: PropTypes.string,
+    helperText: PropTypes.node,
+    description: PropTypes.node,
     hideLabel: PropTypes.bool,
     name: PropTypes.string.isRequired,
     mutator: PropTypes.func,

--- a/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
+++ b/packages/sources/src/sourceFormRenderer/components/SourceWizardSummary.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 import { TextContent, TextListItem, TextListItemVariants, TextListVariants, TextList } from '@patternfly/react-core';
 import get from 'lodash/get';
 import hardcodedSchemas from '../../addSourceWizard/hardcodedSchemas';
@@ -30,7 +31,7 @@ export const createItem = (formField, values, stepKeys) => {
 
     // Boolean value convert to Yes / No
     if (typeof value === 'boolean') {
-        value = value ? 'Yes' : 'No';
+        value = value ? <FormattedMessage id="wizard.Yes" defaultMessage="Yes" /> : <FormattedMessage id="wizard.No" defaultMessage="No" />;
     }
 
     if (!value && formField.name === 'authentication.password' && get(values, 'authentication.id')) {
@@ -68,7 +69,7 @@ const SourceWizardSummary = ({ sourceTypes, applicationTypes, showApp, showAuthT
 
     const application = values.application ? applicationTypes.find(type => type.id === values.application.application_type_id) : undefined;
 
-    const { display_name = 'Not selected', name, id } = application ? application : {};
+    const { display_name = <FormattedMessage id="wizard.NotSelected" defaultMessage="Not selected" />, name, id } = application ? application : {};
 
     const skipEndpoint = shouldSkipEndpoint(type.name, hasAuthentication, name);
 
@@ -121,16 +122,16 @@ const SourceWizardSummary = ({ sourceTypes, applicationTypes, showApp, showAuthT
     return (
         <TextContent>
             <TextList component={ TextListVariants.dl }>
-                <TextListItem component={ TextListItemVariants.dt }>{ 'Name' }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dt }><FormattedMessage id="wizard.Name" defaultMessage="Name" /></TextListItem>
                 <TextListItem component={ TextListItemVariants.dd }>{ values.source.name }</TextListItem>
                 { showApp && <React.Fragment>
-                    <TextListItem component={ TextListItemVariants.dt }>{ 'Application' }</TextListItem>
+                    <TextListItem component={ TextListItemVariants.dt }><FormattedMessage id="wizard.Application" defaultMessage="Application" /></TextListItem>
                     <TextListItem component={ TextListItemVariants.dd }>{ display_name }</TextListItem>
                 </React.Fragment> }
-                <TextListItem component={ TextListItemVariants.dt }>{ 'Source type' }</TextListItem>
+                <TextListItem component={ TextListItemVariants.dt }><FormattedMessage id="wizard.SourceType" defaultMessage="Source type" /></TextListItem>
                 <TextListItem component={ TextListItemVariants.dd }>{ type.product_name }</TextListItem>
                 { !skipEndpoint && authType && showAuthType && <React.Fragment>
-                    <TextListItem component={ TextListItemVariants.dt }>{ 'Authentication type' }</TextListItem>
+                    <TextListItem component={ TextListItemVariants.dt }><FormattedMessage id="wizard.AuthenticationType" defaultMessage="Authentication type" /></TextListItem>
                     <TextListItem component={ TextListItemVariants.dd }>{ authType.name }</TextListItem>
                 </React.Fragment> }
                 { valuesList }

--- a/packages/sources/src/sourceFormRenderer/components/ValuePopover.js
+++ b/packages/sources/src/sourceFormRenderer/components/ValuePopover.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Popover } from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
 
 const ValuePopover = ({ label, value }) => (
     <Popover
@@ -9,7 +10,9 @@ const ValuePopover = ({ label, value }) => (
         position="top"
         maxWidth="80%"
     >
-        <Button variant="link" isInline className="ins-c-sources__wizard--summary-buttonss">Show more</Button>
+        <Button variant="link" isInline className="ins-c-sources__wizard--summary-buttonss">
+            <FormattedMessage id="wizard.ShowMore" defaultMessage="Show more" />
+        </Button>
     </Popover>
 );
 

--- a/packages/sources/src/tests/__mocks__/mount.js
+++ b/packages/sources/src/tests/__mocks__/mount.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { mount as mountEnzyme } from 'enzyme';
+
+const mount = (children) => mountEnzyme(<IntlProvider locale="en">
+    {children}
+</IntlProvider>);
+
+export default mount;

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/finalWizard.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/finalWizard.test.js.snap
@@ -1,138 +1,5407 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Final wizard Renders renders errored step correctly 1`] = `
-<Wizard
-  appendTo={null}
-  backButtonText="Back"
-  cancelButtonText="Cancel"
-  className=""
-  closeButtonAriaLabel="Close"
-  description="Connect a data source to use with your applications."
-  footer={null}
-  hasNoBodyPadding={false}
-  height={null}
-  hideClose={false}
-  isOpen={true}
-  navAriaLabel="Steps"
-  nextButtonText="Next"
-  onBack={null}
-  onClose={[MockFunction]}
-  onGoToStep={null}
-  onNext={null}
-  startAtStep={1}
-  steps={
-    Array [
-      Object {
-        "component": <ErroredStep
-          customText="Your source has not been successfully added:"
-          onClose={[MockFunction]}
-          onRetry={[MockFunction]}
-          progressStep={0}
-          progressTexts={
-            Array [
-              "Completed",
-            ]
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <FinalWizard
+    afterError={[MockFunction]}
+    afterSubmit={[MockFunction]}
+    hideSourcesButton={false}
+    isErrored={true}
+    isFinished={false}
+    onRetry={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Completed",
+      ]
+    }
+    returnButtonTitle="Go back to my application"
+    successfulMessage="Message"
+  >
+    <Wizard
+      appendTo={null}
+      backButtonText="Back"
+      cancelButtonText="Cancel"
+      className=""
+      closeButtonAriaLabel="Close"
+      description={
+        <FormattedMessage
+          defaultMessage="Connect a data source to use with your applications."
+          id="wizard.wizardDescription"
+        />
+      }
+      footer={null}
+      hasNoBodyPadding={false}
+      height={null}
+      hideClose={false}
+      isOpen={true}
+      navAriaLabel="Steps"
+      nextButtonText="Next"
+      onBack={null}
+      onClose={[MockFunction]}
+      onGoToStep={null}
+      onNext={null}
+      startAtStep={1}
+      steps={
+        Array [
+          Object {
+            "canJumpTo": true,
+            "component": <ErroredStep
+              customText={
+                <FormattedMessage
+                  defaultMessage="Your source has not been successfully added:"
+                  id="wizard.errorText"
+                />
+              }
+              onClose={[MockFunction]}
+              onRetry={[MockFunction]}
+              progressStep={0}
+              progressTexts={
+                Array [
+                  "Completed",
+                ]
+              }
+              retryText={
+                <FormattedMessage
+                  defaultMessage="Retry"
+                  id="wizard.retryText"
+                />
+              }
+              returnButtonTitle="Go back to my application"
+              title={
+                <FormattedMessage
+                  defaultMessage="Configuration unsuccessful"
+                  id="wizard.unsuccConfiguration"
+                />
+              }
+            />,
+            "isFinishedStep": true,
+            "name": "Finish",
+          },
+        ]
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Add source"
+          id="wizard.wizardTitle"
+        />
+      }
+      width={null}
+    >
+      <Modal
+        actions={Array []}
+        appendTo={
+          <body
+            class="pf-c-backdrop__open"
+          >
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-0"
+                    aria-labelledby="pf-wizard-title-0"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-0"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-0"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-0"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-1"
+                    aria-labelledby="pf-wizard-title-1"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-1"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-1"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-1"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-2"
+                    aria-labelledby="pf-wizard-title-2"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-2"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-2"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-2"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--success-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration successful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                                        id="finished-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="finished-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="finished-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      Message
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary pf-u-mt-xl"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <a
+                                        href="/hybrid/settings/sources"
+                                      >
+                                        <button
+                                          class="pf-c-button pf-m-link"
+                                          data-ouia-component-type="PF4/Button"
+                                          data-ouia-safe="true"
+                                          type="button"
+                                        >
+                                          Take me to sources
+                                        </button>
+                                      </a>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-3"
+                    aria-labelledby="pf-wizard-title-3"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-3"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-3"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-3"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--success-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration successful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                                        id="finished-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="finished-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="finished-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      Message
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary pf-u-mt-xl"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <a
+                                        href="/hybrid/settings/sources"
+                                      >
+                                        <button
+                                          class="pf-c-button pf-m-link"
+                                          data-ouia-component-type="PF4/Button"
+                                          data-ouia-safe="true"
+                                          type="button"
+                                        >
+                                          Take me to sources
+                                        </button>
+                                      </a>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-4"
+                    aria-labelledby="pf-wizard-title-4"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-4"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-4"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-4"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--danger-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration unsuccessful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-danger pf-u-mb-md ins-c-sources__progress"
+                                        id="errored-step-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="errored-step-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="errored-step-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="pf-c-content"
+                                      >
+                                        <p
+                                          class=""
+                                          data-pf-content="true"
+                                          variant="p"
+                                        >
+                                          Your source has not been successfully added:
+                                        </p>
+                                      </div>
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <button
+                                        class="pf-c-button pf-m-link"
+                                        data-ouia-component-type="PF4/Button"
+                                        data-ouia-safe="true"
+                                        type="button"
+                                      >
+                                        Retry
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        }
+        aria-describedby="pf-wizard-description-4"
+        aria-label=""
+        aria-labelledby="pf-wizard-title-4"
+        className=""
+        hasNoBodyWrapper={true}
+        isOpen={true}
+        onClose={[Function]}
+        showClose={false}
+        title=""
+        variant="large"
+      >
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-4"
+                    aria-labelledby="pf-wizard-title-4"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-4"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-4"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-4"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--danger-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration unsuccessful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-danger pf-u-mb-md ins-c-sources__progress"
+                                        id="errored-step-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="errored-step-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="errored-step-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="pf-c-content"
+                                      >
+                                        <p
+                                          class=""
+                                          data-pf-content="true"
+                                          variant="p"
+                                        >
+                                          Your source has not been successfully added:
+                                        </p>
+                                      </div>
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <button
+                                        class="pf-c-button pf-m-link"
+                                        data-ouia-component-type="PF4/Button"
+                                        data-ouia-safe="true"
+                                        type="button"
+                                      >
+                                        Retry
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           }
-          retryText="Retry"
-          returnButtonTitle="Go back to my application"
-          title="Configuration unsuccessful"
-        />,
-        "isFinishedStep": true,
-        "name": "Finish",
-      },
-    ]
-  }
-  title="Add source"
-  width={null}
-/>
+        >
+          <Component
+            actions={Array []}
+            aria-describedby="pf-wizard-description-4"
+            aria-label=""
+            aria-labelledby="pf-wizard-title-4"
+            boxId="pf-modal-part-4"
+            className=""
+            descriptorId="pf-modal-part-6"
+            hasNoBodyWrapper={true}
+            isOpen={true}
+            labelId="pf-modal-part-5"
+            onClose={[Function]}
+            showClose={false}
+            title=""
+            variant="large"
+          >
+            <Component>
+              <div
+                className="pf-c-backdrop"
+              >
+                <FocusTrap
+                  active={true}
+                  className="pf-l-bullseye"
+                  focusTrapOptions={
+                    Object {
+                      "clickOutsideDeactivates": true,
+                    }
+                  }
+                  paused={false}
+                >
+                  <div
+                    className="pf-l-bullseye"
+                  >
+                    <Component
+                      aria-describedby="pf-wizard-description-4"
+                      aria-label=""
+                      aria-labelledby="pf-wizard-title-4"
+                      className=""
+                      id="pf-modal-part-4"
+                      style={Object {}}
+                      variant="large"
+                    >
+                      <div
+                        aria-describedby="pf-wizard-description-4"
+                        aria-label={null}
+                        aria-labelledby="pf-wizard-title-4"
+                        aria-modal="true"
+                        className="pf-c-modal-box pf-m-lg"
+                        id="pf-modal-part-4"
+                        role="dialog"
+                        style={Object {}}
+                      >
+                        <div
+                          className="pf-c-wizard pf-m-finished"
+                        >
+                          <Component
+                            closeButtonAriaLabel="Close"
+                            description={
+                              <FormattedMessage
+                                defaultMessage="Connect a data source to use with your applications."
+                                id="wizard.wizardDescription"
+                              />
+                            }
+                            descriptionId="pf-wizard-description-4"
+                            hideClose={false}
+                            onClose={[MockFunction]}
+                            title={
+                              <FormattedMessage
+                                defaultMessage="Add source"
+                                id="wizard.wizardTitle"
+                              />
+                            }
+                            titleId="pf-wizard-title-4"
+                          >
+                            <div
+                              className="pf-c-wizard__header"
+                            >
+                              <Component
+                                aria-label="Close"
+                                className="pf-c-wizard__close"
+                                onClick={[MockFunction]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={null}
+                                  aria-label="Close"
+                                  className="pf-c-button pf-m-plain pf-c-wizard__close"
+                                  data-ouia-component-id={null}
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[MockFunction]}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Component>
+                              <Component
+                                aria-label={
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  />
+                                }
+                                className="pf-c-wizard__title"
+                                headingLevel="h2"
+                                id="pf-wizard-title-4"
+                                size="3xl"
+                              >
+                                <h2
+                                  aria-label={
+                                    <FormattedMessage
+                                      defaultMessage="Add source"
+                                      id="wizard.wizardTitle"
+                                    />
+                                  }
+                                  className="pf-c-title pf-m-3xl pf-c-wizard__title"
+                                  id="pf-wizard-title-4"
+                                >
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  >
+                                    Add source
+                                  </FormattedMessage>
+                                </h2>
+                              </Component>
+                              <p
+                                className="pf-c-wizard__description"
+                                id="pf-wizard-description-4"
+                              >
+                                <FormattedMessage
+                                  defaultMessage="Connect a data source to use with your applications."
+                                  id="wizard.wizardDescription"
+                                >
+                                  Connect a data source to use with your applications.
+                                </FormattedMessage>
+                              </p>
+                            </div>
+                          </Component>
+                          <Component
+                            activeStep={
+                              Object {
+                                "component": <ErroredStep
+                                  customText={
+                                    <FormattedMessage
+                                      defaultMessage="Your source has not been successfully added:"
+                                      id="wizard.errorText"
+                                    />
+                                  }
+                                  onClose={[MockFunction]}
+                                  onRetry={[MockFunction]}
+                                  progressStep={0}
+                                  progressTexts={
+                                    Array [
+                                      "Completed",
+                                    ]
+                                  }
+                                  retryText={
+                                    <FormattedMessage
+                                      defaultMessage="Retry"
+                                      id="wizard.retryText"
+                                    />
+                                  }
+                                  returnButtonTitle="Go back to my application"
+                                  title={
+                                    <FormattedMessage
+                                      defaultMessage="Configuration unsuccessful"
+                                      id="wizard.unsuccConfiguration"
+                                    />
+                                  }
+                                />,
+                                "isFinishedStep": true,
+                                "name": "Finish",
+                              }
+                            }
+                            hasNoBodyPadding={false}
+                            isNavOpen={false}
+                            nav={[Function]}
+                            onNavToggle={[Function]}
+                            steps={
+                              Array [
+                                Object {
+                                  "canJumpTo": true,
+                                  "component": <ErroredStep
+                                    customText={
+                                      <FormattedMessage
+                                        defaultMessage="Your source has not been successfully added:"
+                                        id="wizard.errorText"
+                                      />
+                                    }
+                                    onClose={[MockFunction]}
+                                    onRetry={[MockFunction]}
+                                    progressStep={0}
+                                    progressTexts={
+                                      Array [
+                                        "Completed",
+                                      ]
+                                    }
+                                    retryText={
+                                      <FormattedMessage
+                                        defaultMessage="Retry"
+                                        id="wizard.retryText"
+                                      />
+                                    }
+                                    returnButtonTitle="Go back to my application"
+                                    title={
+                                      <FormattedMessage
+                                        defaultMessage="Configuration unsuccessful"
+                                        id="wizard.unsuccConfiguration"
+                                      />
+                                    }
+                                  />,
+                                  "isFinishedStep": true,
+                                  "name": "Finish",
+                                },
+                              ]
+                            }
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-label="Wizard Toggle"
+                              className="pf-c-wizard__toggle"
+                              onClick={[Function]}
+                            >
+                              <ol
+                                className="pf-c-wizard__toggle-list"
+                              >
+                                <li
+                                  className="pf-c-wizard__toggle-list-item"
+                                >
+                                  <span
+                                    className="pf-c-wizard__toggle-num"
+                                  >
+                                    1
+                                  </span>
+                                   
+                                  Finish
+                                </li>
+                              </ol>
+                              <span
+                                className="pf-c-wizard__toggle-icon"
+                              >
+                                <CaretDownIcon
+                                  aria-hidden="true"
+                                  color="currentColor"
+                                  noVerticalAlign={false}
+                                  size="sm"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-labelledby={null}
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style={
+                                      Object {
+                                        "verticalAlign": "-0.125em",
+                                      }
+                                    }
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      transform=""
+                                    />
+                                  </svg>
+                                </CaretDownIcon>
+                              </span>
+                            </button>
+                            <div
+                              className="pf-c-wizard__outer-wrap"
+                            >
+                              <div
+                                className="pf-c-wizard__inner-wrap"
+                              >
+                                <Component
+                                  aria-label="Steps"
+                                  isOpen={false}
+                                >
+                                  <nav
+                                    aria-label="Steps"
+                                    className="pf-c-wizard__nav"
+                                  >
+                                    <ol
+                                      className="pf-c-wizard__nav-list"
+                                    />
+                                  </nav>
+                                </Component>
+                                <Component
+                                  hasNoBodyPadding={false}
+                                >
+                                  <main
+                                    className="pf-c-wizard__main"
+                                  >
+                                    <div
+                                      className="pf-c-wizard__main-body"
+                                    >
+                                      <ErroredStep
+                                        customText={
+                                          <FormattedMessage
+                                            defaultMessage="Your source has not been successfully added:"
+                                            id="wizard.errorText"
+                                          />
+                                        }
+                                        onClose={[MockFunction]}
+                                        onRetry={[MockFunction]}
+                                        progressStep={0}
+                                        progressTexts={
+                                          Array [
+                                            "Completed",
+                                          ]
+                                        }
+                                        retryText={
+                                          <FormattedMessage
+                                            defaultMessage="Retry"
+                                            id="wizard.retryText"
+                                          />
+                                        }
+                                        returnButtonTitle="Go back to my application"
+                                        title={
+                                          <FormattedMessage
+                                            defaultMessage="Configuration unsuccessful"
+                                            id="wizard.unsuccConfiguration"
+                                          />
+                                        }
+                                      >
+                                        <Component>
+                                          <div
+                                            className="pf-l-bullseye"
+                                          >
+                                            <Component
+                                              className="ins-c-sources__empty-state"
+                                              variant="full"
+                                            >
+                                              <div
+                                                className="pf-c-empty-state ins-c-sources__empty-state"
+                                              >
+                                                <div
+                                                  className="pf-c-empty-state__content"
+                                                >
+                                                  <Component
+                                                    className="pf-u-mb-0"
+                                                    color="var(--pf-global--danger-color--100)"
+                                                    icon={[Function]}
+                                                  >
+                                                    <TimesCircleIcon
+                                                      aria-hidden="true"
+                                                      className="pf-c-empty-state__icon pf-u-mb-0"
+                                                      color="var(--pf-global--danger-color--100)"
+                                                      noVerticalAlign={false}
+                                                      size="sm"
+                                                    >
+                                                      <svg
+                                                        aria-hidden="true"
+                                                        aria-labelledby={null}
+                                                        className="pf-c-empty-state__icon pf-u-mb-0"
+                                                        fill="var(--pf-global--danger-color--100)"
+                                                        height="1em"
+                                                        role="img"
+                                                        style={
+                                                          Object {
+                                                            "verticalAlign": "-0.125em",
+                                                          }
+                                                        }
+                                                        viewBox="0 0 512 512"
+                                                        width="1em"
+                                                      >
+                                                        <path
+                                                          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                          transform=""
+                                                        />
+                                                      </svg>
+                                                    </TimesCircleIcon>
+                                                  </Component>
+                                                  <Component
+                                                    className="pf-u-mt-xl"
+                                                    headingLevel="h5"
+                                                    size="lg"
+                                                  >
+                                                    <h5
+                                                      className="pf-c-title pf-m-lg pf-u-mt-xl"
+                                                    >
+                                                      <FormattedMessage
+                                                        defaultMessage="Configuration unsuccessful"
+                                                        id="wizard.unsuccConfiguration"
+                                                      >
+                                                        Configuration unsuccessful
+                                                      </FormattedMessage>
+                                                    </h5>
+                                                  </Component>
+                                                  <Component>
+                                                    <div
+                                                      className="pf-c-empty-state__body"
+                                                    >
+                                                      <Progress
+                                                        className="pf-u-mb-md ins-c-sources__progress"
+                                                        id="errored-step-progress-bar"
+                                                        label="Completed"
+                                                        max={0}
+                                                        measureLocation="top"
+                                                        min={0}
+                                                        size={null}
+                                                        title=" "
+                                                        value={0}
+                                                        valueText="Completed"
+                                                        variant="danger"
+                                                      >
+                                                        <div
+                                                          className="pf-c-progress pf-m-danger pf-u-mb-md ins-c-sources__progress"
+                                                          id="errored-step-progress-bar"
+                                                        >
+                                                          <Component
+                                                            label="Completed"
+                                                            measureLocation="top"
+                                                            parentId="errored-step-progress-bar"
+                                                            progressBarAriaProps={
+                                                              Object {
+                                                                "aria-labelledby": "errored-step-progress-bar-description",
+                                                                "aria-valuemax": 0,
+                                                                "aria-valuemin": 0,
+                                                                "aria-valuenow": 0,
+                                                                "aria-valuetext": "Completed",
+                                                              }
+                                                            }
+                                                            title=" "
+                                                            value={NaN}
+                                                            variant="danger"
+                                                          >
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__description"
+                                                              id="errored-step-progress-bar-description"
+                                                            >
+                                                               
+                                                            </div>
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__status"
+                                                            >
+                                                              <span
+                                                                className="pf-c-progress__measure"
+                                                              >
+                                                                Completed
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-progress__status-icon"
+                                                              >
+                                                                <TimesCircleIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                                                      transform=""
+                                                                    />
+                                                                  </svg>
+                                                                </TimesCircleIcon>
+                                                              </span>
+                                                            </div>
+                                                            <Component
+                                                              progressBarAriaProps={
+                                                                Object {
+                                                                  "aria-labelledby": "errored-step-progress-bar-description",
+                                                                  "aria-valuemax": 0,
+                                                                  "aria-valuemin": 0,
+                                                                  "aria-valuenow": 0,
+                                                                  "aria-valuetext": "Completed",
+                                                                }
+                                                              }
+                                                              role="progressbar"
+                                                              value={NaN}
+                                                            >
+                                                              <div
+                                                                aria-labelledby="errored-step-progress-bar-description"
+                                                                aria-valuemax={0}
+                                                                aria-valuemin={0}
+                                                                aria-valuenow={0}
+                                                                aria-valuetext="Completed"
+                                                                className="pf-c-progress__bar"
+                                                                role="progressbar"
+                                                              >
+                                                                <div
+                                                                  className="pf-c-progress__indicator"
+                                                                  style={
+                                                                    Object {
+                                                                      "width": "NaN%",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <span
+                                                                    className="pf-c-progress__measure"
+                                                                  />
+                                                                </div>
+                                                              </div>
+                                                            </Component>
+                                                          </Component>
+                                                        </div>
+                                                      </Progress>
+                                                      <Component>
+                                                        <div
+                                                          className="pf-c-content"
+                                                        >
+                                                          <Component
+                                                            variant="p"
+                                                          >
+                                                            <p
+                                                              className=""
+                                                              data-pf-content={true}
+                                                              variant="p"
+                                                            >
+                                                              <FormattedMessage
+                                                                defaultMessage="Your source has not been successfully added:"
+                                                                id="wizard.errorText"
+                                                              >
+                                                                Your source has not been successfully added:
+                                                              </FormattedMessage>
+                                                            </p>
+                                                          </Component>
+                                                        </div>
+                                                      </Component>
+                                                    </div>
+                                                  </Component>
+                                                  <Component
+                                                    onClick={[MockFunction]}
+                                                    variant="primary"
+                                                  >
+                                                    <button
+                                                      aria-disabled={null}
+                                                      aria-label={null}
+                                                      className="pf-c-button pf-m-primary"
+                                                      data-ouia-component-id={null}
+                                                      data-ouia-component-type="PF4/Button"
+                                                      data-ouia-safe={true}
+                                                      disabled={false}
+                                                      onClick={[MockFunction]}
+                                                      tabIndex={null}
+                                                      type="button"
+                                                    >
+                                                      Go back to my application
+                                                    </button>
+                                                  </Component>
+                                                  <Component>
+                                                    <div
+                                                      className="pf-c-empty-state__secondary"
+                                                    >
+                                                      <Component
+                                                        onClick={[MockFunction]}
+                                                        variant="link"
+                                                      >
+                                                        <button
+                                                          aria-disabled={null}
+                                                          aria-label={null}
+                                                          className="pf-c-button pf-m-link"
+                                                          data-ouia-component-id={null}
+                                                          data-ouia-component-type="PF4/Button"
+                                                          data-ouia-safe={true}
+                                                          disabled={false}
+                                                          onClick={[MockFunction]}
+                                                          tabIndex={null}
+                                                          type="button"
+                                                        >
+                                                          <FormattedMessage
+                                                            defaultMessage="Retry"
+                                                            id="wizard.retryText"
+                                                          >
+                                                            Retry
+                                                          </FormattedMessage>
+                                                        </button>
+                                                      </Component>
+                                                    </div>
+                                                  </Component>
+                                                </div>
+                                              </div>
+                                            </Component>
+                                          </div>
+                                        </Component>
+                                      </ErroredStep>
+                                    </div>
+                                  </main>
+                                </Component>
+                              </div>
+                              <Component
+                                activeStep={
+                                  Object {
+                                    "component": <ErroredStep
+                                      customText={
+                                        <FormattedMessage
+                                          defaultMessage="Your source has not been successfully added:"
+                                          id="wizard.errorText"
+                                        />
+                                      }
+                                      onClose={[MockFunction]}
+                                      onRetry={[MockFunction]}
+                                      progressStep={0}
+                                      progressTexts={
+                                        Array [
+                                          "Completed",
+                                        ]
+                                      }
+                                      retryText={
+                                        <FormattedMessage
+                                          defaultMessage="Retry"
+                                          id="wizard.retryText"
+                                        />
+                                      }
+                                      returnButtonTitle="Go back to my application"
+                                      title={
+                                        <FormattedMessage
+                                          defaultMessage="Configuration unsuccessful"
+                                          id="wizard.unsuccConfiguration"
+                                        />
+                                      }
+                                    />,
+                                    "isFinishedStep": true,
+                                    "name": "Finish",
+                                  }
+                                }
+                                backButtonText="Back"
+                                cancelButtonText="Cancel"
+                                firstStep={true}
+                                isValid={true}
+                                nextButtonText="Next"
+                                onBack={[Function]}
+                                onClose={[MockFunction]}
+                                onNext={[Function]}
+                              >
+                                <footer
+                                  className="pf-c-wizard__footer"
+                                >
+                                  <Component
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                    variant="primary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-primary"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="submit"
+                                    >
+                                      Next
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    className="pf-m-disabled"
+                                    onClick={[Function]}
+                                    variant="secondary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-secondary pf-m-disabled"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Back
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    onClick={[MockFunction]}
+                                    variant="link"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-link"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[MockFunction]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Component>
+                                </footer>
+                              </Component>
+                            </div>
+                          </Component>
+                        </div>
+                      </div>
+                    </Component>
+                  </div>
+                </FocusTrap>
+              </div>
+            </Component>
+          </Component>
+        </Portal>
+      </Modal>
+    </Wizard>
+  </FinalWizard>
+</IntlProvider>
 `;
 
 exports[`Final wizard Renders renders finished step correctly 1`] = `
-<Wizard
-  appendTo={null}
-  backButtonText="Back"
-  cancelButtonText="Cancel"
-  className=""
-  closeButtonAriaLabel="Close"
-  description="Connect a data source to use with your applications."
-  footer={null}
-  hasNoBodyPadding={false}
-  height={null}
-  hideClose={false}
-  isOpen={true}
-  navAriaLabel="Steps"
-  nextButtonText="Next"
-  onBack={null}
-  onClose={[MockFunction]}
-  onGoToStep={null}
-  onNext={null}
-  startAtStep={1}
-  steps={
-    Array [
-      Object {
-        "component": <FinishedStep
-          hideSourcesButton={false}
-          linkText="Take me to sources"
-          onClose={[MockFunction]}
-          progressStep={0}
-          progressTexts={
-            Array [
-              "Completed",
-            ]
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <FinalWizard
+    afterError={[MockFunction]}
+    afterSubmit={[MockFunction]}
+    hideSourcesButton={false}
+    isErrored={false}
+    isFinished={true}
+    onRetry={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Completed",
+      ]
+    }
+    returnButtonTitle="Go back to my application"
+    successfulMessage="Message"
+  >
+    <Wizard
+      appendTo={null}
+      backButtonText="Back"
+      cancelButtonText="Cancel"
+      className=""
+      closeButtonAriaLabel="Close"
+      description={
+        <FormattedMessage
+          defaultMessage="Connect a data source to use with your applications."
+          id="wizard.wizardDescription"
+        />
+      }
+      footer={null}
+      hasNoBodyPadding={false}
+      height={null}
+      hideClose={false}
+      isOpen={true}
+      navAriaLabel="Steps"
+      nextButtonText="Next"
+      onBack={null}
+      onClose={[MockFunction]}
+      onGoToStep={null}
+      onNext={null}
+      startAtStep={1}
+      steps={
+        Array [
+          Object {
+            "canJumpTo": true,
+            "component": <FinishedStep
+              hideSourcesButton={false}
+              linkText={
+                <FormattedMessage
+                  defaultMessage="Take me to sources"
+                  id="wizard.toSources"
+                />
+              }
+              onClose={[MockFunction]}
+              progressStep={0}
+              progressTexts={
+                Array [
+                  "Completed",
+                ]
+              }
+              returnButtonTitle="Go back to my application"
+              successfulMessage="Message"
+              title={
+                <FormattedMessage
+                  defaultMessage="Configuration successful"
+                  id="wizard.succConfiguration"
+                />
+              }
+            />,
+            "isFinishedStep": true,
+            "name": "Finish",
+          },
+        ]
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Add source"
+          id="wizard.wizardTitle"
+        />
+      }
+      width={null}
+    >
+      <Modal
+        actions={Array []}
+        appendTo={
+          <body
+            class="pf-c-backdrop__open"
+          >
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-0"
+                    aria-labelledby="pf-wizard-title-0"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-0"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-0"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-0"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+            >
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-1"
+                    aria-labelledby="pf-wizard-title-1"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-1"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-1"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-1"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-2"
+                    aria-labelledby="pf-wizard-title-2"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-2"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-2"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-2"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--success-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration successful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                                        id="finished-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="finished-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="finished-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      Message
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary pf-u-mt-xl"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <a
+                                        href="/hybrid/settings/sources"
+                                      >
+                                        <button
+                                          class="pf-c-button pf-m-link"
+                                          data-ouia-component-type="PF4/Button"
+                                          data-ouia-safe="true"
+                                          type="button"
+                                        >
+                                          Take me to sources
+                                        </button>
+                                      </a>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        }
+        aria-describedby="pf-wizard-description-2"
+        aria-label=""
+        aria-labelledby="pf-wizard-title-2"
+        className=""
+        hasNoBodyWrapper={true}
+        isOpen={true}
+        onClose={[Function]}
+        showClose={false}
+        title=""
+        variant="large"
+      >
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-2"
+                    aria-labelledby="pf-wizard-title-2"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-2"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-2"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-2"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="pf-c-empty-state__icon pf-u-mb-0"
+                                      fill="var(--pf-global--success-color--100)"
+                                      height="1em"
+                                      role="img"
+                                      style="vertical-align: -0.125em;"
+                                      viewBox="0 0 512 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                    <h5
+                                      class="pf-c-title pf-m-lg pf-u-mt-xl"
+                                    >
+                                      Configuration successful
+                                    </h5>
+                                    <div
+                                      class="pf-c-empty-state__body"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                                        id="finished-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="finished-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                          <span
+                                            class="pf-c-progress__status-icon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              fill="currentColor"
+                                              height="1em"
+                                              role="img"
+                                              style="vertical-align: -0.125em;"
+                                              viewBox="0 0 512 512"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                transform=""
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="finished-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                      Message
+                                    </div>
+                                    <button
+                                      class="pf-c-button pf-m-primary pf-u-mt-xl"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe="true"
+                                      type="button"
+                                    >
+                                      Go back to my application
+                                    </button>
+                                    <div
+                                      class="pf-c-empty-state__secondary"
+                                    >
+                                      <a
+                                        href="/hybrid/settings/sources"
+                                      >
+                                        <button
+                                          class="pf-c-button pf-m-link"
+                                          data-ouia-component-type="PF4/Button"
+                                          data-ouia-safe="true"
+                                          type="button"
+                                        >
+                                          Take me to sources
+                                        </button>
+                                      </a>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           }
-          returnButtonTitle="Go back to my application"
-          successfulMessage="Message"
-          title="Configuration successful"
-        />,
-        "isFinishedStep": true,
-        "name": "Finish",
-      },
-    ]
-  }
-  title="Add source"
-  width={null}
-/>
+        >
+          <Component
+            actions={Array []}
+            aria-describedby="pf-wizard-description-2"
+            aria-label=""
+            aria-labelledby="pf-wizard-title-2"
+            boxId="pf-modal-part-2"
+            className=""
+            descriptorId="pf-modal-part-4"
+            hasNoBodyWrapper={true}
+            isOpen={true}
+            labelId="pf-modal-part-3"
+            onClose={[Function]}
+            showClose={false}
+            title=""
+            variant="large"
+          >
+            <Component>
+              <div
+                className="pf-c-backdrop"
+              >
+                <FocusTrap
+                  active={true}
+                  className="pf-l-bullseye"
+                  focusTrapOptions={
+                    Object {
+                      "clickOutsideDeactivates": true,
+                    }
+                  }
+                  paused={false}
+                >
+                  <div
+                    className="pf-l-bullseye"
+                  >
+                    <Component
+                      aria-describedby="pf-wizard-description-2"
+                      aria-label=""
+                      aria-labelledby="pf-wizard-title-2"
+                      className=""
+                      id="pf-modal-part-2"
+                      style={Object {}}
+                      variant="large"
+                    >
+                      <div
+                        aria-describedby="pf-wizard-description-2"
+                        aria-label={null}
+                        aria-labelledby="pf-wizard-title-2"
+                        aria-modal="true"
+                        className="pf-c-modal-box pf-m-lg"
+                        id="pf-modal-part-2"
+                        role="dialog"
+                        style={Object {}}
+                      >
+                        <div
+                          className="pf-c-wizard pf-m-finished"
+                        >
+                          <Component
+                            closeButtonAriaLabel="Close"
+                            description={
+                              <FormattedMessage
+                                defaultMessage="Connect a data source to use with your applications."
+                                id="wizard.wizardDescription"
+                              />
+                            }
+                            descriptionId="pf-wizard-description-2"
+                            hideClose={false}
+                            onClose={[MockFunction]}
+                            title={
+                              <FormattedMessage
+                                defaultMessage="Add source"
+                                id="wizard.wizardTitle"
+                              />
+                            }
+                            titleId="pf-wizard-title-2"
+                          >
+                            <div
+                              className="pf-c-wizard__header"
+                            >
+                              <Component
+                                aria-label="Close"
+                                className="pf-c-wizard__close"
+                                onClick={[MockFunction]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={null}
+                                  aria-label="Close"
+                                  className="pf-c-button pf-m-plain pf-c-wizard__close"
+                                  data-ouia-component-id={null}
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[MockFunction]}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Component>
+                              <Component
+                                aria-label={
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  />
+                                }
+                                className="pf-c-wizard__title"
+                                headingLevel="h2"
+                                id="pf-wizard-title-2"
+                                size="3xl"
+                              >
+                                <h2
+                                  aria-label={
+                                    <FormattedMessage
+                                      defaultMessage="Add source"
+                                      id="wizard.wizardTitle"
+                                    />
+                                  }
+                                  className="pf-c-title pf-m-3xl pf-c-wizard__title"
+                                  id="pf-wizard-title-2"
+                                >
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  >
+                                    Add source
+                                  </FormattedMessage>
+                                </h2>
+                              </Component>
+                              <p
+                                className="pf-c-wizard__description"
+                                id="pf-wizard-description-2"
+                              >
+                                <FormattedMessage
+                                  defaultMessage="Connect a data source to use with your applications."
+                                  id="wizard.wizardDescription"
+                                >
+                                  Connect a data source to use with your applications.
+                                </FormattedMessage>
+                              </p>
+                            </div>
+                          </Component>
+                          <Component
+                            activeStep={
+                              Object {
+                                "component": <FinishedStep
+                                  hideSourcesButton={false}
+                                  linkText={
+                                    <FormattedMessage
+                                      defaultMessage="Take me to sources"
+                                      id="wizard.toSources"
+                                    />
+                                  }
+                                  onClose={[MockFunction]}
+                                  progressStep={0}
+                                  progressTexts={
+                                    Array [
+                                      "Completed",
+                                    ]
+                                  }
+                                  returnButtonTitle="Go back to my application"
+                                  successfulMessage="Message"
+                                  title={
+                                    <FormattedMessage
+                                      defaultMessage="Configuration successful"
+                                      id="wizard.succConfiguration"
+                                    />
+                                  }
+                                />,
+                                "isFinishedStep": true,
+                                "name": "Finish",
+                              }
+                            }
+                            hasNoBodyPadding={false}
+                            isNavOpen={false}
+                            nav={[Function]}
+                            onNavToggle={[Function]}
+                            steps={
+                              Array [
+                                Object {
+                                  "canJumpTo": true,
+                                  "component": <FinishedStep
+                                    hideSourcesButton={false}
+                                    linkText={
+                                      <FormattedMessage
+                                        defaultMessage="Take me to sources"
+                                        id="wizard.toSources"
+                                      />
+                                    }
+                                    onClose={[MockFunction]}
+                                    progressStep={0}
+                                    progressTexts={
+                                      Array [
+                                        "Completed",
+                                      ]
+                                    }
+                                    returnButtonTitle="Go back to my application"
+                                    successfulMessage="Message"
+                                    title={
+                                      <FormattedMessage
+                                        defaultMessage="Configuration successful"
+                                        id="wizard.succConfiguration"
+                                      />
+                                    }
+                                  />,
+                                  "isFinishedStep": true,
+                                  "name": "Finish",
+                                },
+                              ]
+                            }
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-label="Wizard Toggle"
+                              className="pf-c-wizard__toggle"
+                              onClick={[Function]}
+                            >
+                              <ol
+                                className="pf-c-wizard__toggle-list"
+                              >
+                                <li
+                                  className="pf-c-wizard__toggle-list-item"
+                                >
+                                  <span
+                                    className="pf-c-wizard__toggle-num"
+                                  >
+                                    1
+                                  </span>
+                                   
+                                  Finish
+                                </li>
+                              </ol>
+                              <span
+                                className="pf-c-wizard__toggle-icon"
+                              >
+                                <CaretDownIcon
+                                  aria-hidden="true"
+                                  color="currentColor"
+                                  noVerticalAlign={false}
+                                  size="sm"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-labelledby={null}
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style={
+                                      Object {
+                                        "verticalAlign": "-0.125em",
+                                      }
+                                    }
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      transform=""
+                                    />
+                                  </svg>
+                                </CaretDownIcon>
+                              </span>
+                            </button>
+                            <div
+                              className="pf-c-wizard__outer-wrap"
+                            >
+                              <div
+                                className="pf-c-wizard__inner-wrap"
+                              >
+                                <Component
+                                  aria-label="Steps"
+                                  isOpen={false}
+                                >
+                                  <nav
+                                    aria-label="Steps"
+                                    className="pf-c-wizard__nav"
+                                  >
+                                    <ol
+                                      className="pf-c-wizard__nav-list"
+                                    />
+                                  </nav>
+                                </Component>
+                                <Component
+                                  hasNoBodyPadding={false}
+                                >
+                                  <main
+                                    className="pf-c-wizard__main"
+                                  >
+                                    <div
+                                      className="pf-c-wizard__main-body"
+                                    >
+                                      <FinishedStep
+                                        hideSourcesButton={false}
+                                        linkText={
+                                          <FormattedMessage
+                                            defaultMessage="Take me to sources"
+                                            id="wizard.toSources"
+                                          />
+                                        }
+                                        onClose={[MockFunction]}
+                                        progressStep={0}
+                                        progressTexts={
+                                          Array [
+                                            "Completed",
+                                          ]
+                                        }
+                                        returnButtonTitle="Go back to my application"
+                                        successfulMessage="Message"
+                                        title={
+                                          <FormattedMessage
+                                            defaultMessage="Configuration successful"
+                                            id="wizard.succConfiguration"
+                                          />
+                                        }
+                                      >
+                                        <Component>
+                                          <div
+                                            className="pf-l-bullseye"
+                                          >
+                                            <Component
+                                              className="ins-c-sources__empty-state"
+                                              variant="full"
+                                            >
+                                              <div
+                                                className="pf-c-empty-state ins-c-sources__empty-state"
+                                              >
+                                                <div
+                                                  className="pf-c-empty-state__content"
+                                                >
+                                                  <Component
+                                                    className="pf-u-mb-0"
+                                                    color="var(--pf-global--success-color--100)"
+                                                    icon={[Function]}
+                                                  >
+                                                    <CheckCircleIcon
+                                                      aria-hidden="true"
+                                                      className="pf-c-empty-state__icon pf-u-mb-0"
+                                                      color="var(--pf-global--success-color--100)"
+                                                      noVerticalAlign={false}
+                                                      size="sm"
+                                                    >
+                                                      <svg
+                                                        aria-hidden="true"
+                                                        aria-labelledby={null}
+                                                        className="pf-c-empty-state__icon pf-u-mb-0"
+                                                        fill="var(--pf-global--success-color--100)"
+                                                        height="1em"
+                                                        role="img"
+                                                        style={
+                                                          Object {
+                                                            "verticalAlign": "-0.125em",
+                                                          }
+                                                        }
+                                                        viewBox="0 0 512 512"
+                                                        width="1em"
+                                                      >
+                                                        <path
+                                                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                          transform=""
+                                                        />
+                                                      </svg>
+                                                    </CheckCircleIcon>
+                                                  </Component>
+                                                  <Component
+                                                    className="pf-u-mt-xl"
+                                                    headingLevel="h5"
+                                                    size="lg"
+                                                  >
+                                                    <h5
+                                                      className="pf-c-title pf-m-lg pf-u-mt-xl"
+                                                    >
+                                                      <FormattedMessage
+                                                        defaultMessage="Configuration successful"
+                                                        id="wizard.succConfiguration"
+                                                      >
+                                                        Configuration successful
+                                                      </FormattedMessage>
+                                                    </h5>
+                                                  </Component>
+                                                  <Component>
+                                                    <div
+                                                      className="pf-c-empty-state__body"
+                                                    >
+                                                      <Progress
+                                                        className="pf-u-mb-md ins-c-sources__progress"
+                                                        id="finished-progress-bar"
+                                                        label="Completed"
+                                                        max={0}
+                                                        measureLocation="top"
+                                                        min={0}
+                                                        size={null}
+                                                        title=" "
+                                                        value={0}
+                                                        valueText="Completed"
+                                                        variant="success"
+                                                      >
+                                                        <div
+                                                          className="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                                                          id="finished-progress-bar"
+                                                        >
+                                                          <Component
+                                                            label="Completed"
+                                                            measureLocation="top"
+                                                            parentId="finished-progress-bar"
+                                                            progressBarAriaProps={
+                                                              Object {
+                                                                "aria-labelledby": "finished-progress-bar-description",
+                                                                "aria-valuemax": 0,
+                                                                "aria-valuemin": 0,
+                                                                "aria-valuenow": 0,
+                                                                "aria-valuetext": "Completed",
+                                                              }
+                                                            }
+                                                            title=" "
+                                                            value={NaN}
+                                                            variant="success"
+                                                          >
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__description"
+                                                              id="finished-progress-bar-description"
+                                                            >
+                                                               
+                                                            </div>
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__status"
+                                                            >
+                                                              <span
+                                                                className="pf-c-progress__measure"
+                                                              >
+                                                                Completed
+                                                              </span>
+                                                              <span
+                                                                className="pf-c-progress__status-icon"
+                                                              >
+                                                                <CheckCircleIcon
+                                                                  color="currentColor"
+                                                                  noVerticalAlign={false}
+                                                                  size="sm"
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    aria-labelledby={null}
+                                                                    fill="currentColor"
+                                                                    height="1em"
+                                                                    role="img"
+                                                                    style={
+                                                                      Object {
+                                                                        "verticalAlign": "-0.125em",
+                                                                      }
+                                                                    }
+                                                                    viewBox="0 0 512 512"
+                                                                    width="1em"
+                                                                  >
+                                                                    <path
+                                                                      d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                                                      transform=""
+                                                                    />
+                                                                  </svg>
+                                                                </CheckCircleIcon>
+                                                              </span>
+                                                            </div>
+                                                            <Component
+                                                              progressBarAriaProps={
+                                                                Object {
+                                                                  "aria-labelledby": "finished-progress-bar-description",
+                                                                  "aria-valuemax": 0,
+                                                                  "aria-valuemin": 0,
+                                                                  "aria-valuenow": 0,
+                                                                  "aria-valuetext": "Completed",
+                                                                }
+                                                              }
+                                                              role="progressbar"
+                                                              value={NaN}
+                                                            >
+                                                              <div
+                                                                aria-labelledby="finished-progress-bar-description"
+                                                                aria-valuemax={0}
+                                                                aria-valuemin={0}
+                                                                aria-valuenow={0}
+                                                                aria-valuetext="Completed"
+                                                                className="pf-c-progress__bar"
+                                                                role="progressbar"
+                                                              >
+                                                                <div
+                                                                  className="pf-c-progress__indicator"
+                                                                  style={
+                                                                    Object {
+                                                                      "width": "NaN%",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <span
+                                                                    className="pf-c-progress__measure"
+                                                                  />
+                                                                </div>
+                                                              </div>
+                                                            </Component>
+                                                          </Component>
+                                                        </div>
+                                                      </Progress>
+                                                      Message
+                                                    </div>
+                                                  </Component>
+                                                  <Component
+                                                    className="pf-u-mt-xl"
+                                                    onClick={[MockFunction]}
+                                                    variant="primary"
+                                                  >
+                                                    <button
+                                                      aria-disabled={null}
+                                                      aria-label={null}
+                                                      className="pf-c-button pf-m-primary pf-u-mt-xl"
+                                                      data-ouia-component-id={null}
+                                                      data-ouia-component-type="PF4/Button"
+                                                      data-ouia-safe={true}
+                                                      disabled={false}
+                                                      onClick={[MockFunction]}
+                                                      tabIndex={null}
+                                                      type="button"
+                                                    >
+                                                      Go back to my application
+                                                    </button>
+                                                  </Component>
+                                                  <Component>
+                                                    <div
+                                                      className="pf-c-empty-state__secondary"
+                                                    >
+                                                      <a
+                                                        href="/hybrid/settings/sources"
+                                                      >
+                                                        <Component
+                                                          variant="link"
+                                                        >
+                                                          <button
+                                                            aria-disabled={null}
+                                                            aria-label={null}
+                                                            className="pf-c-button pf-m-link"
+                                                            data-ouia-component-id={null}
+                                                            data-ouia-component-type="PF4/Button"
+                                                            data-ouia-safe={true}
+                                                            disabled={false}
+                                                            tabIndex={null}
+                                                            type="button"
+                                                          >
+                                                            <FormattedMessage
+                                                              defaultMessage="Take me to sources"
+                                                              id="wizard.toSources"
+                                                            >
+                                                              Take me to sources
+                                                            </FormattedMessage>
+                                                          </button>
+                                                        </Component>
+                                                      </a>
+                                                    </div>
+                                                  </Component>
+                                                </div>
+                                              </div>
+                                            </Component>
+                                          </div>
+                                        </Component>
+                                      </FinishedStep>
+                                    </div>
+                                  </main>
+                                </Component>
+                              </div>
+                              <Component
+                                activeStep={
+                                  Object {
+                                    "component": <FinishedStep
+                                      hideSourcesButton={false}
+                                      linkText={
+                                        <FormattedMessage
+                                          defaultMessage="Take me to sources"
+                                          id="wizard.toSources"
+                                        />
+                                      }
+                                      onClose={[MockFunction]}
+                                      progressStep={0}
+                                      progressTexts={
+                                        Array [
+                                          "Completed",
+                                        ]
+                                      }
+                                      returnButtonTitle="Go back to my application"
+                                      successfulMessage="Message"
+                                      title={
+                                        <FormattedMessage
+                                          defaultMessage="Configuration successful"
+                                          id="wizard.succConfiguration"
+                                        />
+                                      }
+                                    />,
+                                    "isFinishedStep": true,
+                                    "name": "Finish",
+                                  }
+                                }
+                                backButtonText="Back"
+                                cancelButtonText="Cancel"
+                                firstStep={true}
+                                isValid={true}
+                                nextButtonText="Next"
+                                onBack={[Function]}
+                                onClose={[MockFunction]}
+                                onNext={[Function]}
+                              >
+                                <footer
+                                  className="pf-c-wizard__footer"
+                                >
+                                  <Component
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                    variant="primary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-primary"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="submit"
+                                    >
+                                      Next
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    className="pf-m-disabled"
+                                    onClick={[Function]}
+                                    variant="secondary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-secondary pf-m-disabled"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Back
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    onClick={[MockFunction]}
+                                    variant="link"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-link"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[MockFunction]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Component>
+                                </footer>
+                              </Component>
+                            </div>
+                          </Component>
+                        </div>
+                      </div>
+                    </Component>
+                  </div>
+                </FocusTrap>
+              </div>
+            </Component>
+          </Component>
+        </Portal>
+      </Modal>
+    </Wizard>
+  </FinalWizard>
+</IntlProvider>
 `;
 
 exports[`Final wizard Renders renders loading step correctly 1`] = `
-<Wizard
-  appendTo={null}
-  backButtonText="Back"
-  cancelButtonText="Cancel"
-  className=""
-  closeButtonAriaLabel="Close"
-  description="Connect a data source to use with your applications."
-  footer={null}
-  hasNoBodyPadding={false}
-  height={null}
-  hideClose={false}
-  isOpen={true}
-  navAriaLabel="Steps"
-  nextButtonText="Next"
-  onBack={null}
-  onClose={[MockFunction]}
-  onGoToStep={null}
-  onNext={null}
-  startAtStep={1}
-  steps={
-    Array [
-      Object {
-        "component": <LoadingStep
-          cancelTitle="Cancel"
-          customText="Source is being created"
-          progressStep={0}
-          progressTexts={
-            Array [
-              "Completed",
-            ]
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <FinalWizard
+    afterError={[MockFunction]}
+    afterSubmit={[MockFunction]}
+    hideSourcesButton={false}
+    isErrored={false}
+    isFinished={false}
+    onRetry={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Completed",
+      ]
+    }
+    returnButtonTitle="Go back to my application"
+    successfulMessage="Message"
+  >
+    <Wizard
+      appendTo={null}
+      backButtonText="Back"
+      cancelButtonText="Cancel"
+      className=""
+      closeButtonAriaLabel="Close"
+      description={
+        <FormattedMessage
+          defaultMessage="Connect a data source to use with your applications."
+          id="wizard.wizardDescription"
+        />
+      }
+      footer={null}
+      hasNoBodyPadding={false}
+      height={null}
+      hideClose={false}
+      isOpen={true}
+      navAriaLabel="Steps"
+      nextButtonText="Next"
+      onBack={null}
+      onClose={[MockFunction]}
+      onGoToStep={null}
+      onNext={null}
+      startAtStep={1}
+      steps={
+        Array [
+          Object {
+            "canJumpTo": true,
+            "component": <LoadingStep
+              cancelTitle={
+                <FormattedMessage
+                  defaultMessage="Cancel"
+                  id="wizard.cancelText"
+                />
+              }
+              customText={
+                <FormattedMessage
+                  defaultMessage="Source is being created"
+                  id="wizard.loadingText"
+                />
+              }
+              progressStep={0}
+              progressTexts={
+                Array [
+                  "Completed",
+                ]
+              }
+            />,
+            "isFinishedStep": true,
+            "name": "Finish",
+          },
+        ]
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Add source"
+          id="wizard.wizardTitle"
+        />
+      }
+      width={null}
+    >
+      <Modal
+        actions={Array []}
+        appendTo={
+          <body
+            class="pf-c-backdrop__open"
+          >
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-0"
+                    aria-labelledby="pf-wizard-title-0"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-0"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-0"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-0"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </body>
+        }
+        aria-describedby="pf-wizard-description-0"
+        aria-label=""
+        aria-labelledby="pf-wizard-title-0"
+        className=""
+        hasNoBodyWrapper={true}
+        isOpen={true}
+        onClose={[Function]}
+        showClose={false}
+        title=""
+        variant="large"
+      >
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="pf-c-backdrop"
+              >
+                <div
+                  class="pf-l-bullseye"
+                >
+                  <div
+                    aria-describedby="pf-wizard-description-0"
+                    aria-labelledby="pf-wizard-title-0"
+                    aria-modal="true"
+                    class="pf-c-modal-box pf-m-lg"
+                    id="pf-modal-part-0"
+                    role="dialog"
+                  >
+                    
+                    <div
+                      class="pf-c-wizard pf-m-finished"
+                    >
+                      <div
+                        class="pf-c-wizard__header"
+                      >
+                        <button
+                          aria-label="Close"
+                          class="pf-c-button pf-m-plain pf-c-wizard__close"
+                          data-ouia-component-type="PF4/Button"
+                          data-ouia-safe="true"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              transform=""
+                            />
+                          </svg>
+                        </button>
+                        <h2
+                          aria-label="[object Object]"
+                          class="pf-c-title pf-m-3xl pf-c-wizard__title"
+                          id="pf-wizard-title-0"
+                        >
+                          Add source
+                        </h2>
+                        <p
+                          class="pf-c-wizard__description"
+                          id="pf-wizard-description-0"
+                        >
+                          Connect a data source to use with your applications.
+                        </p>
+                      </div>
+                      <button
+                        aria-expanded="false"
+                        aria-label="Wizard Toggle"
+                        class="pf-c-wizard__toggle"
+                      >
+                        <ol
+                          class="pf-c-wizard__toggle-list"
+                        >
+                          <li
+                            class="pf-c-wizard__toggle-list-item"
+                          >
+                            <span
+                              class="pf-c-wizard__toggle-num"
+                            >
+                              1
+                            </span>
+                             
+                            Finish
+                          </li>
+                        </ol>
+                        <span
+                          class="pf-c-wizard__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                              transform=""
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="pf-c-wizard__outer-wrap"
+                      >
+                        <div
+                          class="pf-c-wizard__inner-wrap"
+                        >
+                          <nav
+                            aria-label="Steps"
+                            class="pf-c-wizard__nav"
+                          >
+                            <ol
+                              class="pf-c-wizard__nav-list"
+                            />
+                          </nav>
+                          <main
+                            class="pf-c-wizard__main"
+                          >
+                            <div
+                              class="pf-c-wizard__main-body"
+                            >
+                              <div
+                                class="pf-l-bullseye"
+                              >
+                                <div
+                                  class="pf-c-empty-state ins-c-sources__empty-state"
+                                >
+                                  <div
+                                    class="pf-c-empty-state__content"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      aria-valuetext="Loading..."
+                                      class="pf-c-spinner pf-m-xl"
+                                      role="progressbar"
+                                    >
+                                      <span
+                                        class="pf-c-spinner__clipper"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__lead-ball"
+                                      />
+                                      <span
+                                        class="pf-c-spinner__tail-ball"
+                                      />
+                                    </span>
+                                    <div
+                                      class="pf-c-empty-state__body pf-u-mt-xl"
+                                    >
+                                      <div
+                                        class="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                        id="loading-progress-bar"
+                                      >
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__description"
+                                          id="loading-progress-bar-description"
+                                        >
+                                           
+                                        </div>
+                                        <div
+                                          aria-hidden="true"
+                                          class="pf-c-progress__status"
+                                        >
+                                          <span
+                                            class="pf-c-progress__measure"
+                                          >
+                                            Completed
+                                          </span>
+                                        </div>
+                                        <div
+                                          aria-labelledby="loading-progress-bar-description"
+                                          aria-valuemax="0"
+                                          aria-valuemin="0"
+                                          aria-valuenow="0"
+                                          aria-valuetext="Completed"
+                                          class="pf-c-progress__bar"
+                                          role="progressbar"
+                                        >
+                                          <div
+                                            class="pf-c-progress__indicator"
+                                          >
+                                            <span
+                                              class="pf-c-progress__measure"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </main>
+                        </div>
+                        <footer
+                          class="pf-c-wizard__footer"
+                        >
+                          <button
+                            class="pf-c-button pf-m-primary"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="submit"
+                          >
+                            Next
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-secondary pf-m-disabled"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Back
+                          </button>
+                          <button
+                            class="pf-c-button pf-m-link"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe="true"
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           }
-        />,
-        "isFinishedStep": true,
-        "name": "Finish",
-      },
-    ]
-  }
-  title="Add source"
-  width={null}
-/>
+        >
+          <Component
+            actions={Array []}
+            aria-describedby="pf-wizard-description-0"
+            aria-label=""
+            aria-labelledby="pf-wizard-title-0"
+            boxId="pf-modal-part-0"
+            className=""
+            descriptorId="pf-modal-part-2"
+            hasNoBodyWrapper={true}
+            isOpen={true}
+            labelId="pf-modal-part-1"
+            onClose={[Function]}
+            showClose={false}
+            title=""
+            variant="large"
+          >
+            <Component>
+              <div
+                className="pf-c-backdrop"
+              >
+                <FocusTrap
+                  active={true}
+                  className="pf-l-bullseye"
+                  focusTrapOptions={
+                    Object {
+                      "clickOutsideDeactivates": true,
+                    }
+                  }
+                  paused={false}
+                >
+                  <div
+                    className="pf-l-bullseye"
+                  >
+                    <Component
+                      aria-describedby="pf-wizard-description-0"
+                      aria-label=""
+                      aria-labelledby="pf-wizard-title-0"
+                      className=""
+                      id="pf-modal-part-0"
+                      style={Object {}}
+                      variant="large"
+                    >
+                      <div
+                        aria-describedby="pf-wizard-description-0"
+                        aria-label={null}
+                        aria-labelledby="pf-wizard-title-0"
+                        aria-modal="true"
+                        className="pf-c-modal-box pf-m-lg"
+                        id="pf-modal-part-0"
+                        role="dialog"
+                        style={Object {}}
+                      >
+                        <div
+                          className="pf-c-wizard pf-m-finished"
+                        >
+                          <Component
+                            closeButtonAriaLabel="Close"
+                            description={
+                              <FormattedMessage
+                                defaultMessage="Connect a data source to use with your applications."
+                                id="wizard.wizardDescription"
+                              />
+                            }
+                            descriptionId="pf-wizard-description-0"
+                            hideClose={false}
+                            onClose={[MockFunction]}
+                            title={
+                              <FormattedMessage
+                                defaultMessage="Add source"
+                                id="wizard.wizardTitle"
+                              />
+                            }
+                            titleId="pf-wizard-title-0"
+                          >
+                            <div
+                              className="pf-c-wizard__header"
+                            >
+                              <Component
+                                aria-label="Close"
+                                className="pf-c-wizard__close"
+                                onClick={[MockFunction]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={null}
+                                  aria-label="Close"
+                                  className="pf-c-button pf-m-plain pf-c-wizard__close"
+                                  data-ouia-component-id={null}
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[MockFunction]}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Component>
+                              <Component
+                                aria-label={
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  />
+                                }
+                                className="pf-c-wizard__title"
+                                headingLevel="h2"
+                                id="pf-wizard-title-0"
+                                size="3xl"
+                              >
+                                <h2
+                                  aria-label={
+                                    <FormattedMessage
+                                      defaultMessage="Add source"
+                                      id="wizard.wizardTitle"
+                                    />
+                                  }
+                                  className="pf-c-title pf-m-3xl pf-c-wizard__title"
+                                  id="pf-wizard-title-0"
+                                >
+                                  <FormattedMessage
+                                    defaultMessage="Add source"
+                                    id="wizard.wizardTitle"
+                                  >
+                                    Add source
+                                  </FormattedMessage>
+                                </h2>
+                              </Component>
+                              <p
+                                className="pf-c-wizard__description"
+                                id="pf-wizard-description-0"
+                              >
+                                <FormattedMessage
+                                  defaultMessage="Connect a data source to use with your applications."
+                                  id="wizard.wizardDescription"
+                                >
+                                  Connect a data source to use with your applications.
+                                </FormattedMessage>
+                              </p>
+                            </div>
+                          </Component>
+                          <Component
+                            activeStep={
+                              Object {
+                                "component": <LoadingStep
+                                  cancelTitle={
+                                    <FormattedMessage
+                                      defaultMessage="Cancel"
+                                      id="wizard.cancelText"
+                                    />
+                                  }
+                                  customText={
+                                    <FormattedMessage
+                                      defaultMessage="Source is being created"
+                                      id="wizard.loadingText"
+                                    />
+                                  }
+                                  progressStep={0}
+                                  progressTexts={
+                                    Array [
+                                      "Completed",
+                                    ]
+                                  }
+                                />,
+                                "isFinishedStep": true,
+                                "name": "Finish",
+                              }
+                            }
+                            hasNoBodyPadding={false}
+                            isNavOpen={false}
+                            nav={[Function]}
+                            onNavToggle={[Function]}
+                            steps={
+                              Array [
+                                Object {
+                                  "canJumpTo": true,
+                                  "component": <LoadingStep
+                                    cancelTitle={
+                                      <FormattedMessage
+                                        defaultMessage="Cancel"
+                                        id="wizard.cancelText"
+                                      />
+                                    }
+                                    customText={
+                                      <FormattedMessage
+                                        defaultMessage="Source is being created"
+                                        id="wizard.loadingText"
+                                      />
+                                    }
+                                    progressStep={0}
+                                    progressTexts={
+                                      Array [
+                                        "Completed",
+                                      ]
+                                    }
+                                  />,
+                                  "isFinishedStep": true,
+                                  "name": "Finish",
+                                },
+                              ]
+                            }
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-label="Wizard Toggle"
+                              className="pf-c-wizard__toggle"
+                              onClick={[Function]}
+                            >
+                              <ol
+                                className="pf-c-wizard__toggle-list"
+                              >
+                                <li
+                                  className="pf-c-wizard__toggle-list-item"
+                                >
+                                  <span
+                                    className="pf-c-wizard__toggle-num"
+                                  >
+                                    1
+                                  </span>
+                                   
+                                  Finish
+                                </li>
+                              </ol>
+                              <span
+                                className="pf-c-wizard__toggle-icon"
+                              >
+                                <CaretDownIcon
+                                  aria-hidden="true"
+                                  color="currentColor"
+                                  noVerticalAlign={false}
+                                  size="sm"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    aria-labelledby={null}
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style={
+                                      Object {
+                                        "verticalAlign": "-0.125em",
+                                      }
+                                    }
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      transform=""
+                                    />
+                                  </svg>
+                                </CaretDownIcon>
+                              </span>
+                            </button>
+                            <div
+                              className="pf-c-wizard__outer-wrap"
+                            >
+                              <div
+                                className="pf-c-wizard__inner-wrap"
+                              >
+                                <Component
+                                  aria-label="Steps"
+                                  isOpen={false}
+                                >
+                                  <nav
+                                    aria-label="Steps"
+                                    className="pf-c-wizard__nav"
+                                  >
+                                    <ol
+                                      className="pf-c-wizard__nav-list"
+                                    />
+                                  </nav>
+                                </Component>
+                                <Component
+                                  hasNoBodyPadding={false}
+                                >
+                                  <main
+                                    className="pf-c-wizard__main"
+                                  >
+                                    <div
+                                      className="pf-c-wizard__main-body"
+                                    >
+                                      <LoadingStep
+                                        cancelTitle={
+                                          <FormattedMessage
+                                            defaultMessage="Cancel"
+                                            id="wizard.cancelText"
+                                          />
+                                        }
+                                        customText={
+                                          <FormattedMessage
+                                            defaultMessage="Source is being created"
+                                            id="wizard.loadingText"
+                                          />
+                                        }
+                                        progressStep={0}
+                                        progressTexts={
+                                          Array [
+                                            "Completed",
+                                          ]
+                                        }
+                                      >
+                                        <Component>
+                                          <div
+                                            className="pf-l-bullseye"
+                                          >
+                                            <Component
+                                              className="ins-c-sources__empty-state"
+                                              variant="full"
+                                            >
+                                              <div
+                                                className="pf-c-empty-state ins-c-sources__empty-state"
+                                              >
+                                                <div
+                                                  className="pf-c-empty-state__content"
+                                                >
+                                                  <Component
+                                                    className="pf-u-mb-0"
+                                                    icon={[Function]}
+                                                  >
+                                                    <Component
+                                                      aria-hidden="true"
+                                                      className="pf-c-empty-state__icon pf-u-mb-0"
+                                                    >
+                                                      <span
+                                                        aria-hidden="true"
+                                                        aria-valuetext="Loading..."
+                                                        className="pf-c-spinner pf-m-xl"
+                                                        role="progressbar"
+                                                      >
+                                                        <span
+                                                          className="pf-c-spinner__clipper"
+                                                        />
+                                                        <span
+                                                          className="pf-c-spinner__lead-ball"
+                                                        />
+                                                        <span
+                                                          className="pf-c-spinner__tail-ball"
+                                                        />
+                                                      </span>
+                                                    </Component>
+                                                  </Component>
+                                                  <Component
+                                                    className="pf-u-mt-xl"
+                                                  >
+                                                    <div
+                                                      className="pf-c-empty-state__body pf-u-mt-xl"
+                                                    >
+                                                      <Progress
+                                                        className="pf-u-mb-0 ins-c-sources__progress"
+                                                        id="loading-progress-bar"
+                                                        label="Completed"
+                                                        max={0}
+                                                        measureLocation="top"
+                                                        min={0}
+                                                        size={null}
+                                                        title=" "
+                                                        value={0}
+                                                        valueText="Completed"
+                                                        variant={null}
+                                                      >
+                                                        <div
+                                                          className="pf-c-progress pf-u-mb-0 ins-c-sources__progress"
+                                                          id="loading-progress-bar"
+                                                        >
+                                                          <Component
+                                                            label="Completed"
+                                                            measureLocation="top"
+                                                            parentId="loading-progress-bar"
+                                                            progressBarAriaProps={
+                                                              Object {
+                                                                "aria-labelledby": "loading-progress-bar-description",
+                                                                "aria-valuemax": 0,
+                                                                "aria-valuemin": 0,
+                                                                "aria-valuenow": 0,
+                                                                "aria-valuetext": "Completed",
+                                                              }
+                                                            }
+                                                            title=" "
+                                                            value={NaN}
+                                                            variant={null}
+                                                          >
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__description"
+                                                              id="loading-progress-bar-description"
+                                                            >
+                                                               
+                                                            </div>
+                                                            <div
+                                                              aria-hidden="true"
+                                                              className="pf-c-progress__status"
+                                                            >
+                                                              <span
+                                                                className="pf-c-progress__measure"
+                                                              >
+                                                                Completed
+                                                              </span>
+                                                            </div>
+                                                            <Component
+                                                              progressBarAriaProps={
+                                                                Object {
+                                                                  "aria-labelledby": "loading-progress-bar-description",
+                                                                  "aria-valuemax": 0,
+                                                                  "aria-valuemin": 0,
+                                                                  "aria-valuenow": 0,
+                                                                  "aria-valuetext": "Completed",
+                                                                }
+                                                              }
+                                                              role="progressbar"
+                                                              value={NaN}
+                                                            >
+                                                              <div
+                                                                aria-labelledby="loading-progress-bar-description"
+                                                                aria-valuemax={0}
+                                                                aria-valuemin={0}
+                                                                aria-valuenow={0}
+                                                                aria-valuetext="Completed"
+                                                                className="pf-c-progress__bar"
+                                                                role="progressbar"
+                                                              >
+                                                                <div
+                                                                  className="pf-c-progress__indicator"
+                                                                  style={
+                                                                    Object {
+                                                                      "width": "NaN%",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <span
+                                                                    className="pf-c-progress__measure"
+                                                                  />
+                                                                </div>
+                                                              </div>
+                                                            </Component>
+                                                          </Component>
+                                                        </div>
+                                                      </Progress>
+                                                    </div>
+                                                  </Component>
+                                                </div>
+                                              </div>
+                                            </Component>
+                                          </div>
+                                        </Component>
+                                      </LoadingStep>
+                                    </div>
+                                  </main>
+                                </Component>
+                              </div>
+                              <Component
+                                activeStep={
+                                  Object {
+                                    "component": <LoadingStep
+                                      cancelTitle={
+                                        <FormattedMessage
+                                          defaultMessage="Cancel"
+                                          id="wizard.cancelText"
+                                        />
+                                      }
+                                      customText={
+                                        <FormattedMessage
+                                          defaultMessage="Source is being created"
+                                          id="wizard.loadingText"
+                                        />
+                                      }
+                                      progressStep={0}
+                                      progressTexts={
+                                        Array [
+                                          "Completed",
+                                        ]
+                                      }
+                                    />,
+                                    "isFinishedStep": true,
+                                    "name": "Finish",
+                                  }
+                                }
+                                backButtonText="Back"
+                                cancelButtonText="Cancel"
+                                firstStep={true}
+                                isValid={true}
+                                nextButtonText="Next"
+                                onBack={[Function]}
+                                onClose={[MockFunction]}
+                                onNext={[Function]}
+                              >
+                                <footer
+                                  className="pf-c-wizard__footer"
+                                >
+                                  <Component
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                    variant="primary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-primary"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="submit"
+                                    >
+                                      Next
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    className="pf-m-disabled"
+                                    onClick={[Function]}
+                                    variant="secondary"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-secondary pf-m-disabled"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Back
+                                    </button>
+                                  </Component>
+                                  <Component
+                                    onClick={[MockFunction]}
+                                    variant="link"
+                                  >
+                                    <button
+                                      aria-disabled={null}
+                                      aria-label={null}
+                                      className="pf-c-button pf-m-link"
+                                      data-ouia-component-id={null}
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[MockFunction]}
+                                      tabIndex={null}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Component>
+                                </footer>
+                              </Component>
+                            </div>
+                          </Component>
+                        </div>
+                      </div>
+                    </Component>
+                  </div>
+                </FocusTrap>
+              </div>
+            </Component>
+          </Component>
+        </Portal>
+      </Modal>
+    </Wizard>
+  </FinalWizard>
+</IntlProvider>
 `;

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/sslFormLabel.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/sslFormLabel.test.js.snap
@@ -1,65 +1,161 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SSLFormLabel renders loading step correctly 1`] = `
-<Fragment>
-  SSL Certificate 
-  <Popover
-    appendTo={[Function]}
-    aria-label="Help text"
-    bodyContent={
-      <Unknown>
-        <Unknown
-          component="p"
-        >
-          You can obtain your OpenShift Container Platform provider’s CA certificate for all endpoints (default, metrics, alerts) from
-          <b>
-            /etc/origin/master/ca.crt
-          </b>
-          .
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <SSLFormLabel>
+    <FormattedMessage
+      defaultMessage="SSL Certificate"
+      id="wizard.SslCertificate"
+    >
+      SSL Certificate
+    </FormattedMessage>
+     
+    <Popover
+      appendTo={[Function]}
+      aria-label="Help text"
+      bodyContent={
+        <Unknown>
+          <Unknown
+            component="p"
+          >
+            <FormattedMessage
+              defaultMessage="You can obtain your OpenShift Container Platform provider’s CA certificate for all endpoints (default, metrics, alerts) from {cmd}."
+              id="wizard.YouCanObtainYourOpenshiftContainerPlatformProviderSCaCertificateForAllEndpointsDefaultMetricsAlertsFrom"
+              values={
+                Object {
+                  "cmd": <b>
+                    /etc/origin/master/ca.crt
+                  </b>,
+                }
+              }
+            />
+          </Unknown>
+          <Unknown
+            component="p"
+          >
+            <FormattedMessage
+              defaultMessage="Paste the output (a block of text starting with --BEGIN CERTIFICATE--) into the Trusted CA Certificates field."
+              id="wizard.PasteTheOutputABlockOfTextStartingWithBeginCertificateIntoTheTrustedCaCertificatesField"
+            />
+          </Unknown>
         </Unknown>
-        <Unknown
-          component="p"
+      }
+      boundary="window"
+      className=""
+      closeBtnAriaLabel="Close"
+      distance={25}
+      enableFlip={true}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      footerContent={null}
+      headerContent={null}
+      hideOnOutsideClick={true}
+      isVisible={null}
+      maxWidth="50%"
+      onHidden={[Function]}
+      onHide={[Function]}
+      onMount={[Function]}
+      onShow={[Function]}
+      onShown={[Function]}
+      position="top"
+      shouldClose={[Function]}
+      tippyProps={Object {}}
+      zIndex={9999}
+    >
+      <PopoverBase
+        appendTo={[Function]}
+        arrow={true}
+        boundary="window"
+        content={<React.Fragment />}
+        distance={25}
+        flip={true}
+        flipBehavior={
+          Array [
+            "top",
+            "right",
+            "bottom",
+            "left",
+            "top",
+            "right",
+            "bottom",
+          ]
+        }
+        hideOnClick={true}
+        interactive={true}
+        interactiveBorder={0}
+        isVisible={null}
+        lazy={true}
+        maxWidth="50%"
+        onCreate={[Function]}
+        onHidden={[Function]}
+        onHide={[Function]}
+        onMount={[Function]}
+        onShow={[Function]}
+        onShown={[Function]}
+        placement="top"
+        popperOptions={
+          Object {
+            "modifiers": Object {
+              "hide": Object {
+                "enabled": true,
+              },
+              "preventOverflow": Object {
+                "enabled": true,
+              },
+            },
+          }
+        }
+        theme="pf-popover"
+        trigger="click"
+        zIndex={9999}
+      >
+        <QuestionCircleIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          Paste the output (a block of text starting with --BEGIN CERTIFICATE--) into the Trusted CA Certificates field.
-        </Unknown>
-      </Unknown>
-    }
-    boundary="window"
-    className=""
-    closeBtnAriaLabel="Close"
-    distance={25}
-    enableFlip={true}
-    flipBehavior={
-      Array [
-        "top",
-        "right",
-        "bottom",
-        "left",
-        "top",
-        "right",
-        "bottom",
-      ]
-    }
-    footerContent={null}
-    headerContent={null}
-    hideOnOutsideClick={true}
-    isVisible={null}
-    maxWidth="50%"
-    onHidden={[Function]}
-    onHide={[Function]}
-    onMount={[Function]}
-    onShow={[Function]}
-    onShown={[Function]}
-    position="top"
-    shouldClose={[Function]}
-    tippyProps={Object {}}
-    zIndex={9999}
-  >
-    <QuestionCircleIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-  </Popover>
-</Fragment>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              transform=""
+            />
+          </svg>
+        </QuestionCircleIcon>
+        <Portal
+          containerInfo={<div />}
+        />
+      </PopoverBase>
+    </Popover>
+  </SSLFormLabel>
+</IntlProvider>
 `;

--- a/packages/sources/src/tests/addSourceWizard/__snapshots__/steps.test.js.snap
+++ b/packages/sources/src/tests/addSourceWizard/__snapshots__/steps.test.js.snap
@@ -1,227 +1,1131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Steps components ErroredStep renders correctly 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
-  >
-    <Component
-      className="pf-u-mb-0"
-      color="var(--pf-global--danger-color--100)"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-      headingLevel="h5"
-      size="lg"
-    >
-      Configuration unsuccessful
-    </Component>
-    <Component>
-      <Progress
-        className="pf-u-mb-md ins-c-sources__progress"
-        id=""
-        label="Step 1: create source"
-        max={0}
-        measureLocation="top"
-        min={0}
-        size={null}
-        title=" "
-        value={0}
-        valueText="Step 1: create source"
-        variant="danger"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <ErroredStep
+    customText={
+      <FormattedMessage
+        defaultMessage="Your source has not been successfully added:"
+        id="wizard.errorText"
       />
-      <Component>
-        <Component
-          variant="p"
-        >
-          Your source has not been successfully added:
-        </Component>
-      </Component>
-    </Component>
-    <Component
-      onClick={[MockFunction]}
-      variant="primary"
-    >
-      Go back to my application
-    </Component>
+    }
+    onClose={[MockFunction]}
+    onRetry={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Step 1: create source",
+      ]
+    }
+    retryText={
+      <FormattedMessage
+        defaultMessage="Retry"
+        id="wizard.retryText"
+      />
+    }
+    returnButtonTitle="Go back to my application"
+    title={
+      <FormattedMessage
+        defaultMessage="Configuration unsuccessful"
+        id="wizard.unsuccConfiguration"
+      />
+    }
+  >
     <Component>
-      <Component
-        onClick={[MockFunction]}
-        variant="link"
+      <div
+        className="pf-l-bullseye"
       >
-        Retry
-      </Component>
+        <Component
+          className="ins-c-sources__empty-state"
+          variant="full"
+        >
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                color="var(--pf-global--danger-color--100)"
+                icon={[Function]}
+              >
+                <TimesCircleIcon
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                  color="var(--pf-global--danger-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-labelledby={null}
+                    className="pf-c-empty-state__icon pf-u-mb-0"
+                    fill="var(--pf-global--danger-color--100)"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                      transform=""
+                    />
+                  </svg>
+                </TimesCircleIcon>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+                headingLevel="h5"
+                size="lg"
+              >
+                <h5
+                  className="pf-c-title pf-m-lg pf-u-mt-xl"
+                >
+                  <FormattedMessage
+                    defaultMessage="Configuration unsuccessful"
+                    id="wizard.unsuccConfiguration"
+                  >
+                    Configuration unsuccessful
+                  </FormattedMessage>
+                </h5>
+              </Component>
+              <Component>
+                <div
+                  className="pf-c-empty-state__body"
+                >
+                  <Progress
+                    className="pf-u-mb-md ins-c-sources__progress"
+                    id="errored-step-progress-bar"
+                    label="Step 1: create source"
+                    max={0}
+                    measureLocation="top"
+                    min={0}
+                    size={null}
+                    title=" "
+                    value={0}
+                    valueText="Step 1: create source"
+                    variant="danger"
+                  >
+                    <div
+                      className="pf-c-progress pf-m-danger pf-u-mb-md ins-c-sources__progress"
+                      id="errored-step-progress-bar"
+                    >
+                      <Component
+                        label="Step 1: create source"
+                        measureLocation="top"
+                        parentId="errored-step-progress-bar"
+                        progressBarAriaProps={
+                          Object {
+                            "aria-labelledby": "errored-step-progress-bar-description",
+                            "aria-valuemax": 0,
+                            "aria-valuemin": 0,
+                            "aria-valuenow": 0,
+                            "aria-valuetext": "Step 1: create source",
+                          }
+                        }
+                        title=" "
+                        value={NaN}
+                        variant="danger"
+                      >
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__description"
+                          id="errored-step-progress-bar-description"
+                        >
+                           
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__status"
+                        >
+                          <span
+                            className="pf-c-progress__measure"
+                          >
+                            Step 1: create source
+                          </span>
+                          <span
+                            className="pf-c-progress__status-icon"
+                          >
+                            <TimesCircleIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                                  transform=""
+                                />
+                              </svg>
+                            </TimesCircleIcon>
+                          </span>
+                        </div>
+                        <Component
+                          progressBarAriaProps={
+                            Object {
+                              "aria-labelledby": "errored-step-progress-bar-description",
+                              "aria-valuemax": 0,
+                              "aria-valuemin": 0,
+                              "aria-valuenow": 0,
+                              "aria-valuetext": "Step 1: create source",
+                            }
+                          }
+                          role="progressbar"
+                          value={NaN}
+                        >
+                          <div
+                            aria-labelledby="errored-step-progress-bar-description"
+                            aria-valuemax={0}
+                            aria-valuemin={0}
+                            aria-valuenow={0}
+                            aria-valuetext="Step 1: create source"
+                            className="pf-c-progress__bar"
+                            role="progressbar"
+                          >
+                            <div
+                              className="pf-c-progress__indicator"
+                              style={
+                                Object {
+                                  "width": "NaN%",
+                                }
+                              }
+                            >
+                              <span
+                                className="pf-c-progress__measure"
+                              />
+                            </div>
+                          </div>
+                        </Component>
+                      </Component>
+                    </div>
+                  </Progress>
+                  <Component>
+                    <div
+                      className="pf-c-content"
+                    >
+                      <Component
+                        variant="p"
+                      >
+                        <p
+                          className=""
+                          data-pf-content={true}
+                          variant="p"
+                        >
+                          <FormattedMessage
+                            defaultMessage="Your source has not been successfully added:"
+                            id="wizard.errorText"
+                          >
+                            Your source has not been successfully added:
+                          </FormattedMessage>
+                        </p>
+                      </Component>
+                    </div>
+                  </Component>
+                </div>
+              </Component>
+              <Component
+                onClick={[MockFunction]}
+                variant="primary"
+              >
+                <button
+                  aria-disabled={null}
+                  aria-label={null}
+                  className="pf-c-button pf-m-primary"
+                  data-ouia-component-id={null}
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  onClick={[MockFunction]}
+                  tabIndex={null}
+                  type="button"
+                >
+                  Go back to my application
+                </button>
+              </Component>
+              <Component>
+                <div
+                  className="pf-c-empty-state__secondary"
+                >
+                  <Component
+                    onClick={[MockFunction]}
+                    variant="link"
+                  >
+                    <button
+                      aria-disabled={null}
+                      aria-label={null}
+                      className="pf-c-button pf-m-link"
+                      data-ouia-component-id={null}
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      tabIndex={null}
+                      type="button"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Retry"
+                        id="wizard.retryText"
+                      >
+                        Retry
+                      </FormattedMessage>
+                    </button>
+                  </Component>
+                </div>
+              </Component>
+            </div>
+          </div>
+        </Component>
+      </div>
     </Component>
-  </Component>
-</Component>
+  </ErroredStep>
+</IntlProvider>
 `;
 
 exports[`Steps components FinishedStep renders correctly 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
-  >
-    <Component
-      className="pf-u-mb-0"
-      color="var(--pf-global--success-color--100)"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-      headingLevel="h5"
-      size="lg"
-    >
-      Configuration successful
-    </Component>
-    <Component>
-      <Progress
-        className="pf-u-mb-md ins-c-sources__progress"
-        id=""
-        label="Completed"
-        max={0}
-        measureLocation="top"
-        min={0}
-        size={null}
-        title=" "
-        value={0}
-        valueText="Completed"
-        variant="success"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <FinishedStep
+    hideSourcesButton={false}
+    linkText={
+      <FormattedMessage
+        defaultMessage="Take me to sources"
+        id="wizard.toSources"
       />
-      Here I Am
-    </Component>
-    <Component
-      className="pf-u-mt-xl"
-      onClick={[MockFunction]}
-      variant="primary"
-    >
-      Go back to my application
-    </Component>
+    }
+    onClose={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Completed",
+      ]
+    }
+    returnButtonTitle="Go back to my application"
+    successfulMessage="Here I Am"
+    title={
+      <FormattedMessage
+        defaultMessage="Configuration successful"
+        id="wizard.succConfiguration"
+      />
+    }
+  >
     <Component>
-      <a
-        href="/hybrid/settings/sources"
+      <div
+        className="pf-l-bullseye"
       >
         <Component
-          variant="link"
+          className="ins-c-sources__empty-state"
+          variant="full"
         >
-          Take me to sources
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                color="var(--pf-global--success-color--100)"
+                icon={[Function]}
+              >
+                <CheckCircleIcon
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                  color="var(--pf-global--success-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-labelledby={null}
+                    className="pf-c-empty-state__icon pf-u-mb-0"
+                    fill="var(--pf-global--success-color--100)"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckCircleIcon>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+                headingLevel="h5"
+                size="lg"
+              >
+                <h5
+                  className="pf-c-title pf-m-lg pf-u-mt-xl"
+                >
+                  <FormattedMessage
+                    defaultMessage="Configuration successful"
+                    id="wizard.succConfiguration"
+                  >
+                    Configuration successful
+                  </FormattedMessage>
+                </h5>
+              </Component>
+              <Component>
+                <div
+                  className="pf-c-empty-state__body"
+                >
+                  <Progress
+                    className="pf-u-mb-md ins-c-sources__progress"
+                    id="finished-progress-bar"
+                    label="Completed"
+                    max={0}
+                    measureLocation="top"
+                    min={0}
+                    size={null}
+                    title=" "
+                    value={0}
+                    valueText="Completed"
+                    variant="success"
+                  >
+                    <div
+                      className="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                      id="finished-progress-bar"
+                    >
+                      <Component
+                        label="Completed"
+                        measureLocation="top"
+                        parentId="finished-progress-bar"
+                        progressBarAriaProps={
+                          Object {
+                            "aria-labelledby": "finished-progress-bar-description",
+                            "aria-valuemax": 0,
+                            "aria-valuemin": 0,
+                            "aria-valuenow": 0,
+                            "aria-valuetext": "Completed",
+                          }
+                        }
+                        title=" "
+                        value={NaN}
+                        variant="success"
+                      >
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__description"
+                          id="finished-progress-bar-description"
+                        >
+                           
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__status"
+                        >
+                          <span
+                            className="pf-c-progress__measure"
+                          >
+                            Completed
+                          </span>
+                          <span
+                            className="pf-c-progress__status-icon"
+                          >
+                            <CheckCircleIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                  transform=""
+                                />
+                              </svg>
+                            </CheckCircleIcon>
+                          </span>
+                        </div>
+                        <Component
+                          progressBarAriaProps={
+                            Object {
+                              "aria-labelledby": "finished-progress-bar-description",
+                              "aria-valuemax": 0,
+                              "aria-valuemin": 0,
+                              "aria-valuenow": 0,
+                              "aria-valuetext": "Completed",
+                            }
+                          }
+                          role="progressbar"
+                          value={NaN}
+                        >
+                          <div
+                            aria-labelledby="finished-progress-bar-description"
+                            aria-valuemax={0}
+                            aria-valuemin={0}
+                            aria-valuenow={0}
+                            aria-valuetext="Completed"
+                            className="pf-c-progress__bar"
+                            role="progressbar"
+                          >
+                            <div
+                              className="pf-c-progress__indicator"
+                              style={
+                                Object {
+                                  "width": "NaN%",
+                                }
+                              }
+                            >
+                              <span
+                                className="pf-c-progress__measure"
+                              />
+                            </div>
+                          </div>
+                        </Component>
+                      </Component>
+                    </div>
+                  </Progress>
+                  Here I Am
+                </div>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+                onClick={[MockFunction]}
+                variant="primary"
+              >
+                <button
+                  aria-disabled={null}
+                  aria-label={null}
+                  className="pf-c-button pf-m-primary pf-u-mt-xl"
+                  data-ouia-component-id={null}
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  onClick={[MockFunction]}
+                  tabIndex={null}
+                  type="button"
+                >
+                  Go back to my application
+                </button>
+              </Component>
+              <Component>
+                <div
+                  className="pf-c-empty-state__secondary"
+                >
+                  <a
+                    href="/hybrid/settings/sources"
+                  >
+                    <Component
+                      variant="link"
+                    >
+                      <button
+                        aria-disabled={null}
+                        aria-label={null}
+                        className="pf-c-button pf-m-link"
+                        data-ouia-component-id={null}
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        tabIndex={null}
+                        type="button"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Take me to sources"
+                          id="wizard.toSources"
+                        >
+                          Take me to sources
+                        </FormattedMessage>
+                      </button>
+                    </Component>
+                  </a>
+                </div>
+              </Component>
+            </div>
+          </div>
         </Component>
-      </a>
+      </div>
     </Component>
-  </Component>
-</Component>
+  </FinishedStep>
+</IntlProvider>
 `;
 
 exports[`Steps components FinishedStep renders withou takemetosources button 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
-  >
-    <Component
-      className="pf-u-mb-0"
-      color="var(--pf-global--success-color--100)"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-      headingLevel="h5"
-      size="lg"
-    >
-      Configuration successful
-    </Component>
-    <Component>
-      <Progress
-        className="pf-u-mb-md ins-c-sources__progress"
-        id=""
-        label="Completed"
-        max={0}
-        measureLocation="top"
-        min={0}
-        size={null}
-        title=" "
-        value={0}
-        valueText="Completed"
-        variant="success"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <FinishedStep
+    hideSourcesButton={true}
+    linkText={
+      <FormattedMessage
+        defaultMessage="Take me to sources"
+        id="wizard.toSources"
       />
-      Here I Am
+    }
+    onClose={[MockFunction]}
+    progressStep={0}
+    progressTexts={
+      Array [
+        "Completed",
+      ]
+    }
+    returnButtonTitle="Go back to my application"
+    successfulMessage="Here I Am"
+    title={
+      <FormattedMessage
+        defaultMessage="Configuration successful"
+        id="wizard.succConfiguration"
+      />
+    }
+  >
+    <Component>
+      <div
+        className="pf-l-bullseye"
+      >
+        <Component
+          className="ins-c-sources__empty-state"
+          variant="full"
+        >
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                color="var(--pf-global--success-color--100)"
+                icon={[Function]}
+              >
+                <CheckCircleIcon
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                  color="var(--pf-global--success-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-labelledby={null}
+                    className="pf-c-empty-state__icon pf-u-mb-0"
+                    fill="var(--pf-global--success-color--100)"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckCircleIcon>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+                headingLevel="h5"
+                size="lg"
+              >
+                <h5
+                  className="pf-c-title pf-m-lg pf-u-mt-xl"
+                >
+                  <FormattedMessage
+                    defaultMessage="Configuration successful"
+                    id="wizard.succConfiguration"
+                  >
+                    Configuration successful
+                  </FormattedMessage>
+                </h5>
+              </Component>
+              <Component>
+                <div
+                  className="pf-c-empty-state__body"
+                >
+                  <Progress
+                    className="pf-u-mb-md ins-c-sources__progress"
+                    id="finished-progress-bar"
+                    label="Completed"
+                    max={0}
+                    measureLocation="top"
+                    min={0}
+                    size={null}
+                    title=" "
+                    value={0}
+                    valueText="Completed"
+                    variant="success"
+                  >
+                    <div
+                      className="pf-c-progress pf-m-success pf-u-mb-md ins-c-sources__progress"
+                      id="finished-progress-bar"
+                    >
+                      <Component
+                        label="Completed"
+                        measureLocation="top"
+                        parentId="finished-progress-bar"
+                        progressBarAriaProps={
+                          Object {
+                            "aria-labelledby": "finished-progress-bar-description",
+                            "aria-valuemax": 0,
+                            "aria-valuemin": 0,
+                            "aria-valuenow": 0,
+                            "aria-valuetext": "Completed",
+                          }
+                        }
+                        title=" "
+                        value={NaN}
+                        variant="success"
+                      >
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__description"
+                          id="finished-progress-bar-description"
+                        >
+                           
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          className="pf-c-progress__status"
+                        >
+                          <span
+                            className="pf-c-progress__measure"
+                          >
+                            Completed
+                          </span>
+                          <span
+                            className="pf-c-progress__status-icon"
+                          >
+                            <CheckCircleIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                                  transform=""
+                                />
+                              </svg>
+                            </CheckCircleIcon>
+                          </span>
+                        </div>
+                        <Component
+                          progressBarAriaProps={
+                            Object {
+                              "aria-labelledby": "finished-progress-bar-description",
+                              "aria-valuemax": 0,
+                              "aria-valuemin": 0,
+                              "aria-valuenow": 0,
+                              "aria-valuetext": "Completed",
+                            }
+                          }
+                          role="progressbar"
+                          value={NaN}
+                        >
+                          <div
+                            aria-labelledby="finished-progress-bar-description"
+                            aria-valuemax={0}
+                            aria-valuemin={0}
+                            aria-valuenow={0}
+                            aria-valuetext="Completed"
+                            className="pf-c-progress__bar"
+                            role="progressbar"
+                          >
+                            <div
+                              className="pf-c-progress__indicator"
+                              style={
+                                Object {
+                                  "width": "NaN%",
+                                }
+                              }
+                            >
+                              <span
+                                className="pf-c-progress__measure"
+                              />
+                            </div>
+                          </div>
+                        </Component>
+                      </Component>
+                    </div>
+                  </Progress>
+                  Here I Am
+                </div>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+                onClick={[MockFunction]}
+                variant="primary"
+              >
+                <button
+                  aria-disabled={null}
+                  aria-label={null}
+                  className="pf-c-button pf-m-primary pf-u-mt-xl"
+                  data-ouia-component-id={null}
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  onClick={[MockFunction]}
+                  tabIndex={null}
+                  type="button"
+                >
+                  Go back to my application
+                </button>
+              </Component>
+            </div>
+          </div>
+        </Component>
+      </div>
     </Component>
-    <Component
-      className="pf-u-mt-xl"
-      onClick={[MockFunction]}
-      variant="primary"
-    >
-      Go back to my application
-    </Component>
-  </Component>
-</Component>
+  </FinishedStep>
+</IntlProvider>
 `;
 
 exports[`Steps components LoadingStep renders correctly 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <LoadingStep
+    cancelTitle={
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="wizard.cancelText"
+      />
+    }
+    customText={
+      <FormattedMessage
+        defaultMessage="Loading, please wait."
+        id="wizard.loadingText"
+      />
+    }
   >
-    <Component
-      className="pf-u-mb-0"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-    >
-      Loading, please wait.
+    <Component>
+      <div
+        className="pf-l-bullseye"
+      >
+        <Component
+          className="ins-c-sources__empty-state"
+          variant="full"
+        >
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                icon={[Function]}
+              >
+                <Component
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                >
+                  <span
+                    aria-hidden="true"
+                    aria-valuetext="Loading..."
+                    className="pf-c-spinner pf-m-xl"
+                    role="progressbar"
+                  >
+                    <span
+                      className="pf-c-spinner__clipper"
+                    />
+                    <span
+                      className="pf-c-spinner__lead-ball"
+                    />
+                    <span
+                      className="pf-c-spinner__tail-ball"
+                    />
+                  </span>
+                </Component>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+              >
+                <div
+                  className="pf-c-empty-state__body pf-u-mt-xl"
+                >
+                  <FormattedMessage
+                    defaultMessage="Loading, please wait."
+                    id="wizard.loadingText"
+                  >
+                    Loading, please wait.
+                  </FormattedMessage>
+                </div>
+              </Component>
+            </div>
+          </div>
+        </Component>
+      </div>
     </Component>
-  </Component>
-</Component>
+  </LoadingStep>
+</IntlProvider>
 `;
 
 exports[`Steps components LoadingStep renders correctly with custom props 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <LoadingStep
+    cancelTitle={
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="wizard.cancelText"
+      />
+    }
+    customText="Here I Am"
+    onClose={[MockFunction]}
   >
-    <Component
-      className="pf-u-mb-0"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-    >
-      Here I Am
-    </Component>
-    <Component
-      className="pf-u-mt-xl"
-    >
-      <Component
-        onClick={[MockFunction]}
-        variant="link"
+    <Component>
+      <div
+        className="pf-l-bullseye"
       >
-        Cancel
-      </Component>
+        <Component
+          className="ins-c-sources__empty-state"
+          variant="full"
+        >
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                icon={[Function]}
+              >
+                <Component
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                >
+                  <span
+                    aria-hidden="true"
+                    aria-valuetext="Loading..."
+                    className="pf-c-spinner pf-m-xl"
+                    role="progressbar"
+                  >
+                    <span
+                      className="pf-c-spinner__clipper"
+                    />
+                    <span
+                      className="pf-c-spinner__lead-ball"
+                    />
+                    <span
+                      className="pf-c-spinner__tail-ball"
+                    />
+                  </span>
+                </Component>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+              >
+                <div
+                  className="pf-c-empty-state__body pf-u-mt-xl"
+                >
+                  Here I Am
+                </div>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+              >
+                <div
+                  className="pf-c-empty-state__secondary pf-u-mt-xl"
+                >
+                  <Component
+                    onClick={[MockFunction]}
+                    variant="link"
+                  >
+                    <button
+                      aria-disabled={null}
+                      aria-label={null}
+                      className="pf-c-button pf-m-link"
+                      data-ouia-component-id={null}
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      onClick={[MockFunction]}
+                      tabIndex={null}
+                      type="button"
+                    >
+                      <FormattedMessage
+                        defaultMessage="Cancel"
+                        id="wizard.cancelText"
+                      >
+                        Cancel
+                      </FormattedMessage>
+                    </button>
+                  </Component>
+                </div>
+              </Component>
+            </div>
+          </div>
+        </Component>
+      </div>
     </Component>
-  </Component>
-</Component>
+  </LoadingStep>
+</IntlProvider>
 `;
 
 exports[`Steps components LoadingStep renders correctly with progress bar 1`] = `
-<Component>
-  <Component
-    className="ins-c-sources__empty-state"
-    variant="full"
+<IntlProvider
+  defaultFormats={Object {}}
+  defaultLocale="en"
+  formats={Object {}}
+  locale="en"
+  messages={Object {}}
+  onError={[Function]}
+  textComponent={Symbol(react.fragment)}
+>
+  <LoadingStep
+    cancelTitle={
+      <FormattedMessage
+        defaultMessage="Cancel"
+        id="wizard.cancelText"
+      />
+    }
+    customText={
+      <FormattedMessage
+        defaultMessage="Loading, please wait."
+        id="wizard.loadingText"
+      />
+    }
   >
-    <Component
-      className="pf-u-mb-0"
-      icon={[Function]}
-    />
-    <Component
-      className="pf-u-mt-xl"
-    >
-      Loading, please wait.
+    <Component>
+      <div
+        className="pf-l-bullseye"
+      >
+        <Component
+          className="ins-c-sources__empty-state"
+          variant="full"
+        >
+          <div
+            className="pf-c-empty-state ins-c-sources__empty-state"
+          >
+            <div
+              className="pf-c-empty-state__content"
+            >
+              <Component
+                className="pf-u-mb-0"
+                icon={[Function]}
+              >
+                <Component
+                  aria-hidden="true"
+                  className="pf-c-empty-state__icon pf-u-mb-0"
+                >
+                  <span
+                    aria-hidden="true"
+                    aria-valuetext="Loading..."
+                    className="pf-c-spinner pf-m-xl"
+                    role="progressbar"
+                  >
+                    <span
+                      className="pf-c-spinner__clipper"
+                    />
+                    <span
+                      className="pf-c-spinner__lead-ball"
+                    />
+                    <span
+                      className="pf-c-spinner__tail-ball"
+                    />
+                  </span>
+                </Component>
+              </Component>
+              <Component
+                className="pf-u-mt-xl"
+              >
+                <div
+                  className="pf-c-empty-state__body pf-u-mt-xl"
+                >
+                  <FormattedMessage
+                    defaultMessage="Loading, please wait."
+                    id="wizard.loadingText"
+                  >
+                    Loading, please wait.
+                  </FormattedMessage>
+                </div>
+              </Component>
+            </div>
+          </div>
+        </Component>
+      </div>
     </Component>
-  </Component>
-</Component>
+  </LoadingStep>
+</IntlProvider>
 `;

--- a/packages/sources/src/tests/addSourceWizard/addSourceButton.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceButton.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
 import { AddSourceButton } from '../../addSourceWizard/';
 import sourceTypes from '../helpers/sourceTypes';
 import applicationTypes from '../helpers/applicationTypes';
 import Form from '../../addSourceWizard/SourceAddModal';
+
+import mount from '../__mocks__/mount';
 
 describe('AddSourceButton', () => {
     it('opens wizard', async () => {

--- a/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { nextStep, iconMapper, NameDescription, SummaryDescription, sourceTypeMutator, appMutator } from '../../addSourceWizard/SourceAddSchema';
 import { OPENSHIFT_TYPE } from '../helpers/sourceTypes';
 import { TextContent, Text } from '@patternfly/react-core';
+
+import mount from '../__mocks__/mount';
 
 describe('Add source schema', () => {
     describe('nextStep', () => {

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
 import { Button } from '@patternfly/react-core';
@@ -17,6 +16,8 @@ import * as dependency from '../../api/index';
 import * as createSource from '../../api/createSource';
 import CloseModal from '../../addSourceWizard/CloseModal';
 import LoadingStep from '../../addSourceWizard/steps/LoadingStep';
+
+import mount from '../__mocks__/mount';
 
 describe('AddSourceWizard', () => {
     let initialProps;

--- a/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
+++ b/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
@@ -14,13 +14,15 @@ describe('asyncNameValidator', () => {
         data: { sources: [ ] }
     };
 
+    const intl = { formatMessage: ({ defaultMessage }) => defaultMessage };
+
     it('returns error message when name is taken', async () => {
         expect.assertions(1);
 
         actions.findSource = jest.fn(() => Promise.resolve(returnedSourceResponse));
 
         try {
-            await asyncValidator('a1');
+            await asyncValidator('a1', undefined, intl);
         } catch (e) {
             expect(e).toEqual('Name has already been taken');
         }
@@ -31,13 +33,13 @@ describe('asyncNameValidator', () => {
 
         actions.findSource = jest.fn(() => Promise.resolve(returnedSourceResponse));
 
-        return asyncValidator('a1', '1').then(data => expect(data).toEqual(undefined));
+        return asyncValidator('a1', '1', intl).then(data => expect(data).toEqual(undefined));
     });
 
     it('returns nothing when passes', async () => {
         actions.findSource = jest.fn(() => Promise.resolve(emptySourceResponse));
 
-        const msg = await asyncValidator('a1');
+        const msg = await asyncValidator('a1', undefined, intl);
 
         expect(msg).toEqual(undefined);
     });
@@ -48,7 +50,7 @@ describe('asyncNameValidator', () => {
 
         actions.findSource = jest.fn(() => Promise.reject('Some error'));
 
-        const msg = await asyncValidator('a1');
+        const msg = await asyncValidator('a1', undefined, intl);
 
         expect(msg).toEqual(undefined);
         expect(console.error).toHaveBeenCalledWith('Some error');
@@ -61,20 +63,20 @@ describe('asyncNameValidator', () => {
             setFirstValidated(true);
         });
 
-        it('returns required and then the debounced function when creating', () => {
+        it('do not return promise when value is empty and editing', () => {
             actions.findSource = jest.fn(() => Promise.resolve(emptySourceResponse));
 
-            expect(asyncValidatorDebouncedWrapper()()).toEqual('Required');
+            expect(asyncValidatorDebouncedWrapper(intl)(undefined, undefined, intl)).toEqual(undefined);
 
-            expect(asyncValidatorDebouncedWrapper()()).toEqual(expect.any(Promise));
-            expect(asyncValidatorDebouncedWrapper()()).toEqual(expect.any(Promise));
+            expect(asyncValidatorDebouncedWrapper(intl)(undefined, undefined, intl)).toEqual(expect.any(Promise));
+            expect(asyncValidatorDebouncedWrapper(intl)(undefined, undefined, intl)).toEqual(expect.any(Promise));
         });
 
         it('returns function when editing', () => {
             actions.findSource = jest.fn(() => Promise.resolve(emptySourceResponse));
 
-            expect(asyncValidatorDebouncedWrapper()('a1', '1')).toEqual(expect.any(Promise));
-            expect(asyncValidatorDebouncedWrapper()('a1', '1')).toEqual(expect.any(Promise));
+            expect(asyncValidatorDebouncedWrapper(intl)('a1', '1', intl)).toEqual(expect.any(Promise));
+            expect(asyncValidatorDebouncedWrapper(intl)('a1', '1', intl)).toEqual(expect.any(Promise));
         });
     });
 });

--- a/packages/sources/src/tests/addSourceWizard/closeModal.test.js
+++ b/packages/sources/src/tests/addSourceWizard/closeModal.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { Modal, Button, Text, TextContent } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import CloseModal from '../../addSourceWizard/CloseModal';
+
+import mount from '../__mocks__/mount';
 
 describe('CloseModal', () => {
     let initialProps;

--- a/packages/sources/src/tests/addSourceWizard/createProgressText.test.js
+++ b/packages/sources/src/tests/addSourceWizard/createProgressText.test.js
@@ -3,6 +3,7 @@ import createProgressText from '../../addSourceWizard/createProgressText';
 describe('createProgressText', () => {
     let formData;
     let result;
+    let texts;
 
     it('only source', () => {
         formData = {};
@@ -12,7 +13,11 @@ describe('createProgressText', () => {
             'Completed'
         ];
 
-        expect(createProgressText(formData)).toEqual(result);
+        texts = createProgressText(formData);
+
+        result.forEach((text, index) => {
+            expect(text).toEqual(texts[index].props.defaultMessage.replace('{step}', index + 1));
+        });
     });
 
     it('source with endpoint', () => {
@@ -25,7 +30,11 @@ describe('createProgressText', () => {
             'Completed'
         ];
 
-        expect(createProgressText(formData)).toEqual(result);
+        texts = createProgressText(formData);
+
+        result.forEach((text, index) => {
+            expect(text).toEqual(texts[index].props.defaultMessage.replace('{step}', index + 1));
+        });
     });
 
     it('source with app', () => {
@@ -37,7 +46,11 @@ describe('createProgressText', () => {
             'Completed'
         ];
 
-        expect(createProgressText(formData)).toEqual(result);
+        texts = createProgressText(formData);
+
+        result.forEach((text, index) => {
+            expect(text).toEqual(texts[index].props.defaultMessage.replace('{step}', index + 1));
+        });
     });
 
     it('cost managament', () => {
@@ -51,7 +64,11 @@ describe('createProgressText', () => {
             'Completed'
         ];
 
-        expect(createProgressText(formData)).toEqual(result);
+        texts = createProgressText(formData);
+
+        result.forEach((text, index) => {
+            expect(text).toEqual(texts[index].props.defaultMessage.replace('{step}', index + 1));
+        });
     });
 
     it('application and auth', () => {
@@ -65,6 +82,10 @@ describe('createProgressText', () => {
             'Completed'
         ];
 
-        expect(createProgressText(formData)).toEqual(result);
+        texts = createProgressText(formData);
+
+        result.forEach((text, index) => {
+            expect(text).toEqual(texts[index].props.defaultMessage.replace('{step}', index + 1));
+        });
     });
 });

--- a/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
@@ -1,12 +1,13 @@
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import FinalWizard from '../../addSourceWizard/FinalWizard';
 import FinishedStep from '../../addSourceWizard/steps/FinishedStep';
 import LoadingStep from '../../addSourceWizard/steps/LoadingStep';
 import ErroredStep from '../../addSourceWizard/steps/ErroredStep';
+
+import mount from '../__mocks__/mount';
 
 describe('Final wizard', () => {
     describe('Renders', () => {
@@ -28,7 +29,7 @@ describe('Final wizard', () => {
         });
 
         it('renders loading step correctly', () => {
-            const wrapper = shallow(<FinalWizard { ...initialProps }/>);
+            const wrapper = mount(<FinalWizard { ...initialProps }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
@@ -38,7 +39,7 @@ describe('Final wizard', () => {
         });
 
         it('renders finished step correctly', () => {
-            const wrapper = shallow(<FinalWizard { ...initialProps } isFinished={ true }/>);
+            const wrapper = mount(<FinalWizard { ...initialProps } isFinished={ true }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
@@ -48,7 +49,7 @@ describe('Final wizard', () => {
         });
 
         it('renders errored step correctly', () => {
-            const wrapper = shallow(<FinalWizard { ...initialProps } isErrored={ true }/>);
+            const wrapper = mount(<FinalWizard { ...initialProps } isErrored={ true }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/access_key.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/access_key.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import {
     TextContent,
     Text,
@@ -7,6 +6,7 @@ import {
 } from '@patternfly/react-core';
 
 import * as AwsAccess from '../../../addSourceWizard/hardcodedComponents/aws/access_key';
+import mount from '../../__mocks__/mount';
 
 describe('AWS-Access key hardcoded schemas', () => {
     it('ARN DESCRIPTION is rendered correctly', () => {

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/arn.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import {
     TextContent,
     Text,
@@ -11,6 +10,7 @@ import {
 import RendererContext from '@data-driven-forms/react-form-renderer/dist/cjs/renderer-context';
 
 import * as AwsArn from '../../../addSourceWizard/hardcodedComponents/aws/arn';
+import mount from '../../__mocks__/mount';
 
 describe('AWS-ARN hardcoded schemas', () => {
     it('ARN DESCRIPTION is rendered correctly', () => {

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import {
     TextContent,
     Text,
@@ -8,6 +7,7 @@ import {
 
 import * as Cm from '../../../addSourceWizard/hardcodedComponents/azure/costManagement';
 import RenderContext from '@data-driven-forms/react-form-renderer/dist/cjs/renderer-context';
+import mount from '../../__mocks__/mount';
 
 describe('Cost Management Azure steps components', () => {
     test('Configure Resource Group and Storage Account description', () => {

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/cost_management_openshift.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/cost_management_openshift.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import mount from '../../__mocks__/mount';
 
 import * as OpCm from '../../../addSourceWizard/hardcodedComponents/openshift/costManagement';
 

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/openshift.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/openshift.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import mount from '../../__mocks__/mount';
 import { TextContent, Text } from '@patternfly/react-core';
 
 import * as OpenShift from '../../../addSourceWizard/hardcodedComponents/openshift/endpoint';

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/openshift_token.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/openshift_token.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import mount from '../../__mocks__/mount';
 import {
     TextContent,
     Text,

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import mount from '../../__mocks__/mount';
 import {
     TextContent,
     Text,

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/tower_catalog.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/tower_catalog.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import mount from '../../__mocks__/mount';
 import { TextContent, Text } from '@patternfly/react-core';
 
 import * as TowerCatalog from '../../../addSourceWizard/hardcodedComponents/tower/catalog';

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
@@ -269,7 +269,7 @@ describe('schema builder', () => {
 
                 expectedSchema = expect.objectContaining({
                     fields: expect.arrayContaining(fields),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: OPENSHIFT_TYPE.name,
                     nextStep: 'summary'
                 });
@@ -280,7 +280,7 @@ describe('schema builder', () => {
             it('generate single selection with endpoint', () => {
                 expectedSchema = expect.objectContaining({
                     fields: expect.any(Array),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: OPENSHIFT_TYPE.name,
                     nextStep: `${OPENSHIFT_TYPE.name}-endpoint`
                 });
@@ -297,7 +297,7 @@ describe('schema builder', () => {
                         arnSelect,
                         secretKey
                     ]),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: AMAZON_TYPE.name,
                     nextStep: {
                         when: expect.any(String),
@@ -319,7 +319,7 @@ describe('schema builder', () => {
 
                 expectedSchema = expect.objectContaining({
                     fields: expect.arrayContaining(fields),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: expectedName,
                     nextStep: 'summary'
                 });
@@ -333,7 +333,7 @@ describe('schema builder', () => {
 
                 expectedSchema = expect.objectContaining({
                     fields: expect.arrayContaining(fields),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: expectedName,
                     nextStep: `${AZURE_TYPE.name}-endpoint`
                 });

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionSteps.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionSteps.test.js
@@ -96,7 +96,7 @@ describe('generate auth selection pages', () => {
 
             expectedSchema = expect.objectContaining({
                 fields: expect.arrayContaining(fields),
-                title: expect.any(String),
+                title: expect.any(Object),
                 name: ONE_SINGLE_SELECTION_TYPE.name,
                 nextStep: 'summary'
             });
@@ -116,7 +116,7 @@ describe('generate auth selection pages', () => {
 
             expectedSchema = expect.objectContaining({
                 fields: expect.arrayContaining(fields),
-                title: expect.any(String),
+                title: expect.any(Object),
                 name: ONE_SINGLE_SELECTION_TYPE_ADD_STEPS.name,
                 nextStep: EXPECTED_NEXTSTEP
             });
@@ -127,7 +127,7 @@ describe('generate auth selection pages', () => {
         it('generate single selection with endpoint', () => {
             expectedSchema = expect.objectContaining({
                 fields: expect.any(Array),
-                title: expect.any(String),
+                title: expect.any(Object),
                 name: ONE_SINGLE_SELECTION_TYPE.name,
                 nextStep: `${ONE_SINGLE_SELECTION_TYPE.name}-endpoint`
             });
@@ -148,7 +148,7 @@ describe('generate auth selection pages', () => {
                         firstAuth,
                         secondAuth
                     ]),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: MULTIPLE_SELECTION_TYPE.name,
                     nextStep: {
                         when: expect.any(String),
@@ -170,7 +170,7 @@ describe('generate auth selection pages', () => {
                         firstAuth,
                         secondAuth
                     ]),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: MULTIPLE_SELECTION_TYPE.name,
                     nextStep: {
                         when: expect.any(String),

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionStepsSkipEndpoint.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionStepsSkipEndpoint.test.js
@@ -93,7 +93,7 @@ describe('generate auth selection pages', () => {
 
             expectedSchema = expect.objectContaining({
                 fields: expect.arrayContaining(fields),
-                title: expect.any(String),
+                title: expect.any(Object),
                 name: ONE_SINGLE_SELECTION_TYPE.name,
                 nextStep: 'summary'
             });
@@ -116,7 +116,7 @@ describe('generate auth selection pages', () => {
                         firstAuth,
                         secondAuth
                     ]),
-                    title: expect.any(String),
+                    title: expect.any(Object),
                     name: MULTIPLE_SELECTION_TYPE.name,
                     nextStep: {
                         when: expect.any(String),

--- a/packages/sources/src/tests/addSourceWizard/sourceAddModal.test.js
+++ b/packages/sources/src/tests/addSourceWizard/sourceAddModal.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 
 import AddSourceWizard from '../../addSourceWizard/SourceAddModal';
@@ -8,6 +7,7 @@ import applicationTypes from '../helpers/applicationTypes';
 import SourcesFormRenderer from '../../sourceFormRenderer/index';
 
 import * as dependency from '../../api/index';
+import mount from '../__mocks__/mount';
 
 describe('sourceAddModal', () => {
     let initialProps;

--- a/packages/sources/src/tests/addSourceWizard/sslFormLabel.test.js
+++ b/packages/sources/src/tests/addSourceWizard/sslFormLabel.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 import SSLFormLabel from '../../addSourceWizard/SSLFormLabel';
+import mount from '../__mocks__/mount';
 
 describe('SSLFormLabel', () => {
     it('renders loading step correctly', () => {
-        const wrapper = shallow(<SSLFormLabel />);
+        const wrapper = mount(<SSLFormLabel />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/packages/sources/src/tests/addSourceWizard/steps.test.js
+++ b/packages/sources/src/tests/addSourceWizard/steps.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { Button, EmptyStateBody, Text } from '@patternfly/react-core';
 
 import FinishedStep from '../../addSourceWizard/steps/FinishedStep';
 import LoadingStep from '../../addSourceWizard/steps/LoadingStep';
 import ErroredStep from '../../addSourceWizard/steps/ErroredStep';
+
+import mount from '../__mocks__/mount';
 
 describe('Steps components', () => {
     let initialProps;
@@ -35,20 +36,20 @@ describe('Steps components', () => {
         });
 
         it('renders correctly', () => {
-            const wrapper = shallow(<FinishedStep { ...initialProps }/>);
+            const wrapper = mount(<FinishedStep { ...initialProps }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('a[href="/hybrid/settings/sources"]').length).toBe(1);
             expect(wrapper.find(EmptyStateBody).html().includes('Here I Am')).toBe(true);
         });
 
         it('renders withou takemetosources button', () => {
-            const wrapper = shallow(<FinishedStep { ...initialProps } hideSourcesButton={ true }/>);
+            const wrapper = mount(<FinishedStep { ...initialProps } hideSourcesButton={ true }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('a[href="/hybrid/settings/sources"]').length).toBe(0);
         });
 
         it('calls onClose function', () => {
-            const wrapper = shallow(<FinishedStep { ...initialProps }/>);
+            const wrapper = mount(<FinishedStep { ...initialProps }/>);
             wrapper.find(Button).first().simulate('click');
             expect(spyFunction).toHaveBeenCalled();
         });
@@ -63,18 +64,18 @@ describe('Steps components', () => {
         });
 
         it('renders correctly with custom props', () => {
-            const wrapper = shallow(<LoadingStep { ...initialProps }/>);
+            const wrapper = mount(<LoadingStep { ...initialProps }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find(EmptyStateBody).html().includes('Here I Am')).toBe(true);
         });
 
         it('renders correctly', () => {
-            const wrapper = shallow(<LoadingStep />);
+            const wrapper = mount(<LoadingStep />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
         it('calls onClose function', () => {
-            const wrapper = shallow(<LoadingStep { ...initialProps }/>);
+            const wrapper = mount(<LoadingStep { ...initialProps }/>);
             wrapper.find(Button).first().simulate('click');
             expect(spyFunction).toHaveBeenCalled();
         });
@@ -87,7 +88,7 @@ describe('Steps components', () => {
                 progressStep: 0
             };
 
-            const wrapper = shallow(<LoadingStep />);
+            const wrapper = mount(<LoadingStep />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
     });
@@ -104,25 +105,25 @@ describe('Steps components', () => {
         });
 
         it('renders correctly', () => {
-            const wrapper = shallow(<ErroredStep { ...initialProps }/>);
+            const wrapper = mount(<ErroredStep { ...initialProps }/>);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
         it('renders correctly with message', () => {
             const ERROR_MESSAGE = 'I am a little error, nice to meet you';
-            const wrapper = shallow(<ErroredStep { ...initialProps } message={ERROR_MESSAGE}/>);
+            const wrapper = mount(<ErroredStep { ...initialProps } message={ERROR_MESSAGE}/>);
 
             expect(wrapper.find(Text).last().children().text().includes(ERROR_MESSAGE)).toEqual(true);
         });
 
         it('calls onClose function', () => {
-            const wrapper = shallow(<ErroredStep { ...initialProps }/>);
+            const wrapper = mount(<ErroredStep { ...initialProps }/>);
             wrapper.find(Button).first().simulate('click');
             expect(spyFunction).toHaveBeenCalled();
         });
 
         it('calls onRetry function', () => {
-            const wrapper = shallow(<ErroredStep { ...initialProps }/>);
+            const wrapper = mount(<ErroredStep { ...initialProps }/>);
             wrapper.find(Button).last().simulate('click');
             expect(spyFunctionSecond).toHaveBeenCalled();
         });

--- a/packages/sources/src/tests/sourceFormRenderer/authentication.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/authentication.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import { componentMapper, FormTemplate } from '@data-driven-forms/pf4-component-mapper';
 
 import SourcesFormRenderer from '../../sourceFormRenderer';
 import Authentication from '../../sourceFormRenderer/components/Authentication';
+import mount from '../__mocks__/mount';
 
 describe('Authentication test', () => {
     let schema;
@@ -131,7 +131,7 @@ describe('Authentication test', () => {
 
         expect(wrapper.find(Authentication)).toHaveLength(1);
         expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD]).props().isRequired).toEqual(false);
-        expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD]).props().helperText).toEqual(expect.any(String));
+        expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD]).props().helperText).toEqual(expect.any(Object));
 
         wrapper.find('form').simulate('submit');
         wrapper.update();

--- a/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
+++ b/packages/sources/src/tests/sourceFormRenderer/components/__snapshots__/sourceWizardSummary.test.js.snap
@@ -19,7 +19,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN 1`] 
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -39,7 +44,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN 1`] 
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -49,7 +59,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN 1`] 
             className=""
             data-pf-content={true}
           >
-            Not selected
+            <FormattedMessage
+              defaultMessage="Not selected"
+              id="wizard.NotSelected"
+            >
+              Not selected
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -59,7 +74,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN 1`] 
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -79,7 +99,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN 1`] 
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -157,7 +182,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN cost
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -177,7 +207,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN cost
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -197,7 +232,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN cost
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -217,7 +257,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN cost
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -237,7 +282,12 @@ exports[`SourceWizardSummary component should render correctly amazon - ARN cost
             className=""
             data-pf-content={true}
           >
-            S3 bucket name
+            <FormattedMessage
+              defaultMessage="S3 bucket name"
+              id="wizard.S3Label"
+            >
+              S3 bucket name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -295,7 +345,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -315,7 +370,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -325,7 +385,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Not selected
+            <FormattedMessage
+              defaultMessage="Not selected"
+              id="wizard.NotSelected"
+            >
+              Not selected
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -335,7 +400,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -355,7 +425,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -375,7 +450,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Access key ID
+            <FormattedMessage
+              defaultMessage="Access key ID"
+              id="wizard.AccessKeyId"
+            >
+              Access key ID
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -395,7 +475,12 @@ exports[`SourceWizardSummary component should render correctly amazon 1`] = `
             className=""
             data-pf-content={true}
           >
-            Secret access key
+            <FormattedMessage
+              defaultMessage="Secret access key"
+              id="wizard.SecretAccessKey"
+            >
+              Secret access key
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -433,7 +518,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -453,7 +543,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -463,7 +558,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Not selected
+            <FormattedMessage
+              defaultMessage="Not selected"
+              id="wizard.NotSelected"
+            >
+              Not selected
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -473,7 +573,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -493,7 +598,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -553,7 +663,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Hostname
+            <FormattedMessage
+              defaultMessage="Hostname"
+              id="wizard.Hostname"
+            >
+              Hostname
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -583,7 +698,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Yes
+            <FormattedMessage
+              defaultMessage="Yes"
+              id="wizard.Yes"
+            >
+              Yes
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -593,7 +713,12 @@ exports[`SourceWizardSummary component should render correctly ansible-tower 1`]
             className=""
             data-pf-content={true}
           >
-            Certificate authority
+            <FormattedMessage
+              defaultMessage="Certificate authority"
+              id="wizard.CertificateAuthority"
+            >
+              Certificate authority
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -631,7 +756,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -651,7 +781,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -671,7 +806,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -691,7 +831,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Hostname
+            <FormattedMessage
+              defaultMessage="Hostname"
+              id="wizard.Hostname"
+            >
+              Hostname
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -711,7 +856,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Verify SSL
+            <FormattedMessage
+              defaultMessage="Verify SSL"
+              id="wizard.VerifySsl"
+            >
+              Verify SSL
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -721,7 +871,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Yes
+            <FormattedMessage
+              defaultMessage="Yes"
+              id="wizard.Yes"
+            >
+              Yes
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -731,7 +886,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Certificate authority
+            <FormattedMessage
+              defaultMessage="Certificate authority"
+              id="wizard.CertificateAuthority"
+            >
+              Certificate authority
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -751,7 +911,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Username
+            <FormattedMessage
+              defaultMessage="Username"
+              id="wizard.Username"
+            >
+              Username
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -771,7 +936,12 @@ exports[`SourceWizardSummary component should render correctly hide application 
             className=""
             data-pf-content={true}
           >
-            Password
+            <FormattedMessage
+              defaultMessage="Password"
+              id="wizard.Password"
+            >
+              Password
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -809,7 +979,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -829,7 +1004,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -839,7 +1019,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Not selected
+            <FormattedMessage
+              defaultMessage="Not selected"
+              id="wizard.NotSelected"
+            >
+              Not selected
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -849,7 +1034,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -869,7 +1059,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -939,7 +1134,12 @@ exports[`SourceWizardSummary component should render correctly openshift 1`] = `
             className=""
             data-pf-content={true}
           >
-            Yes
+            <FormattedMessage
+              defaultMessage="Yes"
+              id="wizard.Yes"
+            >
+              Yes
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -987,7 +1187,12 @@ exports[`SourceWizardSummary component should render correctly openshift cost ma
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1007,7 +1212,12 @@ exports[`SourceWizardSummary component should render correctly openshift cost ma
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1027,7 +1237,12 @@ exports[`SourceWizardSummary component should render correctly openshift cost ma
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1047,7 +1262,12 @@ exports[`SourceWizardSummary component should render correctly openshift cost ma
             className=""
             data-pf-content={true}
           >
-            Cluster Identifier
+            <FormattedMessage
+              defaultMessage="Cluster Identifier"
+              id="wizard.clusterId"
+            >
+              Cluster Identifier
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1085,7 +1305,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Name
+            <FormattedMessage
+              defaultMessage="Name"
+              id="wizard.Name"
+            >
+              Name
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1105,7 +1330,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Application
+            <FormattedMessage
+              defaultMessage="Application"
+              id="wizard.Application"
+            >
+              Application
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1125,7 +1355,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Source type
+            <FormattedMessage
+              defaultMessage="Source type"
+              id="wizard.SourceType"
+            >
+              Source type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1145,7 +1380,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Authentication type
+            <FormattedMessage
+              defaultMessage="Authentication type"
+              id="wizard.AuthenticationType"
+            >
+              Authentication type
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1165,7 +1405,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Hostname
+            <FormattedMessage
+              defaultMessage="Hostname"
+              id="wizard.Hostname"
+            >
+              Hostname
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1185,7 +1430,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Verify SSL
+            <FormattedMessage
+              defaultMessage="Verify SSL"
+              id="wizard.VerifySsl"
+            >
+              Verify SSL
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1195,7 +1445,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Yes
+            <FormattedMessage
+              defaultMessage="Yes"
+              id="wizard.Yes"
+            >
+              Yes
+            </FormattedMessage>
           </dd>
         </Component>
         <Component
@@ -1205,7 +1460,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Certificate authority
+            <FormattedMessage
+              defaultMessage="Certificate authority"
+              id="wizard.CertificateAuthority"
+            >
+              Certificate authority
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1225,7 +1485,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Username
+            <FormattedMessage
+              defaultMessage="Username"
+              id="wizard.Username"
+            >
+              Username
+            </FormattedMessage>
           </dt>
         </Component>
         <Component
@@ -1245,7 +1510,12 @@ exports[`SourceWizardSummary component should render correctly selected Catalog 
             className=""
             data-pf-content={true}
           >
-            Password
+            <FormattedMessage
+              defaultMessage="Password"
+              id="wizard.Password"
+            >
+              Password
+            </FormattedMessage>
           </dt>
         </Component>
         <Component

--- a/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/authSelect.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { Radio, FormHelperText } from '@patternfly/react-core';
 
 import FormRenderer from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
 
 import AuthSelect from '../../../sourceFormRenderer/components/AuthSelect';
+import mount from '../../__mocks__/mount';
 
 describe('AuthSelect component', () => {
     let initialProps;

--- a/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/sourceWizardSummary.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { TextListItem, TextContent } from '@patternfly/react-core';
 
@@ -8,6 +7,8 @@ import applicationTypes, { COST_MANAGEMENT_APP } from '../../helpers/application
 import sourceTypes from '../../helpers/sourceTypes';
 import ValuePopover from '../../../sourceFormRenderer/components/ValuePopover';
 import RendererContext from '@data-driven-forms/react-form-renderer/dist/cjs/renderer-context';
+import mount from '../../__mocks__/mount';
+import { FormattedMessage } from 'react-intl';
 
 describe('SourceWizardSummary component', () => {
     describe('should render correctly', () => {
@@ -125,7 +126,7 @@ describe('SourceWizardSummary component', () => {
             const wrapper = mount(<SourceWizardSummary { ...initialProps } formOptions={ formOptions } />);
             expect(toJson(wrapper.find(TextContent))).toMatchSnapshot();
 
-            expect(wrapper.find(TextContent).html().includes('Cluster Identifier')).toEqual(true);
+            expect(wrapper.find(TextContent).find({ defaultMessage: 'Cluster Identifier' })).toHaveLength(1);
             expect(wrapper.find(TextContent).html().includes('CLUSTER ID123')).toEqual(true);
         });
 
@@ -311,7 +312,7 @@ describe('SourceWizardSummary component', () => {
 
             expect(createItem(field, values, availableStepKeys)).toEqual({
                 label: 'Label 1',
-                value: 'Yes'
+                value: <FormattedMessage id="wizard.Yes" defaultMessage="Yes" />
             });
         });
 
@@ -324,7 +325,7 @@ describe('SourceWizardSummary component', () => {
 
             expect(createItem(field, values, availableStepKeys)).toEqual({
                 label: 'Label 1',
-                value: 'No'
+                value: <FormattedMessage id="wizard.No" defaultMessage="No" />
             });
         });
 

--- a/packages/sources/src/tests/sourceFormRenderer/components/valuePopover.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/components/valuePopover.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { Popover, Button } from '@patternfly/react-core';
 import ValuePopover from '../../../sourceFormRenderer/components/ValuePopover';
+
+import mount from '../../__mocks__/mount';
 
 describe('ValuePopover', () => {
     it('renders correctly', () => {

--- a/packages/sources/src/utilities/stringConstants.js
+++ b/packages/sources/src/utilities/stringConstants.js
@@ -1,3 +1,6 @@
-export const WIZARD_DESCRIPTION = 'Connect a data source to use with your applications.';
-export const WIZARD_TITLE = 'Add source';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+export const WIZARD_DESCRIPTION = <FormattedMessage id="wizard.wizardDescription" defaultMessage="Connect a data source to use with your applications."/>;
+export const WIZARD_TITLE = <FormattedMessage id="wizard.wizardTitle" defaultMessage="Add source"/>;
 export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.4';


### PR DESCRIPTION
Make all texts in Sources wizard translatable

KNOWN ISSUES:
- [x] substepOf is not translated
- [x] translated step titles throws warnings

I will fix both issues in DDF. (Addressed here https://github.com/data-driven-forms/react-forms/pull/636 )

Also, there is one aria-label untranslated. Right now, make it translated would take to much time...

TODO:
- [x] tests

Please, can you take a look if everything is OK? @Hyperkid123  @boaz0 

(To check it in UI, uncomment `// modules: [resolve('./node_modules')], // uncomment when using linked package` in webpack config and update intl to the latest)
