### PR TITLE
Add full page and in table view for inventory RBAC

### DIFF
--- a/packages/inventory/doc/inventory.md
+++ b/packages/inventory/doc/inventory.md
@@ -540,6 +540,12 @@ class SomeCmp extends React.Component {
 }
 ```
 
+### Using RBAC with inventory
+
+By default inventory component will check `['inventory:*:*', 'inventory:hosts:read']` in RBAC. If any is found it means that the user has access to inventory host list and will show either container view or full page view.
+
+If you are using just inventory table in your screen please pass `isFullView={true}` to connected inventory component so the component will render in full page view instead of container view.
+
 ### Changing list of entities
 If you want to change list of entities you should change them in redux store so the changes are reflected in entity table automatically.
 
@@ -600,6 +606,7 @@ class SomeCmp extends React.Component {
   //...
 }
 ```
+
 ### Changing detail
 If you want to change detail of selected entity you should change it in redux store so the changes are reflected in entity detail automatically.
 
@@ -670,6 +677,7 @@ class SomeCmp extends React.Component {
   //...
 }
 ```
+
 ### Add custom app entity detail
 If you want to display some information in entity detail you have option to do so, by adding details to store based on your application.
 
@@ -729,7 +737,6 @@ export function entityDetailReducer(INVENTORY_ACTIONS) {
   }
 }
 ```
-
 
 **Please write these application specific details in some place where others can benefit from your implementation.**
 
@@ -792,31 +799,3 @@ Given store will look like
   * Registered: TODO
 * tags - tags data
 
-### Mock data
-To add your own data to inventory you can do that by passing some specific data to inventory endpoint, please do this only on test server.
-
-```JS
-window.insights.chrome.auth.getUser().then(
-    data => fetch('/r/insights/platform/inventory/api/hosts', {
-        method: 'POST',
-        headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            "display_name": "Test computer",
-            "account": data.account_number,
-            "insights_id": "abc-123",
-            facts: [
-                {
-                    facts: {
-                        hostname: `server01.redhat.com`,
-                                machine_id: `c1497de-0ec7-43bb-a8a6-35cabd59e0bf`,
-                                release: 'Red Hat Enterprise Linux Server release 7.5 (Maipo)',
-                    },
-                    namespace: 'inventory'
-                }
-            ]
-        })
-}));
-```

--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -3,6 +3,7 @@ import { AppInfo, InventoryDetail, FullDetail, DetailWrapper } from './component
 import { TagWithDialog, RenderWrapper } from './shared';
 import { InventoryTable } from './components/table';
 import * as inventoryFitlers from './components/filters';
+import AccessDenied from './shared/AccessDenied';
 
 export function inventoryConnector(store, componentsMapper, Wrapper) {
     const showInventoryDrawer = Boolean(Wrapper);
@@ -17,6 +18,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
         ),
         AppInfo: React.forwardRef(
             (props, ref) => <RenderWrapper
+                hideLoader
                 { ...props }
                 {...componentsMapper}
                 inventoryRef={ ref }
@@ -26,6 +28,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
         ),
         InventoryDetailHead: React.forwardRef(
             (props, ref) => <RenderWrapper
+                hideLoader
                 { ...props }
                 {...componentsMapper}
                 inventoryRef={ ref }
@@ -36,6 +39,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
         ),
         InventoryDetail: React.forwardRef(
             (props, ref) => <RenderWrapper
+                hideLoader
                 { ...props }
                 {...componentsMapper}
                 inventoryRef={ ref }
@@ -52,15 +56,21 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
                 cmp={ TagWithDialog }
             />
         ),
-        DetailWrapper: showInventoryDrawer ? React.forwardRef(
+        DetailWrapper: React.forwardRef(
             (props, ref) => <RenderWrapper
                 { ...props }
                 Wrapper={Wrapper}
                 inventoryRef={ ref }
                 store={ store }
-                cmp={ DetailWrapper }
+                cmp={ (props) => {
+                    if (props.hasAccess === false) {
+                        return <AccessDenied />;
+                    }
+
+                    return showInventoryDrawer ? <DetailWrapper {...props} /> : <React.Fragment {...props} />;
+                } }
             />
-        ) : React.Fragment,
+        ),
         ...inventoryFitlers
     };
 }

--- a/packages/inventory/src/components/detail/InventoryDetail.js
+++ b/packages/inventory/src/components/detail/InventoryDetail.js
@@ -26,8 +26,7 @@ const InventoryDetail = ({
     onBackToListClick,
     showDelete,
     appList,
-    showInventoryDrawer,
-    hasAccess
+    showInventoryDrawer
 }) => {
     const { inventoryId } = useParams();
     const dispatch = useDispatch();
@@ -40,39 +39,29 @@ const InventoryDetail = ({
         }
     }, []);
     return <div className="ins-entity-detail">
