### PR TITLE
Filter source types with invalid schema objects

### DIFF
--- a/packages/sources/config/rollup.config.js
+++ b/packages/sources/config/rollup.config.js
@@ -78,6 +78,7 @@ export default rollupConfig(
         costManagementAuthentication: 'src/api/costManagementAuthentication.js',
         handleError: 'src/api/handleError.js',
         filterApps: 'src/utilities/filterApps.js',
+        filterTypes: 'src/utilities/filterTypes.js',
         CloseModal: 'src/addSourceWizard/CloseModal.js',
         hardcodedSchemas: 'src/addSourceWizard/hardcodedSchemas.js',
         AuthSelect: 'src/sourceFormRenderer/components/AuthSelect.js',

--- a/packages/sources/src/addSourceWizard/SourceAddModal.js
+++ b/packages/sources/src/addSourceWizard/SourceAddModal.js
@@ -8,7 +8,9 @@ import createSchema from './SourceAddSchema';
 import { doLoadSourceTypes, doLoadApplicationTypes } from '../api/index';
 import LoadingStep from './steps/LoadingStep';
 import { WIZARD_DESCRIPTION, WIZARD_TITLE } from '../utilities/stringConstants';
+
 import filterApps from '../utilities/filterApps';
+import filterTypes from '../utilities/filterTypes';
 
 const initialValues = {
     schema: {},
@@ -21,7 +23,7 @@ const reducer = (state, { type, sourceTypes, applicationTypes, container, disabl
         case 'loaded':
             return {
                 ...state,
-                schema: createSchema(sourceTypes.filter(type => type.schema), applicationTypes.filter(filterApps), disableAppSelection, container, intl),
+                schema: createSchema(sourceTypes.filter(filterTypes), applicationTypes.filter(filterApps), disableAppSelection, container, intl),
                 isLoading: false,
                 sourceTypes
             };

--- a/packages/sources/src/tests/utilities/filterTypes.spec.js
+++ b/packages/sources/src/tests/utilities/filterTypes.spec.js
@@ -1,0 +1,16 @@
+import filterTypes from '../../utilities/filterTypes';
+
+describe('filterTypes', () => {
+    it('filters types that does not have any endpoint or authentication', () => {
+        const sourceTypes = [
+            { schema: { endpoint: { title: 'endpoint setup' } } }, // remove
+            { schema: { authentication: [{ type: 'password' }], endpoint: { title: 'endpoint setup' } } },
+            { schema: { authentication: [{ type: 'password' }] } }, // remove,
+            { } // remove
+        ];
+
+        expect(sourceTypes.filter(filterTypes)).toEqual([
+            { schema: { authentication: [{ type: 'password' }], endpoint: { title: 'endpoint setup' } } }
+        ]);
+    });
+});

--- a/packages/sources/src/utilities/filterTypes.js
+++ b/packages/sources/src/utilities/filterTypes.js
@@ -1,0 +1,3 @@
+const filterTypes = (type) => type.schema?.authentication && type.schema?.endpoint;
+
+export default filterTypes;


### PR DESCRIPTION
Last week an invalid source type broke the whole wizard. This change should introduce basic checking.