### PR TITLE
Add custom labels

### DIFF
--- a/packages/components/src/Components/InsightsLabel/CriticalIcon.js
+++ b/packages/components/src/Components/InsightsLabel/CriticalIcon.js
@@ -1,0 +1,9 @@
+import './critical-icon.scss';
+
+import React from 'react';
+
+const CriticalIcon = () => <svg className='ins-c-critical-icon' viewbox='0 0 10 10'>
+    <polygon points='10 10, 10 3, 5 0, 0 3, 0 10, 5 8'/>
+</svg>;
+
+export default CriticalIcon;

--- a/packages/components/src/Components/InsightsLabel/CriticalIcon.test.js
+++ b/packages/components/src/Components/InsightsLabel/CriticalIcon.test.js
@@ -1,0 +1,11 @@
+import CriticalIcon from './CriticalIcon';
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+describe('CriticalIcon component', () => {
+    it('should render correctly', () => {
+        const wrapper = shallow(<CriticalIcon/>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/packages/components/src/Components/InsightsLabel/InsightsLabel.js
+++ b/packages/components/src/Components/InsightsLabel/InsightsLabel.js
@@ -1,0 +1,39 @@
+import './labels.scss';
+
+import { AngleDoubleDownIcon } from '@patternfly/react-icons';
+import { AngleDoubleUpIcon } from '@patternfly/react-icons';
+import CriticalIcon from './CriticalIcon';
+import { EqualsIcon } from '@patternfly/react-icons';
+import { Label } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import React  from 'react';
+import classNames from 'classnames';
+
+const VALUE_TO_STATE = {
+    1: { icon: <AngleDoubleDownIcon/>, text: 'Low' },
+    2: { icon: <EqualsIcon/>, text: 'Moderate' },
+    3: { icon: <AngleDoubleUpIcon/>, text: 'High' },
+    4: { icon: <CriticalIcon/>, text: 'Critical' }
+};
+
+const InsightsLabel = ({ value, text, hideIcon, className, rest }) => {
+    return <Label
+        { ...rest }
+        className={ classNames(className, `ins-c-label-${value}`) }
+        icon={ !hideIcon && VALUE_TO_STATE[value].icon }
+    >
+        { text || VALUE_TO_STATE[value].text }
+    </Label>;
+};
+
+InsightsLabel.propTypes = {
+    value: PropTypes.number,
+    text: PropTypes.node,
+    hideIcon: PropTypes.bool
+};
+
+InsightsLabel.defaultProps = {
+    value: 1
+};
+
+export default InsightsLabel;

--- a/packages/components/src/Components/InsightsLabel/InsightsLabel.test.js
+++ b/packages/components/src/Components/InsightsLabel/InsightsLabel.test.js
@@ -1,0 +1,23 @@
+import { AngleDoubleDownIcon } from '@patternfly/react-icons';
+import InsightsLabel from './InsightsLabel';
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+describe('InsightsLabel component', () => {
+    it('should render with icon', () => {
+        const wrapper = shallow(<InsightsLabel value={1}/>).dive();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find(AngleDoubleDownIcon)).toHaveLength(1);
+    });
+    it('should render without icon', () => {
+        const wrapper = shallow(<InsightsLabel value={1} hideIcon/>).dive();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find(AngleDoubleDownIcon)).toHaveLength(0);
+    });
+    it('should render defaults', () => {
+        const wrapper = shallow(<InsightsLabel/>).dive();
+        expect(toJson(wrapper)).toMatchSnapshot();
+        expect(wrapper.find(AngleDoubleDownIcon)).toHaveLength(1);
+    });
+});

--- a/packages/components/src/Components/InsightsLabel/__snapshots__/CriticalIcon.test.js.snap
+++ b/packages/components/src/Components/InsightsLabel/__snapshots__/CriticalIcon.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CriticalIcon component should render correctly 1`] = `
+<svg
+  className="ins-c-critical-icon"
+  viewbox="0 0 10 10"
+>
+  <polygon
+    points="10 10, 10 3, 5 0, 0 3, 0 10, 5 8"
+  />
+</svg>
+`;

--- a/packages/components/src/Components/InsightsLabel/__snapshots__/InsightsLabel.test.js.snap
+++ b/packages/components/src/Components/InsightsLabel/__snapshots__/InsightsLabel.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InsightsLabel component should render defaults 1`] = `
+<span
+  className="pf-c-label ins-c-label-1"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    <span
+      className="pf-c-label__icon"
+    >
+      <AngleDoubleDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    Low
+  </span>
+</span>
+`;
+
+exports[`InsightsLabel component should render with icon 1`] = `
+<span
+  className="pf-c-label ins-c-label-1"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    <span
+      className="pf-c-label__icon"
+    >
+      <AngleDoubleDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    Low
+  </span>
+</span>
+`;
+
+exports[`InsightsLabel component should render without icon 1`] = `
+<span
+  className="pf-c-label ins-c-label-1"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Low
+  </span>
+</span>
+`;

--- a/packages/components/src/Components/InsightsLabel/critical-icon.scss
+++ b/packages/components/src/Components/InsightsLabel/critical-icon.scss
@@ -1,0 +1,8 @@
+.ins-c-critical-icon {
+    width: 10px;
+    height: 10px;
+    stroke: var(--pf-global--palette--red-200);
+    stroke-width: 0.5px;
+    fill: var(--pf-global--palette--red-200);
+    margin: 0.25px;
+}

--- a/packages/components/src/Components/InsightsLabel/index.js
+++ b/packages/components/src/Components/InsightsLabel/index.js
@@ -1,0 +1,1 @@
+export { default as InsightsLabel } from './InsightsLabel';

--- a/packages/components/src/Components/InsightsLabel/labels.scss
+++ b/packages/components/src/Components/InsightsLabel/labels.scss
@@ -1,0 +1,54 @@
+.pf-c-label {
+    --ins-c-label--red-bg:              #faeae8;
+    --inc-c-label--content-red:         var(--pf-global--palette--red-300);
+    --inc-c-label--icon-red:            var(--pf-global--palette--red-200);
+    --ins-c-label--orange-bg:           #FFF5EC;
+    --inc-c-label--content-orange:      #773D00;
+    --inc-c-label--icon-orange:         var(--pf-global--palette--orange-300);
+    --ins-c-label--gold-bg:             #fdf7e7;
+    --inc-c-label--content-gold:        var(--pf-global--palette--gold-700);
+    --inc-c-label--icon-gold:           #F4C145;
+    --ins-c-label--blue-bg:             var(--pf-global--palette--blue-50);
+    --inc-c-label--content-blue:        var(--pf-global--palette--blue-600);
+    --inc-c-label--icon-blue:           var(--pf-global--palette--blue-300);
+}
+
+.ins-c-label-4 {
+    background-color: var(--ins-c-label--red-bg);
+    .pf-c-label__content {
+        color: var(--inc-c-label--content-red);
+        .pf-c-label__icon {
+            color: var(--inc-c-label--icon-red);
+        }
+    }
+}
+
+.ins-c-label-3 {
+    background-color: var(--ins-c-label--orange-bg);
+    .pf-c-label__content {
+        color: var(--inc-c-label--content-orange);
+        .pf-c-label__icon {
+            color: var(--inc-c-label--icon-orange);
+        }
+    }
+}
+
+.ins-c-label-2 {
+    background-color: var(--ins-c-label--gold-bg);
+    .pf-c-label__content {
+        color: var(--inc-c-label--content-gold);
+        .pf-c-label__icon {
+            color: var(--inc-c-label--icon-gold);
+        }
+    }
+}
+
+.ins-c-label-1 {
+    background-color: var(--ins-c-label--blue-bg);
+    .pf-c-label__content {
+        color: var(--inc-c-label--content-blue);
+        .pf-c-label__icon {
+            color: var(--inc-c-label--icon-blue);
+        }
+    }
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -5,6 +5,7 @@ export * from './Components/Main';
 export * from './Components/Pagination';
 export * from './Components/SimpleTableFilter';
 export * from './Components/Input';
+export * from './Components/InsightsLabel';
 export * from './Components/Battery';
 export * from './Components/Breadcrumbs';
 export * from './Components/Shield';


### PR DESCRIPTION
This PR adds the following custom labels to the `redhat-cloud-services/frontend-components` package:
![Screen Shot 2020-07-13 at 3 15 22 PM](https://user-images.githubusercontent.com/4829473/87344305-2fcde400-c51c-11ea-8b4f-50bcd4530a6d.png)
![Screen Shot 2020-07-13 at 3 14 22 PM](https://user-images.githubusercontent.com/4829473/87344307-2fcde400-c51c-11ea-9e6c-b6bce7bf876a.png)
![Screen Shot 2020-07-13 at 3 14 35 PM](https://user-images.githubusercontent.com/4829473/87344308-2fcde400-c51c-11ea-8abb-52370ec0563a.png)
![Screen Shot 2020-07-13 at 3 14 02 PM](https://user-images.githubusercontent.com/4829473/87344309-30667a80-c51c-11ea-98a8-a18205d3af51.png)

The icons can either be show or hidden based on use case. The specifications for these labels are listed in the mocks [here](https://marvelapp.com/prototype/8d7cj33/screen/70992845) and are pertinent to [this](https://projects.engineering.redhat.com/browse/RHCLOUD-7702) JIRA 🎫 
