### PR TITLE
DateFormat: treat `null` date as invalid, not 1970

### DIFF
--- a/packages/components/src/Components/DateFormat/DateFormat.js
+++ b/packages/components/src/Components/DateFormat/DateFormat.js
@@ -4,7 +4,9 @@ import { dateByType } from './helper';
 
 export default function DateFormat({ date, type = 'relative', extraTitle, tooltipProps = {} }) {
     const dateObj = date instanceof Date ? date : new Date(date);
-    const dateType = dateObj.toString() === 'Invalid Date' ? 'invalid' : type;
+    // Prevent treating null as valid. (new Date(null) == new Date(0) returns 1970 Jan 1)
+    const invalid = date === undefined || date === null || dateObj.toString() === 'Invalid Date';
+    const dateType = invalid ? 'invalid' : type;
     return (
         <React.Fragment>
             {dateByType(dateType, tooltipProps, extraTitle)(dateObj)}

--- a/packages/components/src/Components/DateFormat/DateFormat.test.js
+++ b/packages/components/src/Components/DateFormat/DateFormat.test.js
@@ -51,4 +51,19 @@ describe('DateFormat component', () => {
         const wrapper = shallow(<DateFormat date={10} type='onlyDate'/>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
+
+    it('DateFormat treats date undefined as invalid', () => {
+        const wrapper = shallow(<DateFormat date={undefined} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('DateFormat treats date null as invalid', () => {
+        const wrapper = shallow(<DateFormat date={null} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('DateFormat treats date bogus string as invalid', () => {
+        const wrapper = shallow(<DateFormat date={'x'} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/components/src/Components/DateFormat/DateFormat.test.js
+++ b/packages/components/src/Components/DateFormat/DateFormat.test.js
@@ -42,12 +42,12 @@ describe('DateFormat component', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('DateFormat renders with date integer', () => {
+    it('DateFormat renders exact with date integer', () => {
         const wrapper = shallow(<DateFormat date={10} type='exact'/>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('DateFormat renders with date integer', () => {
+    it('DateFormat renders onlyDate with date integer', () => {
         const wrapper = shallow(<DateFormat date={10} type='onlyDate'/>);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
+++ b/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DateFormat component DateFormat renders exact with date integer 1`] = `
+<Fragment>
+  01 Jan 1970 00:00 UTC
+</Fragment>
+`;
+
+exports[`DateFormat component DateFormat renders onlyDate with date integer 1`] = `
+<Fragment>
+  01 Jan 1970
+</Fragment>
+`;
+
 exports[`DateFormat component DateFormat renders with date integer 1`] = `
 <Fragment>
   <Tooltip
@@ -14,18 +26,6 @@ exports[`DateFormat component DateFormat renders with date integer 1`] = `
       Just now
     </span>
   </Tooltip>
-</Fragment>
-`;
-
-exports[`DateFormat component DateFormat renders with date integer 2`] = `
-<Fragment>
-  01 Jan 1970 00:00 UTC
-</Fragment>
-`;
-
-exports[`DateFormat component DateFormat renders with date integer 3`] = `
-<Fragment>
-  01 Jan 1970
 </Fragment>
 `;
 

--- a/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
+++ b/packages/components/src/Components/DateFormat/__snapshots__/DateFormat.test.js.snap
@@ -62,3 +62,21 @@ exports[`DateFormat component DateFormat renders with date string 1`] = `
   </Tooltip>
 </Fragment>
 `;
+
+exports[`DateFormat component DateFormat treats date bogus string as invalid 1`] = `
+<Fragment>
+  Invalid date
+</Fragment>
+`;
+
+exports[`DateFormat component DateFormat treats date null as invalid 1`] = `
+<Fragment>
+  Invalid date
+</Fragment>
+`;
+
+exports[`DateFormat component DateFormat treats date undefined as invalid 1`] = `
+<Fragment>
+  Invalid date
+</Fragment>
+`;


### PR DESCRIPTION
It's easy to make a mistake and pass undefined or null at runtime (despite propTypes not allowing them).
`undefined` was already treated as invalid, but `new Date(null)` silently returns the 1970 epoch because [any single non-string arg gets normalized via "ToNumber()"](https://tc39.es/ecma262/#sec-date-value) and [ToNumber(null) is defined to be 0](https://tc39.es/ecma262/#sec-tonumber), resulting in confusing outputs like "51 years ago".

It's better to surface the caller's bug than show a misleading date.
This changes <DateFormat date={null}> to output "Invalid date".
