### PR TITLE
Add custom TagModal styling

### DIFF
--- a/packages/components/src/Components/TagModal/tagModal.scss
+++ b/packages/components/src/Components/TagModal/tagModal.scss
@@ -1,0 +1,3 @@
+.ins-c-tag-modal {
+    height: calc(var(--pf-global--spacer--4xl) + var(--pf-global--breakpoint--md));
+}


### PR DESCRIPTION
This PR updates the maximum height of the TagModal component. This ensures that the modal remains the same size no matter the number of tags that are displayed in the table ([RHCLOUD-8198](https://projects.engineering.redhat.com/browse/RHCLOUD-8198)). I decided to use `calc(var(--pf-global--spacer--4xl) + var(--pf-global--breakpoint--md));` since it makes all of the content visible on the modal when `perPage` is set to 10.

Before:

<img width="1440" alt="Screen Shot 2020-07-28 at 11 02 59 AM" src="https://user-images.githubusercontent.com/4829473/88683616-02f40200-d0c2-11ea-9fcb-b0995e424b51.png">
<img width="1440" alt="Screen Shot 2020-07-28 at 11 03 05 AM" src="https://user-images.githubusercontent.com/4829473/88683626-04bdc580-d0c2-11ea-88a6-18875509a733.png">
<img width="1440" alt="Screen Shot 2020-07-28 at 11 03 39 AM" src="https://user-images.githubusercontent.com/4829473/88683633-06878900-d0c2-11ea-9d73-1f9cfd769934.png">

After:
 
<img width="1440" alt="Screen Shot 2020-07-28 at 10 56 52 AM" src="https://user-images.githubusercontent.com/4829473/88683380-b7d9ef00-d0c1-11ea-9a05-debe47652958.png">
<img width="1440" alt="Screen Shot 2020-07-28 at 10 57 07 AM" src="https://user-images.githubusercontent.com/4829473/88683389-bb6d7600-d0c1-11ea-894c-f5070a02fb62.png">
<img width="1440" alt="Screen Shot 2020-07-28 at 12 04 24 PM" src="https://user-images.githubusercontent.com/4829473/88691426-d4c6f000-d0ca-11ea-801a-47652f0d1aa8.png">

