### PR TITLE
Add Severity Line Chart

### DIFF
--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -24,3 +24,4 @@ This package is dependent on [@redhat-cloud-services/frontend-components-utiliti
   * [gauge](doc/gauge.md)
   * [matrix](doc/matrix.md)
   * [pie](doc/pie.md)
+  * [severityLine](doc/severityLine.md)

--- a/packages/charts/doc/severityLine.md
+++ b/packages/charts/doc/severityLine.md
@@ -1,0 +1,23 @@
+# Severity Line Chart
+
+Display a level of severity given a value between 1-Low and 4-Critical severity.
+
+```jsx
+import React from react;
+import { SeverityLine } from '@redhat-cloud-services/frontend-components-charts';
+
+<SeverityLine value={2} title='High Severity'/>
+```
+
+## Props
+
+```jsx
+SeverityLine.propTypes = {
+    value: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    config: PropTypes.shape({
+        height: PropTypes.number,
+        width: PropTypes.number
+    })
+};
+```

--- a/packages/charts/src/Charts/SeverityLine/SeverityLine.js
+++ b/packages/charts/src/Charts/SeverityLine/SeverityLine.js
@@ -1,0 +1,65 @@
+import './severity-line.scss';
+
+import React, { useMemo } from 'react';
+
+import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+
+const chartMapper = (width) => ({
+    1: '1',
+    2: (width / 3),
+    3: (width * (2 / 3)),
+    4: (width - 1)
+});
+
+const SeverityLine = ({ title, value, tooltipMessage, config, chartProps }) => {
+
+    const { width, height } = config;
+    const severity = useMemo(() => chartMapper(width)?.[value], [ width, value ]);
+    const points = [
+        { className: 'horizontal', points: `${1}, ${height / 2} ${width - 1}, ${height / 2}` },
+        { className: 'vertical', points: `${width - 1}, ${0} ${width - 1}, ${height}` },
+        { className: 'vertical', points: `${width * (2 / 3)}, ${0} ${width * (2 / 3)}, ${height}` },
+        { className: 'vertical', points: `${width / 3}, ${0} ${width / 3}, ${height}` },
+        { className: 'vertical', points: `${1}, ${0} ${1}, ${height}` },
+        { className: `dataline-${value}`, points: `${1}, ${height / 2} ${severity}, ${height / 2}` }
+    ];
+
+    return <div className='ins-c-severity-line' { ...chartProps }>
+        <div className='ins-l-title'>
+            {title.length > 14 ? <Tooltip content={title}>
+                <span> {`${title.substring(0, 14)}...`} </span>
+            </Tooltip> : <span> {title} </span>}
+        </div>
+        {severity && <div className='ins-l-chart'>
+            <svg height={height} width={width} viewBox={`0 0 ${width} ${height}`}>
+                {points.map(({ className, points }, key) => <polyline key={key} className={className} points={points} />)}
+                {tooltipMessage ? <Tooltip content={tooltipMessage}>
+                    <circle className={`dataline-${value}`} cx={`${severity}`} cy={`${height / 2}`} r={`${2}`}/>
+                </Tooltip> : <circle className={`dataline-${value}`} cx={`${severity}`} cy={`${height / 2}`} r={`${2}`}/>}
+            </svg>
+        </div>}
+    </div>;
+};
+
+SeverityLine.propTypes = {
+    value: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    tooltipMessage: PropTypes.string,
+    config: PropTypes.shape({
+        height: PropTypes.number,
+        width: PropTypes.number
+    }),
+    chartProps: PropTypes.shape({
+        [PropTypes.string]: PropTypes.any
+    })
+};
+
+SeverityLine.defaultProps = {
+    config: {
+        height: 12,
+        width: 302
+    }
+};
+
+export default SeverityLine;

--- a/packages/charts/src/Charts/SeverityLine/index.js
+++ b/packages/charts/src/Charts/SeverityLine/index.js
@@ -1,0 +1,1 @@
+export { default as SeverityLine } from './SeverityLine.js';

--- a/packages/charts/src/Charts/SeverityLine/severity-line.scss
+++ b/packages/charts/src/Charts/SeverityLine/severity-line.scss
@@ -1,0 +1,62 @@
+.ins-c-severity-line {
+    --ins-c-severity-line-text:         var(--pf-global--Color--200);
+    --inc-c-severity-line-base:         var(--pf-global--palette--black-400);
+    --ins-c-severity-line-low:          var(--pf-global--palette--blue-200);
+    --ins-c-severity-line-moderate:     var(--pf-global--palette--gold-200);
+    --ins-c-severity-line-high:         var(--pf-global--palette--orange-200);
+    --ins-c-severity-line-critical:     var(--pf-global--palette--red-100);
+
+    display: inline-flex;
+}
+
+.ins-c-severity-line {
+    .ins-l-title {
+        width: 115px;
+        span {
+            color: var(--inc-c-severity-line-text);
+            font-size: var(--pf-global--FontSize--sm);
+        }
+    }
+}
+
+.ins-c-severity-line {
+    .ins-l-chart {
+        position: relative;
+        svg {
+            overflow: visible;
+            .horizontal {
+                stroke: var(--inc-c-severity-line-base);
+                stroke-width: 2px;
+            }
+
+            .vertical {
+                stroke: var(--inc-c-severity-line-base);
+                stroke-width: 1px;
+            }
+
+            .dataline-1 {
+                stroke: var(--ins-c-severity-line-low);
+                fill: var(--ins-c-severity-line-low);
+                stroke-width: 4px;
+            }
+
+            .dataline-2 {
+                stroke: var(--ins-c-severity-line-moderate);
+                fill: var(--ins-c-severity-line-moderate);
+                stroke-width: 4px;
+            }
+
+            .dataline-3 {
+                stroke: var(--ins-c-severity-line-high);
+                fill: var(--ins-c-severity-line-high);
+                stroke-width: 4px;
+            }
+
+            .dataline-4 {
+                stroke: var(--ins-c-severity-line-critical);
+                fill: var(--ins-c-severity-line-critical);
+                stroke-width: 4px;
+            }
+        }
+    }
+}

--- a/packages/charts/src/index.js
+++ b/packages/charts/src/index.js
@@ -2,3 +2,4 @@ export * from './Charts/Donut';
 export * from './Charts/Gauge';
 export * from './Charts/Matrix';
 export * from './Charts/Pie';
+export * from './Charts/SeverityLine';


### PR DESCRIPTION
This PR adds a new charts to the `charts` package. This chart displays a level of severity from level 1 (low) up to level 4 (critical). The specifications for this chart are given [here](https://marvelapp.com/prototype/8d7cj33/screen/70992845).

Here's what it will look like:
<img width="400" alt="Screen Shot 2020-07-09 at 2 57 58 PM" src="https://user-images.githubusercontent.com/4829473/87079803-99848000-c1f4-11ea-814f-e1cb811a4914.png">
