### PR TITLE
Conditionally render os_release

### DIFF
--- a/packages/inventory/src/components/table/TitleColumn.js
+++ b/packages/inventory/src/components/table/TitleColumn.js
@@ -31,7 +31,7 @@ const onRowClick = (event, key, { loaded, onRowClick: rowClick, noDetail }) => {
  */
 const TitleColumn = (data, id, item, props) => (
     <div className="ins-composed-col">
-        <div>{item?.os_release}</div>
+        {item?.os_release && <div>{item.os_release}</div>}
         <div className={props?.noDetail ? 'ins-m-nodetail' : ''}>
             { props?.noDetail ?
                 data :


### PR DESCRIPTION
By conditionally rendering `item.os_release` in the TitleColumn, we no longer render the associated `<div>`. This means that the styles assigned to `:first-child` for the `ins-composed-col` class can be passed to the `data` element.

This is desirable in use-cases like we have in the advisor systems table. Currently, the default font-size in pf4 is being overridden by `font-size: var(--pf-global--FontSize--lg);`. This change make it so the default is maintained, although still set, by `font-size: var(--pf-global--FontSize--sm);`. (Styles found in `InventoryList.scss`)

🎫 -> https://projects.engineering.redhat.com/browse/RHCLOUD-8661