### PR TITLE
revert changes to toolbar

### DIFF
--- a/packages/components/doc/tableToolbar.md
+++ b/packages/components/doc/tableToolbar.md
@@ -9,7 +9,7 @@ Import TableToolbar and styles from this package.
 ```JSX
 import React from 'react';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components';
-import { PageHeaderToolsGroup, PageHeaderToolsItem } from '@patternfly/react-core';
+import { ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
 
 class YourCmp extends React.Component {
@@ -17,10 +17,10 @@ class YourCmp extends React.Component {
     return (
         <TableToolbar>
             // Whatever content you want inside the toolbar (search, buttons, etc) can go in ToolbarItem
-            <PageHeaderToolsGroup>
-              <PageHeaderToolsItem> Foo </PageHeaderToolsItem>
-              <PageHeaderToolsItem> Bar </PageHeaderToolsItem>
-            </PageHeaderToolsGroup>
+            <ToolbarGroup>
+              <ToolbarItem> Foo </ToolbarItem>
+              <ToolbarItem> Bar </ToolbarItem>
+            </ToolbarGroup>
         </TableToolbar>
         <Table>
             // Table content

--- a/packages/components/src/Components/TableToolbar/TableToolbar.js
+++ b/packages/components/src/Components/TableToolbar/TableToolbar.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
-import { PageHeaderTools } from '@patternfly/react-core';
+import { Toolbar } from '@patternfly/react-core';
 import classNames from 'classnames';
 
 import './TableToolbar.scss';
@@ -23,7 +23,7 @@ const TableToolbar = ({ isFooter, results, className, selected, children, ...pro
 
     return (
         <Fragment>
-            <PageHeaderTools className={ tableToolbarClasses } { ...props }> { children }</PageHeaderTools>
+            <Toolbar className={ tableToolbarClasses } { ...props }> { children }</Toolbar>
             {
                 (results >= 0 || selected >= 0) &&
                 <div className='ins-c-table__toolbar-results'>

--- a/packages/components/src/Components/TableToolbar/__snapshots__/TableToolbar.test.js.snap
+++ b/packages/components/src/Components/TableToolbar/__snapshots__/TableToolbar.test.js.snap
@@ -2,34 +2,34 @@
 
 exports[`TableToolbar component should render 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
 </Fragment>
 `;
 
 exports[`TableToolbar component should render a footer 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar ins-m-footer"
   >
      
     Footer
