### PR TITLE
Fix close modal styling

### DIFF
--- a/packages/sources/src/addSourceWizard/CloseModal.js
+++ b/packages/sources/src/addSourceWizard/CloseModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Button, TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Modal, Button, Title } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { useIntl, FormattedMessage } from 'react-intl';
 
@@ -13,12 +13,10 @@ const CloseModal = ({ onExit, onStay, isOpen, title, exitTitle, stayTitle, descr
             title={title}
             aria-label={intl.formatMessage({ id: 'wizard.closeAriaLabel', defaultMessage: 'Close add source wizard' })}
             header={
-                <TextContent>
-                    <ExclamationTriangleIcon size="lg" className="ins-c-source__warning-icon" />
-                    <Text component={TextVariants.h1}>
-                        {title}
-                    </Text>
-                </TextContent>
+                <Title headingLevel="h1" size="2xl">
+                    <ExclamationTriangleIcon size="sm" className="ins-c-source__warning-icon" />
+                    {title}
+                </Title>
             }
             isOpen={isOpen}
             onClose={onStay}

--- a/packages/sources/src/tests/addSourceWizard/closeModal.test.js
+++ b/packages/sources/src/tests/addSourceWizard/closeModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Button, Text, TextContent } from '@patternfly/react-core';
+import { Modal, Button, Title } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import CloseModal from '../../addSourceWizard/CloseModal';
@@ -30,8 +30,7 @@ describe('CloseModal', () => {
         expect(wrapper.find(Modal)).toHaveLength(1);
         expect(wrapper.find(Button)).toHaveLength(3);
         expect(wrapper.find(ExclamationTriangleIcon)).toHaveLength(1);
-        expect(wrapper.find(Text)).toHaveLength(1);
-        expect(wrapper.find(TextContent)).toHaveLength(1);
+        expect(wrapper.find(Title)).toHaveLength(1);
     });
 
     it('renders correctly with custom title', () => {
@@ -45,9 +44,7 @@ describe('CloseModal', () => {
         expect(wrapper.find(Modal)).toHaveLength(1);
         expect(wrapper.find(Button)).toHaveLength(3);
         expect(wrapper.find(ExclamationTriangleIcon)).toHaveLength(1);
-        expect(wrapper.find(Text)).toHaveLength(1);
-        expect(wrapper.find(Text).text()).toEqual(initialProps.title);
-        expect(wrapper.find(TextContent)).toHaveLength(1);
+        expect(wrapper.find(Title).text()).toEqual(initialProps.title);
     });
 
     it('calls onExit', () => {


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-1043

I have noticed that the close modal went crazy after some PF update

**Before**

![image](https://user-images.githubusercontent.com/32869456/90103370-ab50ca00-dd42-11ea-9044-cd6a7e84ca6c.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/90103389-b3106e80-dd42-11ea-871e-19897af1c582.png)
