### PR TITLE
Do not set filters to empty array and no initial call first render

### DIFF
--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -73,7 +73,7 @@ const EntityTableToolbar = ({
         ...registeredWithFilterState,
         ...tagsFilterState
     });
-    const filters = useSelector(({ entities: { activeFilters } }) => activeFilters || []);
+    const filters = useSelector(({ entities: { activeFilters } }) => activeFilters);
     const loaded = useSelector(({ entities: { loaded } }) => !hasAccess || (
         hasItems && isLoaded !== undefined ? (isLoaded && loaded) : loaded
     ));
@@ -166,11 +166,11 @@ const EntityTableToolbar = ({
      * @param {*} debounced if debounce function should be used.
      */
     const onSetTextFilter = (value, debounced = true) => {
-        const textualFilter = filters.find(oneFilter => oneFilter.value === TEXT_FILTER);
+        const textualFilter = filters?.find(oneFilter => oneFilter.value === TEXT_FILTER);
         if (textualFilter) {
             textualFilter.filter = value;
         } else {
-            filters.push({ value: TEXT_FILTER, filter: value });
+            filters?.push({ value: TEXT_FILTER, filter: value });
         }
 
         const refresh = debounced ? debouncedRefresh : updateData;
@@ -185,7 +185,7 @@ const EntityTableToolbar = ({
      */
     const onSetFilter = (value, filterKey, refresh) => {
         const newFilters = [
-            ...filters.filter(oneFilter => !oneFilter.hasOwnProperty(filterKey)),
+            ...filters?.filter(oneFilter => !oneFilter.hasOwnProperty(filterKey)),
             { [filterKey]: value }
         ];
         refresh({ page: 1, perPage, filters: newFilters });
@@ -280,7 +280,7 @@ const EntityTableToolbar = ({
         ).filter(Boolean).length > 0 ||
         (staleFilter?.length > 0) ||
         (registeredWithFilter?.length > 0) ||
-        (activeFiltersConfig && activeFiltersConfig.filters && activeFiltersConfig.filters.length > 0);
+        (activeFiltersConfig?.filters?.length > 0);
     };
 
     const inventoryFilters = [
@@ -301,11 +301,11 @@ const EntityTableToolbar = ({
                 isDisabled: !hasAccess
             }}
             className={`ins-c-inventory__table--toolbar ${hasItems ? 'ins-c-inventory__table--toolbar-has-items' : ''}`}
-            {...inventoryFilters.length > 0 && {
+            {...inventoryFilters?.length > 0 && {
                 filterConfig: {
                     ...filterConfig || {},
                     isDisabled: !hasAccess,
-                    items: inventoryFilters.map(filter => ({
+                    items: inventoryFilters?.map(filter => ({
                         ...filter,
                         filterValues: {
                             ...filter?.filterValues,

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -52,7 +52,7 @@ class ContextInventoryList extends Component {
     }
 
     componentDidMount() {
-        !this.onRefresh && this.onRefreshData({});
+        !this.props.onRefresh && this.onRefreshData({});
     }
 
     render() {

--- a/packages/inventory/src/shared/constants.js
+++ b/packages/inventory/src/shared/constants.js
@@ -109,7 +109,7 @@ export const arrayToSelection = (selected) => selected.reduce((acc, { cells: [ k
     }
 }), {});
 
-export function reduceFilters(filters) {
+export function reduceFilters(filters = []) {
     return filters.reduce((acc, oneFilter) => {
         if (oneFilter.value === TEXT_FILTER) {
             return { ...acc, textFilter: oneFilter.filter };


### PR DESCRIPTION
### Do not set filters to empty array

The way how API filters work is that if nothing is set it should automatically set `status=fresh, stale` and `source=insights` to properly show correct data. However we've fallback to empty array if no filters were applied which causes problems with initial render to ignore `source=insights` and it shows systems from all sources. This PR removes such fallback and when `filters` are used it will use safe accessor instead so we can actually send `undefined` as default filters.

### No initial call on first render

Not really a bug, but nice to have. If any app hooks itself to `onRefresh` call we'd eventually fire 2 fetches for systems, one in `componentDidMount` of `inventoryList` and the second one would be triggered by `onRefresh`. Let's ignore the one from `componentDidMount`, if any initial render problems occure we know what to remove, but logically it doesn't make sense to make 2 calls on redner.