-  </Component>
+  </Toolbar>
 </Fragment>
 `;
 
 exports[`TableToolbar component should render with results and selection of 1 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -53,12 +53,12 @@ exports[`TableToolbar component should render with results and selection of 1 1`
 
 exports[`TableToolbar component should render with results greater than 1 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -75,12 +75,12 @@ exports[`TableToolbar component should render with results greater than 1 1`] = 
 
 exports[`TableToolbar component should render with results of 0 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -97,12 +97,12 @@ exports[`TableToolbar component should render with results of 0 1`] = `
 
 exports[`TableToolbar component should render with results of 1 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -119,12 +119,12 @@ exports[`TableToolbar component should render with results of 1 1`] = `
 
 exports[`TableToolbar component should render with selection of 0 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >
@@ -141,12 +141,12 @@ exports[`TableToolbar component should render with selection of 0 1`] = `
 
 exports[`TableToolbar component should render with selection of 1 1`] = `
 <Fragment>
-  <Component
+  <Toolbar
     className="ins-c-table__toolbar"
   >
      
     Some
-  </Component>
+  </Toolbar>
   <div
     className="ins-c-table__toolbar-results"
   >

--- a/packages/inventory-general-info/src/__snapshots__/InfoTable.test.js.snap
+++ b/packages/inventory-general-info/src/__snapshots__/InfoTable.test.js.snap
@@ -5189,379 +5189,312 @@ exports[`InfoTable api expandable should open 1`] = `
     className="ins-c-inventory__table--toolbar"
     isFooter={true}
   >
-    <Component
+    <Toolbar
       className="ins-c-table__toolbar ins-m-footer ins-c-inventory__table--toolbar"
     >
-      <div
-        className="pf-c-page__header-tools ins-c-table__toolbar ins-m-footer ins-c-inventory__table--toolbar"
+      <GenerateId
+        prefix="pf-random-id-"
       >
-         
-        <Pagination
-          className=""
-          defaultToFullPage={false}
-          firstPage={1}
-          isCompact={false}
-          isDisabled={false}
-          itemCount={4}
-          itemsEnd={null}
-          itemsStart={null}
-          offset={0}
-          onFirstClick={[Function]}
-          onLastClick={[Function]}
-          onNextClick={[Function]}
-          onPageInput={[Function]}
-          onPerPageSelect={[Function]}
-          onPreviousClick={[Function]}
-          onSetPage={[Function]}
-          ouiaId={null}
-          page={1}
-          perPage={10}
-          perPageOptions={
-            Array [
-              Object {
-                "title": "10",
-                "value": 10,
-              },
-              Object {
-                "title": "20",
-                "value": 20,
-              },
-              Object {
-                "title": "50",
-                "value": 50,
-              },
-              Object {
-                "title": "100",
-                "value": 100,
-              },
-            ]
-          }
-          titles={
-            Object {
-              "currPage": "Current page",
-              "items": "",
-              "itemsPerPage": "Items per page",
-              "optionsToggle": "Items per page",
-              "page": "",
-              "paginationTitle": "Pagination",
-              "perPageSuffix": "per page",
-              "toFirstPage": "Go to first page",
-              "toLastPage": "Go to last page",
-              "toNextPage": "Go to next page",
-              "toPreviousPage": "Go to previous page",
-            }
-          }
-          toggleTemplate={[Function]}
-          variant="bottom"
-          widgetId="pagination-options-menu"
+        <div
+          className="pf-c-toolbar ins-c-table__toolbar ins-m-footer ins-c-inventory__table--toolbar"
+          id="pf-random-id-0"
         >
-          <div
-            className="pf-c-pagination pf-m-bottom"
-            data-ouia-component-id={null}
-            data-ouia-component-type="PF4/Pagination"
-            data-ouia-safe={true}
-            id="pagination-options-menu-3"
-          >
-            <PaginationOptionsMenu
-              className=""
-              defaultToFullPage={false}
-              dropDirection="up"
-              firstIndex={1}
-              isDisabled={false}
-              itemCount={4}
-              itemsPerPageTitle="Items per page"
-              itemsTitle=""
-              lastIndex={4}
-              lastPage={1}
-              onPerPageSelect={[Function]}
-              optionsToggle="Items per page"
-              page={1}
-              perPage={10}
-              perPageOptions={
-                Array [
-                  Object {
-                    "title": "10",
-                    "value": 10,
-                  },
-                  Object {
-                    "title": "20",
-                    "value": 20,
-                  },
-                  Object {
-                    "title": "50",
-                    "value": 50,
-                  },
-                  Object {
-                    "title": "100",
-                    "value": 100,
-                  },
-                ]
+           
+          <Pagination
+            className=""
+            defaultToFullPage={false}
+            firstPage={1}
+            isCompact={false}
+            isDisabled={false}
+            itemCount={4}
+            itemsEnd={null}
+            itemsStart={null}
+            offset={0}
+            onFirstClick={[Function]}
+            onLastClick={[Function]}
+            onNextClick={[Function]}
+            onPageInput={[Function]}
+            onPerPageSelect={[Function]}
+            onPreviousClick={[Function]}
+            onSetPage={[Function]}
+            ouiaId={null}
+            page={1}
+            perPage={10}
+            perPageOptions={
+              Array [
+                Object {
+                  "title": "10",
+                  "value": 10,
+                },
+                Object {
+                  "title": "20",
+                  "value": 20,
+                },
+                Object {
+                  "title": "50",
+                  "value": 50,
+                },
+                Object {
+                  "title": "100",
+                  "value": 100,
+                },
+              ]
+            }
+            titles={
+              Object {
+                "currPage": "Current page",
+                "items": "",
+                "itemsPerPage": "Items per page",
+                "optionsToggle": "Items per page",
+                "page": "",
+                "paginationTitle": "Pagination",
+                "perPageSuffix": "per page",
+                "toFirstPage": "Go to first page",
+                "toLastPage": "Go to last page",
+                "toNextPage": "Go to next page",
+                "toPreviousPage": "Go to previous page",
               }
-              perPageSuffix="per page"
-              toggleTemplate={[Function]}
-              widgetId="pagination-options-menu"
+            }
+            toggleTemplate={[Function]}
+            variant="bottom"
+            widgetId="pagination-options-menu"
+          >
+            <div
+              className="pf-c-pagination pf-m-bottom"
+              data-ouia-component-id={null}
+              data-ouia-component-type="PF4/Pagination"
+              data-ouia-safe={true}
+              id="pagination-options-menu-3"
             >
-              <DropdownWithContext
-                autoFocus={true}
+              <PaginationOptionsMenu
                 className=""
-                direction="up"
-                dropdownItems={
+                defaultToFullPage={false}
+                dropDirection="up"
+                firstIndex={1}
+                isDisabled={false}
+                itemCount={4}
+                itemsPerPageTitle="Items per page"
+                itemsTitle=""
+                lastIndex={4}
+                lastPage={1}
+                onPerPageSelect={[Function]}
+                optionsToggle="Items per page"
+                page={1}
+                perPage={10}
+                perPageOptions={
                   Array [
-                    <Unknown
-                      className="pf-m-selected"
-                      component="button"
-                      data-action="per-page-10"
-                      onClick={[Function]}
-                    >
-                      10
-                       per page
-                      <div
-                        className="pf-c-options-menu__menu-item-icon"
-                      >
-                        <CheckIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                        />
-                      </div>
-                    </Unknown>,
-                    <Unknown
-                      className=""
-                      component="button"
-                      data-action="per-page-20"
-                      onClick={[Function]}
-                    >
-                      20
-                       per page
-                    </Unknown>,
-                    <Unknown
-                      className=""
-                      component="button"
-                      data-action="per-page-50"
-                      onClick={[Function]}
-                    >
-                      50
-                       per page
-                    </Unknown>,
-                    <Unknown
-                      className=""
-                      component="button"
-                      data-action="per-page-100"
-                      onClick={[Function]}
-                    >
-                      100
-                       per page
-                    </Unknown>,
+                    Object {
+                      "title": "10",
+                      "value": 10,
+                    },
+                    Object {
+                      "title": "20",
+                      "value": 20,
+                    },
+                    Object {
+                      "title": "50",
+                      "value": 50,
+                    },
+                    Object {
+                      "title": "100",
+                      "value": 100,
+                    },
                   ]
                 }
-                isGrouped={false}
-                isOpen={false}
-                isPlain={true}
-                onSelect={[Function]}
-                ouiaComponentType="Dropdown"
-                position="left"
-                toggle={
-                  <Unknown
-                    firstIndex={1}
-                    isDisabled={false}
-                    isOpen={false}
-                    itemCount={4}
-                    itemsPerPageTitle="Items per page"
-                    itemsTitle=""
-                    lastIndex={4}
-                    onToggle={[Function]}
-                    optionsToggle="Items per page"
-                    parentRef={null}
-                    showToggle={true}
-                    toggleTemplate={[Function]}
-                    widgetId="pagination-options-menu"
-                  />
-                }
+                perPageSuffix="per page"
+                toggleTemplate={[Function]}
+                widgetId="pagination-options-menu"
               >
-                <div
-                  className="pf-c-options-menu pf-m-top"
-                  data-ouia-component-id={21}
-                  data-ouia-component-type="PF4/Dropdown"
-                  data-ouia-safe={true}
-                >
-                  <Component
-                    aria-haspopup={true}
-                    firstIndex={1}
-                    id="pf-toggle-id-3"
-                    isDisabled={false}
-                    isOpen={false}
-                    isPlain={true}
-                    itemCount={4}
-                    itemsPerPageTitle="Items per page"
-                    itemsTitle=""
-                    key=".0"
-                    lastIndex={4}
-                    onEnter={[Function]}
-                    onToggle={[Function]}
-                    optionsToggle="Items per page"
-                    parentRef={
-                      Object {
-                        "current": <div
-                          class="pf-c-options-menu pf-m-top"
-                          data-ouia-component-id="21"
-                          data-ouia-component-type="PF4/Dropdown"
-                          data-ouia-safe="true"
+                <DropdownWithContext
+                  autoFocus={true}
+                  className=""
+                  direction="up"
+                  dropdownItems={
+                    Array [
+                      <Unknown
+                        className="pf-m-selected"
+                        component="button"
+                        data-action="per-page-10"
+                        onClick={[Function]}
+                      >
+                        10
+                         per page
+                        <div
+                          className="pf-c-options-menu__menu-item-icon"
                         >
-                          <div
-                            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                          <CheckIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />
+                        </div>
+                      </Unknown>,
+                      <Unknown
+                        className=""
+                        component="button"
+                        data-action="per-page-20"
+                        onClick={[Function]}
+                      >
+                        20
+                         per page
+                      </Unknown>,
+                      <Unknown
+                        className=""
+                        component="button"
+                        data-action="per-page-50"
+                        onClick={[Function]}
+                      >
+                        50
+                         per page
+                      </Unknown>,
+                      <Unknown
+                        className=""
+                        component="button"
+                        data-action="per-page-100"
+                        onClick={[Function]}
+                      >
+                        100
+                         per page
+                      </Unknown>,
+                    ]
+                  }
+                  isGrouped={false}
+                  isOpen={false}
+                  isPlain={true}
+                  onSelect={[Function]}
+                  ouiaComponentType="Dropdown"
+                  position="left"
+                  toggle={
+                    <Unknown
+                      firstIndex={1}
+                      isDisabled={false}
+                      isOpen={false}
+                      itemCount={4}
+                      itemsPerPageTitle="Items per page"
+                      itemsTitle=""
+                      lastIndex={4}
+                      onToggle={[Function]}
+                      optionsToggle="Items per page"
+                      parentRef={null}
+                      showToggle={true}
+                      toggleTemplate={[Function]}
+                      widgetId="pagination-options-menu"
+                    />
+                  }
+                >
+                  <div
+                    className="pf-c-options-menu pf-m-top"
+                    data-ouia-component-id={21}
+                    data-ouia-component-type="PF4/Dropdown"
+                    data-ouia-safe={true}
+                  >
+                    <Component
+                      aria-haspopup={true}
+                      firstIndex={1}
+                      id="pf-toggle-id-3"
+                      isDisabled={false}
+                      isOpen={false}
+                      isPlain={true}
+                      itemCount={4}
+                      itemsPerPageTitle="Items per page"
+                      itemsTitle=""
+                      key=".0"
+                      lastIndex={4}
+                      onEnter={[Function]}
+                      onToggle={[Function]}
+                      optionsToggle="Items per page"
+                      parentRef={
+                        Object {
+                          "current": <div
+                            class="pf-c-options-menu pf-m-top"
+                            data-ouia-component-id="21"
+                            data-ouia-component-type="PF4/Dropdown"
+                            data-ouia-safe="true"
                           >
-                            <span
-                              class="pf-c-options-menu__toggle-text"
-                            >
-                              <b>
-                                1
-                                 - 
-                                4
-                              </b>
-                               
-                              of 
-                              <b>
-                                4
-                              </b>
-                               
-                              
-                            </span>
-                            <button
-                              aria-expanded="false"
-                              aria-label="Items per page"
-                              class="  pf-c-options-menu__toggle-button"
-                              id="pagination-options-menu-toggle-3"
-                              type="button"
+                            <div
+                              class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
                             >
                               <span
-                                class="pf-c-options-menu__toggle-button-icon"
+                                class="pf-c-options-menu__toggle-text"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style="vertical-align: -0.125em;"
-                                  viewBox="0 0 320 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    transform=""
-                                  />
-                                </svg>
+                                <b>
+                                  1
+                                   - 
+                                  4
+                                </b>
+                                 
+                                of 
+                                <b>
+                                  4
+                                </b>
+                                 
+                                
                               </span>
-                            </button>
-                          </div>
-                        </div>,
-                      }
-                    }
-                    showToggle={true}
-                    toggleTemplate={[Function]}
-                    widgetId="pagination-options-menu"
-                  >
-                    <div
-                      className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                    >
-                      <span
-                        className="pf-c-options-menu__toggle-text"
-                      >
-                        <Component
-                          firstIndex={1}
-                          itemCount={4}
-                          itemsTitle=""
-                          lastIndex={4}
-                        >
-                          <b>
-                            1
-                             - 
-                            4
-                          </b>
-                           
-                          of 
-                          <b>
-                            4
-                          </b>
-                           
-                        </Component>
-                      </span>
-                      <Component
-                        aria-label="Items per page"
-                        className="pf-c-options-menu__toggle-button"
-                        id="pagination-options-menu-toggle-3"
-                        isDisabled={false}
-                        isOpen={false}
-                        onEnter={[Function]}
-                        onToggle={[Function]}
-                        parentRef={
-                          Object {
-                            "current": <div
-                              class="pf-c-options-menu pf-m-top"
-                              data-ouia-component-id="21"
-                              data-ouia-component-type="PF4/Dropdown"
-                              data-ouia-safe="true"
-                            >
-                              <div
-                                class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                              <button
+                                aria-expanded="false"
+                                aria-label="Items per page"
+                                class="  pf-c-options-menu__toggle-button"
+                                id="pagination-options-menu-toggle-3"
+                                type="button"
                               >
                                 <span
-                                  class="pf-c-options-menu__toggle-text"
+                                  class="pf-c-options-menu__toggle-button-icon"
                                 >
-                                  <b>
-                                    1
-                                     - 
-                                    4
-                                  </b>
-                                   
-                                  of 
-                                  <b>
-                                    4
-                                  </b>
-                                   
-                                  
-                                </span>
-                                <button
-                                  aria-expanded="false"
-                                  aria-label="Items per page"
-                                  class="  pf-c-options-menu__toggle-button"
-                                  id="pagination-options-menu-toggle-3"
-                                  type="button"
-                                >
-                                  <span
-                                    class="pf-c-options-menu__toggle-button-icon"
+                                  <svg
+                                    aria-hidden="true"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: -0.125em;"
+                                    viewBox="0 0 320 512"
+                                    width="1em"
                                   >
-                                    <svg
-                                      aria-hidden="true"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style="vertical-align: -0.125em;"
-                                      viewBox="0 0 320 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </span>
-                                </button>
-                              </div>
-                            </div>,
-                          }
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      transform=""
+                                    />
+                                  </svg>
+                                </span>
+                              </button>
+                            </div>
+                          </div>,
                         }
+                      }
+                      showToggle={true}
+                      toggleTemplate={[Function]}
+                      widgetId="pagination-options-menu"
+                    >
+                      <div
+                        className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
                       >
-                        <Toggle
+                        <span
+                          className="pf-c-options-menu__toggle-text"
+                        >
+                          <Component
+                            firstIndex={1}
+                            itemCount={4}
+                            itemsTitle=""
+                            lastIndex={4}
+                          >
+                            <b>
+                              1
+                               - 
+                              4
+                            </b>
+                             
+                            of 
+                            <b>
+                              4
+                            </b>
+                             
+                          </Component>
+                        </span>
+                        <Component
                           aria-label="Items per page"
-                          bubbleEvent={false}
                           className="pf-c-options-menu__toggle-button"
                           id="pagination-options-menu-toggle-3"
-                          isActive={false}
                           isDisabled={false}
                           isOpen={false}
-                          isPlain={false}
-                          isPrimary={false}
-                          isSplitButton={false}
                           onEnter={[Function]}
                           onToggle={[Function]}
                           parentRef={
@@ -5622,310 +5555,419 @@ exports[`InfoTable api expandable should open 1`] = `
                             }
                           }
                         >
