### PR TITLE
Allow RBAC to be disabled when using inventory

### DIFF
--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import { AppInfo, InventoryDetail, FullDetail, DetailWrapper } from './components/detail';
+import { AppInfo, InventoryDetail, FullDetail } from './components/detail';
 import { TagWithDialog, RenderWrapper } from './shared';
 import { InventoryTable } from './components/table';
 import * as inventoryFitlers from './components/filters';
 import DetailRenderer from './components/detail/DetailRenderer';
 
-export function inventoryConnector(store, componentsMapper, Wrapper) {
+export function inventoryConnector(store, componentsMapper, Wrapper, isRbacEnabled = true) {
     const showInventoryDrawer = Boolean(Wrapper);
     return {
         InventoryTable: React.forwardRef(
             (props, ref) => <RenderWrapper
                 { ...props }
+                isRbacEnabled={ isRbacEnabled }
                 inventoryRef={ ref }
                 store={ store }
                 cmp={ InventoryTable }
@@ -21,6 +22,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
                 hideLoader
                 { ...props }
                 {...componentsMapper}
+                isRbacEnabled={ isRbacEnabled }
                 inventoryRef={ ref }
                 store={ store }
                 cmp={ AppInfo }
@@ -31,6 +33,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
                 hideLoader
                 { ...props }
                 {...componentsMapper}
+                isRbacEnabled={ isRbacEnabled }
                 inventoryRef={ ref }
                 store={ store }
                 showInventoryDrawer={ showInventoryDrawer && !props.hideInvDrawer }
@@ -42,6 +45,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
                 hideLoader
                 { ...props }
                 {...componentsMapper}
+                isRbacEnabled={ isRbacEnabled }
                 inventoryRef={ ref }
                 store={ store }
                 showInventoryDrawer={ showInventoryDrawer }
@@ -52,11 +56,18 @@ export function inventoryConnector(store, componentsMapper, Wrapper) {
             (props, ref) => <RenderWrapper
                 { ...props }
                 inventoryRef={ ref }
+                isRbacEnabled={ isRbacEnabled }
                 store={ store }
                 cmp={ TagWithDialog }
             />
         ),
-        DetailWrapper: DetailRenderer,
+        // eslint-disable-next-line react/display-name
+        DetailWrapper: (props) => <DetailRenderer
+            Wrapper={Wrapper}
+            isRbacEnabled={ isRbacEnabled }
+            showInventoryDrawer={ showInventoryDrawer }
+            {...props}
+        />,
         ...inventoryFitlers
     };
 }

--- a/packages/inventory/src/components/detail/DetailRenderer.js
+++ b/packages/inventory/src/components/detail/DetailRenderer.js
@@ -5,11 +5,11 @@ import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 import DetailWrapper from './DetailWrapper';
 import AccessDenied from '../../shared/AccessDenied';
 
-const DetailRenderer = ({ showInventoryDrawer, ...props }) => {
+const DetailRenderer = ({ showInventoryDrawer, isRbacEnabled, ...props }) => {
     const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
     if (hasAccess === undefined) {
         return <Spinner />;
-    } else if (hasAccess === false) {
+    } else if (isRbacEnabled && hasAccess === false) {
         return <AccessDenied />;
     } else {
         return showInventoryDrawer ? <DetailWrapper {...props} /> : <React.Fragment {...props} />;
@@ -17,7 +17,8 @@ const DetailRenderer = ({ showInventoryDrawer, ...props }) => {
 };
 
 DetailWrapper.propTypes = {
-    showInventoryDrawer: PropTypes.bool
+    showInventoryDrawer: PropTypes.bool,
+    isRbacEnabled: PropTypes.bool
 };
 
 DetailWrapper.defaultProps = {

--- a/packages/inventory/src/shared/Wrapper.js
+++ b/packages/inventory/src/shared/Wrapper.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/files/RBACHook';
 import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
 
-const RenderWrapper = ({ cmp: Component, hideLoader, inventoryRef, store, ...props }) => {
+const RenderWrapper = ({ cmp: Component, hideLoader, isRbacEnabled, inventoryRef, store, ...props }) => {
     const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
     return (
         (hasAccess === undefined && !hideLoader) ?
@@ -13,7 +13,7 @@ const RenderWrapper = ({ cmp: Component, hideLoader, inventoryRef, store, ...pro
                 { ...inventoryRef && {
                     ref: inventoryRef
                 }}
-                hasAccess={hasAccess}
+                hasAccess={isRbacEnabled ? hasAccess : true}
                 store={ store }
             />
     );
@@ -23,7 +23,8 @@ RenderWrapper.propTypes = {
     cmp: PropTypes.any,
     inventoryRef: PropTypes.any,
     store: PropTypes.object,
-    customRender: PropTypes.bool
+    customRender: PropTypes.bool,
+    isRbacEnabled: PropTypes.bool
 };
 
 export default RenderWrapper;


### PR DESCRIPTION
### Inventory RBAC not enabled for qa and prod

Currently a lot of users are missing RBAC permissions in qa and prod environments, we want to allow consumers of inventory to bypass inventory check. By default RBAC will be enabled, but trough chrome we'll disable it on prod for now and once we know RBAC is enabled for all users we'll switch it.

This Piece of code can be removed later down the line.