### PR TITLE
Do not use any loader in detail

### DIFF
--- a/packages/inventory/src/shared/Wrapper.js
+++ b/packages/inventory/src/shared/Wrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
@@ -6,11 +6,8 @@ import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 const RenderWrapper = ({ cmp: Component, hideLoader, inventoryRef, store, ...props }) => {
     const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
     return (
-        hasAccess === undefined ?
-            (hideLoader ?
-                <Fragment /> :
-                <Spinner />
-            ) :
+        (hasAccess === undefined && !hideLoader) ?
+            <Spinner /> :
             <Component
                 {...props}
                 { ...inventoryRef && {


### PR DESCRIPTION
## No loader for inventory detail pages

Inventory detail components should be wrapped with `DetailWrapper`, this component is already showing loader and such, so no need to do it again (it just blocks the UI from rendering)