### PR TITLE
Allow to select same tags with different values

### DIFF
--- a/packages/components/src/Components/FilterHooks/constants.js
+++ b/packages/components/src/Components/FilterHooks/constants.js
@@ -79,7 +79,7 @@ export function constructGroups(allTags, item = 'item') {
                     }
                 },
                 id: `${tagKey}-${value}`,
-                value: tagKey,
+                value: tagText,
                 tagValue: value
             });
         })

--- a/packages/components/src/Components/FilterHooks/constants.test.js
+++ b/packages/components/src/Components/FilterHooks/constants.test.js
@@ -243,7 +243,7 @@ describe('constructGroups', () => {
                 value: 'someValue'
             }
         });
-        expect(result[0].items[0].value).toBe('someKey');
+        expect(result[0].items[0].value).toBe('someKey=someValue');
         expect(result[0].items[0].tagValue).toBe('someValue');
     });
 });

--- a/packages/inventory/src/components/filters/useTagsFilter.test.js
+++ b/packages/inventory/src/components/filters/useTagsFilter.test.js
@@ -64,7 +64,7 @@ describe('useTagsFilter', () => {
                         count: 10,
                         tag: { key: 'test', value: 'something' }
                     },
-                    value: 'test'
+                    value: 'test=something'
                 }],
                 label: 'something',
                 type: 'checkbox',


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHCLOUD-10765

**Before**

![Peek 2020-11-17 15-19](https://user-images.githubusercontent.com/32869456/99527553-40e0a300-299d-11eb-8c68-e94d3a2660ca.gif)


**After**

![multipletagkeys](https://user-images.githubusercontent.com/32869456/99527528-36bea480-299d-11eb-85a1-c4ad457f9338.gif)

It sends these requests:

/api/inventory/v1/hosts?per_page=50&page=1&order_by=updated&order_how=DESC&staleness=fresh&staleness=stale **&tags=system/owners=mary&tags=system/owners=jack&tags=system/yorkshire=jack** &registered_with=insights

/api/inventory/v1/tags? **tags=system/owners=mary&tags=system/owners=jack&tags=different-thing/yorkshire=jack** &order_by=tag&order_how=ASC&per_page=10&page=1&staleness=fresh&staleness=stale&search=&registered_with=insights
