### PR TITLE
Update success color for Inv-Insights

### DIFF
--- a/packages/inventory-insights/src/insights.scss
+++ b/packages/inventory-insights/src/insights.scss
@@ -78,26 +78,16 @@
     }
 }
 
-.batterySectionOverrides{
-    margin-top: 16px;
-}
-
 .smallFontSizeOverride{
     font-size: $ins-fontSize--sm;
 }
 
 .successColorOverride{
-    color: var(--pf-global--success-color--200)
+    color: var(--pf-global--success-color--100)
 }
 
 .remediationButtonOverride{
         margin-top: -8px;
-}
-
-.pf-c-check__label {
-    #battery_svg {
-        height: 1.25rem; 
-    }
 }
 
 .chartSpikeIconColor  {


### PR DESCRIPTION
This PR is similar to https://github.com/RedHatInsights/insights-advisor-frontend/pull/698, which updates the success color in advisor. This will do the same for the inventory-insights package.