### PR TITLE
Fire refresh data on load if inventory has items

### DIFF
--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -52,7 +52,9 @@ class ContextInventoryList extends Component {
     }
 
     componentDidMount() {
-        !this.props.onRefresh && this.onRefreshData({});
+        if (this.props.hasItems) {
+            this.onRefreshData({});
+        }
     }
 
     render() {


### PR DESCRIPTION
### Fix infinit load on systems pages

There is a problem when app passes `items` to inventory the table wouldn't load for some cases, this can happen when app waits for `items` to be loaded and passes them to inventory at the same time as inventory first renders. We don't want to fire the first fetch at all if app didn't defined `items` it means that the app is using full inventory and first fetch is fired from `InventoryTableToolbar`.