### PR TITLE
Bug fix: Change status page link in Unavailable to go to status.redhat.com

### DIFF
--- a/packages/components/src/Components/Unavailable/Unavailable.js
+++ b/packages/components/src/Components/Unavailable/Unavailable.js
@@ -17,7 +17,7 @@ const Unavailable = () => {
             </Title>
             <EmptyStateBody>
                 Try refreshing the page. If the problem persists, contact your organization administrator or visit our
-                <a href='./status' target='_blank' rel='noopener noreferrer'> status page</a> for known outages.
+                <a href='https://status.redhat.com/' target='_blank' rel='noopener noreferrer'> status page</a> for known outages.
             </EmptyStateBody>
         </EmptyState>
     );

--- a/packages/components/src/Components/Unavailable/__snapshots__/Unavailable.test.js.snap
+++ b/packages/components/src/Components/Unavailable/__snapshots__/Unavailable.test.js.snap
@@ -60,7 +60,7 @@ exports[`Unavailable component should render 1`] = `
           >
             Try refreshing the page. If the problem persists, contact your organization administrator or visit our
             <a
-              href="./status"
+              href="https://status.redhat.com/"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Before it led to a relative `./status` path.