### PR TITLE
Remove extraneous h1 display inline rule

### DIFF
--- a/packages/components/src/Components/Ansible/ansible.scss
+++ b/packages/components/src/Components/Ansible/ansible.scss
@@ -12,5 +12,3 @@ i.Ansible {
         @include rem('top', 4px);
     }
 }
-
-h1 { display: inline; }


### PR DESCRIPTION
This h1 styling is preventing us from adding margin to our h1's in curiosity-frontend and does not seem to be necessary, so I have removed it.