### PR TITLE
Fix conditional toolbar groups component by adding value to empty fields

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,7 +15,10 @@
         "build:esm": "BABEL_ENV=esm rollup -c ./config/rollup.config.js --environment NODE_ENV:production,FORMAT:esm",
         "build:umd": "rollup -c ./config/rollup.config.js --format=umd --environment NODE_ENV:production,FORMAT:umd",
         "build:css": "node ./create-styles.js && copyfiles ./components/index.* ./ -f",
-        "start": "rollup -c ./config/rollup.config.js -w"
+        "start": "rollup -c ./config/rollup.config.js -w",
+        "start:js": "BABEL_ENV=cjs rollup -c ./config/rollup.config.js -w --format=cjs --environment FORMAT:cjs",
+        "start:esm": "BABEL_ENV=esm rollup -c ./config/rollup.config.js -w --environment FORMAT:esm",
+        "start:umd": "rollup -c ./config/rollup.config.js -w --format=umd --environment FORMAT:umd"
     },
     "repository": {
         "type": "git",

--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -253,7 +253,7 @@ class Group extends Component {
                 { ...(isFilterable || onFilter) && { onFilter: this.customFilter } }
                 { ...groups && groups.length > 0 && { isGrouped: true }}
             >
-                <div className="ins-c-select__scrollable-section">
+                <div className="ins-c-select__scrollable-section" value="">
                     { groups && groups.length > 0 ? (
                         groups.map(({
                             value: groupValue,
@@ -285,11 +285,12 @@ class Group extends Component {
                             className="pf-c-select__menu-item"
                             variant={showMore.variant}
                             onClick={showMore.items[0].onClick}
+                            value="Show more"
                         >
                             {showMore.items[0].label}
                         </Button>
                     </SelectGroup>
-                    : <Fragment />}
+                    : <Fragment value="" />}
             </Select> }
         </Fragment>);
     }

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
@@ -55,6 +55,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -273,6 +274,7 @@ exports[`Group - component render should render correctly with items - isDisable
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -491,6 +493,7 @@ exports[`Group - component render should render correctly with items 1`] = `
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -709,6 +712,7 @@ exports[`Group - component render should render correctly with items and default
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -927,6 +931,7 @@ exports[`Group - component render should render correctly with items and selecte
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -1145,6 +1150,7 @@ exports[`Group - component render show more should render correctly with items a
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -1331,6 +1337,7 @@ exports[`Group - component render show more should render correctly with items a
           }
         }
         type="button"
+        value="Show more"
         variant="link"
       >
         Show more
@@ -1379,6 +1386,7 @@ exports[`Group - component render show more should render correctly with items a
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -1560,6 +1568,7 @@ exports[`Group - component render show more should render correctly with items a
         label="some title"
         onClick={[Function]}
         type="button"
+        value="Show more"
         variant="link"
       >
         some title
@@ -1608,6 +1617,7 @@ exports[`Group - component render show more should render correctly with items a
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -1789,6 +1799,7 @@ exports[`Group - component render show more should render correctly with items a
         label="Show more"
         onClick={[Function]}
         type="button"
+        value="Show more"
         variant="link"
       >
         Show more
@@ -1837,6 +1848,7 @@ exports[`Group - component render show more should render correctly with items a
   >
     <div
       className="ins-c-select__scrollable-section"
+      value=""
     >
       <SelectGroup
         id="group-0"
@@ -2018,6 +2030,7 @@ exports[`Group - component render show more should render correctly with items a
         label="Show more"
         onClick={[Function]}
         type="button"
+        value="Show more"
         variant="default"
       >
         Show more


### PR DESCRIPTION
### Error while selecting tags in global filter

With new addition to tags filter and option to scroll the filter broke, because PF expects `value` on each children, and when spinner is shown no such thing is passed in any component. This PR fixes such issue by adding empty values to parent component and button to manage all tags.

I've also added option to run start for only JS, UMD or ESM modules.