### PR TITLE
GeneralInfo component should get writePermissions

### DIFF
--- a/packages/inventory-general-info/src/EditButton.js
+++ b/packages/inventory-general-info/src/EditButton.js
@@ -5,33 +5,60 @@ import { usePermissions } from '@redhat-cloud-services/frontend-components-utili
 
 import { PencilAltIcon } from '@patternfly/react-icons';
 
-const EditButton = ({ link, onClick }) => {
+const InnerButton = ({ link, onClick }) => (
+    <a
+        className="ins-c-inventory__detail--action"
+        href={ `${window.location.href}/${link}` }
+        onClick={ onClick }
+    >
+        <PencilAltIcon />
+    </a>
+);
+
+InnerButton.propTypes = {
+    link: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired
+};
+
+let permissionsCache = undefined;
+
+const EditButtonUnknownPermissions = (props) => {
     const { hasAccess } = usePermissions('inventory', [
         'inventory:*:*',
         'inventory:hosts:write',
         'inventory:*:write'
     ]);
 
-    const canPerformActions = insights.chrome.isProd || hasAccess;
+    if (hasAccess) {
+        permissionsCache = hasAccess;
+    }
 
-    if (!canPerformActions) {
+    if (!hasAccess) {
         return null;
     }
 
-    return (
-        <a
-            className="ins-c-inventory__detail--action"
-            href={ `${window.location.href}/${link}` }
-            onClick={ onClick }
-        >
-            <PencilAltIcon />
-        </a>
-    );
+    return <InnerButton {...props}/>;
 };
 
-EditButton.propTypes = {
+EditButtonUnknownPermissions.propTypes = {
     link: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired
 };
 
-export default EditButton;
+const EditButtonWrapper = ({ writePermissions, ...props }) => {
+    if (insights.chrome.isProd || writePermissions || permissionsCache) {
+        return <InnerButton {...props} />;
+    }
+
+    if (typeof writePermissions !== 'boolean') {
+        return <EditButtonUnknownPermissions {...props} />;
+    }
+
+    return null;
+};
+
+EditButtonWrapper.propTypes = {
+    writePermissions: PropTypes.bool
+};
+
+export default EditButtonWrapper;

--- a/packages/inventory-general-info/src/EditButtonWithNoAccess.test.js
+++ b/packages/inventory-general-info/src/EditButtonWithNoAccess.test.js
@@ -18,10 +18,21 @@ describe('EditButton with no access', () => {
         link = 'some-link';
     });
 
-    it('do not render with permission', () => {
+    it('do not render with no permission', () => {
         const wrapper = mount(<EditButton
             onClick={onClick}
             link={link}
+        />);
+
+        expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
+        expect(wrapper.find('a')).toHaveLength(0);
+    });
+
+    it('do not render with no permission - write permissions set to false', () => {
+        const wrapper = mount(<EditButton
+            onClick={onClick}
+            link={link}
+            writePermissions={false}
         />);
 
         expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
@@ -41,5 +52,16 @@ describe('EditButton with no access', () => {
         expect(wrapper.find('a').props().href).toEqual('http://localhost:5000//some-link');
 
         insights.chrome.isProd = tmp;
+    });
+
+    it('render when write permissions are set to true', () => {
+        const wrapper = mount(<EditButton
+            onClick={onClick}
+            link={link}
+            writePermissions={true}
+        />);
+
+        expect(wrapper.find(PencilAltIcon)).toHaveLength(1);
+        expect(wrapper.find('a').props().href).toEqual('http://localhost:5000//some-link');
     });
 });

--- a/packages/inventory-general-info/src/GeneralInformation.js
+++ b/packages/inventory-general-info/src/GeneralInformation.js
@@ -56,13 +56,13 @@ class GeneralInformation extends Component {
 
     render() {
         const { isModalOpen, modalTitle, cells, rows, expandable, filters } = this.state;
-        const { store } = this.props;
+        const { store, writePermissions } = this.props;
         const Wrapper = store ? Provider : Fragment;
         return (
             <Wrapper store={store}>
                 <Grid sm={ 12 } md={ 6 } hasGutter>
                     <GridItem>
-                        <SystemCard handleClick={ this.handleModalToggle } />
+                        <SystemCard handleClick={ this.handleModalToggle } writePermissions={writePermissions} />
                     </GridItem>
                     <GridItem>
                         <OperatingSystemCard handleClick={ this.handleModalToggle } />
@@ -105,7 +105,8 @@ GeneralInformation.propTypes = {
         id: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ])
     }),
     loadSystemDetail: PropTypes.func,
-    store: PropTypes.any
+    store: PropTypes.any,
+    writePermissions: PropTypes.bool
 };
 GeneralInformation.defaultProps = {
     entity: {}

--- a/packages/inventory-general-info/src/SystemCard.js
+++ b/packages/inventory-general-info/src/SystemCard.js
@@ -65,7 +65,7 @@ class SystemCard extends Component {
     };
 
     render() {
-        const { detailLoaded, entity, properties, setDisplayName, setAnsibleHost } = this.props;
+        const { detailLoaded, entity, properties, setDisplayName, setAnsibleHost, writePermissions } = this.props;
         const { isDisplayNameModalOpen, isAnsibleHostModalOpen } = this.state;
         return (
             <Fragment>
@@ -86,7 +86,7 @@ class SystemCard extends Component {
                             value: (
                                 <Fragment>
                                     { entity.display_name }
-                                    <EditButton link="display_name" onClick={this.onShowDisplayModal} />
+                                    <EditButton writePermissions={writePermissions} link="display_name" onClick={this.onShowDisplayModal} />
                                 </Fragment>
                             ), size: 'md'
                         },
@@ -97,7 +97,7 @@ class SystemCard extends Component {
                             value: (
                                 <Fragment>
                                     { this.getAnsibleHost() }
-                                    <EditButton link="ansible_name" onClick={this.onShowAnsibleModal} />
+                                    <EditButton writePermissions={writePermissions} link="ansible_name" onClick={this.onShowAnsibleModal} />
                                 </Fragment>
                             ), size: 'md'
                         },
@@ -152,7 +152,8 @@ SystemCard.propTypes = {
         }))
     }),
     setDisplayName: PropTypes.func,
-    setAnsibleHost: PropTypes.func
+    setAnsibleHost: PropTypes.func,
+    writePermissions: PropTypes.bool
 };
 SystemCard.defaultProps = {
     detailLoaded: false,


### PR DESCRIPTION
See https://github.com/RedHatInsights/insights-inventory-frontend/pull/817

This PR makes **GeneralInfo** to accept `writePermissions` prop.

1. `writePermissions === false`

Edit buttons are **hidden**

2. `writePermissions === true` / `isProd === true`

Edit buttons are **shown**

3. `writePermissions === undefined`

Edit button will use **rbac hook** to decide if it's shown or not. This result is being **cached** to eliminate pop-in when switching tabs.