### PR TITLE
Allow passing custom filter for systems table

### DIFF
--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -71,6 +71,7 @@ export default class TagModal extends React.Component {
                 isOpen={isOpen}
                 title={title || `Tags for ${systemName}`}
                 onClose={(e) => toggleModal(e, false)}
+                variant="medium"
                 {...onApply && {
                     actions: [
                         <Button key="confirm" variant="primary" onClick={(e) => {

--- a/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
+++ b/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
@@ -14,7 +14,7 @@ exports[`TagCount component Render the modal open with row of tags 1`] = `
   ouiaSafe={true}
   showClose={true}
   title="Tags for paul.localhost.com"
-  variant="default"
+  variant="medium"
 >
   <PrimaryToolbar
     pagination={
@@ -149,7 +149,7 @@ exports[`TagCount component Render the modal with a child component 1`] = `
   ouiaSafe={true}
   showClose={true}
   title="Tags for paul.localhost.com"
-  variant="default"
+  variant="medium"
 >
   <PrimaryToolbar
     pagination={

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -35,7 +35,7 @@
         "@redhat-cloud-services/frontend-components": "*",
         "@redhat-cloud-services/frontend-components-notifications": "*",
         "@redhat-cloud-services/frontend-components-utilities": "*",
-        "@redhat-cloud-services/host-inventory-client": "1.0.66",
+        "@redhat-cloud-services/host-inventory-client": "1.0.77",
         "axios": "^0.19.0"
     }
 }

--- a/packages/inventory/src/api/api.js
+++ b/packages/inventory/src/api/api.js
@@ -3,6 +3,7 @@ import flatMap from 'lodash/flatMap';
 export const INVENTORY_API_BASE = '/api/inventory/v1';
 
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
+import { generateFilter } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { HostsApi, TagsApi } from '@redhat-cloud-services/host-inventory-client';
 import { defaultFilters } from '../shared/constants';
 
@@ -64,22 +65,6 @@ export const filtersReducer = (acc, filter = {}) => ({
     ...'staleFilter' in filter && { staleFilter: filter.staleFilter },
     ...'registeredWithFilter' in filter && { registeredWithFilter: filter.registeredWithFilter }
 });
-
-const generateFilter = (data, path = 'filter') =>
-    Object.entries(data || {}).reduce((acc, [ key, value ]) => {
-        const newPath = `${path || ''}[${key}]`;
-        if (value instanceof Function || value instanceof Date) {
-            return acc;
-        }
-
-        return {
-            ...acc,
-            ...(Array.isArray(value) || typeof value !== 'object')
-                ? { [newPath]: value } :
-                generateFilter(value, newPath)
-        };
-
-    }, {});
 
 export function getEntities(items, {
     controller,

--- a/packages/utils/src/helpers.js
+++ b/packages/utils/src/helpers.js
@@ -82,3 +82,19 @@ export function getBaseName(pathname, level = 2) {
         return `${acc}${pathName[key] || ''}${key < (level - 1) ? '/' : ''}`;
     }, release);
 }
+
+export const generateFilter = (data, path = 'filter') =>
+    Object.entries(data || {}).reduce((acc, [ key, value ]) => {
+        const newPath = `${path || ''}[${key}]`;
+        if (value instanceof Function || value instanceof Date) {
+            return acc;
+        }
+
+        return {
+            ...acc,
+            ...(Array.isArray(value) || typeof value !== 'object')
+                ? { [newPath]: value } :
+                generateFilter(value, newPath)
+        };
+
+    }, {});

--- a/packages/utils/src/helpers.test.js
+++ b/packages/utils/src/helpers.test.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { RowLoader, processDate, parseCvssScore, downloadFile, mergeArraysByKey, getBaseName } from './helpers';
+import {
+    RowLoader,
+    processDate,
+    parseCvssScore,
+    downloadFile,
+    mergeArraysByKey,
+    getBaseName,
+    generateFilter
+} from './helpers';
 
 describe('mergeArraysByKey', () => {
     it('should join two arrays by ID', () => {
@@ -155,5 +163,59 @@ describe('getBaseName', () => {
 
     it('should work with root level', () => {
         expect(getBaseName('/really/long/url/with/some/stuff', 0)).toBe('/');
+    });
+});
+
+describe('generateFilter', () => {
+    it('should generate filter for array', () => {
+        const result = generateFilter({
+            some: [ 1, 2 ]
+        });
+        expect(result).toMatchObject({
+            'filter[some]': [ 1, 2 ]
+        });
+    });
+
+    it('should generate nested filter', () => {
+        const result = generateFilter({
+            some: {
+                key: {
+                    obj: {
+                        nested: {
+                            really: {
+                                long: 'value'
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        expect(result).toMatchObject({
+            'filter[some][key][obj][nested][really][long]': 'value'
+        });
+    });
+
+    it('should ignore Dates and Functions', () => {
+        const result = generateFilter({
+            some: () => '',
+            value: new Date(),
+            actual: {
+                value: 'value'
+            }
+        });
+        expect(result).toMatchObject({
+            'filter[actual][value]': 'value'
+        });
+    });
+
+    it('should allow custom prefix', () => {
+        const result = generateFilter({
+            actual: {
+                value: 'value'
+            }
+        }, '');
+        expect(result).toMatchObject({
+            '[actual][value]': 'value'
+        });
     });
 });


### PR DESCRIPTION
### Tags fixtures

When switching between pages in tagsModal the width changes, this PR fixes such issue by passing `medium` variant to this component.

### Inotroduce filter query param

We have new feature in inventory to allow custom filters being passed, however our JS client generator is not working correctly and is not properly mapping `type: object` to proper shape, we have to walk trough the object and map paths as string of `[]`.