### PR TITLE
Allow custom text for PDF battery

### DIFF
--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "build": "rollup -c ./rollup.config.js",
-        "start": "echo \"Error: no start specified\""
+        "start": "rollup -c ./rollup.config.js -w"
     },
     "repository": {
         "type": "git",

--- a/packages/pdf-generator/src/components/Battery.js
+++ b/packages/pdf-generator/src/components/Battery.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
     Canvas,
-    Text,
+    Text as PDFText,
     View
 } from '@react-pdf/renderer';
 // eslint-disable-next-line camelcase
@@ -56,7 +56,7 @@ const batteryMapper = {
     }
 };
 
-const Battery = ({ variant, ...props }) => {
+const Battery = ({ variant, text, ...props }) => {
     const currBattery = batteryMapper[variant] || {
         svg: '',
         title: 'Unknown'
@@ -72,17 +72,18 @@ const Battery = ({ variant, ...props }) => {
             .path(currBattery.svg).fill(currBattery.color);
         } }
         />
-        <Text style={{
+        <PDFText style={{
             alignSelf: 'center',
             color: currBattery.color
         }}>
-            {currBattery.title}
-        </Text>
+            {text || currBattery.title}
+        </PDFText>
     </View>;
 };
 
 Battery.propTypes = {
-    variant: PropTypes.oneOf(Object.keys(batteryMapper))
+    variant: PropTypes.oneOf(Object.keys(batteryMapper)),
+    text: PropTypes.node
 };
 
 export default Battery;


### PR DESCRIPTION
This PR lets us use a custom text field to specify a unique title for any of the battery icon variants presently available in the `pdf-generator` Battery component. In advisor, this would allow us to change `High` to `Important` to better reflect the `Total Risk` hierarchy.

<img width="929" alt="Screen Shot 2020-07-22 at 8 18 48 AM" src="https://user-images.githubusercontent.com/4829473/88175858-709cbb80-cbf4-11ea-8ace-058d3344eea0.png">
