### PR TITLE
Add Tooltip to DownloadButton

### DIFF
--- a/packages/components/src/Components/DownloadButton/DownloadButton.js
+++ b/packages/components/src/Components/DownloadButton/DownloadButton.js
@@ -1,5 +1,6 @@
+import { Dropdown, DropdownItem, DropdownToggle, Tooltip } from '@patternfly/react-core';
 import React, { Component } from 'react';
-import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
+
 import { ExportIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
@@ -20,11 +21,20 @@ class DownloadButton extends Component {
         });
     }
 
+    conditionallyTooltip = (children) => {
+        const { tooltipText } = this.props;
+        return <React.Fragment>
+            {tooltipText ? <Tooltip distance={0} content={tooltipText}>
+                {children}
+            </Tooltip> : children}
+        </React.Fragment>;
+    };
+
     render() {
         const { isOpen } = this.state;
         const { extraItems, onSelect, isDisabled, ...props } = this.props;
-        return (
-            <Dropdown
+        return <React.Fragment>
+            {this.conditionallyTooltip(<Dropdown
                 { ...props }
                 isPlain
                 onSelect={ this.onSelect }
@@ -45,13 +55,14 @@ class DownloadButton extends Component {
                         Export to JSON</DropdownItem>,
                     ...extraItems
                 ] }
-            />
-        );
+            />)}
+        </React.Fragment>;
     }
 }
 
 DownloadButton.propTypes = {
     extraItems: PropTypes.arrayOf(PropTypes.node),
+    tooltipText: PropTypes.node,
     onSelect: PropTypes.func
 };
 DownloadButton.defaultProps = {

--- a/packages/components/src/Components/DownloadButton/__snapshots__/DownloadButton.test.js.snap
+++ b/packages/components/src/Components/DownloadButton/__snapshots__/DownloadButton.test.js.snap
@@ -457,118 +457,124 @@ exports[`DownloadButton component API clicking should open dropdown 1`] = `
 `;
 
 exports[`DownloadButton component should render CSV and JSON by default 1`] = `
-<Component
-  dropdownItems={
-    Array [
+<Fragment>
+  <Component
+    dropdownItems={
+      Array [
+        <Unknown
+          component="button"
+          onClick={[Function]}
+        >
+          Export to CSV
+        </Unknown>,
+        <Unknown
+          component="button"
+          onClick={[Function]}
+        >
+          Export to JSON
+        </Unknown>,
+      ]
+    }
+    isOpen={false}
+    isPlain={true}
+    onSelect={[Function]}
+    toggle={
       <Unknown
-        component="button"
-        onClick={[Function]}
+        onToggle={[Function]}
+        toggleIndicator={null}
       >
-        Export to CSV
-      </Unknown>,
-      <Unknown
-        component="button"
-        onClick={[Function]}
-      >
-        Export to JSON
-      </Unknown>,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  toggle={
-    <Unknown
-      onToggle={[Function]}
-      toggleIndicator={null}
-    >
-      <ExportIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </Unknown>
-  }
-/>
+        <ExportIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </Unknown>
+    }
+  />
+</Fragment>
 `;
 
 exports[`DownloadButton component should render custom items 1`] = `
-<Component
-  dropdownItems={
-    Array [
+<Fragment>
+  <Component
+    dropdownItems={
+      Array [
+        <Unknown
+          component="button"
+          onClick={[Function]}
+        >
+          Export to CSV
+        </Unknown>,
+        <Unknown
+          component="button"
+          onClick={[Function]}
+        >
+          Export to JSON
+        </Unknown>,
+        <Unknown
+          component="button"
+        />,
+      ]
+    }
+    isOpen={false}
+    isPlain={true}
+    onSelect={[Function]}
+    toggle={
       <Unknown
-        component="button"
-        onClick={[Function]}
+        onToggle={[Function]}
+        toggleIndicator={null}
       >
-        Export to CSV
-      </Unknown>,
-      <Unknown
-        component="button"
-        onClick={[Function]}
-      >
-        Export to JSON
-      </Unknown>,
-      <Unknown
-        component="button"
-      />,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  toggle={
-    <Unknown
-      onToggle={[Function]}
-      toggleIndicator={null}
-    >
-      <ExportIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </Unknown>
-  }
-/>
+        <ExportIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </Unknown>
+    }
+  />
+</Fragment>
 `;
 
 exports[`DownloadButton component should render disabled 1`] = `
-<Component
-  dropdownItems={
-    Array [
+<Fragment>
+  <Component
+    dropdownItems={
+      Array [
+        <Unknown
+          component="button"
+          isDisabled={true}
+          onClick={[Function]}
+        >
+          Export to CSV
+        </Unknown>,
+        <Unknown
+          component="button"
+          isDisabled={true}
+          onClick={[Function]}
+        >
+          Export to JSON
+        </Unknown>,
+        <Unknown
+          component="button"
+        />,
+      ]
+    }
+    isOpen={false}
+    isPlain={true}
+    onSelect={[Function]}
+    toggle={
       <Unknown
-        component="button"
         isDisabled={true}
-        onClick={[Function]}
+        onToggle={[Function]}
+        toggleIndicator={null}
       >
-        Export to CSV
-      </Unknown>,
-      <Unknown
-        component="button"
-        isDisabled={true}
-        onClick={[Function]}
-      >
-        Export to JSON
-      </Unknown>,
-      <Unknown
-        component="button"
-      />,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  toggle={
-    <Unknown
-      isDisabled={true}
-      onToggle={[Function]}
-      toggleIndicator={null}
-    >
-      <ExportIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </Unknown>
-  }
-/>
+        <ExportIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </Unknown>
+    }
+  />
+</Fragment>
 `;


### PR DESCRIPTION
This PR addresses https://projects.engineering.redhat.com/browse/RHCLOUD-8729 by adding a Tooltip to the DownloadButton used in the PrimaryToolbar `exportConfig`.

After:

<img width="1440" alt="Screen Shot 2020-08-21 at 11 47 08 AM" src="https://user-images.githubusercontent.com/4829473/90910009-a922e700-e3a4-11ea-926d-f8b9f2739949.png">
