### PR TITLE
Update remediations not to use external deps

### DIFF
--- a/packages/remediations/.gitignore
+++ b/packages/remediations/.gitignore
@@ -8,3 +8,4 @@
 /cjs
 /*.css
 *.txt
+*.jpg

--- a/packages/remediations/config/webpack.constants.js
+++ b/packages/remediations/config/webpack.constants.js
@@ -8,12 +8,7 @@ module.exports = {
                 amd: '@patternfly/react-icons',
                 root: 'PFReactIcons'
             },
-            '@patternfly/react-table': {
-                commonjs: 'PFReactTable',
-                commonjs2: 'PFReactTable',
-                amd: 'PFReactTable',
-                root: 'PFReactTable'
-            },
+            '@patternfly/react-table': '@patternfly/react-table',
             '@redhat-cloud-services/frontend-components-utilities': '@redhat-cloud-services/frontend-components-utilities',
             '@redhat-cloud-services/frontend-components': '@redhat-cloud-services/frontend-components',
             '@redhat-cloud-services/frontend-components-notifications': '@redhat-cloud-services/frontend-components-notifications',
@@ -25,11 +20,11 @@ module.exports = {
             'react-dom': 'react-dom',
             redux: 'redux',
             axios: 'axios',
-            react: 'customReact'
+            react: 'react'
         },
         function(context, request, callback) {
             if (/^@patternfly\/react-core.*/.test(request)) {
-                return callback(null, 'PFReactCore');
+                return callback(null, '@patternfly/react-core');
             }
 
             callback();

--- a/packages/remediations/src/RemediationButton.js
+++ b/packages/remediations/src/RemediationButton.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import * as pfReactTable from '@patternfly/react-table';
-import * as ReactRedux from 'react-redux';
 
 import propTypes from 'prop-types';
 import { reactCore } from '../../utils/src/inventoryDependencies';
@@ -24,12 +22,8 @@ class RemediationButton extends React.Component {
 
     componentDidMount() {
         Promise.all([
-            getLoader()({
-                ReactRedux,
-                react: React,
-                pfReact: reactCore,
-                pfReactTable
-            }),
+            // Remediations does not require external deps anymore
+            getLoader()({}),
             insights.chrome.getUserPermissions('remediations')
         ]).then(([
             remediations,

--- a/packages/remediations/src/RemediationWizard.js
+++ b/packages/remediations/src/RemediationWizard.js
@@ -18,12 +18,6 @@ import './RemediationWizard.scss';
 
 const nameRegex = /^$|^.*[\w\d]+.*$/;
 
-let mountedInstance = false;
-
-export function getMountedInstance () {
-    return mountedInstance;
-}
-
 function createNotification (id, name, isNewSwitch) {
     const verb = isNewSwitch ? 'created' : 'updated';
 
@@ -38,13 +32,9 @@ function createNotification (id, name, isNewSwitch) {
 /* eslint camelcase: off */
 class RemediationWizard extends Component {
 
-    constructor (props) {
-        super(props);
-        this.setState = this.setState.bind(this);
-        this.state = {
-            open: false
-        };
-    };
+    state = {
+        open: false
+    }
 
     setOpen = open => {
         this.setState({ open });
@@ -158,14 +148,6 @@ class RemediationWizard extends Component {
             getNotification: () => createNotification(id, name, isNewSwitch)
         });
     };
-
-    componentDidMount () {
-        mountedInstance = this;
-    }
-
-    componentWillUnmount () {
-        mountedInstance = false;
-    }
 
     /*
      * Accessing state

--- a/packages/remediations/src/index.js
+++ b/packages/remediations/src/index.js
@@ -1,16 +1,15 @@
 
 import validate from './validator';
-import RemediationWizard, { getMountedInstance } from './RemediationWizard';
+import RemediationWizard from './RemediationWizard';
 export { RemediationWizard };
 
-export function openWizard(data, basePath) {
-    const instance = getMountedInstance();
+export function openWizard(data, basePath, wizardRef) {
 
-    if (!instance) {
+    if (!wizardRef.current) {
         throw new Error('Wizard component not mounted');
     }
 
     validate(data);
 
-    return instance.openWizard(data, basePath);
+    return wizardRef.current?.openWizard(data, basePath);
 }


### PR DESCRIPTION
### Simple external deps
Since remediations is not using directly props from parent component we can safely remove all external dependencies and use deps in chrome.

### Changed instance reference
Remove instance generation and use refs, this is more React like approach.