### PR TITLE
[RHICOMPL-859][RHICOMPL-955] Improve compliance policy card labels and tooltip

### DIFF
--- a/packages/inventory-compliance/src/SystemPolicyCard.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.js
@@ -29,7 +29,7 @@ class SystemPolicyCard extends React.Component {
                 <CheckCircleIcon /> Compliant
             </div> :
             <div className='ins-c-policy-card ins-m-noncompliant'>
-                <ExclamationCircleIcon/> Noncompliant
+                <ExclamationCircleIcon/> Not compliant
             </div>;
     }
 

--- a/packages/inventory-compliance/src/SystemPolicyCard.js
+++ b/packages/inventory-compliance/src/SystemPolicyCard.js
@@ -54,7 +54,7 @@ class SystemPolicyCard extends React.Component {
     }
 
     render() {
-        const { policy, benchmark, rulesPassed, rulesFailed, compliant, lastScanned, score } = this.state.policy;
+        const { policy, benchmark, rulesFailed, compliant, lastScanned, score } = this.state.policy;
         const { refIdTruncated, cardTitle } = this.state;
         const passedPercentage = this.fixedPercentage(score);
         const FormattedRelativeCmp = FormattedRelativeTime || FormattedRelative || Fragment;
@@ -81,15 +81,20 @@ class SystemPolicyCard extends React.Component {
                         </Tooltip> }
                     </TextContent>
                     <div className='margin-bottom-md' >
-                        <Tooltip content={
-                            'The system compliance score is calculated by OpenSCAP and ' +
-                            'is a normalized weighted sum of rules selected for this policy.'
-                        }>
-                            { this.complianceIcon(compliant) }
-                            <Text component={ TextVariants.small }>
-                                { rulesPassed } of { rulesPassed + rulesFailed } rules passed ({ passedPercentage })
-                            </Text>
-                        </Tooltip>
+                        { this.complianceIcon(compliant) }
+                        <Text component={ TextVariants.small }>
+                            { rulesFailed } rule{ rulesFailed === 1 ? '' : 's' } failed
+                            {' '}
+                            <Tooltip
+                                position='bottom'
+                                maxWidth='22em'
+                                content={
+                                    'The system compliance score is calculated by OpenSCAP and ' +
+                                    'is a normalized weighted sum of rules selected for this policy.'
+                                }>
+                                <span>(Score: { passedPercentage })</span>
+                            </Tooltip>
+                        </Text>
                     </div>
                     <div className='margin-bottom-md' >
                         <Text

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
@@ -72,7 +72,7 @@ exports[`SystemPolicyCard component should render 1`] = `
             transform=""
           />
         </svg>
-         Noncompliant
+         Not compliant
       </div>
       <small
         class=""

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCard.test.js.snap
@@ -78,7 +78,12 @@ exports[`SystemPolicyCard component should render 1`] = `
         class=""
         data-pf-content="true"
       >
-        30 of 40 rules passed (75%)
+        10 rules failed 
+        <span
+          aria-describedby="pf-tooltip-2"
+        >
+          (Score: 75%)
+        </span>
       </small>
     </div>
     <div

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -275,7 +275,7 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
                               />
                             </svg>
                           </ExclamationCircleIcon>
-                           Noncompliant
+                           Not compliant
                         </div>
                         <Text
                           component="small"
@@ -805,7 +805,7 @@ exports[`SystemPolicyCards component should render real table 1`] = `
                               />
                             </svg>
                           </ExclamationCircleIcon>
-                           Noncompliant
+                           Not compliant
                         </div>
                         <Text
                           component="small"

--- a/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemPolicyCards.test.js.snap
@@ -247,140 +247,133 @@ exports[`SystemPolicyCards component should render loading state 1`] = `
                       <div
                         className="margin-bottom-md"
                       >
-                        <Tooltip
-                          content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
+                        <div
+                          className="ins-c-policy-card ins-m-noncompliant"
                         >
-                          <Popper
-                            appendTo={[Function]}
-                            distance={15}
-                            enableFlip={true}
-                            flipBehavior={
-                              Array [
-                                "top",
-                                "right",
-                                "bottom",
-                                "left",
-                                "top",
-                                "right",
-                                "bottom",
-                              ]
-                            }
-                            isVisible={false}
-                            onBlur={[Function]}
-                            onDocumentClick={false}
-                            onDocumentKeyDown={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            onTriggerEnter={[Function]}
-                            placement="top"
-                            popper={
-                              <div
-                                className="pf-c-tooltip"
-                                id="pf-tooltip-2"
-                                role="tooltip"
-                                style={
-                                  Object {
-                                    "maxWidth": null,
-                                    "opacity": 0,
-                                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                  }
-                                }
-                              >
-                                <TooltipArrow />
-                                <TooltipContent
-                                  isLeftAligned={false}
-                                >
-                                  The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
-                                </TooltipContent>
-                              </div>
-                            }
-                            popperMatchesTriggerWidth={false}
-                            positionModifiers={
-                              Object {
-                                "bottom": "pf-m-bottom",
-                                "left": "pf-m-left",
-                                "right": "pf-m-right",
-                                "top": "pf-m-top",
-                              }
-                            }
-                            trigger={
-                              Array [
-                                <div
-                                  className="ins-c-policy-card ins-m-noncompliant"
-                                >
-                                  <ExclamationCircleIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  />
-                                   Noncompliant
-                                </div>,
-                                <Text
-                                  component="small"
-                                >
-                                  30
-                                   of 
-                                  40
-                                   rules passed (
-                                  75%
-                                  )
-                                </Text>,
-                              ]
-                            }
-                            zIndex={9999}
+                          <ExclamationCircleIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
                           >
-                            <FindRefWrapper
-                              onFoundRef={[Function]}
+                            <svg
+                              aria-hidden={true}
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 512 512"
+                              width="1em"
                             >
-                              <div
-                                className="ins-c-policy-card ins-m-noncompliant"
-                              >
-                                <ExclamationCircleIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
+                              <path
+                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                transform=""
+                              />
+                            </svg>
+                          </ExclamationCircleIcon>
+                           Noncompliant
+                        </div>
+                        <Text
+                          component="small"
+                        >
+                          <small
+                            className=""
+                            data-pf-content={true}
+                          >
+                            10
+                             rule
+                            s
+                             failed
+                             
+                            <Tooltip
+                              content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
+                              maxWidth="22em"
+                              position="bottom"
+                            >
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="bottom"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-2"
+                                    role="tooltip"
                                     style={
                                       Object {
-                                        "verticalAlign": "-0.125em",
+                                        "maxWidth": "22em",
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
                                       }
                                     }
-                                    viewBox="0 0 512 512"
-                                    width="1em"
                                   >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      transform=""
-                                    />
-                                  </svg>
-                                </ExclamationCircleIcon>
-                                 Noncompliant
-                              </div>
-                              <Text
-                                component="small"
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
+                                  Object {
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
+                                  }
+                                }
+                                trigger={
+                                  <span
+                                    aria-describedby="pf-tooltip-2"
+                                  >
+                                    (Score: 
+                                    75%
+                                    )
+                                  </span>
+                                }
+                                zIndex={9999}
                               >
-                                <small
-                                  className=""
-                                  data-pf-content={true}
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
                                 >
-                                  30
-                                   of 
-                                  40
-                                   rules passed (
-                                  75%
-                                  )
-                                </small>
-                              </Text>
-                            </FindRefWrapper>
-                          </Popper>
-                        </Tooltip>
+                                  <span
+                                    aria-describedby="pf-tooltip-2"
+                                  >
+                                    (Score: 
+                                    75%
+                                    )
+                                  </span>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
+                          </small>
+                        </Text>
                       </div>
                       <div
                         className="margin-bottom-md"
@@ -784,140 +777,133 @@ exports[`SystemPolicyCards component should render real table 1`] = `
                       <div
                         className="margin-bottom-md"
                       >
-                        <Tooltip
-                          content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
+                        <div
+                          className="ins-c-policy-card ins-m-noncompliant"
                         >
-                          <Popper
-                            appendTo={[Function]}
-                            distance={15}
-                            enableFlip={true}
-                            flipBehavior={
-                              Array [
-                                "top",
-                                "right",
-                                "bottom",
-                                "left",
-                                "top",
-                                "right",
-                                "bottom",
-                              ]
-                            }
-                            isVisible={false}
-                            onBlur={[Function]}
-                            onDocumentClick={false}
-                            onDocumentKeyDown={[Function]}
-                            onFocus={[Function]}
-                            onMouseEnter={[Function]}
-                            onMouseLeave={[Function]}
-                            onTriggerEnter={[Function]}
-                            placement="top"
-                            popper={
-                              <div
-                                className="pf-c-tooltip"
-                                id="pf-tooltip-4"
-                                role="tooltip"
-                                style={
-                                  Object {
-                                    "maxWidth": null,
-                                    "opacity": 0,
-                                    "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
-                                  }
-                                }
-                              >
-                                <TooltipArrow />
-                                <TooltipContent
-                                  isLeftAligned={false}
-                                >
-                                  The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
-                                </TooltipContent>
-                              </div>
-                            }
-                            popperMatchesTriggerWidth={false}
-                            positionModifiers={
-                              Object {
-                                "bottom": "pf-m-bottom",
-                                "left": "pf-m-left",
-                                "right": "pf-m-right",
-                                "top": "pf-m-top",
-                              }
-                            }
-                            trigger={
-                              Array [
-                                <div
-                                  className="ins-c-policy-card ins-m-noncompliant"
-                                >
-                                  <ExclamationCircleIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  />
-                                   Noncompliant
-                                </div>,
-                                <Text
-                                  component="small"
-                                >
-                                  30
-                                   of 
-                                  40
-                                   rules passed (
-                                  75%
-                                  )
-                                </Text>,
-                              ]
-                            }
-                            zIndex={9999}
+                          <ExclamationCircleIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
                           >
-                            <FindRefWrapper
-                              onFoundRef={[Function]}
+                            <svg
+                              aria-hidden={true}
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 512 512"
+                              width="1em"
                             >
-                              <div
-                                className="ins-c-policy-card ins-m-noncompliant"
-                              >
-                                <ExclamationCircleIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
+                              <path
+                                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                transform=""
+                              />
+                            </svg>
+                          </ExclamationCircleIcon>
+                           Noncompliant
+                        </div>
+                        <Text
+                          component="small"
+                        >
+                          <small
+                            className=""
+                            data-pf-content={true}
+                          >
+                            10
+                             rule
+                            s
+                             failed
+                             
+                            <Tooltip
+                              content="The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy."
+                              maxWidth="22em"
+                              position="bottom"
+                            >
+                              <Popper
+                                appendTo={[Function]}
+                                distance={15}
+                                enableFlip={true}
+                                flipBehavior={
+                                  Array [
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                    "left",
+                                    "top",
+                                    "right",
+                                    "bottom",
+                                  ]
+                                }
+                                isVisible={false}
+                                onBlur={[Function]}
+                                onDocumentClick={false}
+                                onDocumentKeyDown={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onTriggerEnter={[Function]}
+                                placement="bottom"
+                                popper={
+                                  <div
+                                    className="pf-c-tooltip"
+                                    id="pf-tooltip-4"
+                                    role="tooltip"
                                     style={
                                       Object {
-                                        "verticalAlign": "-0.125em",
+                                        "maxWidth": "22em",
+                                        "opacity": 0,
+                                        "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
                                       }
                                     }
-                                    viewBox="0 0 512 512"
-                                    width="1em"
                                   >
-                                    <path
-                                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-                                      transform=""
-                                    />
-                                  </svg>
-                                </ExclamationCircleIcon>
-                                 Noncompliant
-                              </div>
-                              <Text
-                                component="small"
+                                    <TooltipArrow />
+                                    <TooltipContent
+                                      isLeftAligned={false}
+                                    >
+                                      The system compliance score is calculated by OpenSCAP and is a normalized weighted sum of rules selected for this policy.
+                                    </TooltipContent>
+                                  </div>
+                                }
+                                popperMatchesTriggerWidth={false}
+                                positionModifiers={
+                                  Object {
+                                    "bottom": "pf-m-bottom",
+                                    "left": "pf-m-left",
+                                    "right": "pf-m-right",
+                                    "top": "pf-m-top",
+                                  }
+                                }
+                                trigger={
+                                  <span
+                                    aria-describedby="pf-tooltip-4"
+                                  >
+                                    (Score: 
+                                    75%
+                                    )
+                                  </span>
+                                }
+                                zIndex={9999}
                               >
-                                <small
-                                  className=""
-                                  data-pf-content={true}
+                                <FindRefWrapper
+                                  onFoundRef={[Function]}
                                 >
-                                  30
-                                   of 
-                                  40
-                                   rules passed (
-                                  75%
-                                  )
-                                </small>
-                              </Text>
-                            </FindRefWrapper>
-                          </Popper>
-                        </Tooltip>
+                                  <span
+                                    aria-describedby="pf-tooltip-4"
+                                  >
+                                    (Score: 
+                                    75%
+                                    )
+                                  </span>
+                                </FindRefWrapper>
+                              </Popper>
+                            </Tooltip>
+                          </small>
+                        </Text>
                       </div>
                       <div
                         className="margin-bottom-md"


### PR DESCRIPTION
Improved Policy Card to match the UI mocks:
* show number failed rules only
* mention Score
* tooltip about scoring moved to the score and shown on the bottom of  the text
* corrected "Noncompliant" label to "Not compliant". 

![Screenshot from 2020-09-24 18-17-35](https://user-images.githubusercontent.com/7695766/94172073-5308fe00-fe92-11ea-89e9-4bc4645f58df.png)

