### PR TITLE
Add validating and validated states for source.name field

### DIFF
--- a/packages/sources/config/rollup.config.js
+++ b/packages/sources/config/rollup.config.js
@@ -88,7 +88,8 @@ export default rollupConfig(
         ErroredStep: 'src/addSourceWizard/steps/ErroredStep',
         TimeoutStep: 'src/addSourceWizard/steps/TimeoutStep',
         getApplicationStatus: 'src/api/getApplicationStatus.js',
-        constants: 'src/api/constants.js'
+        constants: 'src/api/constants.js',
+        validated: 'src/sourceFormRenderer/resolveProps/validated.js'
     }, {
         index: 'src/index.js'
     }],

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -28,8 +28,8 @@
         "awesome-debounce-promise": "^2.1.0"
     },
     "devDependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^2.6.7",
-        "@data-driven-forms/react-form-renderer": "^2.6.7",
+        "@data-driven-forms/pf4-component-mapper": "^2.8.3",
+        "@data-driven-forms/react-form-renderer": "^2.8.3",
         "@patternfly/react-core": "^4.18.5",
         "@patternfly/react-icons": "^4.3.5",
         "prop-types": "^15.7.2",

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -38,8 +38,8 @@
     },
     "peerDependencies": {
         "react": "^16.12.0",
-        "@data-driven-forms/pf4-component-mapper": "^2.6.7",
-        "@data-driven-forms/react-form-renderer": "^2.6.7",
+        "@data-driven-forms/pf4-component-mapper": "^2.8.3",
+        "@data-driven-forms/react-form-renderer": "^2.8.3",
         "lodash": "^4.17.15",
         "react-intl": "^5.0.2",
         "react-router-dom": "^5.2.0"

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -25,7 +25,7 @@ export const asyncValidator = async (value, sourceId = undefined, intl) => {
     }
 
     if (response.data.sources.find(({ id }) => id !== sourceId)) {
-        throw intl.formatMessage({ defaultMessage: 'Name has already been taken', id: 'wizard.nameTaken' });
+        throw intl.formatMessage({ defaultMessage: 'That name is taken. Try another.', id: 'wizard.nameTaken' });
     }
 
     return undefined;

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -9,6 +9,7 @@ import { schemaBuilder } from './schemaBuilder';
 import { WIZARD_DESCRIPTION, WIZARD_TITLE } from '../utilities/stringConstants';
 import ValidatorReset from './ValidatorReset';
 import { handleError } from '../api/handleError';
+import validated from '../sourceFormRenderer/resolveProps/validated';
 
 export const asyncValidator = async (value, sourceId = undefined, intl) => {
     if (!value) {
@@ -178,7 +179,8 @@ const nameStep = (intl) => ({
             validate: [
                 (value) => asyncValidatorDebouncedWrapper(intl)(value, undefined, intl),
                 { type: validatorTypes.REQUIRED }
-            ]
+            ],
+            resolveProps: validated
         }
     ]
 });

--- a/packages/sources/src/sourceFormRenderer/resolveProps/validated.js
+++ b/packages/sources/src/sourceFormRenderer/resolveProps/validated.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { Spinner, FormHelperText } from '@patternfly/react-core';
+
+export const ValidatingSpinner = () => {
+    const intl = useIntl();
+
+    return (<FormHelperText isHidden={false}>
+        <Spinner size="md" className="pf-u-mr-md" />{ intl.formatMessage({ id: 'wizard.validating', defaultMessage: 'Validating' })}
+    </FormHelperText>);
+};
+
+const validated = (_, { meta }) => {
+    if (meta.validating) {
+        return {
+            helperText: <ValidatingSpinner />
+        };
+    }
+
+    if (meta.valid) {
+        return {
+            validated: 'success',
+            FormGroupProps: {
+                validated: 'success'
+            }
+        };
+    }
+
+    return {};
+};
+
+export default validated;

--- a/packages/sources/src/sourceFormRenderer/resolveProps/validated.js
+++ b/packages/sources/src/sourceFormRenderer/resolveProps/validated.js
@@ -1,19 +1,30 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Spinner, FormHelperText } from '@patternfly/react-core';
+import FormSpy from '@data-driven-forms/react-form-renderer/dist/cjs/form-spy';
 
