### PR TITLE
Prevent Group filtering from fail on empty result

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -238,15 +238,13 @@ class Group extends Component {
                     groups.map(({ value: groupValue, onSelect, label: groupLabel, id: groupId, type, items, ...group }, groupKey) => {
                         const filteredItems = this.mapItems({ groupValue, onSelect, groupLabel, groupId, type, items, ...group }, groupKey)
                         .filter(Boolean);
-                        return filteredItems.length > 0
-                            ? <SelectGroup
-                                {...group}
-                                key={groupId || groupValue || groupKey}
-                                value={groupId || groupValue || groupKey}
-                                label={groupLabel || ''}
-                                id={groupId || `group-${groupValue || groupKey}`}
-                            >{filteredItems}</SelectGroup>
-                            : <Fragment/>;
+                        return (<SelectGroup
+                            {...group}
+                            key={groupId || groupValue || groupKey}
+                            value={groupId || groupValue || groupKey}
+                            label={groupLabel || ''}
+                            id={groupId || `group-${groupValue || groupKey}`}
+                        >{filteredItems}</SelectGroup>);
                     })
                 ) : (
                     this.mapItems({ items })


### PR DESCRIPTION
This should solve issue in conditional filtering - error when filter returned an empty array.

![001](https://user-images.githubusercontent.com/50696716/87356310-29faf180-c562-11ea-959d-8326a088d860.png)

@karelhala 
@PanSpagetka 