### PR TITLE
Add fitContent to Ansible header in inv-insights

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -3,7 +3,7 @@ import './insights.scss';
 
 import { BASE_FETCH_URL, FILTER_CATEGORIES as FC, IMPACT_LABEL, LIKELIHOOD_LABEL } from './Constants';
 import React, { Component, Fragment } from 'react';
-import { SortByDirection, Table, TableBody, TableHeader, cellWidth, sortable } from '@patternfly/react-table';
+import { SortByDirection, Table, TableBody, TableHeader, cellWidth, fitContent, sortable } from '@patternfly/react-table';
 import { Stack, StackItem } from '@patternfly/react-core/dist/js/layouts/Stack/index';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
 import { flatten, sortBy } from 'lodash';
@@ -43,8 +43,8 @@ class InventoryRuleList extends Component {
             { title: 'Added', transforms: [ sortable, cellWidth(15) ] },
             { title: 'Total risk', transforms: [ sortable ] },
             {
-                title: <span>{AnsibeTowerIcon && <AnsibeTowerIcon size='md' />}Ansible</span>,
-                transforms: [ sortable ],
+                title: <span>{AnsibeTowerIcon && <AnsibeTowerIcon size='md' />} Ansible</span>,
+                transforms: [ sortable, fitContent ],
                 dataLabel: 'Ansible'
             }
         ],


### PR DESCRIPTION
This PR adds the `fitContent` transformation to the Ansible header in the `InventoryRuleList` component.

Before:
<img width="1114" alt="Screen Shot 2020-07-28 at 8 08 52 AM" src="https://user-images.githubusercontent.com/4829473/88663636-e8ae2a00-d0a9-11ea-9b85-23c965f222d8.png">

After:
<img width="1114" alt="Screen Shot 2020-07-28 at 8 09 30 AM" src="https://user-images.githubusercontent.com/4829473/88663650-ee0b7480-d0a9-11ea-9fc0-bdb24388e3fd.png">
