### PR TITLE
Fix failing global filter by passing empty value to view more group

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -279,7 +279,7 @@ class Group extends Component {
                     ) }
                 </div>
                 { onShowMore ?
-                    <SelectGroup>
+                    <SelectGroup value="">
                         <Button
                             {...showMore.items[0]}
                             className="pf-c-select__menu-item"

--- a/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
+++ b/packages/components/src/Components/ConditionalFilter/__snapshots__/Group.test.js.snap
@@ -1327,7 +1327,9 @@ exports[`Group - component render show more should render correctly with items a
         </SelectOption>
       </SelectGroup>
     </div>
-    <SelectGroup>
+    <SelectGroup
+      value=""
+    >
       <Button
         className="pf-c-select__menu-item"
         label="Show more"
@@ -1563,7 +1565,9 @@ exports[`Group - component render show more should render correctly with items a
         </SelectOption>
       </SelectGroup>
     </div>
-    <SelectGroup>
+    <SelectGroup
+      value=""
+    >
       <Button
         className="pf-c-select__menu-item"
         label="some title"
@@ -1794,7 +1798,9 @@ exports[`Group - component render show more should render correctly with items a
         </SelectOption>
       </SelectGroup>
     </div>
-    <SelectGroup>
+    <SelectGroup
+      value=""
+    >
       <Button
         className="pf-c-select__menu-item"
         label="Show more"
@@ -2025,7 +2031,9 @@ exports[`Group - component render show more should render correctly with items a
         </SelectOption>
       </SelectGroup>
     </div>
-    <SelectGroup>
+    <SelectGroup
+      value=""
+    >
       <Button
         className="pf-c-select__menu-item"
         label="Show more"

--- a/packages/components/src/Components/FilterHooks/tagFilterHook.js
+++ b/packages/components/src/Components/FilterHooks/tagFilterHook.js
@@ -61,8 +61,10 @@ export const useTagsFilter = (
                 ...constructGroups(allTags, itemText)
             ]
         } : {
+            value: '',
             items: [
                 {
+                    value: '',
                     label: !state.loaded ?
                         <span> <Spinner size="md" /> </span> :
                         <div className="ins-c-tagfilter__no-tags"> No tags available </div>,

--- a/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
@@ -339,11 +339,13 @@ exports[`EntityTableToolbar DOM should render correctly - with custom activeFilt
                   />
                    
                 </span>,
+                "value": "",
               },
             ],
             "onChange": [Function],
             "onFilter": [Function],
             "selected": Object {},
+            "value": "",
           },
           "label": "Tags",
           "placeholder": "Filter system by tag",
@@ -917,11 +919,13 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
                   />
                    
                 </span>,
+                "value": "",
               },
             ],
             "onChange": [Function],
             "onFilter": [Function],
             "selected": Object {},
+            "value": "",
           },
           "label": "Tags",
           "placeholder": "Filter system by tag",


### PR DESCRIPTION
### Broken UI when no value prop is passed

Hopefully this is the last place where FF just fails if no prop `value` is present.