### PR TITLE
Use id as value for select option

### DIFF
--- a/packages/components/src/Components/ConditionalFilter/Group.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.js
@@ -95,10 +95,9 @@ class Group extends Component {
                         <Checkbox
                             {...itemProps}
                             label={label}
-                            isChecked={
-                                isChecked ||
-                            this.isChecked(groupValue || groupKey, value || key) ||
-                            false
+                            isChecked={isChecked ||
+                                this.isChecked(groupValue || groupKey, value || key, id, item?.tagValue) ||
+                                false
                             }
                             onChange={(value, event) => {
                                 item.onChange && item.onChange(value, event);
@@ -109,7 +108,7 @@ class Group extends Component {
                             <Radio
                                 isChecked={
                                     isChecked ||
-                            this.isChecked(groupValue || groupKey, value || key) ||
+                            this.isChecked(groupValue || groupKey, value || key, id, item?.tagValue) ||
                             false
                                 }
                                 onChange={(value, event) => {
@@ -188,7 +187,7 @@ class Group extends Component {
         });
     };
 
-    isChecked = (groupValue, itemValue) => {
+    isChecked = (groupValue, itemValue, id, tagValue) => {
         const { selected: stateSelected } = this.state;
         const { selected: propSelected } = this.props;
         const selected = {
@@ -199,9 +198,19 @@ class Group extends Component {
             return false;
         }
 
-        return selected[groupValue][itemValue] instanceof Object ?
-            selected[groupValue][itemValue].isSelected :
-            Boolean(selected[groupValue][itemValue]);
+        if (selected[groupValue][itemValue] instanceof Object) {
+            if (selected[groupValue][itemValue].isSelected) {
+                if (selected[groupValue][itemValue]?.item?.id) {
+                    return id === selected[groupValue][itemValue]?.item?.id;
+                } else if (selected[groupValue][itemValue]?.item?.tagValue) {
+                    return tagValue === selected[groupValue][itemValue]?.item?.tagValue;
+                }
+            }
+
+            return selected[groupValue][itemValue].isSelected;
+        }
+
+        return Boolean(selected[groupValue][itemValue]);
     }
 
     customFilter = (e) => {

--- a/packages/components/src/Components/ConditionalFilter/Group.test.js
+++ b/packages/components/src/Components/ConditionalFilter/Group.test.js
@@ -187,6 +187,82 @@ describe('Group - component', () => {
             expect(onSelect).toHaveBeenCalled();
         });
 
+        it(`should select correct item with same values but different id`, () => {
+            const wrapper = mount(
+                <Group
+                    {...config}
+                    groups={[{
+                        label: 'First value',
+                        type: 'checkbox',
+                        items: [
+                            {
+                                label: 'First value',
+                                value: 'first',
+                                id: 'first-value'
+                            },
+                            {
+                                label: 'Second value',
+                                value: 'first',
+                                id: 'second-value'
+                            }
+                        ]
+                    }]}
+                    selected={{
+                        0: {
+                            first: {
+                                isSelected: true,
+                                item: {
+                                    id: 'first-value'
+                                }
+                            }
+                        }
+                    }}
+                />
+            );
+            wrapper.find('button.pf-c-select__toggle-button').first().simulate('click');
+            wrapper.update();
+            expect(wrapper.find('input[type="checkbox"]').first().props().checked).toBe(true);
+            expect(wrapper.find('input[type="checkbox"]').at(1).props().checked).toBe(false);
+        });
+
+        it(`should select correct item with same values but different tagValue`, () => {
+            const wrapper = mount(
+                <Group
+                    {...config}
+                    groups={[{
+                        label: 'First value',
+                        type: 'checkbox',
+                        items: [
+                            {
+                                label: 'First value',
+                                value: 'first',
+                                tagValue: 'first'
+                            },
+                            {
+                                label: 'Second value',
+                                value: 'first',
+                                tagValue: 'second'
+                            }
+                        ]
+                    }]}
+                    selected={{
+                        0: {
+                            first: {
+                                isSelected: true,
+                                item: {
+                                    tagValue: 'first'
+                                }
+                            }
+                        }
+                    }}
+                />
+            );
+            wrapper.find('button.pf-c-select__toggle-button').first().simulate('click');
+            wrapper.update();
+            expect(wrapper.find('input[type="checkbox"]').first().props().checked).toBe(true);
+            expect(wrapper.find('input[type="checkbox"]').at(1).props().checked).toBe(false);
+        });
+
         [ 'check', 'radio' ].map((type, key) => {
             it(`should call item onChange - ${type}`, () => {
                 const onChange = jest.fn();

--- a/packages/components/src/Components/FilterHooks/constants.js
+++ b/packages/components/src/Components/FilterHooks/constants.js
@@ -78,6 +78,7 @@ export function constructGroups(allTags, item = 'item') {
                         value
                     }
                 },
+                id: `${tagKey}-${value}`,
                 value: tagKey,
                 tagValue: value
             });


### PR DESCRIPTION
### Fixes double select of same value in groupped view

If there are multiple group entries with same value (calculated option) we want to use either `id` or `tagValue` for checking what has been selected in order to prevent multiple selected when clicked on one item.

Fixes: RHCLOUD-10042