### PR TITLE
Fix UMD packages imports.

### DIFF
--- a/packages/inventory-compliance/src/PresentationalComponents/RuleLoadingTable.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/RuleLoadingTable.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import propTypes from 'prop-types';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
-import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
 
 const RuleLoadingTable = ({ columns }) => (
     <Table

--- a/packages/inventory/src/components/detail/InventoryDetail.js
+++ b/packages/inventory/src/components/detail/InventoryDetail.js
@@ -8,7 +8,7 @@ import SystemNotFound from './SystemNotFound';
 import TopBar from './TopBar';
 import FactsInfo from './FactsInfo';
 import { reloadWrapper } from '../../shared';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/components/cjs/NotAuthorized';
 import ApplicationDetails from './ApplicationDetails';
 import './InventoryDetail.scss';


### PR DESCRIPTION
This is a part of a larger effort to remove PF background images from chrome build. Old imports were referencing UMD versions of FCE packages which indirectly leads to importing the whole "@patternfly/react-core" package and that injects PF about modal background images to chrome build. And those are pretty big.