### PR TITLE
Updating Cost AWS wizard to include prefix name

### DIFF
--- a/packages/sources/src/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/packages/sources/src/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -75,7 +75,7 @@ export const UsageDescription = () => {
                     <TextListItem>
                         { intl.formatMessage({
                             id: 'cost.usageDescription.reportPathPrefix',
-                            defaultMessage: 'Report path prefix: (leave blank)'
+                            defaultMessage: 'Report path prefix: cost'
                         }) }
                     </TextListItem>
                     <TextListItem>


### PR DESCRIPTION
AWS recently started requiring a report prefix for cost and usage reports.  This PR will update the AWS-Cost wizard to give a suggestion for a prefix to use, rather than saying to leave blank.

Corresponding docs issue: https://issues.redhat.com/browse/COST-612 will explain that any value is technically acceptable.