### PR TITLE
Disable bulk select in inventory if isDisabled passed in bulk props

### DIFF
--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -298,7 +298,7 @@ const EntityTableToolbar = ({
             {...props}
             bulkSelect={{
                 ...bulkSelect,
-                isDisabled: !hasAccess
+                isDisabled: bulkSelect?.isDisabled || !hasAccess
             }}
             className={`ins-c-inventory__table--toolbar ${hasItems ? 'ins-c-inventory__table--toolbar-has-items' : ''}`}
             {...inventoryFilters?.length > 0 && {


### PR DESCRIPTION
### Do not shadow `isDisabled`

Since inventory consumers might decide to disable bulk select on their own do not shadow that property and rather use the one passed in from consumer app and only if that is either undefined or false use `hasAccess`.