-                          <button
-                            aria-expanded={false}
+                          <Toggle
                             aria-label="Items per page"
-                            className="  pf-c-options-menu__toggle-button"
-                            disabled={false}
+                            bubbleEvent={false}
+                            className="pf-c-options-menu__toggle-button"
                             id="pagination-options-menu-toggle-3"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="pf-c-options-menu__toggle-button-icon"
-                            >
-                              <CaretDownIcon
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style={
-                                    Object {
-                                      "verticalAlign": "-0.125em",
-                                    }
-                                  }
-                                  viewBox="0 0 320 512"
-                                  width="1em"
+                            isActive={false}
+                            isDisabled={false}
+                            isOpen={false}
+                            isPlain={false}
+                            isPrimary={false}
+                            isSplitButton={false}
+                            onEnter={[Function]}
+                            onToggle={[Function]}
+                            parentRef={
+                              Object {
+                                "current": <div
+                                  class="pf-c-options-menu pf-m-top"
+                                  data-ouia-component-id="21"
+                                  data-ouia-component-type="PF4/Dropdown"
+                                  data-ouia-safe="true"
                                 >
-                                  <path
-                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    transform=""
-                                  />
-                                </svg>
-                              </CaretDownIcon>
-                            </span>
-                          </button>
-                        </Toggle>
-                      </Component>
-                    </div>
-                  </Component>
-                </div>
-              </DropdownWithContext>
-            </PaginationOptionsMenu>
-            <Navigation
-              className=""
-              currPage="Current page"
-              firstPage={1}
-              isCompact={false}
-              isDisabled={false}
-              lastPage={1}
-              onFirstClick={[Function]}
-              onLastClick={[Function]}
-              onNextClick={[Function]}
-              onPageInput={[Function]}
-              onPreviousClick={[Function]}
-              onSetPage={[Function]}
-              page={1}
-              pagesTitle=""
-              paginationTitle="Pagination"
-              perPage={10}
-              toFirstPage="Go to first page"
-              toLastPage="Go to last page"
-              toNextPage="Go to next page"
-              toPreviousPage="Go to previous page"
-            >
-              <nav
-                aria-label="Pagination"
-                className="pf-c-pagination__nav"
+                                  <div
+                                    class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                  >
+                                    <span
+                                      class="pf-c-options-menu__toggle-text"
+                                    >
+                                      <b>
+                                        1
+                                         - 
+                                        4
+                                      </b>
+                                       
+                                      of 
+                                      <b>
+                                        4
+                                      </b>
+                                       
+                                      
+                                    </span>
+                                    <button
+                                      aria-expanded="false"
+                                      aria-label="Items per page"
+                                      class="  pf-c-options-menu__toggle-button"
+                                      id="pagination-options-menu-toggle-3"
+                                      type="button"
+                                    >
+                                      <span
+                                        class="pf-c-options-menu__toggle-button-icon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          style="vertical-align: -0.125em;"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            transform=""
+                                          />
+                                        </svg>
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>,
+                              }
+                            }
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-label="Items per page"
+                              className="  pf-c-options-menu__toggle-button"
+                              disabled={false}
+                              id="pagination-options-menu-toggle-3"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              type="button"
+                            >
+                              <span
+                                className="pf-c-options-menu__toggle-button-icon"
+                              >
+                                <CaretDownIcon
+                                  color="currentColor"
+                                  noVerticalAlign={false}
+                                  size="sm"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    aria-labelledby={null}
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style={
+                                      Object {
+                                        "verticalAlign": "-0.125em",
+                                      }
+                                    }
+                                    viewBox="0 0 320 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                      transform=""
+                                    />
+                                  </svg>
+                                </CaretDownIcon>
+                              </span>
+                            </button>
+                          </Toggle>
+                        </Component>
+                      </div>
+                    </Component>
+                  </div>
+                </DropdownWithContext>
+              </PaginationOptionsMenu>
+              <Navigation
+                className=""
+                currPage="Current page"
+                firstPage={1}
+                isCompact={false}
+                isDisabled={false}
+                lastPage={1}
+                onFirstClick={[Function]}
+                onLastClick={[Function]}
+                onNextClick={[Function]}
+                onPageInput={[Function]}
+                onPreviousClick={[Function]}
+                onSetPage={[Function]}
+                page={1}
+                pagesTitle=""
+                paginationTitle="Pagination"
+                perPage={10}
+                toFirstPage="Go to first page"
+                toLastPage="Go to last page"
+                toNextPage="Go to next page"
+                toPreviousPage="Go to previous page"
               >
