### PR TITLE
Fix inventory tags by passing correct fields and observing custom filters

### DIFF
--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -97,12 +97,12 @@ const EntityTableToolbar = ({
      */
     const debounceGetAllTags = useCallback(debounce((config, options) => {
         if (showTags && !hasItems && hasAccess) {
-            dispatch(fetchAllTags({
+            dispatch(fetchAllTags(config, {
                 ...customFilters,
-                ...config
-            }, options));
+                ...options
+            }));
         }
-    }, 800), []);
+    }, 800), [ customFilters?.tags ]);
 
     /**
      * Function to dispatch load systems and fetch all tags.
@@ -114,7 +114,7 @@ const EntityTableToolbar = ({
                 dispatch(fetchAllTags(filterTagsBy, { ...customFilters, filters: options.filters }));
             }
         }
-    });
+    }, [ customFilters?.tags ]);
 
     /**
      * Function used to update data, it either calls `onRefresh` from props or dispatches `onRefreshData`.
@@ -197,7 +197,7 @@ const EntityTableToolbar = ({
         if (shouldReload && showTags) {
             debounceGetAllTags(filterTagsBy, { filters });
         }
-    }, [ filterTagsBy ]);
+    }, [ filterTagsBy, customFilters?.tags ]);
 
     useEffect(() => {
         if (shouldReload) {

--- a/packages/inventory/src/components/table/InventoryList.scss
+++ b/packages/inventory/src/components/table/InventoryList.scss
@@ -22,6 +22,8 @@
     }
 
     .ins-c-chip-filters .pf-c-chip-group:not(:last-of-type) { margin-right: var(--pf-global--spacer--xs); }
+
+    .ins-c-tagfilter { width: initial; }
 }
 
 .ins-c-table__empty {


### PR DESCRIPTION
### Tags are not filtered when user inputs something in search

There is an error when user types something in tags filter the filter renders all tags. This PR fixes such issue by using correct arguments and also introduces observers on `customFilters.tags` in order to drill down tags when global filter is applied.

Minor change to styling - global filter is chaning how tags filter look like in inventory, so prevent that by adding custom rule for inventory filter.