### PR TITLE
Center align ansible check, removes depreciated classes

### DIFF
--- a/packages/inventory-insights/src/Insights.js
+++ b/packages/inventory-insights/src/Insights.js
@@ -157,7 +157,7 @@ class InventoryRuleList extends Component {
                     selected,
                     cells: [
                         {
-                            title: <div className='pf-m-center'>
+                            title: <div>
                                 {resolution.has_playbook ? <input
                                     aria-label='select-checkbox'
                                     type="checkbox"
@@ -174,7 +174,7 @@ class InventoryRuleList extends Component {
                             </div>
                         },
                         {
-                            title: <div className='pf-m-center' key={key} style={{ verticalAlign: 'top' }}>
+                            title: <div key={key} style={{ verticalAlign: 'top' }}>
                                 <Tooltip key={key} position={TooltipPosition.bottom} content={<span>The <strong>likelihood</strong> that this will be
                                 a problem is {LIKELIHOOD_LABEL[rule.likelihood]}. The <strong>impact</strong> of the problem would be
                                 &nbsp;{IMPACT_LABEL[rule.impact.impact]} if it occurred.</span>}>
@@ -183,7 +183,7 @@ class InventoryRuleList extends Component {
                             </div >
                         },
                         {
-                            title: <div className='pf-m-center ' key={key}>
+                            title: <div className='ins-c-center-text' key={key}>
                                 {resolution.has_playbook ?
                                     <CheckCircleIcon className='successColorOverride' />
                                     : 'No'}

--- a/packages/inventory-insights/src/insights.scss
+++ b/packages/inventory-insights/src/insights.scss
@@ -113,3 +113,7 @@
 .ins-c-background__default {
     color: var(--pf-global--BackgroundColor--100);
 }
+
+.ins-c-center-text{
+    text-align: center;
+}


### PR DESCRIPTION
similar to https://github.com/RedHatInsights/insights-advisor-frontend/pull/720
#### looks like
<img width="1394" alt="Screen Shot 2020-08-07 at 11 33 27 AM" src="https://user-images.githubusercontent.com/6640236/89664795-ae147080-d8a5-11ea-85ed-579dea004540.png">
