### PR TITLE
Add new rules to eslint plugin

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -22,6 +22,16 @@ module.exports = {
         'plugin:react/recommended',
         'prettier/react'
     ],
+    rules: {
+        'no-unused-vars': [
+            'error',
+            { ignoreRestSiblings: true }
+        ],
+        'prettier/prettier': [
+            'error',
+            { singleQuote: true }
+        ]
+    },
     parserOptions: {
         ecmaVersion: 7,
         sourceType: 'module'


### PR DESCRIPTION
### Update default rules

When consuming eslint-plugin it will throw errors when destructing object with unused vars, this PR fixes it by using `ignoreRestSiblings` rule. Also force prettier to use single quotes over double ones by adding `prettier/prettier: [ { singleQuote: true } ]`.