-                <div
-                  className="pf-c-pagination__nav-control pf-m-first"
+                <nav
+                  aria-label="Pagination"
+                  className="pf-c-pagination__nav"
                 >
-                  <Component
-                    aria-label="Go to first page"
-                    data-action="first"
-                    isDisabled={true}
-                    onClick={[Function]}
-                    variant="plain"
+                  <div
+                    className="pf-c-pagination__nav-control pf-m-first"
                   >
-                    <button
-                      aria-disabled={null}
+                    <Component
                       aria-label="Go to first page"
-                      className="pf-c-button pf-m-plain"
                       data-action="first"
-                      data-ouia-component-id={null}
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={true}
+                      isDisabled={true}
                       onClick={[Function]}
-                      tabIndex={null}
-                      type="button"
+                      variant="plain"
                     >
-                      <AngleDoubleLeftIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={null}
+                        aria-label="Go to first page"
+                        className="pf-c-button pf-m-plain"
+                        data-action="first"
+                        data-ouia-component-id={null}
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 448 512"
-                          width="1em"
+                        <AngleDoubleLeftIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                            transform=""
-                          />
-                        </svg>
-                      </AngleDoubleLeftIcon>
-                    </button>
-                  </Component>
-                </div>
-                <div
-                  className="pf-c-pagination__nav-control"
-                >
-                  <Component
-                    aria-label="Go to previous page"
-                    data-action="previous"
-                    isDisabled={true}
-                    onClick={[Function]}
-                    variant="plain"
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                              transform=""
+                            />
+                          </svg>
+                        </AngleDoubleLeftIcon>
+                      </button>
+                    </Component>
+                  </div>
+                  <div
+                    className="pf-c-pagination__nav-control"
                   >