-        {
-            hasAccess === false ?
-                <NotAuthorized
-                    serviceName="Inventory"
-                    description={
-                        <Fragment>
-                            <div>Your organization administrator must grant</div>
-                            <div>you inventory access to view your systems.</div>
-                        </Fragment>
-                    }
-                /> : loaded && !entity ? (
-                    <SystemNotFound
-                        onBackToListClick={onBackToListClick}
-                        inventoryId={location.pathname.split('/')[location.pathname.split('/').length - 1]}
-                    />
-                ) : <Fragment>
-                    <TopBar
-                        entity={ entity }
-                        loaded={ loaded }
-                        onBackToListClick={ onBackToListClick }
-                        actions={ actions }
-                        deleteEntity={ (systems, displayName, callback) => {
-                            const action = deleteEntity(systems, displayName);
-                            dispatch(reloadWrapper(action, callback));
-                        } }
-                        addNotification={ (payload) => dispatch(addNotification(payload))}
-                        hideInvLink={ hideInvLink }
-                        showInventoryDrawer={ showInventoryDrawer }
-                        showDelete={ showDelete }
-                        showTags={ showTags }
-                    />
-                    <FactsInfo loaded={ loaded } entity={ entity } />
-                </Fragment>
+        {loaded && !entity ? (
+            <SystemNotFound
+                onBackToListClick={onBackToListClick}
+                inventoryId={location.pathname.split('/')[location.pathname.split('/').length - 1]}
+            />
+        ) : <Fragment>
+            <TopBar
+                entity={ entity }
+                loaded={ loaded }
+                onBackToListClick={ onBackToListClick }
+                actions={ actions }
+                deleteEntity={ (systems, displayName, callback) => {
+                    const action = deleteEntity(systems, displayName);
+                    dispatch(reloadWrapper(action, callback));
+                } }
+                addNotification={ (payload) => dispatch(addNotification(payload))}
+                hideInvLink={ hideInvLink }
+                showInventoryDrawer={ showInventoryDrawer }
+                showDelete={ showDelete }
+                showTags={ showTags }
+            />
+            <FactsInfo loaded={ loaded } entity={ entity } />
+        </Fragment>
         }
         <ApplicationDetails onTabSelect={ onTabSelect } appList={ appList } />
     </div>;
@@ -83,7 +72,6 @@ InventoryDetail.propTypes = {
     hideBack: PropTypes.bool,
     showTags: PropTypes.bool,
     showDelete: PropTypes.bool,
-    hasAccess: PropTypes.bool,
     showInventoryDrawer: PropTypes.bool,
     actions: PropTypes.arrayOf(PropTypes.shape({
         title: PropTypes.node,

--- a/packages/inventory/src/components/detail/InventoryDetail.js
+++ b/packages/inventory/src/components/detail/InventoryDetail.js
@@ -9,6 +9,7 @@ import TopBar from './TopBar';
 import FactsInfo from './FactsInfo';
 import { reloadWrapper } from '../../shared';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import ApplicationDetails from './ApplicationDetails';
 import './InventoryDetail.scss';
 
@@ -25,7 +26,8 @@ const InventoryDetail = ({
     onBackToListClick,
     showDelete,
     appList,
-    showInventoryDrawer
+    showInventoryDrawer,
+    hasAccess
 }) => {
     const { inventoryId } = useParams();
     const dispatch = useDispatch();
@@ -38,29 +40,40 @@ const InventoryDetail = ({
         }
     }, []);
     return <div className="ins-entity-detail">
-        { loaded && !entity ? (
-            <SystemNotFound
-                onBackToListClick={onBackToListClick}
-                inventoryId={location.pathname.split('/')[location.pathname.split('/').length - 1]}
-            />
-        ) : <Fragment>
-            <TopBar
-                entity={ entity }
-                loaded={ loaded }
-                onBackToListClick={ onBackToListClick }
-                actions={ actions }
-                deleteEntity={ (systems, displayName, callback) => {
-                    const action = deleteEntity(systems, displayName);
-                    dispatch(reloadWrapper(action, callback));
-                } }
-                addNotification={ (payload) => dispatch(addNotification(payload))}
-                hideInvLink={ hideInvLink }
-                showInventoryDrawer={ showInventoryDrawer }
-                showDelete={ showDelete }
-                showTags={ showTags }
-            />
-            <FactsInfo loaded={ loaded } entity={ entity } />
-        </Fragment>}
+        {
+            hasAccess === false ?
+                <NotAuthorized
+                    serviceName="Inventory"
+                    description={
+                        <Fragment>
+                            <div>Your organization administrator must grant</div>
+                            <div>you inventory access to view your systems.</div>
+                        </Fragment>
+                    }
+                /> : loaded && !entity ? (
+                    <SystemNotFound
+                        onBackToListClick={onBackToListClick}
+                        inventoryId={location.pathname.split('/')[location.pathname.split('/').length - 1]}
+                    />
+                ) : <Fragment>
+                    <TopBar
+                        entity={ entity }
+                        loaded={ loaded }
+                        onBackToListClick={ onBackToListClick }
+                        actions={ actions }
+                        deleteEntity={ (systems, displayName, callback) => {
+                            const action = deleteEntity(systems, displayName);
+                            dispatch(reloadWrapper(action, callback));
+                        } }
+                        addNotification={ (payload) => dispatch(addNotification(payload))}
+                        hideInvLink={ hideInvLink }
+                        showInventoryDrawer={ showInventoryDrawer }
+                        showDelete={ showDelete }
+                        showTags={ showTags }
+                    />
+                    <FactsInfo loaded={ loaded } entity={ entity } />
+                </Fragment>
+        }
         <ApplicationDetails onTabSelect={ onTabSelect } appList={ appList } />
     </div>;
 };
@@ -70,6 +83,7 @@ InventoryDetail.propTypes = {
     hideBack: PropTypes.bool,
     showTags: PropTypes.bool,
     showDelete: PropTypes.bool,
+    hasAccess: PropTypes.bool,
     showInventoryDrawer: PropTypes.bool,
     actions: PropTypes.arrayOf(PropTypes.shape({
         title: PropTypes.node,

--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -292,6 +292,7 @@ const EntityTableToolbar = ({
         ] : [],
         ...filterConfig?.items || []
     ];
+
     return <Fragment>
         <PrimaryToolbar
             {...props}
@@ -340,6 +341,7 @@ const EntityTableToolbar = ({
 
 EntityTableToolbar.propTypes = {
     showTags: PropTypes.bool,
+    hasAccess: PropTypes.bool,
     filterConfig: PropTypes.shape(PrimaryToolbar.propTypes.filterConfig),
     total: PropTypes.number,
     filters: PropTypes.array,
@@ -363,6 +365,7 @@ EntityTableToolbar.propTypes = {
 
 EntityTableToolbar.defaultProps = {
     showTags: false,
+    hasAccess: true,
     activeFiltersConfig: {},
     filters: []
 };

--- a/packages/inventory/src/components/table/EntityTableToolbar.test.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.test.js
@@ -80,6 +80,15 @@ describe('EntityTableToolbar', () => {
             expect(toJson(wrapper.find('TagsModal'), { mode: 'shallow' })).toMatchSnapshot();
         });
 
+        it('should render correctly - with no access', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={store}>
+                <EntityTableToolbar hasAccess={false} />
+            </Provider>);
+            expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
+            expect(toJson(wrapper.find('TagsModal'), { mode: 'shallow' })).toMatchSnapshot();
+        });
+
         it('should render correctly - with items', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { Fragment, Component } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import InventoryEntityTable from './EntityTable';
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import PropTypes from 'prop-types';
 import './InventoryList.scss';
 import { loadSystems } from '../../shared';
@@ -10,7 +11,7 @@ import isEqual from 'lodash/isEqual';
 /**
  * Component that works as a side channel for consumers to notify inventory of new data changes.
  */
-class ContextInventoryList extends React.Component {
+class ContextInventoryList extends Component {
     /**
      * If conumer wants to change data they can call this function via component ref.
      * @param {*} options new options to be applied, like pagination, filters, etc.
@@ -69,17 +70,30 @@ class ContextInventoryList extends React.Component {
 /**
  * Component that consumes active filters and passes them down to component.
  */
-const InventoryList = React.forwardRef((props, ref) => {
+const InventoryList = React.forwardRef(({ hasAccess, ...props }, ref) => {
     const dispatch = useDispatch();
     const activeFilters = useSelector(({ entities: { activeFilters } }) => activeFilters);
-    return (
-        <ContextInventoryList
-            { ...props }
-            ref={ref}
-            activeFilters={ activeFilters }
-            loadEntities={ (config, showTags) => dispatch(loadSystems(config, showTags)) }
-        />
-    );
+    return !hasAccess ?
+        <div className="ins-c-inventory__no-access">
+            <NotAuthorized
+                serviceName="Inventory"
+                showReturnButton={false}
+                description={
+                    <Fragment>
+                        <div>Your organization administrator must grant</div>
+                        <div>you inventory access to view your systems.</div>
+                    </Fragment>
+                }
+            />
+        </div>
+        : (
+            <ContextInventoryList
+                { ...props }
+                ref={ref}
+                activeFilters={ activeFilters }
+                loadEntities={ (config, showTags) => dispatch(loadSystems(config, showTags)) }
+            />
+        );
 });
 
 ContextInventoryList.propTypes = {

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -126,4 +126,8 @@ InventoryList.propTypes = {
     })
 };
 
+InventoryList.defaultProps = {
+    hasAccess: true
+};
+
 export default InventoryList;

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -1,12 +1,12 @@
-import React, { Fragment, Component } from 'react';
+import React, { Component } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import InventoryEntityTable from './EntityTable';
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid';
-import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import PropTypes from 'prop-types';
 import './InventoryList.scss';
 import { loadSystems } from '../../shared';
 import isEqual from 'lodash/isEqual';
+import AccessDenied from '../../shared/AccessDenied';
 
 /**
  * Component that works as a side channel for consumers to notify inventory of new data changes.
@@ -75,16 +75,7 @@ const InventoryList = React.forwardRef(({ hasAccess, ...props }, ref) => {
     const activeFilters = useSelector(({ entities: { activeFilters } }) => activeFilters);
     return !hasAccess ?
         <div className="ins-c-inventory__no-access">
-            <NotAuthorized
-                serviceName="Inventory"
-                showReturnButton={false}
-                description={
-                    <Fragment>
-                        <div>Your organization administrator must grant</div>
-                        <div>you inventory access to view your systems.</div>
-                    </Fragment>
-                }
-            />
+            <AccessDenied showReturnButton={false} />
         </div>
         : (
             <ContextInventoryList

--- a/packages/inventory/src/components/table/InventoryList.scss
+++ b/packages/inventory/src/components/table/InventoryList.scss
@@ -126,3 +126,5 @@
 .ins-c-inventory__tags-modal .ins-c-primary-toolbar .pf-c-toolbar__content {
     padding: 0;
 }
+
+.ins-c-inventory__no-access { background-color: var(--pf-global--BackgroundColor--100); }

--- a/packages/inventory/src/components/table/InventoryList.test.js
+++ b/packages/inventory/src/components/table/InventoryList.test.js
@@ -38,6 +38,16 @@ describe('InventoryList', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render correctly - with no access', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<MemoryRouter>
+            <Provider store={ store }>
+                <InventoryList hasAccess={false}/>
+            </Provider>
+        </MemoryRouter>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     describe('API', () => {
         it('should fire refresh after changing sort', () => {
             mock.onGet('/api/inventory/v1/hosts').reply(200, {});

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -2,6 +2,7 @@ import React, { Fragment, forwardRef } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/cjs/TableToolbar';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import InventoryList from './InventoryList';
 import Pagination from './Pagination';
 
@@ -24,6 +25,8 @@ const InventoryTable = forwardRef(({
     showTags,
     sortBy: propsSortBy,
     customFilters,
+    hasAccess,
+    isFullView = false,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
@@ -52,47 +55,60 @@ const InventoryTable = forwardRef(({
     ), shallowEqual);
 
     return (
-        <Fragment>
-            <EntityTableToolbar
-                { ...props }
-                customFilters={customFilters}
-                items={ items }
-                onRefresh={onRefresh}
-                filters={ filters }
-                hasItems={ hasItems }
-                total={ pagination.total }
-                page={ pagination.page }
-                perPage={ pagination.perPage }
-                showTags={ showTags }
-            >
-                { children }
-            </EntityTableToolbar>
-            <InventoryList
-                { ...props }
-                customFilters={customFilters}
-                ref={ref}
-                hasItems={ hasItems }
-                onRefresh={ onRefresh }
-                items={ items }
-                page={ pagination.page }
-                sortBy={ sortBy }
-                perPage={ pagination.perPage }
-                showTags={ showTags }
-            />
-            <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
-                <Pagination
+        (hasAccess === false && isFullView) ?
+            <NotAuthorized
+                serviceName="Inventory"
+                description={
+                    <Fragment>
+                        <div>Your organization administrator must grant</div>
+                        <div>you inventory access to view your systems.</div>
+                    </Fragment>
+                }
+            /> :
+            <Fragment>
+                <EntityTableToolbar
+                    { ...props }
                     customFilters={customFilters}
-                    isFull
+                    hasAccess={hasAccess}
                     items={ items }
+                    onRefresh={onRefresh}
+                    filters={ filters }
+                    hasItems={ hasItems }
                     total={ pagination.total }
                     page={ pagination.page }
                     perPage={ pagination.perPage }
+                    showTags={ showTags }
+                >
+                    { children }
+                </EntityTableToolbar>
+                <InventoryList
+                    { ...props }
+                    customFilters={customFilters}
+                    hasAccess={hasAccess}
+                    ref={ref}
                     hasItems={ hasItems }
                     onRefresh={ onRefresh }
+                    items={ items }
+                    page={ pagination.page }
+                    sortBy={ sortBy }
+                    perPage={ pagination.perPage }
                     showTags={ showTags }
                 />
-            </TableToolbar>
-        </Fragment>
+                <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
+                    <Pagination
+                        customFilters={customFilters}
+                        hasAccess={hasAccess}
+                        isFull
+                        items={ items }
+                        total={ pagination.total }
+                        page={ pagination.page }
+                        perPage={ pagination.perPage }
+                        hasItems={ hasItems }
+                        onRefresh={ onRefresh }
+                        showTags={ showTags }
+                    />
+                </TableToolbar>
+            </Fragment>
     );
 });
 

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -25,7 +25,7 @@ const InventoryTable = forwardRef(({
     showTags,
     sortBy: propsSortBy,
     customFilters,
-    hasAccess,
+    hasAccess = true,
     isFullView = false,
     ...props
 }, ref) => {

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -2,9 +2,9 @@ import React, { Fragment, forwardRef } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/components/cjs/TableToolbar';
-import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import InventoryList from './InventoryList';
 import Pagination from './Pagination';
+import AccessDenied from '../../shared/AccessDenied';
 
 /**
  * This component is used to combine all essential components together:
@@ -56,15 +56,7 @@ const InventoryTable = forwardRef(({
 
     return (
         (hasAccess === false && isFullView) ?
-            <NotAuthorized
-                serviceName="Inventory"
-                description={
-                    <Fragment>
-                        <div>Your organization administrator must grant</div>
-                        <div>you inventory access to view your systems.</div>
-                    </Fragment>
-                }
-            /> :
+            <AccessDenied /> :
             <Fragment>
                 <EntityTableToolbar
                     { ...props }

--- a/packages/inventory/src/components/table/InventoryTable.test.js
+++ b/packages/inventory/src/components/table/InventoryTable.test.js
@@ -51,6 +51,26 @@ describe('NoSystemsTable', () => {
         expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
     });
 
+    it('should render correctly - with no access', () => {
+        const store = mockStore(initialState);
+        const wrapper = mount(<Provider store={ store }>
+            <Router>
+                <InventoryTable hasAccess={false}/>
+            </Router>
+        </Provider>);
+        expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
+    });
+
+    it('should render correctly - with no access and full view', () => {
+        const store = mockStore(initialState);
+        const wrapper = mount(<Provider store={ store }>
+            <Router>
+                <InventoryTable hasAccess={false} isFullView/>
+            </Router>
+        </Provider>);
+        expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
+    });
+
     it('should render correctly with items', () => {
         const store = mockStore(initialState);
         const wrapper = mount(<Provider store={ store }>

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -72,7 +72,7 @@ class FooterPagination extends Component {
     }
 
     render() {
-        const { total, page, perPage, loaded, direction, isFull, hasItems } = this.props;
+        const { total, page, perPage, loaded, direction, isFull, hasItems, hasAccess } = this.props;
         const { page: statePage } = this.state;
         const extra = isFull ? {
             variant: PaginationVariant.bottom
@@ -80,9 +80,10 @@ class FooterPagination extends Component {
 
         return (
             <Fragment>
-                { loaded && (
+                { (loaded || !hasAccess) && (
                     <Pagination
                         { ...extra }
+                        isDisabled={!hasAccess}
                         itemCount={ total }
                         page={ hasItems ? page : statePage || page }
                         perPage={ perPage }
@@ -101,6 +102,7 @@ const propTypes = {
     total: PropTypes.number,
     loaded: PropTypes.bool,
     isFull: PropTypes.bool,
+    hasAccess: PropTypes.bool,
     onRefresh: PropTypes.func,
     direction: PropTypes.string,
     customFilters: PropTypes.shape({

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -119,7 +119,8 @@ FooterPagination.defaultProps = {
     total: 0,
     loaded: false,
     isFull: false,
-    direction: 'up'
+    direction: 'up',
+    hasAccess: true
 };
 
 function stateToProps(

--- a/packages/inventory/src/components/table/Pagination.test.js
+++ b/packages/inventory/src/components/table/Pagination.test.js
@@ -35,6 +35,12 @@ describe('Pagination', () => {
             expect(wrapper.find('button[disabled=""]').length).toBe(5);
         });
 
+        it('should render correctly - with no access', () => {
+            const store = mockStore(initialState);
+            const wrapper = render(<Pagination store={ store } hasAccess={false} />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
         it('should render correctly with data and props', () => {
             const store = mockStore(initialState);
             const wrapper = render(<Pagination store={ store } page={1} perPage={50} total={500} />);

--- a/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
@@ -34,12 +34,19 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -49,6 +56,7 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -75,6 +83,7 @@ exports[`EntityTableToolbar DOM should render correctly - no data 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -137,12 +146,19 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -152,6 +168,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -178,6 +195,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -199,6 +217,7 @@ exports[`EntityTableToolbar DOM should render correctly - with children 1`] = `
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -254,12 +273,19 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -269,6 +295,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -295,6 +322,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -314,6 +342,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
           "filterValues": Object {
             "className": "ins-c-tagfilter",
             "filterBy": "",
+            "isDisabled": false,
             "items": Array [
               Object {
                 "className": "ins-c-tagfilter__tail",
@@ -342,6 +371,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -386,12 +416,19 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -401,6 +438,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -427,6 +465,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -443,6 +482,9 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
           "value": "source-registered-with",
         },
         Object {
+          "filterValues": Object {
+            "isDisabled": false,
+          },
           "label": "Filter by text",
         },
       ],
@@ -451,6 +493,7 @@ exports[`EntityTableToolbar DOM should render correctly - with custom filters 1`
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -491,12 +534,19 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -506,6 +556,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -531,6 +582,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -552,6 +604,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default filters 1
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -596,12 +649,19 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -611,6 +671,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -637,6 +698,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -658,6 +720,7 @@ exports[`EntityTableToolbar DOM should render correctly - with default tag filte
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -677,10 +740,16 @@ exports[`EntityTableToolbar DOM should render correctly - with items 1`] = `
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar ins-c-inventory__table--toolbar-has-items"
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -691,6 +760,93 @@ exports[`EntityTableToolbar DOM should render correctly - with items 1`] = `
   toggleIsExpanded={[Function]}
 />
 `;
+
+exports[`EntityTableToolbar DOM should render correctly - with no access 1`] = `
+<PrimaryToolbar
+  bulkSelect={
+    Object {
+      "isDisabled": true,
+    }
+  }
+  className="ins-c-inventory__table--toolbar "
+  filterConfig={
+    Object {
+      "isDisabled": true,
+      "items": Array [
+        Object {
+          "filterValues": Object {
+            "isDisabled": true,
+            "onChange": [Function],
+            "placeholder": "Filter by name",
+            "value": "",
+          },
+          "label": "Name",
+          "value": "name-filter",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": true,
+            "items": Array [
+              Object {
+                "label": "Fresh",
+                "value": "fresh",
+              },
+              Object {
+                "label": "Stale",
+                "value": "stale",
+              },
+              Object {
+                "label": "Stale warning",
+                "value": "stale_warning",
+              },
+            ],
+            "onChange": [Function],
+            "value": Array [
+              "fresh",
+              "stale",
+            ],
+          },
+          "label": "Status",
+          "type": "checkbox",
+          "value": "stale-status",
+        },
+        Object {
+          "filterValues": Object {
+            "isDisabled": true,
+            "items": Array [
+              Object {
+                "label": "Insights",
+                "value": "insights",
+              },
+            ],
+            "onChange": [Function],
+            "value": Array [
+              "insights",
+            ],
+          },
+          "label": "Source",
+          "type": "checkbox",
+          "value": "source-registered-with",
+        },
+      ],
+    }
+  }
+  filters={Array []}
+  pagination={
+    Object {
+      "isDisabled": true,
+      "itemCount": 0,
+      "onPerPageSelect": [Function],
+      "onSetPage": [Function],
+      "page": undefined,
+      "perPage": undefined,
+    }
+  }
+  toggleIsExpanded={[Function]}
+/>
+`;
+
+exports[`EntityTableToolbar DOM should render correctly - with no access 2`] = `null`;
 
 exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
 <PrimaryToolbar
@@ -725,12 +881,19 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -740,6 +903,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -766,6 +930,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -785,6 +950,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
           "filterValues": Object {
             "className": "ins-c-tagfilter",
             "filterBy": "",
+            "isDisabled": false,
             "items": Array [
               Object {
                 "className": "ins-c-tagfilter__tail",
@@ -813,6 +979,7 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": undefined,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],
@@ -901,12 +1068,19 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
       "onDelete": [Function],
     }
   }
+  bulkSelect={
+    Object {
+      "isDisabled": false,
+    }
+  }
   className="ins-c-inventory__table--toolbar "
   filterConfig={
     Object {
+      "isDisabled": false,
       "items": Array [
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "onChange": [Function],
             "placeholder": "Filter by name",
             "value": "",
@@ -916,6 +1090,7 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Fresh",
@@ -942,6 +1117,7 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
         },
         Object {
           "filterValues": Object {
+            "isDisabled": false,
             "items": Array [
               Object {
                 "label": "Insights",
@@ -963,6 +1139,7 @@ exports[`EntityTableToolbar DOM should render correctly 1`] = `
   filters={Array []}
   pagination={
     Object {
+      "isDisabled": false,
       "itemCount": 500,
       "onPerPageSelect": [Function],
       "onSetPage": [Function],

--- a/packages/inventory/src/components/table/__snapshots__/InventoryList.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryList.test.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`InventoryList should render correctly - with no access 1`] = `
+<div
+  class="ins-c-inventory__no-access"
+>
+  <div
+    class="pf-c-empty-state ins-c-not-authorized"
+  >
+    <div
+      class="pf-c-empty-state__content"
+    >
+      <svg
+        aria-hidden="true"
+        class="pf-c-empty-state__icon"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align:-0.125em"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"
+          transform=""
+        />
+      </svg>
+      <h5
+        class="pf-c-title pf-m-lg"
+      >
+         You do not have access to Inventory
+      </h5>
+      <div
+        class="pf-c-empty-state__body"
+      >
+        Contact your organization administrator(s) for more information.
+      </div>
+      <a
+        aria-disabled="false"
+        class="pf-c-button pf-m-primary"
+        data-ouia-component-id="2"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        href="."
+      >
+        Go to landing page
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`InventoryList should render correctly 1`] = `
 <div
   class="pf-l-grid ins-inventory-list"

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -5,12 +5,14 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
     filters={Array []}
+    hasAccess={true}
     hasItems={false}
     page={1}
     perPage={50}
     showTags={false}
   />
   <ForwardRef
+    hasAccess={true}
     hasItems={false}
     page={1}
     perPage={50}
@@ -29,11 +31,14 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly 1`] = `
-<ForwardRef>
+exports[`NoSystemsTable should render correctly - with no access 1`] = `
+<ForwardRef
+  hasAccess={false}
+>
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
     filters={Array []}
+    hasAccess={false}
     hasItems={false}
     page={1}
     perPage={50}
@@ -41,6 +46,56 @@ exports[`NoSystemsTable should render correctly 1`] = `
     total={500}
   />
   <ForwardRef
+    hasAccess={false}
+    hasItems={false}
+    page={1}
+    perPage={50}
+    sortBy={
+      Object {
+        "direction": "asc",
+        "index": 1,
+        "key": "one",
+      }
+    }
+  >
+    <div
+      className="ins-c-inventory__no-access"
+    >
+      <AccessDenied
+        showReturnButton={false}
+      />
+    </div>
+  </ForwardRef>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  />
+</ForwardRef>
+`;
+
+exports[`NoSystemsTable should render correctly - with no access and full view 1`] = `
+<ForwardRef
+  hasAccess={false}
+  isFullView={true}
+>
+  <AccessDenied />
+</ForwardRef>
+`;
+
+exports[`NoSystemsTable should render correctly 1`] = `
+<ForwardRef>
+  <EntityTableToolbar
+    activeFiltersConfig={Object {}}
+    filters={Array []}
+    hasAccess={true}
+    hasItems={false}
+    page={1}
+    perPage={50}
+    showTags={false}
+    total={500}
+  />
+  <ForwardRef
+    hasAccess={true}
     hasItems={false}
     page={1}
     perPage={50}
@@ -105,6 +160,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
     filters={Array []}
+    hasAccess={true}
     hasItems={true}
     items={
       Array [
@@ -119,6 +175,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
     total={200}
   />
   <ForwardRef
+    hasAccess={true}
     hasItems={true}
     items={
       Array [
@@ -196,6 +253,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
     filters={Array []}
+    hasAccess={true}
     hasItems={true}
     items={
       Array [
@@ -210,6 +268,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
     total={1}
   />
   <ForwardRef
+    hasAccess={true}
     hasItems={true}
     items={
       Array [

--- a/packages/inventory/src/components/table/__snapshots__/Pagination.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/Pagination.test.js.snap
@@ -2,6 +2,222 @@
 
 exports[`Pagination render should render correctly - no data 1`] = `null`;
 
+exports[`Pagination render should render correctly - with no access 1`] = `
+<div
+  class="pf-c-pagination"
+  data-ouia-component-id="6"
+  data-ouia-component-type="PF4/Pagination"
+  data-ouia-safe="true"
+  id="pagination-options-menu-1"
+>
+  <div
+    class="pf-c-pagination__total-items"
+  >
+    <b>
+      0 - 0
+    </b>
+     of 
+    <b>
+      0
+    </b>
+     
+  </div>
+  <div
+    class="pf-c-options-menu pf-m-top"
+    data-ouia-component-id="7"
+    data-ouia-component-type="PF4/PaginationOptionsMenu"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
+    >
+      <span
+        class="pf-c-options-menu__toggle-text"
+      >
+        <b>
+          0 - 0
+        </b>
+         of 
+        <b>
+          0
+        </b>
+         
+      </span>
+      <button
+        aria-expanded="false"
+        aria-label="Items per page"
+        class="  pf-c-options-menu__toggle-button"
+        disabled=""
+        id="pagination-options-menu-toggle-1"
+        type="button"
+      >
+        <span
+          class="pf-c-options-menu__toggle-button-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align:-0.125em"
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <nav
+    aria-label="Pagination"
+    class="pf-c-pagination__nav"
+  >
+    <div
+      class="pf-c-pagination__nav-control pf-m-first"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to first page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="first"
+        data-ouia-component-id="8"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 448 512"
+          width="1em"
+        >
+          <path
+            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to previous page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="previous"
+        data-ouia-component-id="9"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-page-select"
+    >
+      <input
+        aria-label="Current page"
+        class="pf-c-form-control"
+        disabled=""
+        max="0"
+        min="1"
+        type="number"
+        value="0"
+      />
+      <span
+        aria-hidden="true"
+      >
+        of 0
+      </span>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to next page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="next"
+        data-ouia-component-id="10"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control pf-m-last"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to last page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="last"
+        data-ouia-component-id="11"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 448 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
 exports[`Pagination render should render correctly with data 1`] = `
 <div
   class="pf-c-pagination"
@@ -221,11 +437,223 @@ exports[`Pagination render should render correctly with data 1`] = `
 exports[`Pagination render should render correctly with data and isFull 1`] = `
 <div
   class="pf-c-pagination pf-m-bottom"
+  data-ouia-component-id="18"
+  data-ouia-component-type="PF4/Pagination"
+  data-ouia-safe="true"
+  id="pagination-options-menu-3"
+>
+  <div
+    class="pf-c-options-menu pf-m-top"
+    data-ouia-component-id="19"
+    data-ouia-component-type="PF4/PaginationOptionsMenu"
+    data-ouia-safe="true"
+  >
+    <div
+      class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+    >
+      <span
+        class="pf-c-options-menu__toggle-text"
+      >
+        <b>
+          1 - 50
+        </b>
+         of 
+        <b>
+          500
+        </b>
+         
+      </span>
+      <button
+        aria-expanded="false"
+        aria-label="Items per page"
+        class="  pf-c-options-menu__toggle-button"
+        id="pagination-options-menu-toggle-3"
+        type="button"
+      >
+        <span
+          class="pf-c-options-menu__toggle-button-icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align:-0.125em"
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <nav
+    aria-label="Pagination"
+    class="pf-c-pagination__nav"
+  >
+    <div
+      class="pf-c-pagination__nav-control pf-m-first"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to first page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="first"
+        data-ouia-component-id="20"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 448 512"
+          width="1em"
+        >
+          <path
+            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control"
+    >
+      <button
+        aria-disabled="true"
+        aria-label="Go to previous page"
+        class="pf-c-button pf-m-plain pf-m-disabled"
+        data-action="previous"
+        data-ouia-component-id="21"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-page-select"
+    >
+      <input
+        aria-label="Current page"
+        class="pf-c-form-control"
+        max="10"
+        min="1"
+        type="number"
+        value="1"
+      />
+      <span
+        aria-hidden="true"
+      >
+        of 10
+      </span>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Go to next page"
+        class="pf-c-button pf-m-plain"
+        data-action="next"
+        data-ouia-component-id="22"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="pf-c-pagination__nav-control pf-m-last"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Go to last page"
+        class="pf-c-button pf-m-plain"
+        data-action="last"
+        data-ouia-component-id="23"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 448 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            transform=""
+          />
+        </svg>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`Pagination render should render correctly with data and props 1`] = `
+<div
+  class="pf-c-pagination"
   data-ouia-component-id="12"
   data-ouia-component-type="PF4/Pagination"
   data-ouia-safe="true"
   id="pagination-options-menu-2"
 >
+  <div
+    class="pf-c-pagination__total-items"
+  >
+    <b>
+      1 - 50
+    </b>
+     of 
+    <b>
+      500
+    </b>
+     
+  </div>
   <div
     class="pf-c-options-menu pf-m-top"
     data-ouia-component-id="13"
@@ -394,218 +822,6 @@ exports[`Pagination render should render correctly with data and isFull 1`] = `
         class="pf-c-button pf-m-plain"
         data-action="last"
         data-ouia-component-id="17"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align:-0.125em"
-          viewBox="0 0 448 512"
-          width="1em"
-        >
-          <path
-            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-            transform=""
-          />
-        </svg>
-      </button>
-    </div>
-  </nav>
-</div>
-`;
-
-exports[`Pagination render should render correctly with data and props 1`] = `
-<div
-  class="pf-c-pagination"
-  data-ouia-component-id="6"
-  data-ouia-component-type="PF4/Pagination"
-  data-ouia-safe="true"
-  id="pagination-options-menu-1"
->
-  <div
-    class="pf-c-pagination__total-items"
-  >
-    <b>
-      1 - 50
-    </b>
-     of 
-    <b>
-      500
-    </b>
-     
-  </div>
-  <div
-    class="pf-c-options-menu pf-m-top"
-    data-ouia-component-id="7"
-    data-ouia-component-type="PF4/PaginationOptionsMenu"
-    data-ouia-safe="true"
-  >
-    <div
-      class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-    >
-      <span
-        class="pf-c-options-menu__toggle-text"
-      >
-        <b>
-          1 - 50
-        </b>
-         of 
-        <b>
-          500
-        </b>
-         
-      </span>
-      <button
-        aria-expanded="false"
-        aria-label="Items per page"
-        class="  pf-c-options-menu__toggle-button"
-        id="pagination-options-menu-toggle-1"
-        type="button"
-      >
-        <span
-          class="pf-c-options-menu__toggle-button-icon"
-        >
-          <svg
-            aria-hidden="true"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style="vertical-align:-0.125em"
-            viewBox="0 0 320 512"
-            width="1em"
-          >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </span>
-      </button>
-    </div>
-  </div>
-  <nav
-    aria-label="Pagination"
-    class="pf-c-pagination__nav"
-  >
-    <div
-      class="pf-c-pagination__nav-control pf-m-first"
-    >
-      <button
-        aria-disabled="true"
-        aria-label="Go to first page"
-        class="pf-c-button pf-m-plain pf-m-disabled"
-        data-action="first"
-        data-ouia-component-id="8"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        disabled=""
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align:-0.125em"
-          viewBox="0 0 448 512"
-          width="1em"
-        >
-          <path
-            d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-            transform=""
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="pf-c-pagination__nav-control"
-    >
-      <button
-        aria-disabled="true"
-        aria-label="Go to previous page"
-        class="pf-c-button pf-m-plain pf-m-disabled"
-        data-action="previous"
-        data-ouia-component-id="9"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        disabled=""
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align:-0.125em"
-          viewBox="0 0 256 512"
-          width="1em"
-        >
-          <path
-            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-            transform=""
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="pf-c-pagination__nav-page-select"
-    >
-      <input
-        aria-label="Current page"
-        class="pf-c-form-control"
-        max="10"
-        min="1"
-        type="number"
-        value="1"
-      />
-      <span
-        aria-hidden="true"
-      >
-        of 10
-      </span>
-    </div>
-    <div
-      class="pf-c-pagination__nav-control"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Go to next page"
-        class="pf-c-button pf-m-plain"
-        data-action="next"
-        data-ouia-component-id="10"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe="true"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align:-0.125em"
-          viewBox="0 0 256 512"
-          width="1em"
-        >
-          <path
-            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-            transform=""
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="pf-c-pagination__nav-control pf-m-last"
-    >
-      <button
-        aria-disabled="false"
-        aria-label="Go to last page"
-        class="pf-c-button pf-m-plain"
-        data-action="last"
-        data-ouia-component-id="11"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"

--- a/packages/inventory/src/shared/AccessDenied.js
+++ b/packages/inventory/src/shared/AccessDenied.js
@@ -1,0 +1,17 @@
+import React, { Fragment } from 'react';
+import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
+
+const AccessDenied = (props) => (
+    <NotAuthorized
+        {...props}
+        serviceName="Inventory"
+        description={
+            <Fragment>
+                <div>Your organization administrator must grant</div>
+                <div>you inventory access to view your systems.</div>
+            </Fragment>
+        }
+    />
+);
+
+export default AccessDenied;

--- a/packages/inventory/src/shared/Wrapper.js
+++ b/packages/inventory/src/shared/Wrapper.js
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 
-const RenderWrapper = ({ cmp: Component, inventoryRef, store, ...props }) => {
+const RenderWrapper = ({ cmp: Component, hideLoader, inventoryRef, store, ...props }) => {
     const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
     return (
         hasAccess === undefined ?
-            <Spinner /> :
+            (hideLoader ?
+                <Fragment /> :
+                <Spinner />
+            ) :
             <Component
                 {...props}
                 { ...inventoryRef && {

--- a/packages/inventory/src/shared/Wrapper.js
+++ b/packages/inventory/src/shared/Wrapper.js
@@ -1,15 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
+import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 
-const RenderWrapper = ({ cmp: Component, inventoryRef, store, ...props }) => (
-    <Component
-        {...props}
-        { ...inventoryRef && {
-            ref: inventoryRef
-        }}
-        store={ store }
-    />
-);
+const RenderWrapper = ({ cmp: Component, inventoryRef, store, ...props }) => {
+    const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
+    return (
+        hasAccess === undefined ?
+            <Spinner /> :
+            <Component
+                {...props}
+                { ...inventoryRef && {
+                    ref: inventoryRef
+                }}
+                hasAccess={hasAccess}
+                store={ store }
+            />
+    );
+};
 
 RenderWrapper.propTypes = {
     cmp: PropTypes.any,


### PR DESCRIPTION
### In container view
![Screenshot from 2020-09-22 15-40-23](https://user-images.githubusercontent.com/3439771/93895328-fff74580-fcef-11ea-84eb-6a4a04d7152d.png)

### Full page view
![Screenshot from 2020-09-22 16-24-58](https://user-images.githubusercontent.com/3439771/93895538-3765f200-fcf0-11ea-83db-aec2e3df9da8.png)

### Direct link to inventory detail
![Screenshot from 2020-09-23 09-05-11](https://user-images.githubusercontent.com/3439771/93978219-f5828d80-fd7b-11ea-83db-8e07e62b2f14.png)

By default `In container view` is used and apps using this component has to pass `isFullView` to inventory component.
