### PR TITLE
Allow custom PrimaryToolbar props in TagsModal

### DIFF
--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -60,6 +60,7 @@ export default class TagModal extends React.Component {
             onSelect,
             selected,
             onApply,
+            primaryToolbarProps,
             ...props
         } = this.props;
 
@@ -119,6 +120,7 @@ export default class TagModal extends React.Component {
                         onSetPage: (_e, page) => onUpdateData({ ...pagination, page }),
                         onPerPageSelect: (_e, perPage) => onUpdateData({ ...pagination, page: 1, perPage })
                     } : <Skeleton size="lg" />}
+                    {...primaryToolbarProps}
                 /> }
                 {children}
                 {loaded ? <Table
@@ -188,6 +190,9 @@ TagModal.propTypes = {
         count: PropTypes.number,
         page: PropTypes.number,
         perPage: PropTypes.number
+    }),
+    primaryToolbarProps: PropTypes.shape({
+        [PropTypes.string]: PropTypes.any
     }),
     selected: PropTypes.array
 };


### PR DESCRIPTION
This PR allows for the passage of custom props to the PrimaryToolbar component embedded within the TagsModal.

In advisor, this will allows us to build filter chips using the PrimaryToolbar.