### PR TITLE
Fix showMoreTitle and onShowMore prop warnings

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/Components/ConditionalFilter/ConditionalFilter.js
@@ -83,8 +83,8 @@ class ConditionalFilter extends Component {
                             {
                                 ActiveComponent && <SplitItem isFilled>
                                     <ActiveComponent
-                                        onShowMore={activeItem.onShowMore}
-                                        showMoreTitle={activeItem.showMoreTitle}
+                                        {...(activeItem.showMoreTitle && { showMoreTitle: activeItem.showMoreTitle })}
+                                        {...(activeItem.onShowMore && { onShowMore: activeItem.onShowMore })}
                                         {
                                         ...activeItem.type !== conditionalFilterType.custom &&
                                             {


### PR DESCRIPTION
- these props should not be passed when there are undefined

Fixes these errors:

```jsx
react_devtools_backend.js:2273 Warning: Unknown event handler property `onShowMore`. It will be ignored.
    in input (created by TextInputBase)
    in TextInputBase (created by ForwardRef)
    in ForwardRef (created by Text)
    in Text (created by ConditionalFilter)
    in div (created by SplitItem)
    in SplitItem (created by ConditionalFilter)
    in div (created by Split)
    in Split (created by ConditionalFilter)
    in ConditionalFilter (created by PrimaryToolbar)
```

```jsx
react_devtools_backend.js:2273 Warning: React does not recognize the `showMoreTitle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `showmoretitle` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in input (created by TextInputBase)
    in TextInputBase (created by ForwardRef)
    in ForwardRef (created by Text)
    in Text (created by ConditionalFilter)
    in div (created by SplitItem)
    in SplitItem (created by ConditionalFilter)
    in div (created by Split)
    in Split (created by ConditionalFilter)
    in ConditionalFilter (created by PrimaryToolbar)
```