### PR TITLE
[RHICOMPL-732] Values for radio filters aren't arrays

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -33,7 +33,7 @@ class SystemRulesTable extends React.Component {
         openIds: [],
         activeFilters: this.filterConfigBuilder.initialDefaultState({
             selected: this.props.selectedFilter ? [ 'selected' ] : undefined,
-            passed: this.props.hidePassed ? [ 'failed' ] : undefined
+            passed: this.props.hidePassed ? 'failed' : undefined
         })
     };
 


### PR DESCRIPTION
When enabling `hidePassed` the filter value needs to be a single one and not an array.
