### PR TITLE
Add NODE_ENV=production to rollup build.

### DIFF
--- a/config/rollup-plugins.js
+++ b/config/rollup-plugins.js
@@ -1,0 +1,9 @@
+import replace from 'rollup-plugin-replace';
+
+const rollupPlugins = [
+    replace({
+        'process.env.NODE_ENV': '\'production\''
+    })
+];
+
+export default rollupPlugins;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14563,7 +14563,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -14587,13 +14588,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14603,19 +14606,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -14736,7 +14742,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -14750,6 +14757,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14766,6 +14774,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14774,13 +14783,15 @@
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -14869,7 +14880,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14883,6 +14895,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14978,7 +14991,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -15020,6 +15034,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -15041,6 +15056,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -15083,7 +15099,8 @@
               "version": "5.2.1",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
               "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -15108,13 +15125,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -24577,9 +24596,9 @@
       },
       "dependencies": {
         "magic-string": {
-          "version": "0.25.6",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
-          "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
           "dev": true,
           "requires": {
             "sourcemap-codec": "^1.4.4"
@@ -24996,6 +25015,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -25095,7 +25115,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "p-limit": {
           "version": "2.3.0",
@@ -28938,6 +28959,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -28953,7 +28975,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "readdirp": {
           "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
         "rollup-plugin-copy": "^3.3.0",
         "rollup-plugin-node-globals": "^1.4.0",
         "rollup-plugin-postcss": "^2.0.3",
+        "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-sass": "^1.2.2",
         "rollup-plugin-scss": "^2.5.0",
         "rollup-plugin-size-snapshot": "^0.10.0",

--- a/packages/charts/config/rollup.config.js
+++ b/packages/charts/config/rollup.config.js
@@ -14,6 +14,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -36,6 +37,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/components/config/rollup.config.js
+++ b/packages/components/config/rollup.config.js
@@ -16,6 +16,7 @@ import {
     globals
 } from '../../../config/rollup-contants';
 import copy from 'rollup-plugin-copy';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -41,6 +42,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/inventory-compliance/config/rollup.config.js
+++ b/packages/inventory-compliance/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -35,6 +36,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/inventory-general-info/config/rollup.config.js
+++ b/packages/inventory-general-info/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -35,6 +36,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/inventory-insights/config/rollup.config.js
+++ b/packages/inventory-insights/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -36,6 +37,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/notifications/config/rollup.config.js
+++ b/packages/notifications/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -35,6 +36,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/pdf-generator/rollup.config.js
+++ b/packages/pdf-generator/rollup.config.js
@@ -10,6 +10,7 @@ import nodeGlobals from 'rollup-plugin-node-globals';
 import { terser } from 'rollup-plugin-terser';
 import postcss from 'rollup-plugin-postcss';
 import json from '@rollup/plugin-json';
+import rollupPlugins from '../../config/rollup-plugins';
 
 const external = createFilter(
     Object.keys(dependencies).map(item => item.includes('@patternfly') ? `${item}/**` : item),
@@ -36,6 +37,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/rule-components/config/rollup.config.js
+++ b/packages/rule-components/config/rollup.config.js
@@ -14,6 +14,7 @@ import {
     globals,
     globMapper
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -27,6 +28,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/sources/config/rollup.config.js
+++ b/packages/sources/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const commonjsOptions = {
     ignoreGlobal: true,
@@ -35,6 +36,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/translations/config/rollup.config.js
+++ b/packages/translations/config/rollup.config.js
@@ -13,6 +13,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const entryMapper = {
     index: './src/index.js',
@@ -40,6 +41,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve({
         browser: true
     }),

--- a/packages/utils/config/rollup.config.js
+++ b/packages/utils/config/rollup.config.js
@@ -14,6 +14,7 @@ import {
     external,
     globals
 } from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
 
 const entryMapper = {
     ReducerRegistry: './src/ReducerRegistry.js',
@@ -52,6 +53,7 @@ const babelOptions = {
 };
 
 const plugins = [
+    ...rollupPlugins,
     nodeResolve(),
     babel(babelOptions),
     commonjs(commonjsOptions),


### PR DESCRIPTION
This removes the annoying redux warning that we use a production bundle outside of the production environment. Rollup does not take the variable from CLI so we have to use replace plugin to manually set it in the build process.