### PR TITLE
Fix system detail information if user has only inventory read permissions

### DIFF
--- a/packages/inventory/doc/inventory.md
+++ b/packages/inventory/doc/inventory.md
@@ -542,7 +542,7 @@ class SomeCmp extends React.Component {
 
 ### Using RBAC with inventory
 
-By default inventory component will check `['inventory:*:*', 'inventory:hosts:read']` in RBAC. If any is found it means that the user has access to inventory host list and will show either container view or full page view.
+By default inventory component will check `['inventory:*:*', 'inventory:*:read', 'inventory:hosts:read']` in RBAC. If any is found it means that the user has access to inventory host list and will show either container view or full page view.
 
 If you are using just inventory table in your screen please pass `isFullView={true}` to connected inventory component so the component will render in full page view instead of container view.
 

--- a/packages/inventory/src/components/detail/DetailRenderer.js
+++ b/packages/inventory/src/components/detail/DetailRenderer.js
@@ -6,7 +6,11 @@ import DetailWrapper from './DetailWrapper';
 import AccessDenied from '../../shared/AccessDenied';
 
 const DetailRenderer = ({ showInventoryDrawer, isRbacEnabled, ...props }) => {
-    const { hasAccess } = usePermissions('inventory', [ 'inventory:*:*', 'inventory:hosts:read' ]);
+    const { hasAccess } = usePermissions('inventory', [
+        'inventory:*:*',
+        'inventory:*:read',
+        'inventory:hosts:read'
+    ]);
     if (hasAccess === undefined) {
         return <Spinner />;
     } else if (isRbacEnabled && hasAccess === false) {

--- a/packages/inventory/src/components/table/InventoryList.scss
+++ b/packages/inventory/src/components/table/InventoryList.scss
@@ -9,7 +9,7 @@
 @import '~@redhat-cloud-services/frontend-components/components/CullingInfo.css';
 
 .ins-c-inventory__no--access .pf-c-empty-state__body > div {
-    max-width: 300px;
+    max-width: 500px;
     margin: auto;
 
     @media screen and (max-width: 768px) {


### PR DESCRIPTION
### Incorrect list of permissions

When user has access to hosts and navigates to system detail they can't really see any info because they are blocked by RBAC. Change this by updating list of permissions user can have.