### PR TITLE
Fix start scripts by adding generic configuration

### DIFF
--- a/config/rollup-contants.js
+++ b/config/rollup-contants.js
@@ -49,32 +49,35 @@ export const globals = {
 };
 
 export const rollupConfig = (external, plugins, globals, name, entries = [ globMapper('src/**/index.js') ], outputDir = './') => {
-    if (process.env.FORMAT === 'umd' || !process.env.FORMAT) {
-        return [ ...Object.entries(entries[1] || entries[0]).map(([ key, input ]) => ({
-            input,
-            output: {
-                file: `${outputDir}${key}.js`,
-                format: 'umd',
-                name: `${name}-${key}`,
-                globals,
-                exports: 'named'
-            },
-            external,
-            plugins
-        }))
-        ];
-    }
-
-    return  {
+    const outputBuilder = (format) => ({
         input: entries[0],
         output: {
-            dir: `${outputDir}${process.env.FORMAT}`,
+            dir: `${outputDir}${format}`,
+            format,
             name,
             globals,
             exports: 'named'
-
         },
         external,
         plugins
-    };
+    });
+
+    return [
+        ...process.env.FORMAT === 'umd' || !process.env.FORMAT ? [
+            ...Object.entries(entries[1] || entries[0]).map(([ key, input ]) => ({
+                input,
+                output: {
+                    file: `${outputDir}${key}.js`,
+                    format: 'umd',
+                    name: `${name}-${key}`,
+                    globals,
+                    exports: 'named'
+                },
+                external,
+                plugins
+            }))
+        ] : [],
+        ...process.env.FORMAT === 'cjs' || !process.env.FORMAT ? [ outputBuilder('cjs') ] : [],
+        ...process.env.FORMAT === 'esm' || !process.env.FORMAT ? [ outputBuilder('esm') ] : []
+    ];
 };


### PR DESCRIPTION
When running `npm start` the build would produce `umd` package only, if app is using any other environment it won't include these changes in final build. This PR fixes it that if no env passed it'll produce one array with all envs.