### PR TITLE
When app wants to render composed item they want to see title column

### DIFF
--- a/packages/inventory/src/components/table/helpers.js
+++ b/packages/inventory/src/components/table/helpers.js
@@ -3,10 +3,18 @@ import NoSystemsTable from './NoSystemsTable';
 import { cellWidth, sortable, expandable } from '@patternfly/react-table';
 import get from 'lodash/get';
 import flatten from 'lodash/flatten';
+import TitleColumn from './TitleColumn';
 
 export const buildCells = (item, columns, extra) => {
-    return columns.map(({ key, renderFunc }) => {
-        const data = get(item, key, ' ');
+    return columns.map(({ key, composed, renderFunc }) => {
+        const data = composed ? {
+            title: TitleColumn(
+                composed.map(key => get(item, key, ' ')),
+                item.id,
+                item,
+                extra
+            )
+        } : get(item, key, ' ');
         return renderFunc ? {
             title: renderFunc(data, item.id, item, extra)
         } : data;


### PR DESCRIPTION
Vulnerability is relying on composed column, without it the UI shows blank name. This PR fixes such issue, by using `TitleColumn` when `composed` is passed in redux column definition.

### Before
![Screenshot from 2020-07-20 11-07-41](https://user-images.githubusercontent.com/3439771/87920312-4f639000-ca79-11ea-9d4b-8a2ca3f1bcd0.png)

### After
![Screenshot from 2020-07-20 11-22-39](https://user-images.githubusercontent.com/3439771/87921780-568b9d80-ca7b-11ea-82ed-19f0e771f060.png)