-                    <button
-                      aria-disabled={null}
+                    <Component
                       aria-label="Go to previous page"
-                      className="pf-c-button pf-m-plain"
                       data-action="previous"
-                      data-ouia-component-id={null}
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={true}
+                      isDisabled={true}
                       onClick={[Function]}
-                      tabIndex={null}
-                      type="button"
+                      variant="plain"
                     >
-                      <AngleLeftIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={null}
+                        aria-label="Go to previous page"
+                        className="pf-c-button pf-m-plain"
+                        data-action="previous"
+                        data-ouia-component-id={null}
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                        <AngleLeftIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                            transform=""
-                          />
-                        </svg>
-                      </AngleLeftIcon>
-                    </button>
-                  </Component>
-                </div>
-                <div
-                  className="pf-c-pagination__nav-page-select"
-                >
-                  <input
-                    aria-label="Current page"
-                    className="pf-c-form-control"
-                    disabled={true}
-                    max={1}
-                    min={1}
-                    onChange={[Function]}
-                    onKeyDown={[Function]}
-                    type="number"
-                    value={1}
-                  />
-                  <span
-                    aria-hidden="true"
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                              transform=""
+                            />
+                          </svg>
+                        </AngleLeftIcon>
+                      </button>
+                    </Component>
+                  </div>
+                  <div
+                    className="pf-c-pagination__nav-page-select"
                   >
