### PR TITLE
Trade Battery for InsightLabel in Insights component

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import './insights.scss';
 
-import { BASE_FETCH_URL, FILTER_CATEGORIES as FC, IMPACT_LABEL, LIKELIHOOD_LABEL, RISK_TO_STRING } from './Constants';
+import { BASE_FETCH_URL, FILTER_CATEGORIES as FC, IMPACT_LABEL, LIKELIHOOD_LABEL } from './Constants';
 import React, { Component, Fragment } from 'react';
 import { SortByDirection, Table, TableBody, TableHeader, cellWidth, sortable } from '@patternfly/react-table';
 import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
@@ -10,7 +10,6 @@ import { flatten, sortBy } from 'lodash';
 
 import API from './Api';
 import AnsibeTowerIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon';
-import { Battery } from '@redhat-cloud-services/frontend-components/components/Battery';
 import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye/Bullseye';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
 import { Card } from '@patternfly/react-core/dist/js/components/Card/Card';
@@ -21,6 +20,7 @@ import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import { ClipboardCopy } from '@patternfly/react-core/dist/js/components/ClipboardCopy/ClipboardCopy';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/DateFormat';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import { InsightsLabel } from '@redhat-cloud-services/frontend-components/components/InsightsLabel';
 import { List } from 'react-content-loader';
 import MessageState from './MessageState';
 import PficonSatelliteIcon from '@patternfly/react-icons/dist/js/icons/pficon-satellite-icon';
@@ -173,7 +173,7 @@ class InventoryRuleList extends Component {
                                 <Tooltip key={key} position={TooltipPosition.bottom} content={<span>The <strong>likelihood</strong> that this will be
                                 a problem is {LIKELIHOOD_LABEL[rule.likelihood]}. The <strong>impact</strong> of the problem would be
                                 &nbsp;{IMPACT_LABEL[rule.impact.impact]} if it occurred.</span>}>
-                                    <Battery label={RISK_TO_STRING[rule.total_risk]} severity={rule.total_risk} />
+                                    <InsightsLabel value={rule.total_risk} />
                                 </Tooltip>
                             </div >
                         },


### PR DESCRIPTION
As part of the grading changes for Advisor we need to switch the Battery component for the InsightsLabel in the `inventory-insights` Insights component. 🎉 😁 

We will be going from this...

<img width="1147" alt="Screen Shot 2020-07-16 at 3 35 19 PM" src="https://user-images.githubusercontent.com/4829473/87715322-2ee6bd80-c77b-11ea-8d02-0fa305b942f6.png">

to this...

<img width="1147" alt="Screen Shot 2020-07-16 at 3 27 30 PM" src="https://user-images.githubusercontent.com/4829473/87715346-3a39e900-c77b-11ea-9c3e-4ea87c858059.png">

