### PR TITLE
Fetch subscription watch IAM policy config from API

### DIFF
--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     TextContent,
     Text,
@@ -8,7 +8,9 @@ import {
     ClipboardCopy,
     ClipboardCopyVariant
 } from '@patternfly/react-core';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { getSubWatchConfig } from '../../../api/subscriptionWatch';
 
 export const IAMRoleDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>
@@ -43,69 +45,62 @@ export const IAMRoleDescription = () => (<TextContent>
     </TextList>
 </TextContent>);
 
-export const IAMPolicyDescription = () =>  (<TextContent>
-    <Text component={ TextVariants.p }>
-        <FormattedMessage
-            id="wizard.ToGrantPermissionsToObtainSubscriptionDataCreateAnAwsIdentityAccessManagementIamPolicy"
-            defaultMessage="To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy."
-        />
-    </Text>
-    <TextList>
-        <TextListItem>
+export const IAMPolicyDescription = () =>  {
+    const intl = useIntl();
+    const [ config, setConfig ] = useState();
+
+    useEffect(() => {
+        getSubWatchConfig().then((conf) => setConfig(conf)).catch((e) => {
+            console.error(e);
+            setConfig(intl.formatMessage({
+                id: 'wizard.subWatchConfigError',
+                defaultMessage: 'There is an error with loading of the configuration. Please go back and return to this step.'
+            }));
+        });
+    }, []);
+
+    return (<TextContent>
+        <Text component={ TextVariants.p }>
             <FormattedMessage
-                id="wizard.SignInToThe"
-                defaultMessage="Sign in to the {link}."
-                values={{ link: <a
-                    href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html"
-                    rel="noopener noreferrer"
-                    target="_blank">
-                    <FormattedMessage id="wizard.AwsIdentityAccessManagementIamConsole" defaultMessage="AWS Identity Access Management* (IAM) console" />
-                </a>
-                }}
+                id="wizard.ToGrantPermissionsToObtainSubscriptionDataCreateAnAwsIdentityAccessManagementIamPolicy"
+                defaultMessage="To grant permissions to obtain subscription data, create an AWS identity access management (IAM) policy."
             />
-        </TextListItem>
-        <TextListItem>
+        </Text>
+        <TextList>
+            <TextListItem>
+                <FormattedMessage
+                    id="wizard.SignInToThe"
+                    defaultMessage="Sign in to the {link}."
+                    values={{ link: <a
+                        href="https://docs.aws.amazon.com/IAM/latest/UserGuide/console.html"
+                        rel="noopener noreferrer"
+                        target="_blank">
+                        <FormattedMessage id="wizard.AwsIdentityAccessManagementIamConsole" defaultMessage="AWS Identity Access Management* (IAM) console" />
+                    </a>
+                    }}
+                />
+            </TextListItem>
+            <TextListItem>
+                <FormattedMessage
+                    id="wizard.CreateANewPolicyPastingTheFollowingContentIntoTheJsonTextBox"
+                    defaultMessage="Create a new policy, pasting the following content into the JSON text box."
+                />
+            </TextListItem>
+            <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
+                {config ? JSON.stringify(config, null, 2) : intl.formatMessage({ id: 'wizard.loading', defaultMessage: 'Loading configuration...' })}
+            </ClipboardCopy>
+            <TextListItem>
+                <FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewPolicy" defaultMessage="Complete the process to create your new policy." />
+            </TextListItem>
+        </TextList>
+        <Text component={ TextVariants.p }>
             <FormattedMessage
-                id="wizard.CreateANewPolicyPastingTheFollowingContentIntoTheJsonTextBox"
-                defaultMessage="Create a new policy, pasting the following content into the JSON text box."
+                id="wizard.BDoNotCloseYourBrowserBYouWillNeedToBeLoggedInToTheIamConsoleToComputeTheNextStep"
+                defaultMessage="{bold} You will need to be logged in to the IAM console to compute the next step."
+                values={{ bold: <b><FormattedMessage id="wizard.DoNotCloseYourBrowser" defaultMessage="Do not close your browser." /></b> }}
             />
-        </TextListItem>
-        <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-u-m-sm-on-sm" isReadOnly>
-            {JSON.stringify({
-                Version: '2012-10-17',
-                Statement: [{
-                    Sid: 'VisualEditor0',
-                    Effect: 'Allow',
-                    Action: [
-                        'ec2:DescribeInstances',
-                        'ec2:DescribeImages',
-                        'ec2:DescribeSnapshots',
-                        'ec2:ModifySnapshotAttribute',
-                        'ec2:DescribeSnapshotAttribute',
-                        'ec2:CopyImage',
-                        'ec2:CreateTags',
-                        'ec2:DescribeRegions',
-                        'cloudtrail:CreateTrail',
-                        'cloudtrail:UpdateTrail',
-                        'cloudtrail:PutEventSelectors',
-                        'cloudtrail:DescribeTrails',
-                        'cloudtrail:StartLogging',
-                        'cloudtrail:DeleteTrail'
-                    ],
-                    Resource: '*'
-                }]
-            }, null, 2)}
-        </ClipboardCopy>
-        <TextListItem><FormattedMessage id="wizard.CompleteTheProcessToCreateYourNewPolicy" defaultMessage="Complete the process to create your new policy." /></TextListItem>
-    </TextList>
-    <Text component={ TextVariants.p }>
-        <FormattedMessage
-            id="wizard.BDoNotCloseYourBrowserBYouWillNeedToBeLoggedInToTheIamConsoleToComputeTheNextStep"
-            defaultMessage="{bold} You will need to be logged in to the IAM console to compute the next step."
-            values={{ bold: <b><FormattedMessage id="wizard.DoNotCloseYourBrowser" defaultMessage="Do not close your browser." /></b> }}
-        />
-    </Text>
-</TextContent>);
+        </Text>
+    </TextContent>);};
 
 export const ArnDescription = () => (<TextContent>
     <Text component={ TextVariants.p }>

--- a/packages/sources/src/api/subscriptionWatch.js
+++ b/packages/sources/src/api/subscriptionWatch.js
@@ -1,0 +1,3 @@
+import { axiosInstance } from './index';
+
+export const getSubWatchConfig = () => axiosInstance.get('/api/cloudigrade/v2/sysconfig/');

--- a/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
+++ b/packages/sources/src/tests/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import mount from '../../__mocks__/mount';
 import {
     TextContent,
@@ -9,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import * as SubsAwsArn from '../../../addSourceWizard/hardcodedComponents/aws/subscriptionWatch';
+import * as api from '../../../api/subscriptionWatch';
 
 describe('AWS-ARN hardcoded schemas', () => {
     it('ARN DESCRIPTION is rendered correctly', () => {
@@ -20,14 +22,52 @@ describe('AWS-ARN hardcoded schemas', () => {
         expect(wrapper.find(TextListItem)).toHaveLength(2);
     });
 
-    it('IAM POLICY is rendered correctly', () => {
-        const wrapper = mount(<SubsAwsArn.IAMPolicyDescription />);
+    it('IAM POLICY is rendered correctly', async () => {
+        const CONFIG = { some: 'fake', config: 'oh yeah' };
+        api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.resolve(CONFIG));
+
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(<SubsAwsArn.IAMPolicyDescription />);
+        });
+        expect(wrapper.find('input').props().value).toEqual('Loading configuration...');
+
+        wrapper.update();
 
         expect(wrapper.find(TextContent)).toHaveLength(1);
         expect(wrapper.find(Text)).toHaveLength(2);
         expect(wrapper.find(TextList)).toHaveLength(1);
         expect(wrapper.find(TextListItem)).toHaveLength(3);
         expect(wrapper.find(ClipboardCopy)).toHaveLength(1);
+
+        expect(wrapper.find('input').props().value).toEqual(JSON.stringify(CONFIG, null, 2));
+    });
+
+    it('IAM POLICY is rendered correctly with error', async () => {
+        const _cons = console.error;
+        console.error = jest.fn();
+
+        const ERROR = 'Something went wrong';
+        api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.reject(ERROR));
+
+        let wrapper;
+        await act(async () => {
+            wrapper = mount(<SubsAwsArn.IAMPolicyDescription />);
+        });
+        expect(wrapper.find('input').props().value).toEqual('Loading configuration...');
+
+        wrapper.update();
+
+        expect(console.error).toHaveBeenCalledWith(ERROR);
+        expect(wrapper.find('input').props().value).toEqual(
+            JSON.stringify(
+                'There is an error with loading of the configuration. Please go back and return to this step.',
+                null,
+                2
+            )
+        );
+
+        console.error = _cons;
     });
 
     it('IAM ROLE is rendered correctly', () => {


### PR DESCRIPTION
subscription watch IAM policy is being loaded from the API.

It there is any error, a text stating that user should go back and try it again is used. (Or should we use hardcoded config instead of it?)

Success

![success](https://user-images.githubusercontent.com/32869456/87639639-d6e19400-c745-11ea-8d29-126a46697888.gif)

Error

![error](https://user-images.githubusercontent.com/32869456/87639738-faa4da00-c745-11ea-8d40-a482c2dfb283.gif)

@infinitewarp @katherine-black