### PR TITLE
Set tooltip distance as default

### DIFF
--- a/packages/components/src/Components/DownloadButton/DownloadButton.js
+++ b/packages/components/src/Components/DownloadButton/DownloadButton.js
@@ -24,7 +24,7 @@ class DownloadButton extends Component {
     conditionallyTooltip = (children) => {
         const { tooltipText } = this.props;
         return <React.Fragment>
-            {tooltipText ? <Tooltip distance={0} content={tooltipText}>
+            {tooltipText ? <Tooltip content={tooltipText}>
                 {children}
             </Tooltip> : children}
         </React.Fragment>;


### PR DESCRIPTION
This PR uses the default patternfly value for the tooltip distance.