### PR TITLE
Allow multiple entities to be passed into tags modal

### DIFF
--- a/packages/components/src/Components/TagModal/TableWithFilter.js
+++ b/packages/components/src/Components/TagModal/TableWithFilter.js
@@ -37,7 +37,7 @@ const TableWithFilter = ({
     entityName
 }) => {
     const onRowSelect = ({ isSelected, rowId }) => {
-        const currRow = rows[rowId];
+        const currRow = rows?.[rowId];
         if (currRow) {
             onSelect(isSelected ? [ ...selected, currRow ] : selected.filter(({ id }) => id !== currRow.id));
         }
@@ -50,7 +50,6 @@ const TableWithFilter = ({
                     bulkSelect: {
                         count: selected?.length,
                         onSelect: (isSelected) => {
-                            console.log('mhhh');
                             if (isSelected) {
                                 onSelect(unique?.([ ...rows, ...selected ]));
                             } else {
@@ -63,7 +62,7 @@ const TableWithFilter = ({
                             onClick: () => onSelect([])
                         },
                         {
-                            ...loaded && rows && rows.length > 0 ? {
+                            ...loaded && rows?.length > 0 ? {
                                 title: `Select page (${ rows.length })`,
                                 onClick: () => onSelect(unique([ ...rows, ...selected ]))
                             } : {}

--- a/packages/components/src/Components/TagModal/TableWithFilter.js
+++ b/packages/components/src/Components/TagModal/TableWithFilter.js
@@ -48,15 +48,16 @@ const TableWithFilter = ({
             {onUpdateData && <PrimaryToolbar
                 {...onSelect && pagination && {
                     bulkSelect: {
-                        count: selected.length,
+                        count: selected?.length,
                         onSelect: (isSelected) => {
+                            console.log('mhhh');
                             if (isSelected) {
-                                onSelect(unique([ ...rows, ...selected ]));
+                                onSelect(unique?.([ ...rows, ...selected ]));
                             } else {
                                 onSelect(selected.filter(({ id }) => !rows.find(({ id: rowId }) => rowId === id)));
                             }
                         },
-                        checked: loaded && calculateChecked(rows, selected),
+                        checked: loaded && calculateChecked?.(rows, selected),
                         items: [{
                             title: 'Select none (0)',
                             onClick: () => onSelect([])
@@ -75,8 +76,8 @@ const TableWithFilter = ({
                     }
                 } }
                 pagination={loaded ? {
-                    ...pagination,
-                    itemCount: pagination.count,
+                    ...pagination || {},
+                    itemCount: pagination?.count,
                     onSetPage: (_e, page) => onUpdateData({ ...pagination, page }),
                     onPerPageSelect: (_e, perPage) => onUpdateData({ ...pagination, page: 1, perPage })
                 } : <Skeleton size="lg" />}
@@ -88,7 +89,7 @@ const TableWithFilter = ({
                 variant="compact"
                 className="ins-c-tag-modal__table"
                 cells={columns}
-                rows={rows.length ? rows : [{
+                rows={rows?.length ? rows : [{
                     cells: [{
                         title: (
                             <EmptyTable>
@@ -109,19 +110,19 @@ const TableWithFilter = ({
                         }
                     }]
                 }]}
-                {...onSelect && rows.length && {
+                {...onSelect && rows?.length && {
                     onSelect: (_event, isSelected, rowId) => onRowSelect({ isSelected, rowId })
                 }}
                 { ...tableProps }
             >
                 <TableHeader />
                 <TableBody />
-            </Table> : <SkeletonTable columns={columns} rowSize={pagination.perPage || 10} /> }
-            {onUpdateData && pagination && <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
+            </Table> : <SkeletonTable columns={columns} rowSize={pagination?.perPage || 10} /> }
+            {onUpdateData && pagination && loaded && <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
                 <Pagination
-                    itemCount={pagination.count}
-                    perPage={pagination.perPage}
-                    page={pagination.page}
+                    itemCount={pagination?.count}
+                    perPage={pagination?.perPage}
+                    page={pagination?.page || 0}
                     variant="bottom"
                     onSetPage={(_event, page) => onUpdateData({ ...pagination, page })}
                     onPerPageSelect={(_event, perPage) => onUpdateData({ ...pagination, page: 1, perPage })}

--- a/packages/components/src/Components/TagModal/TableWithFilter.js
+++ b/packages/components/src/Components/TagModal/TableWithFilter.js
@@ -1,0 +1,161 @@
+import React, { Fragment } from 'react';
+import {
+    Pagination,
+    Bullseye,
+    EmptyState,
+    EmptyStateVariant,
+    Title,
+    EmptyStateBody
+} from '@patternfly/react-core';
+import { PropTypes } from 'prop-types';
+import {
+    Table,
+    TableHeader,
+    TableBody
+} from '@patternfly/react-table';
+import { EmptyTable } from '../EmptyTable';
+import { TableToolbar } from '../TableToolbar';
+import { PrimaryToolbar } from '../PrimaryToolbar';
+import { Skeleton } from '../Skeleton';
+import { SkeletonTable } from '../SkeletonTable';
+const TableWithFilter = ({
+    rows,
+    onSelect,
+    selected,
+    onUpdateData,
+    pagination,
+    loaded,
+    calculateChecked,
+    unique,
+    filters,
+    primaryToolbarProps,
+    children,
+    title,
+    systemName,
+    columns,
+    tableProps,
+    entityName
+}) => {
+    const onRowSelect = ({ isSelected, rowId }) => {
+        const currRow = rows[rowId];
+        if (currRow) {
+            onSelect(isSelected ? [ ...selected, currRow ] : selected.filter(({ id }) => id !== currRow.id));
+        }
+    };
+
+    return (
+        <Fragment>
+            {onUpdateData && <PrimaryToolbar
+                {...onSelect && pagination && {
+                    bulkSelect: {
+                        count: selected.length,
+                        onSelect: (isSelected) => {
+                            if (isSelected) {
+                                onSelect(unique([ ...rows, ...selected ]));
+                            } else {
+                                onSelect(selected.filter(({ id }) => !rows.find(({ id: rowId }) => rowId === id)));
+                            }
+                        },
+                        checked: loaded && calculateChecked(rows, selected),
+                        items: [{
+                            title: 'Select none (0)',
+                            onClick: () => onSelect([])
+                        },
+                        {
+                            ...loaded && rows && rows.length > 0 ? {
+                                title: `Select page (${ rows.length })`,
+                                onClick: () => onSelect(unique([ ...rows, ...selected ]))
+                            } : {}
+                        }]
+                    }
+                }}
+                {...filters && {
+                    filterConfig: {
+                        items: filters
+                    }
+                } }
+                pagination={loaded ? {
+                    ...pagination,
+                    itemCount: pagination.count,
+                    onSetPage: (_e, page) => onUpdateData({ ...pagination, page }),
+                    onPerPageSelect: (_e, perPage) => onUpdateData({ ...pagination, page: 1, perPage })
+                } : <Skeleton size="lg" />}
+                {...primaryToolbarProps}
+            /> }
+            {children}
+            {loaded ? <Table
+                aria-label={title || `${systemName} ${entityName}`}
+                variant="compact"
+                className="ins-c-tag-modal__table"
+                cells={columns}
+                rows={rows.length ? rows : [{
+                    cells: [{
+                        title: (
+                            <EmptyTable>
+                                <Bullseye>
+                                    <EmptyState variant={ EmptyStateVariant.full }>
+                                        <Title headingLevel="h5" size="lg">
+                                            No {entityName} found
+                                        </Title>
+                                        <EmptyStateBody>
+                                            This filter criteria matches no {entityName}. <br /> Try changing your filter settings.
+                                        </EmptyStateBody>
+                                    </EmptyState>
+                                </Bullseye>
+                            </EmptyTable>
+                        ),
+                        props: {
+                            colSpan: columns.length
+                        }
+                    }]
+                }]}
+                {...onSelect && rows.length && {
+                    onSelect: (_event, isSelected, rowId) => onRowSelect({ isSelected, rowId })
+                }}
+                { ...tableProps }
+            >
+                <TableHeader />
+                <TableBody />
+            </Table> : <SkeletonTable columns={columns} rowSize={pagination.perPage || 10} /> }
+            {onUpdateData && pagination && <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
+                <Pagination
+                    itemCount={pagination.count}
+                    perPage={pagination.perPage}
+                    page={pagination.page}
+                    variant="bottom"
+                    onSetPage={(_event, page) => onUpdateData({ ...pagination, page })}
+                    onPerPageSelect={(_event, perPage) => onUpdateData({ ...pagination, page: 1, perPage })}
+                />
+            </TableToolbar> }
+        </Fragment>
+    );
+};
+
+TableWithFilter.propTypes = {
+    entityName: PropTypes.string,
+    loaded: PropTypes.bool,
+    systemName: PropTypes.string,
+    rows: PropTypes.array,
+    selected: PropTypes.array,
+    columns: PropTypes.array,
+    filters: PropTypes.array,
+    pagination: PropTypes.shape({
+        count: PropTypes.number,
+        page: PropTypes.number,
+        perPage: PropTypes.number
+    }),
+    primaryToolbarProps: PropTypes.object,
+    tableProps: PropTypes.object,
+    children: PropTypes.node,
+    title: PropTypes.node,
+    calculateChecked: PropTypes.func,
+    unique: PropTypes.func,
+    onSelect: PropTypes.func,
+    onUpdateData: PropTypes.func
+};
+
+TableWithFilter.defaultProps = {
+    entityName: 'tags'
+};
+
+export default TableWithFilter;

--- a/packages/components/src/Components/TagModal/TableWithFilter.test.js
+++ b/packages/components/src/Components/TagModal/TableWithFilter.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import TableWithFilter from './TableWithFilter';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+describe('TableWithFilter', () => {
+    describe('should render', () => {
+        it('without data', () => {
+            const wrapper = shallow(<TableWithFilter />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
+        it('loading and pagination', () => {
+            const onUpdateData = jest.fn();
+            const wrapper = shallow(<TableWithFilter
+                loaded={false}
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+                pagination={{
+                    page: 1
+                }}
+                onUpdateData={onUpdateData}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
+        it('with data', () => {
+            const wrapper = shallow(<TableWithFilter
+                loaded
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
+        it('with data and pagination', () => {
+            const onUpdateData = jest.fn();
+            const wrapper = shallow(<TableWithFilter
+                loaded
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+                pagination={{
+                    page: 1
+                }}
+                onUpdateData={onUpdateData}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+        it('with data and filters', () => {
+            const onUpdateData = jest.fn();
+            const wrapper = shallow(<TableWithFilter
+                loaded
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+                filters={[{ something: '1' }]}
+                onUpdateData={onUpdateData}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
+        it('with data and bulk select without calculate checked', () => {
+            const onUpdateData = jest.fn();
+            const onSelect = jest.fn();
+            const wrapper = shallow(<TableWithFilter
+                loaded
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+                pagination={{
+                    page: 1
+                }}
+                onUpdateData={onUpdateData}
+                onSelect={onSelect}
+                selected={[]}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+        });
+
+        it('with data and bulk select with calculate checked', () => {
+            const onUpdateData = jest.fn();
+            const onSelect = jest.fn();
+            const calculateChecked = jest.fn();
+            const wrapper = shallow(<TableWithFilter
+                loaded
+                rows={[ [ 'one' ] ]}
+                columns={[{ title: 'something' }]}
+                pagination={{
+                    page: 1
+                }}
+                onUpdateData={onUpdateData}
+                onSelect={onSelect}
+                calculateChecked={calculateChecked}
+                selected={[]}
+            />);
+            expect(toJson(wrapper)).toMatchSnapshot();
+            expect(calculateChecked).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -71,6 +71,8 @@ class TagModal extends Component {
             ...props
         } = this.props;
 
+        const isTabbed = Array.isArray(tabNames);
+
         return (
             <Modal
                 {...props}
@@ -85,7 +87,7 @@ class TagModal extends Component {
                             onApply();
                             toggleModal(e, true);
                         }}>
-                            Apply {Array.isArray(tabNames) ? 'selected' : 'tags'}
+                            Apply {isTabbed ? 'selected' : 'tags'}
                         </Button>,
                         <Button key="cancel" variant="link" onClick={(e) => toggleModal(e, false)}>
                             Cancel
@@ -93,33 +95,31 @@ class TagModal extends Component {
                     ]
                 }}
             >
-                {Array.isArray(tabNames) ?
-                    <Fragment>
-                        <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
-                            {
-                                tabNames.map((item, key) => (
-                                    <Tab
-                                        key={key}
-                                        eventKey={key}
-                                        title={<TabTitleText>All {item}</TabTitleText>}
-                                    >
-                                        {
-                                            this.renderTable(
-                                                rows?.[key],
-                                                columns?.[key],
-                                                pagination?.[key],
-                                                loaded?.[key],
-                                                filters?.[key],
-                                                selected?.[key],
-                                                onSelect?.[key],
-                                                onUpdateData?.[key]
-                                            )
-                                        }
-                                    </Tab>
-                                ))
-                            }
-                        </Tabs>
-                    </Fragment> :
+                {isTabbed ?
+                    <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+                        {
+                            tabNames.map((item, key) => (
+                                <Tab
+                                    key={key}
+                                    eventKey={key}
+                                    title={<TabTitleText>All {item}</TabTitleText>}
+                                >
+                                    {
+                                        this.renderTable(
+                                        rows?.[key],
+                                        columns?.[key],
+                                        pagination?.[key],
+                                        loaded?.[key],
+                                        filters?.[key],
+                                        selected?.[key],
+                                        onSelect?.[key],
+                                        onUpdateData?.[key]
+                                        )
+                                    }
+                                </Tab>
+                            ))
+                        }
+                    </Tabs> :
                     this.renderTable(
                         rows,
                         columns,

--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -1,27 +1,16 @@
-import React from 'react';
+import React, { Component, Fragment, createRef } from 'react';
 import PropTypes from 'prop-types';
 import './tagModal.scss';
 import {
     Modal,
-    Pagination,
-    Bullseye,
-    EmptyState,
-    EmptyStateVariant,
-    Title,
-    EmptyStateBody,
-    Button
+    Button,
+    Tabs,
+    Tab,
+    TabTitleText,
+    TabContent
 } from '@patternfly/react-core';
 import classNames from 'classnames';
-import {
-    Table,
-    TableHeader,
-    TableBody
-} from '@patternfly/react-table';
-import { EmptyTable } from '../EmptyTable';
-import { TableToolbar } from '../TableToolbar';
-import { PrimaryToolbar } from '../PrimaryToolbar';
-import { Skeleton } from '../Skeleton';
-import { SkeletonTable } from '../SkeletonTable';
+import TableWithFilter from './TableWithFilter';
 
 const calculateChecked = (rows = [], selected) => (
     rows.every(({ id }) => selected && selected.find(({ id: selectedId }) => selectedId === id))
@@ -33,14 +22,41 @@ const unique = (arr) => (
     arr.filter(({ id }, index, arr) => arr.findIndex(({ id: currId }) => currId === id) === index)
 );
 
-export default class TagModal extends React.Component {
-    onSelect = ({ isSelected, rowId }) => {
-        const { rows, onSelect, selected } = this.props;
-        const currRow = rows[rowId];
-        if (currRow) {
-            onSelect(isSelected ? [ ...selected, currRow ] : selected.filter(({ id }) => id !== currRow.id));
+class TagModal extends Component {
+    contentRefs = [];
+    state = {
+        selectedTab: 0
+    };
+
+    componentDidMount() {
+        const { tabNames } = this.props;
+        if (Array.isArray(tabNames)) {
+            tabNames.forEach((_item, key) => {
+                this.contentRefs[key] = createRef();
+            });
         }
     }
+
+    handleTabClick = (_event, tabIndex) => {
+        this.setState({ activeTabKey: tabIndex });
+    };
+
+    renderTable = (rows, columns, pagination, loaded, filters) => (
+        <TableWithFilter
+            rows={rows}
+            pagination={pagination}
+            loaded={loaded}
+            calculateChecked={calculateChecked}
+            unique={unique}
+            filters={filters}
+            title={this.props.title}
+            systemName={this.props.systemName}
+            columns={columns}
+            {...this.props}
+        >
+            {this.props.children}
+        </TableWithFilter>
+    );
 
     render() {
         const {
@@ -52,15 +68,11 @@ export default class TagModal extends React.Component {
             rows,
             columns,
             children,
-            tableProps,
             pagination,
-            onUpdateData,
             loaded,
             filters,
-            onSelect,
-            selected,
             onApply,
-            primaryToolbarProps,
+            tabNames,
             ...props
         } = this.props;
 
@@ -86,94 +98,45 @@ export default class TagModal extends React.Component {
                     ]
                 }}
             >
-                {onUpdateData && <PrimaryToolbar
-                    {...onSelect && pagination && {
-                        bulkSelect: {
-                            count: selected.length,
-                            onSelect: (isSelected) => {
-                                if (isSelected) {
-                                    onSelect(unique([ ...rows, ...selected ]));
-                                } else {
-                                    onSelect(selected.filter(({ id }) => !rows.find(({ id: rowId }) => rowId === id)));
-                                }
-                            },
-                            checked: loaded && calculateChecked(rows, selected),
-                            items: [{
-                                title: 'Select none (0)',
-                                onClick: () => onSelect([])
-                            },
+                {Array.isArray(tabNames) ?
+                    <Fragment>
+                        <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
                             {
-                                ...loaded && rows && rows.length > 0 ? {
-                                    title: `Select page (${ rows.length })`,
-                                    onClick: () => onSelect(unique([ ...rows, ...selected ]))
-                                } : {}
-                            }]
-                        }
-                    }}
-                    {...filters && {
-                        filterConfig: {
-                            items: filters
-                        }
-                    } }
-                    pagination={loaded ? {
-                        ...pagination,
-                        itemCount: pagination.count,
-                        onSetPage: (_e, page) => onUpdateData({ ...pagination, page }),
-                        onPerPageSelect: (_e, perPage) => onUpdateData({ ...pagination, page: 1, perPage })
-                    } : <Skeleton size="lg" />}
-                    {...primaryToolbarProps}
-                /> }
-                {children}
-                {loaded ? <Table
-                    aria-label={title || `${systemName} tags`}
-                    variant="compact"
-                    className="ins-c-tag-modal__table"
-                    cells={columns}
-                    rows={rows.length ? rows : [{
-                        cells: [{
-                            title: (
-                                <EmptyTable>
-                                    <Bullseye>
-                                        <EmptyState variant={ EmptyStateVariant.full }>
-                                            <Title headingLevel="h5" size="lg">
-                                                No tags found
-                                            </Title>
-                                            <EmptyStateBody>
-                                                This filter criteria matches no tags. <br /> Try changing your filter settings.
-                                            </EmptyStateBody>
-                                        </EmptyState>
-                                    </Bullseye>
-                                </EmptyTable>
-                            ),
-                            props: {
-                                colSpan: columns.length
+                                tabNames.map((item, key) => (
+                                    <Tab
+                                        key={key}
+                                        eventKey={key}
+                                        title={<TabTitleText>All {item}</TabTitleText>}
+                                        tabContentId={`refTab${key}Section`}
+                                        tabContentRef={this.contentRefs[key]}
+                                    />
+                                ))
                             }
-                        }]
-                    }]}
-                    {...onSelect && rows.length && {
-                        onSelect: (_event, isSelected, rowId) => this.onSelect({ isSelected, rowId })
-                    }}
-                    { ...tableProps }
-                >
-                    <TableHeader />
-                    <TableBody />
-                </Table> : <SkeletonTable columns={columns} rowSize={pagination.perPage || 10} /> }
-                {onUpdateData && pagination && <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
-                    <Pagination
-                        itemCount={pagination.count}
-                        perPage={pagination.perPage}
-                        page={pagination.page}
-                        variant="bottom"
-                        onSetPage={(_event, page) => onUpdateData({ ...pagination, page })}
-                        onPerPageSelect={(_event, perPage) => onUpdateData({ ...pagination, page: 1, perPage })}
-                    />
-                </TableToolbar> }
+                        </Tabs>
+                        <div>
+                            {
+                                tabNames.map((item, key) => (
+                                    <TabContent
+                                        key={key}
+                                        eventKey={key}
+                                        id={`refTab${key}Section`}
+                                        ref={this.contentRefs[key]}
+                                        aria-label={`All ${item}`}
+                                    >
+                                        {this.renderTable(rows, columns, pagination, loaded, filters)}
+                                    </TabContent>
+                                ))
+                            }
+                        </div>
+                    </Fragment> :
+                    this.renderTable(rows, columns, pagination, loaded, filters)}
             </Modal>
         );
     }
 }
 
 TagModal.propTypes = {
+    tabNames: PropTypes.string,
     loaded: PropTypes.bool,
     title: PropTypes.string,
     systemName: PropTypes.string,
@@ -211,3 +174,5 @@ TagModal.defaultProps = {
     tableProps: {},
     pagination: { count: 10 }
 };
+
+export default TagModal;

--- a/packages/components/src/Components/TagModal/TagModal.test.js
+++ b/packages/components/src/Components/TagModal/TagModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import TagModal from './TagModal';
 
@@ -13,6 +13,43 @@ describe('TagCount component', () => {
         const wrapper = shallow(<TagModal loaded isOpen={true} systemName={'paul.localhost.com'}>
             <h1>I am a child component</h1>
         </TagModal>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});
+
+describe('Two tables', () => {
+    it('should render two tables in loading state', () => {
+        const wrapper = shallow(<TagModal
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            tabNames={[ 'something', 'another' ]}
+            rows={[
+                [ [ 'something' ] ],
+                [ [ 'another' ] ]
+            ]}
+            columns={[
+                [{ title: 'one' }],
+                [{ title: 'two' }]
+            ]}
+        />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render two tables', () => {
+        const wrapper = shallow(<TagModal
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            tabNames={[ 'something', 'another' ]}
+            loaded={[ true, true ]}
+            rows={[
+                [ [ 'something' ] ],
+                [ [ 'another' ] ]
+            ]}
+            columns={[
+                [{ title: 'one' }],
+                [{ title: 'two' }]
+            ]}
+        />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/packages/components/src/Components/TagModal/__snapshots__/TableWithFilter.test.js.snap
+++ b/packages/components/src/Components/TagModal/__snapshots__/TableWithFilter.test.js.snap
@@ -1,0 +1,502 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableWithFilter should render loading and pagination 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    pagination={
+      <Skeleton
+        isDark={false}
+        size="lg"
+      />
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <SkeletonTable
+    columns={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    paddingColumnSize={0}
+    rowSize={10}
+  />
+</Fragment>
+`;
+
+exports[`TableWithFilter should render with data 1`] = `
+<Fragment>
+  <Table
+    aria-label="undefined tags"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    className="ins-c-tag-modal__table"
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Array [
+          "one",
+        ],
+      ]
+    }
+    variant="compact"
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+</Fragment>
+`;
+
+exports[`TableWithFilter should render with data and bulk select with calculate checked 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    bulkSelect={
+      Object {
+        "checked": undefined,
+        "count": 0,
+        "items": Array [
+          Object {
+            "onClick": [Function],
+            "title": "Select none (0)",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Select page (1)",
+          },
+        ],
+        "onSelect": [Function],
+      }
+    }
+    pagination={
+      Object {
+        "itemCount": undefined,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+        "page": 1,
+      }
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <Table
+    aria-label="undefined tags"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    className="ins-c-tag-modal__table"
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Array [
+          "one",
+        ],
+      ]
+    }
+    variant="compact"
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Pagination
+      className=""
+      defaultToFullPage={false}
+      firstPage={1}
+      isCompact={false}
+      isDisabled={false}
+      itemsEnd={null}
+      itemsStart={null}
+      offset={0}
+      onFirstClick={[Function]}
+      onLastClick={[Function]}
+      onNextClick={[Function]}
+      onPageInput={[Function]}
+      onPerPageSelect={[Function]}
+      onPreviousClick={[Function]}
+      onSetPage={[Function]}
+      ouiaSafe={true}
+      page={1}
+      perPage={10}
+      perPageOptions={
+        Array [
+          Object {
+            "title": "10",
+            "value": 10,
+          },
+          Object {
+            "title": "20",
+            "value": 20,
+          },
+          Object {
+            "title": "50",
+            "value": 50,
+          },
+          Object {
+            "title": "100",
+            "value": 100,
+          },
+        ]
+      }
+      titles={
+        Object {
+          "currPage": "Current page",
+          "items": "",
+          "itemsPerPage": "Items per page",
+          "optionsToggle": "Items per page",
+          "page": "",
+          "paginationTitle": "Pagination",
+          "perPageSuffix": "per page",
+          "toFirstPage": "Go to first page",
+          "toLastPage": "Go to last page",
+          "toNextPage": "Go to next page",
+          "toPreviousPage": "Go to previous page",
+        }
+      }
+      toggleTemplate={[Function]}
+      variant="bottom"
+      widgetId="pagination-options-menu"
+    />
+  </TableToolbar>
+</Fragment>
+`;
+
+exports[`TableWithFilter should render with data and bulk select without calculate checked 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    bulkSelect={
+      Object {
+        "checked": undefined,
+        "count": 0,
+        "items": Array [
+          Object {
+            "onClick": [Function],
+            "title": "Select none (0)",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Select page (1)",
+          },
+        ],
+        "onSelect": [Function],
+      }
+    }
+    pagination={
+      Object {
+        "itemCount": undefined,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+        "page": 1,
+      }
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <Table
+    aria-label="undefined tags"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    className="ins-c-tag-modal__table"
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Array [
+          "one",
+        ],
+      ]
+    }
+    variant="compact"
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Pagination
+      className=""
+      defaultToFullPage={false}
+      firstPage={1}
+      isCompact={false}
+      isDisabled={false}
+      itemsEnd={null}
+      itemsStart={null}
+      offset={0}
+      onFirstClick={[Function]}
+      onLastClick={[Function]}
+      onNextClick={[Function]}
+      onPageInput={[Function]}
+      onPerPageSelect={[Function]}
+      onPreviousClick={[Function]}
+      onSetPage={[Function]}
+      ouiaSafe={true}
+      page={1}
+      perPage={10}
+      perPageOptions={
+        Array [
+          Object {
+            "title": "10",
+            "value": 10,
+          },
+          Object {
+            "title": "20",
+            "value": 20,
+          },
+          Object {
+            "title": "50",
+            "value": 50,
+          },
+          Object {
+            "title": "100",
+            "value": 100,
+          },
+        ]
+      }
+      titles={
+        Object {
+          "currPage": "Current page",
+          "items": "",
+          "itemsPerPage": "Items per page",
+          "optionsToggle": "Items per page",
+          "page": "",
+          "paginationTitle": "Pagination",
+          "perPageSuffix": "per page",
+          "toFirstPage": "Go to first page",
+          "toLastPage": "Go to last page",
+          "toNextPage": "Go to next page",
+          "toPreviousPage": "Go to previous page",
+        }
+      }
+      toggleTemplate={[Function]}
+      variant="bottom"
+      widgetId="pagination-options-menu"
+    />
+  </TableToolbar>
+</Fragment>
+`;
+
+exports[`TableWithFilter should render with data and filters 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    filterConfig={
+      Object {
+        "items": Array [
+          Object {
+            "something": "1",
+          },
+        ],
+      }
+    }
+    pagination={
+      Object {
+        "itemCount": undefined,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+      }
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <Table
+    aria-label="undefined tags"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    className="ins-c-tag-modal__table"
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Array [
+          "one",
+        ],
+      ]
+    }
+    variant="compact"
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+</Fragment>
+`;
+
+exports[`TableWithFilter should render with data and pagination 1`] = `
+<Fragment>
+  <PrimaryToolbar
+    pagination={
+      Object {
+        "itemCount": undefined,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+        "page": 1,
+      }
+    }
+    toggleIsExpanded={[Function]}
+  />
+  <Table
+    aria-label="undefined tags"
+    borders={true}
+    canSelectAll={true}
+    cells={
+      Array [
+        Object {
+          "title": "something",
+        },
+      ]
+    }
+    className="ins-c-tag-modal__table"
+    contentId="expanded-content"
+    dropdownDirection="down"
+    dropdownPosition="right"
+    expandId="expandable-toggle"
+    gridBreakPoint="grid-md"
+    isStickyHeader={false}
+    ouiaSafe={true}
+    role="grid"
+    rowLabeledBy="simple-node"
+    rows={
+      Array [
+        Array [
+          "one",
+        ],
+      ]
+    }
+    variant="compact"
+  >
+    <TableHeader />
+    <Component />
+  </Table>
+  <TableToolbar
+    className="ins-c-inventory__table--toolbar"
+    isFooter={true}
+  >
+    <Pagination
+      className=""
+      defaultToFullPage={false}
+      firstPage={1}
+      isCompact={false}
+      isDisabled={false}
+      itemsEnd={null}
+      itemsStart={null}
+      offset={0}
+      onFirstClick={[Function]}
+      onLastClick={[Function]}
+      onNextClick={[Function]}
+      onPageInput={[Function]}
+      onPerPageSelect={[Function]}
+      onPreviousClick={[Function]}
+      onSetPage={[Function]}
+      ouiaSafe={true}
+      page={1}
+      perPage={10}
+      perPageOptions={
+        Array [
+          Object {
+            "title": "10",
+            "value": 10,
+          },
+          Object {
+            "title": "20",
+            "value": 20,
+          },
+          Object {
+            "title": "50",
+            "value": 50,
+          },
+          Object {
+            "title": "100",
+            "value": 100,
+          },
+        ]
+      }
+      titles={
+        Object {
+          "currPage": "Current page",
+          "items": "",
+          "itemsPerPage": "Items per page",
+          "optionsToggle": "Items per page",
+          "page": "",
+          "paginationTitle": "Pagination",
+          "perPageSuffix": "per page",
+          "toFirstPage": "Go to first page",
+          "toLastPage": "Go to last page",
+          "toNextPage": "Go to next page",
+          "toPreviousPage": "Go to previous page",
+        }
+      }
+      toggleTemplate={[Function]}
+      variant="bottom"
+      widgetId="pagination-options-menu"
+    />
+  </TableToolbar>
+</Fragment>
+`;
+
+exports[`TableWithFilter should render without data 1`] = `
+<Fragment>
+  <SkeletonTable
+    paddingColumnSize={0}
+    rowSize={10}
+  />
+</Fragment>
+`;

--- a/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
+++ b/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
@@ -13,25 +13,13 @@ exports[`TagCount component Render the modal open with row of tags 1`] = `
   onClose={[Function]}
   ouiaSafe={true}
   showClose={true}
+  tableProps={Object {}}
   title="Tags for paul.localhost.com"
   variant="medium"
 >
-  <PrimaryToolbar
-    pagination={
-      Object {
-        "count": 10,
-        "itemCount": 10,
-        "onPerPageSelect": [Function],
-        "onSetPage": [Function],
-      }
-    }
-    toggleIsExpanded={[Function]}
-  />
-  <Table
-    aria-label="paul.localhost.com tags"
-    borders={true}
-    canSelectAll={true}
-    cells={
+  <TableWithFilter
+    calculateChecked={[Function]}
+    columns={
       Array [
         Object {
           "title": "Name",
@@ -41,16 +29,15 @@ exports[`TagCount component Render the modal open with row of tags 1`] = `
         },
       ]
     }
-    className="ins-c-tag-modal__table"
-    contentId="expanded-content"
-    dropdownDirection="down"
-    dropdownPosition="right"
-    expandId="expandable-toggle"
-    gridBreakPoint="grid-md"
-    isStickyHeader={false}
-    ouiaSafe={true}
-    role="grid"
-    rowLabeledBy="simple-node"
+    entityName="tags"
+    isOpen={true}
+    loaded={true}
+    onUpdateData={[Function]}
+    pagination={
+      Object {
+        "count": 10,
+      }
+    }
     rows={
       Array [
         Array [
@@ -63,75 +50,11 @@ exports[`TagCount component Render the modal open with row of tags 1`] = `
         ],
       ]
     }
-    variant="compact"
-  >
-    <TableHeader />
-    <Component />
-  </Table>
-  <TableToolbar
-    className="ins-c-inventory__table--toolbar"
-    isFooter={true}
-  >
-    <Pagination
-      className=""
-      defaultToFullPage={false}
-      firstPage={1}
-      isCompact={false}
-      isDisabled={false}
-      itemCount={10}
-      itemsEnd={null}
-      itemsStart={null}
-      offset={0}
-      onFirstClick={[Function]}
-      onLastClick={[Function]}
-      onNextClick={[Function]}
-      onPageInput={[Function]}
-      onPerPageSelect={[Function]}
-      onPreviousClick={[Function]}
-      onSetPage={[Function]}
-      ouiaSafe={true}
-      page={0}
-      perPage={10}
-      perPageOptions={
-        Array [
-          Object {
-            "title": "10",
-            "value": 10,
-          },
-          Object {
-            "title": "20",
-            "value": 20,
-          },
-          Object {
-            "title": "50",
-            "value": 50,
-          },
-          Object {
-            "title": "100",
-            "value": 100,
-          },
-        ]
-      }
-      titles={
-        Object {
-          "currPage": "Current page",
-          "items": "",
-          "itemsPerPage": "Items per page",
-          "optionsToggle": "Items per page",
-          "page": "",
-          "paginationTitle": "Pagination",
-          "perPageSuffix": "per page",
-          "toFirstPage": "Go to first page",
-          "toLastPage": "Go to last page",
-          "toNextPage": "Go to next page",
-          "toPreviousPage": "Go to previous page",
-        }
-      }
-      toggleTemplate={[Function]}
-      variant="bottom"
-      widgetId="pagination-options-menu"
-    />
-  </TableToolbar>
+    systemName="paul.localhost.com"
+    tableProps={Object {}}
+    toggleModal={[Function]}
+    unique={[Function]}
+  />
 </Modal>
 `;
 
@@ -148,28 +71,13 @@ exports[`TagCount component Render the modal with a child component 1`] = `
   onClose={[Function]}
   ouiaSafe={true}
   showClose={true}
+  tableProps={Object {}}
   title="Tags for paul.localhost.com"
   variant="medium"
 >
-  <PrimaryToolbar
-    pagination={
-      Object {
-        "count": 10,
-        "itemCount": 10,
-        "onPerPageSelect": [Function],
-        "onSetPage": [Function],
-      }
-    }
-    toggleIsExpanded={[Function]}
-  />
-  <h1>
-    I am a child component
-  </h1>
-  <Table
-    aria-label="paul.localhost.com tags"
-    borders={true}
-    canSelectAll={true}
-    cells={
+  <TableWithFilter
+    calculateChecked={[Function]}
+    columns={
       Array [
         Object {
           "title": "Name",
@@ -179,116 +87,256 @@ exports[`TagCount component Render the modal with a child component 1`] = `
         },
       ]
     }
-    className="ins-c-tag-modal__table"
-    contentId="expanded-content"
-    dropdownDirection="down"
-    dropdownPosition="right"
-    expandId="expandable-toggle"
-    gridBreakPoint="grid-md"
-    isStickyHeader={false}
-    ouiaSafe={true}
-    role="grid"
-    rowLabeledBy="simple-node"
-    rows={
-      Array [
-        Object {
-          "cells": Array [
-            Object {
-              "props": Object {
-                "colSpan": 2,
-              },
-              "title": <EmptyTable>
-                <Bullseye>
-                  <EmptyState
-                    variant="full"
-                  >
-                    <Title
-                      headingLevel="h5"
-                      size="lg"
-                    >
-                      No tags found
-                    </Title>
-                    <EmptyStateBody>
-                      This filter criteria matches no tags. 
-                      <br />
-                       Try changing your filter settings.
-                    </EmptyStateBody>
-                  </EmptyState>
-                </Bullseye>
-              </EmptyTable>,
-            },
-          ],
-        },
-      ]
+    entityName="tags"
+    isOpen={true}
+    loaded={true}
+    onUpdateData={[Function]}
+    pagination={
+      Object {
+        "count": 10,
+      }
     }
-    variant="compact"
+    rows={Array []}
+    systemName="paul.localhost.com"
+    tableProps={Object {}}
+    toggleModal={[Function]}
+    unique={[Function]}
   >
-    <TableHeader />
-    <Component />
-  </Table>
-  <TableToolbar
-    className="ins-c-inventory__table--toolbar"
-    isFooter={true}
+    <h1>
+      I am a child component
+    </h1>
+  </TableWithFilter>
+</Modal>
+`;
+
+exports[`Two tables should render two tables 1`] = `
+<Modal
+  actions={Array []}
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <Tabs
+    activeKey={0}
+    component="div"
+    isBox={false}
+    isFilled={false}
+    isSecondary={false}
+    isVertical={false}
+    leftScrollAriaLabel="Scroll left"
+    mountOnEnter={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    rightScrollAriaLabel="Scroll right"
+    unmountOnExit={false}
   >
-    <Pagination
-      className=""
-      defaultToFullPage={false}
-      firstPage={1}
-      isCompact={false}
-      isDisabled={false}
-      itemCount={10}
-      itemsEnd={null}
-      itemsStart={null}
-      offset={0}
-      onFirstClick={[Function]}
-      onLastClick={[Function]}
-      onNextClick={[Function]}
-      onPageInput={[Function]}
-      onPerPageSelect={[Function]}
-      onPreviousClick={[Function]}
-      onSetPage={[Function]}
-      ouiaSafe={true}
-      page={0}
-      perPage={10}
-      perPageOptions={
-        Array [
-          Object {
-            "title": "10",
-            "value": 10,
-          },
-          Object {
-            "title": "20",
-            "value": 20,
-          },
-          Object {
-            "title": "50",
-            "value": 50,
-          },
-          Object {
-            "title": "100",
-            "value": 100,
-          },
-        ]
+    <Tab
+      eventKey={0}
+      key="0"
+      title={
+        <TabTitleText>
+          All 
+          something
+        </TabTitleText>
       }
-      titles={
-        Object {
-          "currPage": "Current page",
-          "items": "",
-          "itemsPerPage": "Items per page",
-          "optionsToggle": "Items per page",
-          "page": "",
-          "paginationTitle": "Pagination",
-          "perPageSuffix": "per page",
-          "toFirstPage": "Go to first page",
-          "toLastPage": "Go to last page",
-          "toNextPage": "Go to next page",
-          "toPreviousPage": "Go to previous page",
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "one",
+            },
+          ]
         }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        rows={
+          Array [
+            Array [
+              "something",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+    <Tab
+      eventKey={1}
+      key="1"
+      title={
+        <TabTitleText>
+          All 
+          another
+        </TabTitleText>
       }
-      toggleTemplate={[Function]}
-      variant="bottom"
-      widgetId="pagination-options-menu"
-    />
-  </TableToolbar>
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "two",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        rows={
+          Array [
+            Array [
+              "another",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+  </Tabs>
+</Modal>
+`;
+
+exports[`Two tables should render two tables in loading state 1`] = `
+<Modal
+  actions={Array []}
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <Tabs
+    activeKey={0}
+    component="div"
+    isBox={false}
+    isFilled={false}
+    isSecondary={false}
+    isVertical={false}
+    leftScrollAriaLabel="Scroll left"
+    mountOnEnter={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    rightScrollAriaLabel="Scroll right"
+    unmountOnExit={false}
+  >
+    <Tab
+      eventKey={0}
+      key="0"
+      title={
+        <TabTitleText>
+          All 
+          something
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "one",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        rows={
+          Array [
+            Array [
+              "something",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+    <Tab
+      eventKey={1}
+      key="1"
+      title={
+        <TabTitleText>
+          All 
+          another
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "two",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        rows={
+          Array [
+            Array [
+              "another",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+  </Tabs>
 </Modal>
 `;


### PR DESCRIPTION
### Enable multiple tabs in tags modal

Since we have tags and SIDs fro users as single global filter, we should also allow them to see all SIDs and tags on one place. By default only 10 SIDs is visible so if user has more then these 10 items they could be hidden, introduce tabbed tags modal in order to show all tags and SIDs on one place. This is achieved by passing array of `rows`, `columns`, `paginations`, `loaded`, `filters`, `selected`, `onSelect` and `onUpdateData`. This means that consumers willing to show more than one table will have to pass array of these props matching tabs and it will show tables with corresponding data. If they pass something bad in there, for instance wrong rows it will break, but that's to be expected.

### Screenshots
![Screenshot from 2020-10-14 14-32-57](https://user-images.githubusercontent.com/3439771/95989976-3de91480-0e2b-11eb-98b0-3ed093ac042e.png)
![Screenshot from 2020-10-14 14-33-03](https://user-images.githubusercontent.com/3439771/95989989-417c9b80-0e2b-11eb-9d80-9b8e8173bc91.png)