-                    of 
-                    1
-                  </span>
-                </div>
-                <div
-                  className="pf-c-pagination__nav-control"
-                >
-                  <Component
-                    aria-label="Go to next page"
-                    data-action="next"
-                    isDisabled={true}
-                    onClick={[Function]}
-                    variant="plain"
+                    <input
+                      aria-label="Current page"
+                      className="pf-c-form-control"
+                      disabled={true}
+                      max={1}
+                      min={1}
+                      onChange={[Function]}
+                      onKeyDown={[Function]}
+                      type="number"
+                      value={1}
+                    />
+                    <span
+                      aria-hidden="true"
+                    >
+                      of 
+                      1
+                    </span>
+                  </div>
+                  <div
+                    className="pf-c-pagination__nav-control"
                   >
-                    <button
-                      aria-disabled={null}
+                    <Component
                       aria-label="Go to next page"
-                      className="pf-c-button pf-m-plain"
                       data-action="next"
-                      data-ouia-component-id={null}
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={true}
+                      isDisabled={true}
                       onClick={[Function]}
-                      tabIndex={null}
-                      type="button"
+                      variant="plain"
                     >
-                      <AngleRightIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={null}
+                        aria-label="Go to next page"
+                        className="pf-c-button pf-m-plain"
+                        data-action="next"
+                        data-ouia-component-id={null}
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                        <AngleRightIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                            transform=""
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </button>
-                  </Component>
-                </div>
-                <div
-                  className="pf-c-pagination__nav-control pf-m-last"
-                >
-                  <Component
-                    aria-label="Go to last page"
-                    data-action="last"
-                    isDisabled={true}
-                    onClick={[Function]}
-                    variant="plain"
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                              transform=""
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </button>
+                    </Component>
+                  </div>
+                  <div
+                    className="pf-c-pagination__nav-control pf-m-last"
                   >
