### PR TITLE
Allow to check updated to get the latest status

### DIFF
--- a/packages/sources/src/tests/api/getApplicationStatus.test.js
+++ b/packages/sources/src/tests/api/getApplicationStatus.test.js
@@ -76,4 +76,56 @@ describe('patch cost management source', () => {
 
         expect(getApplication.mock.calls.length).toBe(3);
     });
+
+    it('with updated time', async () => {
+        const UPDATED_TIME = new Date();
+        const ENTITY = 'getApplication';
+
+        getApplication = jest.fn()
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME }))
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME }))
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: new Date(Number(UPDATED_TIME) + 1000) }));
+
+        api.getSourcesApi = () => ({
+            getApplication
+        });
+
+        await checkAppAvailability(ID, TIMEOUT, INTERVAL, ENTITY, UPDATED_TIME);
+
+        expect(getApplication.mock.calls.length).toBe(3);
+    });
+
+    it('with updated time - with last_checked_at', async () => {
+        const UPDATED_TIME = new Date();
+        const ENTITY = 'getApplication';
+
+        getApplication = jest.fn()
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME }))
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME }))
+        .mockImplementationOnce(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME, last_checked_at: new Date(Number(UPDATED_TIME) + 1000) }));
+
+        api.getSourcesApi = () => ({
+            getApplication
+        });
+
+        await checkAppAvailability(ID, TIMEOUT, INTERVAL, ENTITY, UPDATED_TIME);
+
+        expect(getApplication.mock.calls.length).toBe(3);
+    });
+
+    it('timeouts with updated time', async () => {
+        const UPDATED_TIME = new Date();
+        const ENTITY = 'getApplication';
+
+        getApplication = jest.fn()
+        .mockImplementation(() => Promise.resolve({ availability_status: 'available', updated_at: UPDATED_TIME }));
+
+        api.getSourcesApi = () => ({
+            getApplication
+        });
+
+        const result = await checkAppAvailability(ID, TIMEOUT, INTERVAL, ENTITY, UPDATED_TIME);
+
+        expect(result.availability_status).toEqual(null);
+    });
 });


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/RHCLOUD-10246

- When checking a status of an app in the edit form, the status is already set - so we need to check if the status is updated after the credentials were updated.