-export const ValidatingSpinner = () => {
+export const ValidatingSpinner = ({ validating }) => {
     const intl = useIntl();
 
-    return (<FormHelperText isHidden={false}>
+    return (<FormHelperText isHidden={!validating}>
         <Spinner size="md" className="pf-u-mr-md" />{ intl.formatMessage({ id: 'wizard.validating', defaultMessage: 'Validating' })}
     </FormHelperText>);
+};
+
+ValidatingSpinner.propTypes = {
+    validating: PropTypes.bool.isRequired
 };
 
 const validated = (_, { meta }) => {
     if (meta.validating) {
         return {
-            helperText: <ValidatingSpinner />
+            // FormSpy is a fallback solution
+            // FF sometimes does not set validating to 'false' on the field
+            // So we need to also check the FormSpy.validating
+            helperText: <FormSpy>
+                {({ validating }) => <ValidatingSpinner validating={validating} />}
+            </FormSpy>
         };
     }
 

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -107,7 +107,7 @@ describe('AddSourceWizard', () => {
         jest.useRealTimers();
     });
 
-    it.only('pass created source to afterSuccess function', async () => {
+    it('pass created source to afterSuccess function', async () => {
         jest.useFakeTimers();
 
         const afterSubmitMock = jest.fn();

--- a/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
+++ b/packages/sources/src/tests/addSourceWizard/asyncValidator.test.js
@@ -34,7 +34,7 @@ describe('asyncNameValidator', () => {
         try {
             await asyncValidator('a1', undefined, intl);
         } catch (e) {
-            expect(e).toEqual('Name has already been taken');
+            expect(e).toEqual('That name is taken. Try another.');
         }
     });
 

--- a/packages/sources/src/tests/sourceFormRenderer/resolveProps/validated.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/resolveProps/validated.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import mount from '../../__mocks__/mount';
+import validated, { ValidatingSpinner } from '../../../sourceFormRenderer/resolveProps/validated';
+import { Spinner, FormHelperText } from '@patternfly/react-core';
+
+describe('resolveProps - validated', () => {
+    it('Spinner is renderer correctly', () => {
+        const wrapper = mount(<ValidatingSpinner />);
+
+        expect(wrapper.find(Spinner)).toHaveLength(1);
+        expect(wrapper.find(FormHelperText).text()).toEqual('Validating');
+    });
+
+    const props = {};
+
+    it('returns spinner when validating', () => {
+        expect(validated(props, { meta: { validating: true } })).toEqual({
+            helperText: expect.any(Object)
+        });
+
+        expect(
+            mount(validated(props, { meta: { validating: true } }).helperText).find(ValidatingSpinner)
+        ).toHaveLength(1);
+    });
+
+    it('returns success state when valid', () => {
+        expect(validated(props, { meta: { valid: true } })).toEqual({
+            validated: 'success',
+            FormGroupProps: {
+                validated: 'success'
+            }
+        });
+    });
+
+    it('return empty object when not valid and not validating', () => {
+        expect(validated(props, { meta: { valid: false, validating: false } })).toEqual({});
+    });
+});

--- a/packages/sources/src/tests/sourceFormRenderer/resolveProps/validated.test.js
+++ b/packages/sources/src/tests/sourceFormRenderer/resolveProps/validated.test.js
@@ -2,10 +2,13 @@ import React from 'react';
 import mount from '../../__mocks__/mount';
 import validated, { ValidatingSpinner } from '../../../sourceFormRenderer/resolveProps/validated';
 import { Spinner, FormHelperText } from '@patternfly/react-core';
+import Form from '@data-driven-forms/react-form-renderer/dist/cjs/form';
 
 describe('resolveProps - validated', () => {
     it('Spinner is renderer correctly', () => {
-        const wrapper = mount(<ValidatingSpinner />);
+        const wrapper = mount(
+            <ValidatingSpinner validating/>
+        );
 
         expect(wrapper.find(Spinner)).toHaveLength(1);
         expect(wrapper.find(FormHelperText).text()).toEqual('Validating');
@@ -19,7 +22,11 @@ describe('resolveProps - validated', () => {
         });
 
         expect(
-            mount(validated(props, { meta: { validating: true } }).helperText).find(ValidatingSpinner)
+            mount(
+                <Form onSubmit={jest.fn()}>
+                    {() => validated(props, { meta: { validating: true } }).helperText}
+                </Form>
+            ).find(ValidatingSpinner)
         ).toHaveLength(1);
     });
 


### PR DESCRIPTION
This add two states for source.name

**Validating**

![image](https://user-images.githubusercontent.com/32869456/88166519-a99a5780-cc17-11ea-9baf-fd2be4dd4c75.png)

**Validated**

![image](https://user-images.githubusercontent.com/32869456/88166495-a1dab300-cc17-11ea-8d0c-5a9f4f0b7fdb.png)

**Error message**

![image](https://user-images.githubusercontent.com/32869456/88192755-3277ba00-cc3d-11ea-8cbb-b20c332c5a58.png)

Example

![resolveProps](https://user-images.githubusercontent.com/32869456/88166542-b3bc5600-cc17-11ea-921f-7053cc7e9608.gif)

Any thoughts, @beccaglass ?