### PR TITLE
Add options to filter generator

### DIFF
--- a/packages/utils/src/helpers.js
+++ b/packages/utils/src/helpers.js
@@ -83,9 +83,11 @@ export function getBaseName(pathname, level = 2) {
     }, release);
 }
 
-export const generateFilter = (data, path = 'filter') =>
+export const generateFilter = (data, path = 'filter', options) =>
     Object.entries(data || {}).reduce((acc, [ key, value ]) => {
-        const newPath = `${path || ''}[${key}]${Array.isArray(value) ? '[]' : ''}`;
+        const newPath = `${path || ''}[${key}]${Array.isArray(value) ? `${
+            options?.arrayEnhancer ? `[${options.arrayEnhancer}]` : ''
+        }[]` : ''}`;
         if (value instanceof Function || value instanceof Date) {
             return acc;
         }
@@ -94,7 +96,7 @@ export const generateFilter = (data, path = 'filter') =>
             ...acc,
             ...(Array.isArray(value) || typeof value !== 'object')
                 ? { [newPath]: value } :
-                generateFilter(value, newPath)
+                generateFilter(value, newPath, options)
         };
 
     }, {});

--- a/packages/utils/src/helpers.test.js
+++ b/packages/utils/src/helpers.test.js
@@ -176,6 +176,15 @@ describe('generateFilter', () => {
         });
     });
 
+    it('should generate filter for array with enhancer', () => {
+        const result = generateFilter({
+            some: [ 1, 2 ]
+        }, undefined, { arrayEnhancer: 'contains' });
+        expect(result).toMatchObject({
+            'filter[some][contains][]': [ 1, 2 ]
+        });
+    });
+
     it('should generate nested filter', () => {
         const result = generateFilter({
             some: {


### PR DESCRIPTION
### Generate filter enhancer

Based on the API consumer should be able to pass array with options:
* `generateFilter({ something: [1] }, undefined, { arrayEnhancer: 'contains' }) -> `filter[something][contains][]=1`
* `generateFilter({ something: [1] }, undefined, { arrayEnhancer: 'includes' }) -> `filter[something][includes][]=1`
* `generateFilter({ something: [1] })` -> `filter[something][includes][]=1`