### PR TITLE
 Add option for having title text only on first page of PDF

### DIFF
--- a/packages/pdf-generator/src/components/PDFDocument.js
+++ b/packages/pdf-generator/src/components/PDFDocument.js
@@ -18,6 +18,7 @@ const PDFDocument = ({
     title,
     reportName,
     size,
+    allPagesHaveTitle,
     ...props
 }) => {
     const appliedStyles = styles(style);
@@ -34,10 +35,12 @@ const PDFDocument = ({
                             Prepared {DateFormat({ date: new Date(), type: 'exact' }).props.children}
                         </Text>
                     </View>
-                    <View>
-                        <Text style={[ appliedStyles.reportName, appliedStyles.largeSpacing, appliedStyles.displayFont ]}>
-                            {reportName} {type}
-                        </Text>
+                    <View style={appliedStyles.largeSpacing}>
+                        {(allPagesHaveTitle || key === 0) && (
+                            <Text style={[ appliedStyles.reportName, appliedStyles.displayFont ]}>
+                                {reportName} {type}
+                            </Text>
+                        )}
                     </View>
                     <View>
                         <Text style={ appliedStyles.displayFont }>
@@ -94,14 +97,16 @@ PDFDocument.propTypes = {
     ]),
     style: PropTypes.shape({
         [PropTypes.string]: PropTypes.any
-    })
+    }),
+    allPagesHaveTitle: PropTypes.bool
 };
 PDFDocument.defaultProps = {
     size: 'A4',
     reportName: 'Executive report:',
     pages: [],
     title: '',
-    type: 'Default'
+    type: 'Default',
+    allPagesHaveTitle: true
 };
 
 export default PDFDocument;

--- a/packages/pdf-generator/src/components/Table.js
+++ b/packages/pdf-generator/src/components/Table.js
@@ -26,7 +26,6 @@ const Table = ({
             withHeader && <View style={{
                 ...appliedStyles.flexRow,
                 ...appliedStyles.compactCellPadding,
-                justifyContent: 'flex-start',
                 ...headerStyles
             }}>
                 {header.map((cell, key) => (


### PR DESCRIPTION
We only need to have title text on first page [here](https://marvelapp.com/prototype/737a64d/screen/69637228).

Second commit sets table header flex layout to space between, the same setting as table body, previously would this happen:
![misalignment](https://user-images.githubusercontent.com/8426204/89650839-51c04980-d8c3-11ea-90ac-c318c2518802.png)

With this it looks good:
![good-alignment](https://user-images.githubusercontent.com/8426204/89651022-8b915000-d8c3-11ea-8d0b-b15a6bcab60d.png)