-                    <button
-                      aria-disabled={null}
+                    <Component
                       aria-label="Go to last page"
-                      className="pf-c-button pf-m-plain"
                       data-action="last"
-                      data-ouia-component-id={null}
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={true}
+                      isDisabled={true}
                       onClick={[Function]}
-                      tabIndex={null}
-                      type="button"
+                      variant="plain"
                     >
-                      <AngleDoubleRightIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={null}
+                        aria-label="Go to last page"
+                        className="pf-c-button pf-m-plain"
+                        data-action="last"
+                        data-ouia-component-id={null}
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={true}
+                        onClick={[Function]}
+                        tabIndex={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 448 512"
-                          width="1em"
+                        <AngleDoubleRightIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                            transform=""
-                          />
-                        </svg>
-                      </AngleDoubleRightIcon>
-                    </button>
-                  </Component>
-                </div>
-              </nav>
-            </Navigation>
-          </div>
-        </Pagination>
-      </div>
-    </Component>
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                              transform=""
+                            />
+                          </svg>
+                        </AngleDoubleRightIcon>
+                      </button>
+                    </Component>
+                  </div>
+                </nav>
+              </Navigation>
+            </div>
+          </Pagination>
+          <ToolbarChipGroupContent
+            chipGroupContentRef={
+              Object {
+                "current": <div
+                  class="pf-c-toolbar__content pf-m-hidden"
+                  hidden=""
+                >
+                  <div
+                    class="pf-c-toolbar__group"
+                  />
+                </div>,
+              }
+            }
+            clearFiltersButtonText="Clear all filters"
+            collapseListedFiltersBreakpoint="lg"
+            isExpanded={false}
+            numberOfFilters={0}
+            showClearFiltersButton={false}
+          >
+            <div
+              className="pf-c-toolbar__content pf-m-hidden"
+              hidden={true}
+            >
+              <ForwardRef
+                className=""
+              >
+                <ToolbarGroupWithRef
+                  className=""
+                  innerRef={null}
+                >
+                  <div
+                    className="pf-c-toolbar__group"
+                  />
+                </ToolbarGroupWithRef>
+              </ForwardRef>
+            </div>
+          </ToolbarChipGroupContent>
+        </div>
+      </GenerateId>
+    </Toolbar>
   </TableToolbar>
 </InfoTable>
 `;


### PR DESCRIPTION
Toolbar got updated to `PageHeaderTools` in #583. This should revert this to give us the toolbar functionality back