### PR TITLE
Change TitleColumn fontsize to match pf default

### DIFF
--- a/packages/inventory/src/components/table/InventoryList.scss
+++ b/packages/inventory/src/components/table/InventoryList.scss
@@ -84,7 +84,7 @@
         }
 
         * {
-            font-size: var(	--pf-global--FontSize--lg);
+            font-size: var(--pf-global--FontSize--md);
         }
 
         .ins-composed-col {


### PR DESCRIPTION
This PR fixes https://projects.engineering.redhat.com/browse/RHCLOUD-8661. We would like the `FontSize` used in the title column to conform to the patternfly default to maintain uniformity.