### PR TITLE
Introduce useApplicationAuth to create authentication on application

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -123,6 +123,7 @@ In [hardcodedSchema](src/addSourceWizard/hardcodedSchemas.js), there is an objec
 |`additionalSteps`|Defines additional steps.|
 |`skipSelection`|If there is only one authType, this flag will cause to skip the selection page.|
 |`skipEndpoint`|If it is set to `true`, all `endpoint.*` and `authentications.*` values will be ignored and no endpoint step will be shown to user.|
+|`useApplicationAuth`|If it is set to `true`, the `authentication` record will be linked to a `application`, not `endpoint`. Use if you want to avoid using topology for checking source status.|
 
 # Additional components
 

--- a/packages/sources/src/addSourceWizard/hardcodedSchemas.js
+++ b/packages/sources/src/addSourceWizard/hardcodedSchemas.js
@@ -152,6 +152,7 @@ export default {
         authentication: {
             tenant_id_client_id_client_secret: {
                 [COST_MANAGEMENT_APP_NAME]: {
+                    useApplicationAuth: true,
                     skipSelection: true,
                     'credentials.subscription_id': {
                         placeholder: '',
@@ -337,6 +338,7 @@ export default {
                     'authentication.password': arnField
                 },
                 [COST_MANAGEMENT_APP_NAME]: {
+                    useApplicationAuth: true,
                     skipSelection: true,
                     'authentication.password': arnField,
                     'billing_source.data_source.bucket': {

--- a/packages/sources/src/api/createSource.js
+++ b/packages/sources/src/api/createSource.js
@@ -73,11 +73,11 @@ export const doCreateSource = async (formData, sourceTypes, timetoutedApps = [])
 
         let authenticationDataOut;
 
-        if (endpointDataOut) {
+        if (endpointDataOut || (formData.authentication && applicationDataOut?.id)) {
             const authenticationData = {
                 ...formData.authentication,
-                resource_id: endpointDataOut.id,
-                resource_type: 'Endpoint'
+                resource_id: endpointDataOut?.id || applicationDataOut?.id,
+                resource_type: endpointDataOut?.id ? 'Endpoint' : 'Application'
             };
 
             authenticationDataOut = await getSourcesApi().createAuthentication(authenticationData);

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder.test.js
@@ -12,7 +12,8 @@ import {
     shouldSkipSelection,
     getAdditionalStepKeys,
     createGenericAuthTypeSelection,
-    createSpecificAuthTypeSelection
+    createSpecificAuthTypeSelection,
+    shouldUseAppAuth
 } from '../../addSourceWizard/schemaBuilder';
 import hardcodedSchemas from '../../addSourceWizard/hardcodedSchemas';
 import sourceTypes, { AMAZON_TYPE, OPENSHIFT_TYPE, AZURE_TYPE } from '../helpers/sourceTypes';
@@ -67,6 +68,16 @@ describe('schema builder', () => {
             expect(getAdditionalSteps('amazon', 'arn', COST_MANAGEMENT_APP.name)).toEqual(
                 hardcodedSchemas.amazon.authentication.arn[COST_MANAGEMENT_APP.name].additionalSteps
             );
+        });
+    });
+
+    describe('shouldUseAppAuth', () => {
+        it('returns true for amazon-arn-cost', () => {
+            expect(shouldUseAppAuth('amazon', 'arn', COST_MANAGEMENT_APP.name)).toEqual(true);
+        });
+
+        it('returns false for tower-username-topology', () => {
+            expect(shouldUseAppAuth('ansible-tower', 'username_password', TOPOLOGY_INV_APP.name)).toEqual(false);
         });
     });
 
@@ -325,6 +336,20 @@ describe('schema builder', () => {
                 });
 
                 expect(createSpecificAuthTypeSelection(AZURE_TYPE, TOPOLOGY_INV_APP, APPEND_ENDPOINT_FIELDS)).toEqual(expectedSchema);
+            });
+
+            it('generate single selection - do not append endpoint fields for azure/cost', () => {
+                const ENDPOINT_FIELDS = [{ name: 'endpoint' }];
+
+                expect(createSpecificAuthTypeSelection(AZURE_TYPE, COST_MANAGEMENT_APP, ENDPOINT_FIELDS).fields.map(({ name }) => name)).toEqual(
+                    [
+                        'authentication.authtype',
+                        'azure-storage-account-description',
+                        'all-required',
+                        'billing_source.data_source.resource_group',
+                        'billing_source.data_source.storage_account'
+                    ]
+                );
             });
 
             it('generate single selection with endpoints', () => {

--- a/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionSteps.test.js
+++ b/packages/sources/src/tests/addSourceWizard/schemaBuilder/generateGenericAuthSelectionSteps.test.js
@@ -13,6 +13,15 @@ jest.mock('../../../addSourceWizard/hardcodedSchemas', () => ({
                 }
             }
         }
+    },
+    useAppAuth: {
+        authentication: {
+            token: {
+                generic: {
+                    useApplicationAuth: true
+                }
+            }
+        }
     }
 }));
 
@@ -92,7 +101,12 @@ describe('generate auth selection pages', () => {
 
     describe('createGenericAuthTypeSelection', () => {
         it('generate single selection', () => {
-            const fields = ONE_SINGLE_SELECTION_TYPE.schema.authentication[0].fields.filter(({ stepKey }) => !stepKey);
+            const ENDPOINT_FIELDS = [{ name: 'endpoint' }];
+
+            const fields = [
+                ...ENDPOINT_FIELDS,
+                ...ONE_SINGLE_SELECTION_TYPE.schema.authentication[0].fields.filter(({ stepKey }) => !stepKey)
+            ];
 
             expectedSchema = expect.objectContaining({
                 fields: expect.arrayContaining(fields),
@@ -101,7 +115,27 @@ describe('generate auth selection pages', () => {
                 nextStep: 'summary'
             });
 
-            expect(createGenericAuthTypeSelection(ONE_SINGLE_SELECTION_TYPE, APPEND_ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+            expect(createGenericAuthTypeSelection(ONE_SINGLE_SELECTION_TYPE, ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
+        });
+
+        it('do not containe endpoint fields when useApplicationAuth set', () => {
+            const ENDPOINT_FIELDS = [{ name: 'endpoint' }];
+
+            const TYPE = {
+                ...ONE_SINGLE_SELECTION_TYPE,
+                name: 'useAppAuth'
+            };
+
+            const fields = ONE_SINGLE_SELECTION_TYPE.schema.authentication[0].fields.filter(({ stepKey }) => !stepKey);
+
+            expectedSchema = expect.objectContaining({
+                fields: expect.arrayContaining(fields),
+                title: expect.any(Object),
+                name: TYPE.name,
+                nextStep: 'summary'
+            });
+
+            expect(createGenericAuthTypeSelection(TYPE, ENDPOINT_FIELDS, NOT_EDITING)).toEqual(expectedSchema);
         });
 
         it('generate single selection with additional steps', () => {

--- a/packages/sources/src/tests/api/createSource.test.js
+++ b/packages/sources/src/tests/api/createSource.test.js
@@ -310,7 +310,8 @@ describe('doCreateSource', () => {
             const FORM_DATA = {
                 ...INITIAL_VALUES,
                 application: { ...APPLICATION_FORM_DATA, application_type_id: APP_ID },
-                endpoint: undefined
+                endpoint: undefined,
+                authentication: undefined
             };
 
             const EXPECTED_RESULT = {
@@ -339,6 +340,56 @@ describe('doCreateSource', () => {
             expect(createApplication).toHaveBeenCalledWith(EXPECTED_CREATE_APPLICATION_ARG);
             expect(patchSource).not.toHaveBeenCalled();
             expect(createAuthApp).not.toHaveBeenCalled();
+            expect(checkAppMock).toHaveBeenCalledWith(CREATE_APPLICATION_DATA_OUT.id, 0);
+        });
+
+        it('create source with app and no endpoint set', async () => {
+            const APP_ID = COST_MANAGEMENT_APP.id;
+
+            const FORM_DATA = {
+                ...INITIAL_VALUES,
+                application: { ...APPLICATION_FORM_DATA, application_type_id: APP_ID },
+                endpoint: undefined,
+                authentication: AUTHENTICATION_FORM_DATA
+            };
+
+            const EXPECTED_RESULT = {
+                id: CREATED_SOURCE_ID,
+                endpoint: [ undefined ],
+                applications: [{
+                    ...CREATE_APPLICATION_DATA_OUT
+                }]
+            };
+
+            const EXPECTED_CREATE_APPLICATION_ARG = {
+                ...APPLICATION_FORM_DATA,
+                source_id: CREATED_SOURCE_ID,
+                application_type_id: APP_ID
+            };
+
+            EXPECTED_AUTHENTICATION_SOURCE_ARG = {
+                ...AUTHENTICATION_FORM_DATA,
+                resource_id: CREATE_APPLICATION_DATA_OUT.id,
+                resource_type: 'Application'
+            };
+
+            EXPECTED_CREATE_AUTH_APP_ARG = {
+                application_id: CREATE_APPLICATION_DATA_OUT.id,
+                authentication_id: CREATE_AUTHENTICATION_DATA_OUT.id
+            };
+
+            api.getSourcesApi = () => mocks;
+
+            const result = await doCreateSource(FORM_DATA, sourceTypes);
+
+            expect(result).toEqual(EXPECTED_RESULT);
+
+            expect(createSource).toHaveBeenCalledWith(EXPECTED_CREATE_SOURCE_ARG);
+            expect(createEndpoint).not.toHaveBeenCalled();
+            expect(createAuthentication).toHaveBeenCalledWith(EXPECTED_AUTHENTICATION_SOURCE_ARG);
+            expect(createApplication).toHaveBeenCalledWith(EXPECTED_CREATE_APPLICATION_ARG);
+            expect(patchSource).not.toHaveBeenCalled();
+            expect(createAuthApp).toHaveBeenCalledWith(EXPECTED_CREATE_AUTH_APP_ARG);
             expect(checkAppMock).toHaveBeenCalledWith(CREATE_APPLICATION_DATA_OUT.id, 0);
         });
 


### PR DESCRIPTION
`useApplicationAuth`- If it is set to `true`, the `authentication` record will be linked to a `application`, not `endpoint`. Use if you want to avoid using topology for checking source status.|