### PR TITLE
Fix remediation file generator by adding proper css chunks

### DIFF
--- a/packages/remediations/.gitignore
+++ b/packages/remediations/.gitignore
@@ -7,3 +7,4 @@
 /esm
 /cjs
 /*.css
+*.txt

--- a/packages/remediations/config/webpack.config.js
+++ b/packages/remediations/config/webpack.config.js
@@ -1,4 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TerserJSPlugin = require('terser-webpack-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const { resolve } = require('path');
 const { externals } = require('./webpack.constants.js');
 const { buildPlugins } = require('./webpack.plugins.js');
@@ -7,7 +9,8 @@ module.exports = (env) => ({
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     devtool: 'source-map',
     optimization: {
-        minimize: process.env.NODE_ENV === 'production'
+        minimize: process.env.NODE_ENV === 'production',
+        minimizer: [ new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({}) ]
     },
     entry: {
         index: './src/index.js',

--- a/packages/remediations/config/webpack.plugins.js
+++ b/packages/remediations/config/webpack.plugins.js
@@ -23,8 +23,8 @@ const LodashWebpackPlugin = new(require('lodash-webpack-plugin'))({ currying: tr
  * Writes final css to file
  */
 const ExtractCssWebpackPlugin = new(require('mini-css-extract-plugin'))({
-    chunkFilename: '[name].css',
-    filename: '[id].css'
+    chunkFilename: '[id].css',
+    filename: '[name].css'
 });
 
 module.exports = { buildPlugins: (env) => ({
@@ -32,6 +32,6 @@ module.exports = { buildPlugins: (env) => ({
         WriteFileWebpackPlugin,
         LodashWebpackPlugin,
         ExtractCssWebpackPlugin,
-        ...env && env.server === 'true' ? [ HtmlWebpackPlugin, HotModuleReplacementPlugin ] : []
+        ...env && env.server === 'true' ? [ HotModuleReplacementPlugin ] : []
     ]
 }) };


### PR DESCRIPTION
Currently the build creates `1.css` which is incorrect, so I've changed the css generation to create `index.css`.