### PR TITLE
Fix tags assigned to system pagination by using local state

### DIFF
--- a/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/EntityTableToolbar.test.js.snap
@@ -952,45 +952,9 @@ exports[`EntityTableToolbar DOM should render correctly - with tags 1`] = `
 
 exports[`EntityTableToolbar DOM should render correctly - with tags 2`] = `
 <TagsModal
-  fetchAllTags={[Function]}
-  fetchTagsForSystem={[Function]}
   filterTagsBy=""
-  filters={
-    Array [
-      Object {},
-    ]
-  }
-  loaded={false}
   onApply={[Function]}
   onToggleModal={[Function]}
-  onToggleTagModal={[Function]}
-  pagination={
-    Object {
-      "page": 1,
-      "perPage": 10,
-    }
-  }
-  showTagDialog={false}
-  tags={
-    Array [
-      Object {
-        "key": "some key",
-        "namespace": "something",
-        "value": "some value",
-      },
-      Object {
-        "key": "some key",
-        "namespace": "something",
-        "value": null,
-      },
-      Object {
-        "key": "some key",
-        "namespace": null,
-        "value": null,
-      },
-    ]
-  }
-  tagsCount={0}
 />
 `;
 

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -161,7 +161,7 @@ function selectFilter(state, { payload: { item: { items, ...item }, selected } }
 }
 
 export function showTags(state, { payload, meta }) {
-    const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity;
+    const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity || {};
     return {
         ...state,
         activeSystemTag: {
@@ -176,7 +176,7 @@ export function showTags(state, { payload, meta }) {
 }
 
 export function showTagsPending(state, { meta }) {
-    const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity;
+    const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity || {};
     return {
         ...state,
         activeSystemTag: {

--- a/packages/inventory/src/shared/TagsModal.js
+++ b/packages/inventory/src/shared/TagsModal.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useState, useCallback, useEffect } from 'react';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import PropTypes from 'prop-types';
 import { toggleTagModal, fetchAllTags, loadTags } from '../redux/actions';
 import { TagModal } from '@redhat-cloud-services/frontend-components/components/cjs/TagModal';
@@ -7,135 +7,137 @@ import { cellWidth } from '@patternfly/react-table';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 
-class TagsModal extends React.Component {
-    state = {
-        filterTagsBy: '',
-        selected: []
-    }
+const TagsModal = ({
+    customFilters,
+    filterTagsBy,
+    onToggleModal,
+    onApply
+}) => {
+    const dispatch = useDispatch();
+    const [ filterBy, setFilterBy ] = useState('');
+    const [ selected, setSelected ] = useState([]);
+    const [ statePagination, setStatePagination ] = useState({
+        perPage: 10,
+        page: 1
+    });
 
-    debouncedFetch = debounce((pagination) => this.fetchTags(pagination), 800);
+    const showTagDialog = useSelector(({ entities, entityDetails }) => (entities || entityDetails)?.showTagDialog);
 
-    fetchTags = (pagination) => {
-        const { filterTagsBy } = this.state;
-        const { fetchAllTags, fetchTagsForSystem, activeSystemTag, tagsCount, filters, customFilters } = this.props;
+    const pagination = useSelector(({ entities, entityDetails }) => {
+        if (entities?.activeSystemTag || entityDetails?.entity) {
+            return statePagination;
+        }
+
+        return entities?.allTagsPagination || statePagination;
+    }, shallowEqual);
+
+    const loaded = useSelector(({ entities, entityDetails }) => {
+        if (entityDetails?.entity) {
+            return entityDetails?.loaded;
+        }
+
+        return entities?.activeSystemTag?.tagsLoaded || (entities || entityDetails)?.allTagsLoaded;
+    });
+    const activeSystemTag = useSelector(({ entities, entityDetails }) => entities?.activeSystemTag || entityDetails?.entity);
+    const tags = useSelector(({ entities, entityDetails }) => {
+        const activeTags = entities?.activeSystemTag?.tags || entityDetails?.entity?.tags;
+        if (activeTags) {
+            return activeTags?.filter(
+                (tag) => Object.values(tag).some((val) => val?.includes(filterBy))
+            ).slice(statePagination?.perPage * (statePagination?.page - 1), statePagination?.perPage * statePagination?.page);
+        }
+
+        return entities?.allTags?.reduce((acc, { tags }) => ([
+            ...acc,
+            ...flatten(tags.map(({ tag }) => tag))
+        ]), []);
+    });
+    const filters = useSelector(({ entities, entityDetails }) => (entities || entityDetails)?.activeFilters);
+    const tagsCount = useSelector(({ entities, entityDetails }) => {
+        const activeTags = (entities?.activeSystemTag?.tags || entityDetails?.entity?.tags)?.filter(
+            (tag) => Object.values(tag).some((val) => val?.includes(filterBy))
+        );
+        return activeTags ? activeTags.length : entities?.allTagsTotal;
+    });
+
+    useEffect(() => {
+        setFilterBy(filterTagsBy);
+    }, [ filterTagsBy ]);
+
+    const fetchTags = (pagination, filterBy) => {
         if (!activeSystemTag) {
-            fetchAllTags(filterTagsBy, { ...customFilters, pagination, filters });
+            dispatch(fetchAllTags(filterBy, { ...customFilters, pagination, filters }));
         } else {
-            fetchTagsForSystem(activeSystemTag.id, filterTagsBy, { pagination }, tagsCount);
+            setStatePagination(() => pagination);
         }
     };
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.filterTagsBy !== this.props.filterTagsBy) {
-            this.setState({ filterTagsBy: this.props.filterTagsBy });
-        }
-    }
+    const debouncedFetch = useCallback(debounce(fetchTags, 800), [ activeSystemTag ]);
 
-    componentDidMount() {
-        if (this.props.filterTagsBy) {
-            this.setState({ filterTagsBy: this.props.filterTagsBy });
-        }
-    }
-
-    render() {
-        const {
-            showTagDialog,
-            tags,
-            activeSystemTag,
-            tagsCount,
-            onToggleTagModal,
-            onToggleModal,
-            pagination,
-            loaded,
-            onApply
-        } = this.props;
-        const { filterTagsBy, selected } = this.state;
-        return (
-            <TagModal
-                className="ins-c-inventory__tags-modal"
-                tableProps={{
-                    canSelectAll: false
-                }}
-                {...loaded && {
-                    loaded,
-                    pagination: {
-                        ...pagination,
-                        count: tagsCount
-                    },
-                    rows: tags.map(({ key, value, namespace }) => ({
-                        id: `${namespace}/${key}=${value}`,
-                        selected: selected.find(({ id }) => id === `${namespace}/${key}=${value}`),
-                        cells: [ key, value, namespace ]
-                    }))
-                }}
-                loaded={ loaded }
-                width="auto"
-                isOpen={ showTagDialog }
-                toggleModal={() => {
-                    this.setState({
-                        selected: [],
-                        filterTagsBy: ''
-                    });
-                    onToggleModal();
-                    onToggleTagModal();
-                }}
-                filters={[
-                    {
-                        label: 'Tags filter',
-                        placeholder: 'Filter tags',
-                        value: 'tags-filter',
-                        filterValues: {
-                            value: filterTagsBy,
-                            onChange: (_e, value) => {
-                                this.debouncedFetch(pagination);
-                                this.setState({ filterTagsBy: value });
-                            }
+    return (
+        <TagModal
+            className="ins-c-inventory__tags-modal"
+            tableProps={{
+                canSelectAll: false
+            }}
+            {...loaded && {
+                loaded,
+                pagination: {
+                    ...pagination,
+                    count: tagsCount
+                },
+                rows: tags.map(({ key, value, namespace }) => ({
+                    id: `${namespace}/${key}=${value}`,
+                    selected: selected.find(({ id }) => id === `${namespace}/${key}=${value}`),
+                    cells: [ key, value, namespace ]
+                }))
+            }}
+            loaded={ loaded }
+            width="auto"
+            isOpen={ showTagDialog }
+            toggleModal={() => {
+                setSelected([]);
+                setFilterBy('');
+                onToggleModal();
+                dispatch(toggleTagModal(false));
+            }}
+            filters={[
+                {
+                    label: 'Tags filter',
+                    placeholder: 'Filter tags',
+                    value: 'tags-filter',
+                    filterValues: {
+                        value: filterBy,
+                        onChange: (_e, value) => {
+                            debouncedFetch(pagination, value);
+                            setFilterBy(value);
                         }
                     }
-                ]}
-                onUpdateData={ this.fetchTags }
-                columns={ [
-                    { title: 'Name' },
-                    { title: 'Value', transforms: [ cellWidth(30) ] },
-                    { title: 'Tag source', transforms: [ cellWidth(30) ] }
-                ] }
-                {...!activeSystemTag && {
-                    onSelect: (selected) => this.setState({ selected }),
-                    selected,
-                    onApply: () => onApply && onApply(selected)
-                }}
-                title={ activeSystemTag ?
-                    `${activeSystemTag.display_name} (${tagsCount})` :
-                    `All tags in inventory (${tagsCount})`
                 }
-            />
-        );
-    }
-}
+            ]}
+            onUpdateData={ fetchTags }
+            columns={ [
+                { title: 'Name' },
+                { title: 'Value', transforms: [ cellWidth(30) ] },
+                { title: 'Tag source', transforms: [ cellWidth(30) ] }
+            ] }
+            {...!activeSystemTag && {
+                onSelect: (selected) => setSelected(selected),
+                selected,
+                onApply: () => onApply && onApply(selected)
+            }}
+            title={ activeSystemTag ?
+                `${activeSystemTag.display_name} (${tagsCount})` :
+                `All tags in inventory (${tagsCount})`
+            }
+        />
+    );
+};
 
 TagsModal.propTypes = {
-    showTagDialog: PropTypes.bool,
-    tags: PropTypes.arrayOf(PropTypes.shape({
-        key: PropTypes.node,
-        value: PropTypes.node,
-        namespace: PropTypes.node
-    })),
-    filterTagsBy: PropTypes.string,
-    tagsCount: PropTypes.number,
-    activeSystemTag: PropTypes.shape({
-        id: PropTypes.string,
-        // eslint-disable-next-line camelcase
-        display_name: PropTypes.string
-    }),
-    pagination: PropTypes.shape({
-        page: PropTypes.number,
-        perPage: PropTypes.number
-    }),
-    loaded: PropTypes.bool,
-    onToggleTagModal: PropTypes.func,
-    fetchAllTags: PropTypes.func,
     onApply: PropTypes.func,
     onToggleModal: PropTypes.func,
+    filterTagsBy: PropTypes.string,
     customFilters: PropTypes.shape({
         tags: PropTypes.oneOfType([
             PropTypes.object,
@@ -145,35 +147,8 @@ TagsModal.propTypes = {
 };
 
 TagsModal.defaultProps = {
-    showTagDialog: false,
-    loaded: false,
-    tagsCount: 0,
     filterTagsBy: '',
     onToggleModal: () => undefined
 };
 
-export default connect(({ entities, entityDetails }) => {
-    const { showTagDialog, activeFilters, activeSystemTag, allTagsTotal, allTags, allTagsPagination, allTagsLoaded } = entities || entityDetails || {};
-    return ({
-        showTagDialog,
-        tags: activeSystemTag ? activeSystemTag.tags : allTags && allTags.reduce((acc, { tags }) => ([
-            ...acc,
-            ...flatten(tags.map(({ tag }) => tag))
-        ]), []),
-        filters: activeFilters,
-        activeSystemTag,
-        loaded: activeSystemTag ? activeSystemTag.tagsLoaded : allTagsLoaded,
-        tagsCount: activeSystemTag ? activeSystemTag.tagsCount : allTagsTotal,
-        pagination: activeSystemTag ? {
-            page: activeSystemTag.page,
-            perPage: activeSystemTag.perPage
-        } : allTagsPagination || {
-            page: 1,
-            perPage: 10
-        }
-    });
-}, (dispatch) => ({
-    onToggleTagModal: () => dispatch(toggleTagModal(false)),
-    fetchAllTags: (search, options) => dispatch(fetchAllTags(search, options)),
-    fetchTagsForSystem: (systemId, search, options, tagsCount) => dispatch(loadTags(systemId, search, options, tagsCount))
-}))(TagsModal);
+export default TagsModal;

--- a/packages/inventory/src/shared/__snapshots__/TagsModal.test.js.snap
+++ b/packages/inventory/src/shared/__snapshots__/TagsModal.test.js.snap
@@ -1,133 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TagsModal DOM should render activeSystemTag 1`] = `
-<ContextProvider
-  value={null}
->
-  <TagsModal
-    activeSystemTag={
-      Object {
-        "page": 1,
-        "perPage": 10,
-        "tags": Array [
-          Object {
-            "key": "some",
-            "namespace": "something",
-            "value": "test",
-          },
-        ],
-        "tagsCount": 50,
-        "tagsLoaded": true,
-      }
-    }
-    fetchAllTags={[Function]}
-    fetchTagsForSystem={[Function]}
-    filterTagsBy=""
-    loaded={true}
-    onToggleModal={[Function]}
-    onToggleTagModal={[Function]}
-    pagination={
-      Object {
-        "page": 1,
-        "perPage": 10,
-      }
-    }
-    showTagDialog={true}
-    store={
-      Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      }
-    }
-    tags={
-      Array [
-        Object {
-          "key": "some",
-          "namespace": "something",
-          "value": "test",
-        },
-      ]
-    }
-    tagsCount={50}
-  />
-</ContextProvider>
+<TagsModal
+  filterTagsBy=""
+  onToggleModal={[Function]}
+/>
 `;
 
 exports[`TagsModal DOM should render alltags 1`] = `
-<ContextProvider
-  value={null}
->
-  <TagsModal
-    fetchAllTags={[Function]}
-    fetchTagsForSystem={[Function]}
-    filterTagsBy=""
-    loaded={true}
-    onToggleModal={[Function]}
-    onToggleTagModal={[Function]}
-    pagination={
-      Object {
-        "page": 1,
-        "perPage": 10,
-      }
+<TagsModal
+  filterTagsBy=""
+  onToggleModal={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
     }
-    showTagDialog={true}
-    store={
-      Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      }
-    }
-    tags={
-      Array [
-        Object {
-          "key": "some",
-          "namespace": "something",
-          "value": "test",
-        },
-      ]
-    }
-    tagsCount={50}
-  />
-</ContextProvider>
+  }
+/>
 `;
 
 exports[`TagsModal DOM should render loading state correctly 1`] = `
-<ContextProvider
-  value={null}
->
-  <TagsModal
-    fetchAllTags={[Function]}
-    fetchTagsForSystem={[Function]}
-    filterTagsBy=""
-    loaded={false}
-    onToggleModal={[Function]}
-    onToggleTagModal={[Function]}
-    pagination={
-      Object {
-        "page": 1,
-        "perPage": 10,
-      }
-    }
-    showTagDialog={false}
-    store={
-      Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      }
-    }
-    tagsCount={0}
-  />
-</ContextProvider>
+<TagsModal
+  filterTagsBy=""
+  onToggleModal={[Function]}
+/>
 `;


### PR DESCRIPTION
### Error while changing pages in tags

When changing pages of tags assigned to system there is an error thrown from the server with 404 status code. This is caused because API does not allow changing pages of assigned tags, however we are receiving the whole list of tags so we can paginate and filter in this list.

While working on this I've refactored the `TagsModal` to functional component.