### PR TITLE
fix(RHICOMPL-880): Set fitContent for columns to not trigger tooltip

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -2,7 +2,7 @@ import React from 'react';
 import propTypes from 'prop-types';
 import { Pagination, PaginationVariant, ToolbarItem } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, AnsibeTowerIcon } from '@patternfly/react-icons';
-import { Table, TableHeader, TableBody, sortable } from '@patternfly/react-table';
+import { Table, TableHeader, TableBody, sortable, fitContent } from '@patternfly/react-table';
 import { TableToolbar, PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 
 import './compliance.scss';
@@ -17,11 +17,15 @@ import ComplianceRemediationButton from './ComplianceRemediationButton';
 export const columns = [
     { title: 'Rule', transforms: [ sortable ] },
     { title: 'Policy', transforms: [ sortable ] },
-    { title: 'Severity', transforms: [ sortable ] },
-    { title: 'Passed', transforms: [ sortable ] },
+    { title: 'Severity', transforms: [ sortable, fitContent ] },
+    { title: 'Passed', transforms: [ sortable, fitContent ] },
     { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>,
-        original: 'Ansible', transforms: [ sortable ] }
+        original: 'Ansible', props: { tooltip: 'Ansible' }, transforms: [ sortable, fitContent ] }
 ];
+
+export const selectColumns = (columnTitles) => (
+    columns.filter((column) => columnTitles.includes(column.original || column.title))
+);
 
 class SystemRulesTable extends React.Component {
     config = buildFilterConfig({

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -204,16 +204,21 @@ exports[`SystemRulesTable component should render 1`] = `
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -223,6 +228,7 @@ exports[`SystemRulesTable component should render 1`] = `
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -1058,16 +1064,21 @@ exports[`SystemRulesTable component should render a loading table 1`] = `
         "title": "Severity",
         "transforms": Array [
           [Function],
+          [Function],
         ],
       },
       Object {
         "title": "Passed",
         "transforms": Array [
           [Function],
+          [Function],
         ],
       },
       Object {
         "original": "Ansible",
+        "props": Object {
+          "tooltip": "Ansible",
+        },
         "title": <React.Fragment>
           <AnsibeTowerIcon
             color="currentColor"
@@ -1077,6 +1088,7 @@ exports[`SystemRulesTable component should render a loading table 1`] = `
            Ansible
         </React.Fragment>,
         "transforms": Array [
+          [Function],
           [Function],
         ],
       },
@@ -1328,16 +1340,21 @@ exports[`SystemRulesTable component should render filtered and search mixed resu
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -1347,6 +1364,7 @@ exports[`SystemRulesTable component should render filtered and search mixed resu
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -1683,16 +1701,21 @@ exports[`SystemRulesTable component should render search results by rule name 1`
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -1702,6 +1725,7 @@ exports[`SystemRulesTable component should render search results by rule name 1`
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -2088,16 +2112,21 @@ exports[`SystemRulesTable component should render search results on any page, re
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -2107,6 +2136,7 @@ exports[`SystemRulesTable component should render search results on any page, re
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -2484,16 +2514,21 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -2503,6 +2538,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -3522,16 +3558,21 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -3541,6 +3582,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },
@@ -4496,16 +4538,21 @@ exports[`SystemRulesTable component should render without remediations if prop p
           "title": "Severity",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "title": "Passed",
           "transforms": Array [
             [Function],
+            [Function],
           ],
         },
         Object {
           "original": "Ansible",
+          "props": Object {
+            "tooltip": "Ansible",
+          },
           "title": <React.Fragment>
             <AnsibeTowerIcon
               color="currentColor"
@@ -4515,6 +4562,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
              Ansible
           </React.Fragment>,
           "transforms": Array [
+            [Function],
             [Function],
           ],
         },

--- a/packages/inventory-compliance/src/index.js
+++ b/packages/inventory-compliance/src/index.js
@@ -1,5 +1,5 @@
 export { default as default } from './Compliance';
-export { default as SystemRulesTable } from './SystemRulesTable';
+export { default as SystemRulesTable, selectColumns as selectRulesTableColumns } from './SystemRulesTable';
 export { default as ComplianceRemediationButton } from './ComplianceRemediationButton';
 export { default as ComplianceEmptyState } from './ComplianceEmptyState';
 export { ChipBuilder, FilterBuilder, FilterConfigBuilder } from './Utilities';


### PR DESCRIPTION
When a column header contains html it will render this as a string for the tooltip.
Setting `props: { tooltip '...' }` should allow to set an alternative, according to the Patternfly (code), but this appears broken.

Using `fitContent` will avoid the issue by avoiding to show a tooltip. 

This also adds a function and exports it to select certain columns instead of redefine them everywhere[1].

[1] https://github.com/RedHatInsights/compliance-frontend/pull/788