### PR TITLE
Allow custom filters to be passed from parent

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,6 +24,7 @@ const frontendComponentsMappe = {
     NullBattery: 'Battery',
     ConnectedBreadcrumbs: 'Breadcrumbs',
     ConditionalFilterType: 'ConditionalFilter',
+    conditionalFilterType: 'ConditionalFilter',
     groupType: 'ConditionalFilter',
     DarkContext: 'Dark',
     FilterDropdown: 'Filters',

--- a/packages/inventory/src/api/api.js
+++ b/packages/inventory/src/api/api.js
@@ -72,7 +72,8 @@ export function getEntities(items, {
     per_page: perPage,
     page,
     orderBy = 'updated',
-    orderDirection = 'DESC'
+    orderDirection = 'DESC',
+    ...options
 }, showTags) {
     const {
         hostnameOrId,
@@ -106,7 +107,10 @@ export function getEntities(items, {
             orderBy,
             orderDirection,
             staleFilter,
-            constructTags(tagFilters),
+            [
+                ...constructTags(tagFilters),
+                ...options.tags || []
+            ],
             registeredWithFilter,
             { cancelToken: controller && controller.token }
         )
@@ -143,14 +147,17 @@ export function getTags(systemId, search, { pagination } = { pagination: {} }) {
     );
 }
 
-export function getAllTags(search, { filters, pagination } = { pagination: {} }) {
+export function getAllTags(search, { filters, pagination, ...options } = { pagination: {} }) {
     const {
         tagFilters,
         staleFilter,
         registeredWithFilter
     } = filters ? filters.reduce(filtersReducer, defaultFilters) : defaultFilters;
     return tags.apiTagGetTags(
-        tagFilters ? constructTags(tagFilters) : undefined,
+        [
+            ...tagFilters ? constructTags(tagFilters) : [],
+            ...options.tags || []
+        ],
         'tag',
         'ASC',
         (pagination && pagination.perPage) || 10,

--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -56,6 +56,7 @@ const EntityTableToolbar = ({
     isLoaded,
     items,
     sortBy,
+    customFilters,
     ...props
 }) => {
     const dispatch = useDispatch();
@@ -92,7 +93,10 @@ const EntityTableToolbar = ({
      */
     const debounceGetAllTags = useCallback(debounce((config, options) => {
         if (showTags && !hasItems) {
-            dispatch(fetchAllTags(config, options));
+            dispatch(fetchAllTags({
+                ...customFilters,
+                ...config
+            }, options));
         }
     }, 800), []);
 
@@ -102,7 +106,7 @@ const EntityTableToolbar = ({
     const onRefreshData = useCallback((options) => {
         dispatch(loadSystems(options, showTags));
         if (showTags && !hasItems) {
-            dispatch(fetchAllTags(filterTagsBy, { filters: options.filters }));
+            dispatch(fetchAllTags(filterTagsBy, { ...customFilters, filters: options.filters }));
         }
     });
 
@@ -124,8 +128,11 @@ const EntityTableToolbar = ({
         };
         onRefresh ? onRefresh(params, (options) => {
             dispatch(entitiesLoading());
-            onRefreshData({ ...params, ...options });
-        }) : onRefreshData(params);
+            onRefreshData({ ...params, ...customFilters, ...options });
+        }) : onRefreshData({
+            ...customFilters,
+            ...params
+        });
     };
 
     /**
@@ -302,6 +309,7 @@ const EntityTableToolbar = ({
         {
             showTags &&
             <TagsModal
+                customFilters={customFilters}
                 filterTagsBy={filterTagsBy}
                 onApply={(selected) => setSelectedTags(arrayToSelection(selected))}
                 onToggleModal={() => seFilterTagsBy('')}
@@ -324,7 +332,13 @@ EntityTableToolbar.propTypes = {
     pagination: PrimaryToolbar.propTypes.pagination,
     actionsConfig: PrimaryToolbar.propTypes.actionsConfig,
     activeFiltersConfig: PrimaryToolbar.propTypes.activeFiltersConfig,
-    onRefreshData: PropTypes.func
+    onRefreshData: PropTypes.func,
+    customFilters: PropTypes.shape({
+        tags: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.arrayOf(PropTypes.string)
+        ])
+    })
 };
 
 EntityTableToolbar.defaultProps = {

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -16,7 +16,7 @@ class ContextInventoryList extends React.Component {
      * @param {*} options new options to be applied, like pagination, filters, etc.
      */
     onRefreshData = (options = {}) => {
-        const { page, perPage, items, hasItems, sortBy, activeFilters, showTags } = this.props;
+        const { page, perPage, items, hasItems, sortBy, activeFilters, showTags, customFilters } = this.props;
         this.props.loadEntities && this.props.loadEntities({
             page,
             perPage,
@@ -24,6 +24,7 @@ class ContextInventoryList extends React.Component {
             hasItems,
             sortBy,
             activeFilters,
+            ...customFilters,
             ...options
         }, showTags);
     }
@@ -111,7 +112,13 @@ InventoryList.propTypes = {
             title: PropTypes.node
         })
     ]),
-    entities: PropTypes.arrayOf(PropTypes.any)
+    entities: PropTypes.arrayOf(PropTypes.any),
+    customFilters: PropTypes.shape({
+        tags: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.arrayOf(PropTypes.string)
+        ])
+    })
 };
 
 export default InventoryList;

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -23,6 +23,7 @@ const InventoryTable = forwardRef(({
     filters,
     showTags,
     sortBy: propsSortBy,
+    customFilters,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
@@ -54,6 +55,7 @@ const InventoryTable = forwardRef(({
         <Fragment>
             <EntityTableToolbar
                 { ...props }
+                customFilters={customFilters}
                 items={ items }
                 onRefresh={onRefresh}
                 filters={ filters }
@@ -67,6 +69,7 @@ const InventoryTable = forwardRef(({
             </EntityTableToolbar>
             <InventoryList
                 { ...props }
+                customFilters={customFilters}
                 ref={ref}
                 hasItems={ hasItems }
                 onRefresh={ onRefresh }
@@ -78,6 +81,7 @@ const InventoryTable = forwardRef(({
             />
             <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
                 <Pagination
+                    customFilters={customFilters}
                     isFull
                     items={ items }
                     total={ pagination.total }

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -21,12 +21,18 @@ class FooterPagination extends Component {
      * @param {*} pagination contains new pagination config.
      */
     updatePagination = (pagination) => {
-        const { onRefresh, dataLoading, loadEntities, showTags } = this.props;
+        const { onRefresh, dataLoading, loadEntities, showTags, customFilters } = this.props;
         if (onRefresh) {
             dataLoading();
-            onRefresh(pagination, (options) => loadEntities(options, showTags));
+            onRefresh(pagination, (options) => loadEntities({
+                ...customFilters,
+                ...options
+            }, showTags));
         } else {
-            loadEntities(pagination, showTags);
+            loadEntities({
+                ...customFilters,
+                ...pagination
+            }, showTags);
         }
     }
 
@@ -96,7 +102,13 @@ const propTypes = {
     loaded: PropTypes.bool,
     isFull: PropTypes.bool,
     onRefresh: PropTypes.func,
-    direction: PropTypes.string
+    direction: PropTypes.string,
+    customFilters: PropTypes.shape({
+        tags: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.arrayOf(PropTypes.string)
+        ])
+    })
 };
 
 FooterPagination.propTypes = propTypes;

--- a/packages/inventory/src/shared/TagsModal.js
+++ b/packages/inventory/src/shared/TagsModal.js
@@ -17,9 +17,9 @@ class TagsModal extends React.Component {
 
     fetchTags = (pagination) => {
         const { filterTagsBy } = this.state;
-        const { fetchAllTags, fetchTagsForSystem, activeSystemTag, tagsCount, filters } = this.props;
+        const { fetchAllTags, fetchTagsForSystem, activeSystemTag, tagsCount, filters, customFilters } = this.props;
         if (!activeSystemTag) {
-            fetchAllTags(filterTagsBy, { pagination, filters });
+            fetchAllTags(filterTagsBy, { ...customFilters, pagination, filters });
         } else {
             fetchTagsForSystem(activeSystemTag.id, filterTagsBy, { pagination }, tagsCount);
         }
@@ -135,7 +135,13 @@ TagsModal.propTypes = {
     onToggleTagModal: PropTypes.func,
     fetchAllTags: PropTypes.func,
     onApply: PropTypes.func,
-    onToggleModal: PropTypes.func
+    onToggleModal: PropTypes.func,
+    customFilters: PropTypes.shape({
+        tags: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.arrayOf(PropTypes.string)
+        ])
+    })
 };
 
 TagsModal.defaultProps = {


### PR DESCRIPTION
This PR allows consumers to pass custom filters (mainly global filter) to inventory component trough `customFilters`