### PR TITLE
relative DateFormat: prepend "almost " when rounding up

### DIFF
--- a/packages/components/src/Components/DateFormat/helper.js
+++ b/packages/components/src/Components/DateFormat/helper.js
@@ -7,14 +7,22 @@ const hour = minute * 60;
 const day = hour * 24;
 const month = day * 30; // let's count that every month has 30 days
 const year = day * 365;
-const formatTime = (number, unit) => `${number} ${number > 1 ? `${unit}s` : unit} ago`;
+const formatTime = (number, unit) => {
+    const rounded = Math.round(number);
+    const unitPlural = rounded > 1 ? `${unit}s` : unit;
+    if (number < rounded) {
+        return `almost ${rounded} ${unitPlural} ago`;
+    } else {
+        return `${rounded} ${unitPlural} ago`;
+    }
+};
 
 const relativeTimeTable = [
-    { rightBound: Infinity, description: date => formatTime(Math.round(date / (year)), 'year') },
-    { rightBound: year, description: date => formatTime(Math.round(date / (month)), 'month') },
-    { rightBound: month, description: date => formatTime(Math.round(date / (day)), 'day') },
-    { rightBound: day, description: date => formatTime(Math.round(date / (hour)), 'hour') },
-    { rightBound: hour, description: date => formatTime(Math.round(date / (minute)), 'minute') },
+    { rightBound: Infinity, description: date => formatTime(date / year, 'year') },
+    { rightBound: year, description: date => formatTime(date / month, 'month') },
+    { rightBound: month, description: date => formatTime(date / day, 'day') },
+    { rightBound: day, description: date => formatTime(date / hour, 'hour') },
+    { rightBound: hour, description: date => formatTime(date / minute, 'minute') },
     { rightBound: minute, description: () => 'Just now' }
 ];
 

--- a/packages/components/src/Components/DateFormat/helper.test.js
+++ b/packages/components/src/Components/DateFormat/helper.test.js
@@ -4,13 +4,17 @@ describe('dateStringByType component', () => {
     const date = new Date('Dec 31 2019 00:00:00 UTC');
     const tenSecondsAgo = new Date('Dec 30 2019 23:59:50 UTC');
     const tenMinutesAgo = new Date('Dec 30 2019 23:50:00 UTC');
+    const almostHourAgo = new Date('Dec 30 2019 23:01:00 UTC');
     const hourAgo = new Date('Dec 30 2019 23:00:00 UTC');
+    const almostTwoHoursAgo = new Date('Dec 30 2019 22:29:00 UTC');
     const fourHoursAgo = new Date('Dec 30 2019 20:00:00 UTC');
     const dayAgo = new Date('Dec 30 2019 00:00:00 UTC');
     const twoDaysAgo = new Date('Dec 29 2019 00:00:00 UTC');
     const weekAgo = new Date('Dec 24 2019 00:00:00 UTC');
+    // Note Dec 31 - Dec 1 is less than calendaric month but is >= 30 days.
     const monthAgo = new Date('Dec 1 2019 00:00:00 UTC');
     const monthAgo2 = new Date('Nov 30 2019 00:00:00 UTC');
+    const almostTwoMonthsAgo = new Date('Nov 2 2019 00:00:00 UTC');
     const twoMonthsAgo = new Date('Nov 1 2019 00:00:00 UTC');
     const twoMonthsAgo2 = new Date('Oct 31 2019 00:00:00 UTC');
     const sixMonthsAgo = new Date('Jun 30 2019 00:00:00 UTC');
@@ -42,8 +46,16 @@ describe('dateStringByType component', () => {
         expect(dateStringByType('relative')(tenMinutesAgo)).toEqual('10 minutes ago');
     });
 
+    it('Relative datetime matches 59 minutes ago', () => {
+        expect(dateStringByType('relative')(almostHourAgo)).toEqual('59 minutes ago');
+    });
+
     it('Relative datetime matches 1 hour ago', () => {
         expect(dateStringByType('relative')(hourAgo)).toEqual('1 hour ago');
+    });
+
+    it('Relative datetime matches almost 2 hours ago', () => {
+        expect(dateStringByType('relative')(almostTwoHoursAgo)).toEqual('almost 2 hours ago');
     });
 
     it('Relative datetime matches 4 hours ago', () => {
@@ -66,8 +78,12 @@ describe('dateStringByType component', () => {
         expect(dateStringByType('relative')(monthAgo)).toEqual('1 month ago');
     });
 
-    it('Relative datetime matches 1 months ago', () => {
+    it('Relative datetime matches month ago', () => {
         expect(dateStringByType('relative')(monthAgo2)).toEqual('1 month ago');
+    });
+
+    it('Relative datetime matches almost 2 months ago', () => {
+        expect(dateStringByType('relative')(almostTwoMonthsAgo)).toEqual('almost 2 months ago');
     });
 
     it('Relative datetime matches 2 months ago', () => {


### PR DESCRIPTION
Motivation: I want to use DateFormat more in [OpenShift Cluster Manager](https://cloud.redhat.com/openshift).  It's already used there in a couple places (cluster details -> Insights tab). 
But some things change behavior at some round thresholds (3 hours, 60 days) and I'd like wording to somehow change when we cross them.

If it was "2 months" before and is still "2 months" now, it's confusing — why did evaluation period expire??
Differentiating e.g. "almost 2 months" vs "2 months" would help.