### PR TITLE
Bumping OCP docs version to 4.6

### DIFF
--- a/packages/sources/src/utilities/stringConstants.js
+++ b/packages/sources/src/utilities/stringConstants.js
@@ -3,4 +3,4 @@ import { FormattedMessage } from 'react-intl';
 
 export const WIZARD_DESCRIPTION = <FormattedMessage id="wizard.wizardDescription" defaultMessage="Connect a data source to use with your applications."/>;
 export const WIZARD_TITLE = <FormattedMessage id="wizard.wizardTitle" defaultMessage="Add source"/>;
-export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5';
+export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6';


### PR DESCRIPTION
With the release of OCP 4.6; the docs team has migrated the cost management content to 4.6.  This change updates the sources wizards to use 4.6.