### PR TITLE
Show currently selected tags above tags table

### DIFF
--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -9,7 +9,9 @@ import {
     EmptyStateVariant,
     Title,
     EmptyStateBody,
-    Button
+    Button,
+    ChipGroup,
+    Chip
 } from '@patternfly/react-core';
 import classNames from 'classnames';
 import {
@@ -63,7 +65,6 @@ export default class TagModal extends React.Component {
             primaryToolbarProps,
             ...props
         } = this.props;
-
         return (
             <Modal
                 {...props}
@@ -86,6 +87,16 @@ export default class TagModal extends React.Component {
                     ]
                 }}
             >
+                {selected?.length > 0 && <ChipGroup>
+                    {selected?.map(({ id, key }) => <Chip
+                        key={key}
+                        isTruncated
+                        onClick={() => onSelect(selected.filter(({ id: currId }) => currId !== id))}
+                    >
+                        {id}
+                    </Chip>)}
+                </ChipGroup>
+                }
                 {onUpdateData && <PrimaryToolbar
                     {...onSelect && pagination && {
                         bulkSelect: {

--- a/packages/components/src/Components/TagModal/tagModal.scss
+++ b/packages/components/src/Components/TagModal/tagModal.scss
@@ -1,3 +1,14 @@
 .ins-c-tag-modal {
     height: calc(var(--pf-global--spacer--4xl) + var(--pf-global--breakpoint--md));
+
+    .pf-c-chip-group {
+        background-color: var(--pf-global--BackgroundColor--100);
+
+        .pf-c-chip {
+            background-color: var(--pf-global--palette--blue-50);
+            border-radius: var(--pf-global--BorderRadius--lg);
+
+            &:before { border-style: none; }
+        }
+    }
 }

--- a/packages/inventory/src/shared/TagsModal.js
+++ b/packages/inventory/src/shared/TagsModal.js
@@ -69,7 +69,7 @@ class TagsModal extends React.Component {
                     }))
                 }}
                 loaded={ loaded }
-                width="auto"
+                width="50%"
                 isOpen={ showTagDialog }
                 toggleModal={() => {
                     this.setState({


### PR DESCRIPTION
### Show currently selected tags

The selection of tags can be a bit confusing and when users switch page they can loose focus on what has been selected. We don't want to group these tags to chipGroups based on the source as this is only informative.

![animation](https://user-images.githubusercontent.com/3439771/95585649-c89ecd80-0a3f-11eb-8357-2165a435994a.gif)
