### PR TITLE
Fix possible absolute node module path in babel transform.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -56,7 +56,7 @@ const createPfReactTransform = (env) => [
                     throw new Error(`File with importName ${importName} does not exist. Glob path: ${pathname}`);
                 }
 
-                res = res.replace(path.resolve(__dirname, '../../node_modules/'), '');
+                res = res.split('/node_modules/').pop();
                 res = res.replace(/^\//, '');
                 return res;
             },
@@ -81,7 +81,7 @@ const createPfReactTransform = (env) => [
                     throw new Error(`File with importName ${importName} does not exist`);
                 }
 
-                res = res.replace(path.resolve(__dirname, '../../node_modules/'), '');
+                res = res.split('/node_modules/').pop();
                 res = res.replace(/^\//, '');
                 return res;
             },


### PR DESCRIPTION
@karelhala this should remove the package prefix from the Patternfly import paths. 