### PR TITLE
Add tooltip to all tag filter options

### DIFF
--- a/packages/components/src/Components/FilterHooks/__snapshots__/constants.test.js.snap
+++ b/packages/components/src/Components/FilterHooks/__snapshots__/constants.test.js.snap
@@ -6,8 +6,7 @@ Array [
     aria-describedby="pf-tooltip-1"
     className="ins-c-tagfilter__option-value"
   >
-    someKey
-    =someValue
+    someKey=someValue
   </div>,
   <span
     aria-describedby="pf-tooltip-2"
@@ -24,8 +23,7 @@ Array [
     aria-describedby="pf-tooltip-3"
     className="ins-c-tagfilter__option-value"
   >
-    someKey
-    =someValue
+    someKey=someValue
   </div>,
   <span
     aria-describedby="pf-tooltip-4"

--- a/packages/components/src/Components/FilterHooks/__snapshots__/constants.test.js.snap
+++ b/packages/components/src/Components/FilterHooks/__snapshots__/constants.test.js.snap
@@ -3,13 +3,14 @@
 exports[`constructGroups should build filter with empty badge 1`] = `
 Array [
   <div
+    aria-describedby="pf-tooltip-1"
     className="ins-c-tagfilter__option-value"
   >
     someKey
     =someValue
   </div>,
   <span
-    aria-describedby="pf-tooltip-1"
+    aria-describedby="pf-tooltip-2"
     className="pf-c-badge pf-m-read"
   >
     0
@@ -20,13 +21,14 @@ Array [
 exports[`constructGroups should render correctly 1`] = `
 Array [
   <div
+    aria-describedby="pf-tooltip-3"
     className="ins-c-tagfilter__option-value"
   >
     someKey
     =someValue
   </div>,
   <span
-    aria-describedby="pf-tooltip-2"
+    aria-describedby="pf-tooltip-4"
     className="pf-c-badge pf-m-unread"
   >
     1

--- a/packages/components/src/Components/FilterHooks/constants.js
+++ b/packages/components/src/Components/FilterHooks/constants.js
@@ -49,35 +49,38 @@ export function constructGroups(allTags, item = 'item') {
         label: name,
         value: name,
         type,
-        items: tags.map(({ count, tag: { key: tagKey, value } }) => ({
-            className: 'ins-c-tagfilter__option',
-            label: <React.Fragment>
-                <Tooltip
-                    content={`${tagKey}${value ? `=${value}` : ''}`}
-                >
-                    <div className="ins-c-tagfilter__option-value">{tagKey}{value ? `=${value}` : ''}</div>
-                </Tooltip>
-                {
-                    count !== undefined && (
-                        <Tooltip
-                            position="right"
-                            enableFlip
-                            content={`Applicable to ${count} ${item}${count === 1 ? '' : 's'}.`}
-                        >
-                            <Badge isRead={count <= 0}>{ count }</Badge>
-                        </Tooltip>
-                    )
-                }
-            </React.Fragment>,
-            meta: {
-                count,
-                tag: {
-                    key: tagKey,
-                    value
-                }
-            },
-            value: tagKey,
-            tagValue: value
-        }))
+        items: tags.map(({ count, tag: { key: tagKey, value } }) => {
+            const tagText = `${tagKey}${value ? `=${value}` : ''}`;
+            return ({
+                className: 'ins-c-tagfilter__option',
+                label: <React.Fragment>
+                    <Tooltip
+                        content={tagText}
+                    >
+                        <div className="ins-c-tagfilter__option-value">{tagText}</div>
+                    </Tooltip>
+                    {
+                        count !== undefined && (
+                            <Tooltip
+                                position="right"
+                                enableFlip
+                                content={`Applicable to ${count} ${item}${count === 1 ? '' : 's'}.`}
+                            >
+                                <Badge isRead={count <= 0}>{ count }</Badge>
+                            </Tooltip>
+                        )
+                    }
+                </React.Fragment>,
+                meta: {
+                    count,
+                    tag: {
+                        key: tagKey,
+                        value
+                    }
+                },
+                value: tagKey,
+                tagValue: value
+            });
+        })
     }));
 }

--- a/packages/components/src/Components/FilterHooks/constants.js
+++ b/packages/components/src/Components/FilterHooks/constants.js
@@ -52,7 +52,11 @@ export function constructGroups(allTags, item = 'item') {
         items: tags.map(({ count, tag: { key: tagKey, value } }) => ({
             className: 'ins-c-tagfilter__option',
             label: <React.Fragment>
-                <div className="ins-c-tagfilter__option-value">{tagKey}{value ? `=${value}` : ''}</div>
+                <Tooltip
+                    content={`${tagKey}${value ? `=${value}` : ''}`}
+                >
+                    <div className="ins-c-tagfilter__option-value">{tagKey}{value ? `=${value}` : ''}</div>
+                </Tooltip>
                 {
                     count !== undefined && (
                         <Tooltip


### PR DESCRIPTION
### Tooltip in tags filter

Since tags can be long we want to wrap them in tooltip so users can hover over them and see full tag.