### PR TITLE
Disable apply selected if nothing is selected

### DIFF
--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -88,8 +88,8 @@ class TagModal extends Component {
                             variant="primary"
                             isDisabled={
                                 isTabbed ?
-                                    Object.values(selected).every(values => values?.length === 0) :
-                                    selected?.length === 0
+                                    Object.values(selected || {}).every(values => !values || values?.length === 0) :
+                                    !selected || selected?.length === 0
                             }
                             onClick={(e) => {
                                 onApply();

--- a/packages/components/src/Components/TagModal/TagModal.js
+++ b/packages/components/src/Components/TagModal/TagModal.js
@@ -83,10 +83,19 @@ class TagModal extends Component {
                 variant="medium"
                 {...onApply && {
                     actions: [
-                        <Button key="confirm" variant="primary" onClick={(e) => {
-                            onApply();
-                            toggleModal(e, true);
-                        }}>
+                        <Button
+                            key="confirm"
+                            variant="primary"
+                            isDisabled={
+                                isTabbed ?
+                                    Object.values(selected).every(values => values?.length === 0) :
+                                    selected?.length === 0
+                            }
+                            onClick={(e) => {
+                                onApply();
+                                toggleModal(e, true);
+                            }}
+                        >
                             Apply {isTabbed ? 'selected' : 'tags'}
                         </Button>,
                         <Button key="cancel" variant="link" onClick={(e) => toggleModal(e, false)}>

--- a/packages/components/src/Components/TagModal/TagModal.test.js
+++ b/packages/components/src/Components/TagModal/TagModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import TagModal from './TagModal';
 
@@ -13,6 +13,29 @@ describe('TagCount component', () => {
         const wrapper = shallow(<TagModal loaded isOpen={true} systemName={'paul.localhost.com'}>
             <h1>I am a child component</h1>
         </TagModal>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('Should render modal with disabled button', () => {
+        const wrapper = shallow(<TagModal
+            loaded
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            rows={[ [ 'key', 'value' ], [ 'thing', 'otherthing' ] ]}
+            onApply={jest.fn()}
+        />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render modal with enabled button', () => {
+        const wrapper = shallow(<TagModal
+            loaded
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            rows={[ [ 'key', 'value' ], [ 'thing', 'otherthing' ] ]}
+            selected={[ 'thing' ]}
+            onApply={jest.fn()}
+        />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });
@@ -49,6 +72,45 @@ describe('Two tables', () => {
                 [{ title: 'one' }],
                 [{ title: 'two' }]
             ]}
+        />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('Should render modal with disabled button', () => {
+        const wrapper = shallow(<TagModal
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            tabNames={[ 'something', 'another' ]}
+            loaded={[ true, true ]}
+            rows={[
+                [ [ 'something' ] ],
+                [ [ 'another' ] ]
+            ]}
+            columns={[
+                [{ title: 'one' }],
+                [{ title: 'two' }]
+            ]}
+            onApply={jest.fn()}
+        />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render modal with enabled button', () => {
+        const wrapper = shallow(<TagModal
+            isOpen={true}
+            systemName={'paul.localhost.com'}
+            tabNames={[ 'something', 'another' ]}
+            loaded={[ true, true ]}
+            rows={[
+                [ [ 'something' ] ],
+                [ [ 'another' ] ]
+            ]}
+            columns={[
+                [{ title: 'one' }],
+                [{ title: 'two' }]
+            ]}
+            selected={[ [ 'thing' ] ]}
+            onApply={jest.fn()}
         />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
+++ b/packages/components/src/Components/TagModal/__snapshots__/TagModal.test.js.snap
@@ -109,6 +109,440 @@ exports[`TagCount component Render the modal with a child component 1`] = `
 </Modal>
 `;
 
+exports[`TagCount component Should render modal with disabled button 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        isDisabled={true}
+        onClick={[Function]}
+        variant="primary"
+      >
+        Apply 
+        tags
+      </Button>,
+      <Button
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <TableWithFilter
+    calculateChecked={[Function]}
+    columns={
+      Array [
+        Object {
+          "title": "Name",
+        },
+        Object {
+          "title": "Tag source",
+        },
+      ]
+    }
+    entityName="tags"
+    isOpen={true}
+    loaded={true}
+    onApply={[MockFunction]}
+    onUpdateData={[Function]}
+    pagination={
+      Object {
+        "count": 10,
+      }
+    }
+    rows={
+      Array [
+        Array [
+          "key",
+          "value",
+        ],
+        Array [
+          "thing",
+          "otherthing",
+        ],
+      ]
+    }
+    systemName="paul.localhost.com"
+    tableProps={Object {}}
+    toggleModal={[Function]}
+    unique={[Function]}
+  />
+</Modal>
+`;
+
+exports[`TagCount component should render modal with enabled button 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        isDisabled={false}
+        onClick={[Function]}
+        variant="primary"
+      >
+        Apply 
+        tags
+      </Button>,
+      <Button
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <TableWithFilter
+    calculateChecked={[Function]}
+    columns={
+      Array [
+        Object {
+          "title": "Name",
+        },
+        Object {
+          "title": "Tag source",
+        },
+      ]
+    }
+    entityName="tags"
+    isOpen={true}
+    loaded={true}
+    onApply={[MockFunction]}
+    onUpdateData={[Function]}
+    pagination={
+      Object {
+        "count": 10,
+      }
+    }
+    rows={
+      Array [
+        Array [
+          "key",
+          "value",
+        ],
+        Array [
+          "thing",
+          "otherthing",
+        ],
+      ]
+    }
+    selected={
+      Array [
+        "thing",
+      ]
+    }
+    systemName="paul.localhost.com"
+    tableProps={Object {}}
+    toggleModal={[Function]}
+    unique={[Function]}
+  />
+</Modal>
+`;
+
+exports[`Two tables Should render modal with disabled button 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        isDisabled={true}
+        onClick={[Function]}
+        variant="primary"
+      >
+        Apply 
+        selected
+      </Button>,
+      <Button
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <Tabs
+    activeKey={0}
+    component="div"
+    isBox={false}
+    isFilled={false}
+    isSecondary={false}
+    isVertical={false}
+    leftScrollAriaLabel="Scroll left"
+    mountOnEnter={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    rightScrollAriaLabel="Scroll right"
+    unmountOnExit={false}
+  >
+    <Tab
+      eventKey={0}
+      key="0"
+      title={
+        <TabTitleText>
+          All 
+          something
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "one",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        onApply={[MockFunction]}
+        rows={
+          Array [
+            Array [
+              "something",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+    <Tab
+      eventKey={1}
+      key="1"
+      title={
+        <TabTitleText>
+          All 
+          another
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "two",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        onApply={[MockFunction]}
+        rows={
+          Array [
+            Array [
+              "another",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+  </Tabs>
+</Modal>
+`;
+
+exports[`Two tables should render modal with enabled button 1`] = `
+<Modal
+  actions={
+    Array [
+      <Button
+        isDisabled={false}
+        onClick={[Function]}
+        variant="primary"
+      >
+        Apply 
+        selected
+      </Button>,
+      <Button
+        onClick={[Function]}
+        variant="link"
+      >
+        Cancel
+      </Button>,
+    ]
+  }
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className="ins-c-tag-modal"
+  hasNoBodyWrapper={false}
+  isOpen={true}
+  onClose={[Function]}
+  ouiaSafe={true}
+  showClose={true}
+  tableProps={Object {}}
+  title="Tags for paul.localhost.com"
+  variant="medium"
+>
+  <Tabs
+    activeKey={0}
+    component="div"
+    isBox={false}
+    isFilled={false}
+    isSecondary={false}
+    isVertical={false}
+    leftScrollAriaLabel="Scroll left"
+    mountOnEnter={false}
+    onSelect={[Function]}
+    ouiaSafe={true}
+    rightScrollAriaLabel="Scroll right"
+    unmountOnExit={false}
+  >
+    <Tab
+      eventKey={0}
+      key="0"
+      title={
+        <TabTitleText>
+          All 
+          something
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "one",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        onApply={[MockFunction]}
+        rows={
+          Array [
+            Array [
+              "something",
+            ],
+          ]
+        }
+        selected={
+          Array [
+            "thing",
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+    <Tab
+      eventKey={1}
+      key="1"
+      title={
+        <TabTitleText>
+          All 
+          another
+        </TabTitleText>
+      }
+    >
+      <TableWithFilter
+        calculateChecked={[Function]}
+        columns={
+          Array [
+            Object {
+              "title": "two",
+            },
+          ]
+        }
+        entityName="tags"
+        isOpen={true}
+        loaded={true}
+        onApply={[MockFunction]}
+        rows={
+          Array [
+            Array [
+              "another",
+            ],
+          ]
+        }
+        systemName="paul.localhost.com"
+        tabNames={
+          Array [
+            "something",
+            "another",
+          ]
+        }
+        tableProps={Object {}}
+        toggleModal={[Function]}
+        unique={[Function]}
+      />
+    </Tab>
+  </Tabs>
+</Modal>
+`;
+
 exports[`Two tables should render two tables 1`] = `
 <Modal
   actions={Array []}


### PR DESCRIPTION
### Fixes RHCLOUD-9829

When no tags are selected we don't have to allow users to submit selection of tags via modal. This PR fixes such issue by checking if every tab has nothing selected.