### PR TITLE
Add InsightsLabel component to pdf-generator

### DIFF
--- a/packages/pdf-generator/src/components/InsightsLabel.js
+++ b/packages/pdf-generator/src/components/InsightsLabel.js
@@ -1,0 +1,83 @@
+/* eslint-disable max-len */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { View, Canvas, Text } from '@react-pdf/renderer';
+import styles from '../utils/styles';
+
+const appliedStyles = styles();
+
+const lowPath = 'M143 256.3L7 120.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0L313 86.3c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.4 9.5-24.6 9.5-34 .1zm34 192l136-136c9.4-9.4 9.4-24.6 0-33.9l-22.6-22.6c-9.4-9.4-24.6-9.4-33.9 0L160 352.1l-96.4-96.4c-9.4-9.4-24.6-9.4-33.9 0L7 278.3c-9.4 9.4-9.4 24.6 0 33.9l136 136c9.4 9.5 24.6 9.5 34 .1z';
+const moderatePath = 'M416 304H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32zm0-192H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z';
+const importantPath = 'M177 255.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 351.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 425.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1zm-34-192L7 199.7c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l96.4-96.4 96.4 96.4c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9l-136-136c-9.2-9.4-24.4-9.4-33.8 0z';
+const criticalPath = 'M0 84l189-84L378 84L378 441l-189-84L0 441z';
+
+const labelMapper = {
+    1: {
+        text: 'Low',
+        iconPath: lowPath,
+        width: 40,
+        ...appliedStyles.labelColorsLow
+    },
+    2: {
+        text: 'Moderate',
+        iconPath: moderatePath,
+        width: 65,
+        ...appliedStyles.labelColorsModerate
+    },
+    3: {
+        text: 'Important',
+        iconPath: importantPath,
+        width: 63,
+        ...appliedStyles.labelColorsImportant
+    },
+    4: {
+        text: 'Critical',
+        iconPath: criticalPath,
+        width: 55,
+        ...appliedStyles.labelColorsCrit
+    }
+};
+
+const InsightsLabel = ({ variant, props }) => {
+    const { bgColor, iconColor, iconPath, width, text, textColor } = labelMapper[variant];
+    return <View style={appliedStyles.flexRow} {...props}>
+        <Canvas
+            style={{
+                backgroundColor: bgColor,
+                width: width,
+                height: 20,
+                borderRadius: 30
+            }}
+        />
+        <Canvas
+            style={{
+                left: -width + 7,
+                top: 5,
+                width: 10,
+                height: 10
+            }}
+            paint={({ path, scale }) => {
+                scale(0.02);
+                path(iconPath).fill(iconColor);
+            }}
+        />
+        <Text style={{
+            left: variant % 2 === 0 ? -width + 10 : -width + 7,
+            top: 4,
+            color: textColor
+        }}>
+            {text}
+        </Text>
+    </View>;
+};
+
+InsightsLabel.propTypes = {
+    variant: PropTypes.number
+};
+
+InsightsLabel.defaultProps = {
+    variant: 1
+};
+
+export default InsightsLabel;

--- a/packages/pdf-generator/src/index.js
+++ b/packages/pdf-generator/src/index.js
@@ -8,4 +8,5 @@ export { default as PanelItem } from './components/PanelItem';
 export { default as Battery } from './components/Battery';
 export { default as Chart } from './components/Chart';
 export { default as Paragraph } from './components/Paragraph';
+export { default as InsightsLabel } from './components/InsightsLabel';
 export * from './utils/text';

--- a/packages/pdf-generator/src/utils/styles.js
+++ b/packages/pdf-generator/src/utils/styles.js
@@ -10,6 +10,16 @@ import global_Color_light_300 from '@patternfly/react-tokens/dist/js/global_Colo
 import global_Color_dark_200 from '@patternfly/react-tokens/dist/js/global_Color_dark_200';
 import global_Color_dark_100 from '@patternfly/react-tokens/dist/js/global_Color_dark_100';
 import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
+import chart_color_red_200 from '@patternfly/react-tokens/dist/js/chart_color_red_200';
+import chart_color_red_300 from '@patternfly/react-tokens/dist/js/chart_color_red_300';
+import global_primary_color_100 from '@patternfly/react-tokens/dist/js/global_primary_color_100';
+import global_palette_blue_50 from '@patternfly/react-tokens/dist/js/global_palette_blue_50';
+import global_palette_blue_600 from '@patternfly/react-tokens/dist/js/global_palette_blue_600';
+import global_palette_gold_50 from '@patternfly/react-tokens/dist/js/global_palette_gold_50';
+import global_palette_gold_700 from '@patternfly/react-tokens/dist/js/global_palette_gold_700';
+import global_palette_orange_600 from '@patternfly/react-tokens/dist/js/global_palette_orange_600';
+import global_palette_red_50 from '@patternfly/react-tokens/dist/js/global_palette_red_50';
+import global_palette_red_200 from '@patternfly/react-tokens/dist/js/global_palette_red_200';
 import { fontTypes, generateFonts, redhatFont } from './fonts';
 
 Font.register({ family: 'Overpass', fonts: generateFonts(fontTypes) });
@@ -93,6 +103,26 @@ export default (style = {}) => StyleSheet.create({
     },
     defaultColor: {
         color: global_Color_light_300.value
+    },
+    labelColorsLow: {
+        bgColor: global_palette_blue_50.value,
+        textColor: global_palette_blue_600.value,
+        iconColor: global_primary_color_100.value
+    },
+    labelColorsModerate: {
+        bgColor: global_palette_gold_50.value,
+        textColor: global_palette_gold_700.value,
+        iconColor: chart_global_warning_Color_200.value
+    },
+    labelColorsImportant: {
+        bgColor: '#fff5ec',
+        textColor: global_palette_orange_600.value,
+        iconColor: chart_global_warning_Color_100.value
+    },
+    labelColorsCrit: {
+        bgColor: global_palette_red_50.value,
+        textColor: chart_color_red_300.value,
+        iconColor: chart_color_red_200.value
     },
     compactCellPadding: {
         paddingLeft: c_table_m_compact_cell_PaddingLeft.value,


### PR DESCRIPTION
This PR is in response to https://projects.engineering.redhat.com/browse/RHCLOUD-8451.

It adds the `InsightsLabel` component to the `pdf-generator` package. This component is a recreation of the component of the same name found in the `components` package. The addition of this component will allow for us to move away from the usage of the Battery component completely.

Here are some screenshots of the new svgs:

<img width="1440" alt="Screen Shot 2020-08-07 at 1 40 37 PM" src="https://user-images.githubusercontent.com/4829473/89673964-4e25c600-d8b5-11ea-8cde-42191f6a9c21.png">

<img width="1440" alt="Screen Shot 2020-08-07 at 1 47 55 PM" src="https://user-images.githubusercontent.com/4829473/89673977-5251e380-d8b5-11ea-9b72-5cfce2ef9ccf.png">