### PR TITLE
Improve inventory build by adding esm and cjs modules

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -55,6 +55,10 @@ const notificationsMapper = {
     addNotification: 'actions'
 };
 
+const inventoryMapper = {
+    loadEntity: 'actions'
+};
+
 const createPfReactTransform = (env) => [
     'transform-imports',
     {
@@ -124,7 +128,7 @@ const createFrontendComponentsTransform = env => [
             skipDefaultConversion: true
         },
         '@redhat-cloud-services/frontend-components-inventory': {
-            transform: (importName) => `@redhat-cloud-services/frontend-components-inventory/${env}/${importName}.js`,
+            transform: (importName) => `@redhat-cloud-services/frontend-components-inventory/${env}/${inventoryMapper[importName] || importName}.js`,
             preventFullImport: true,
             skipDefaultConversion: true
         },

--- a/packages/inventory-general-info/src/SystemCard.js
+++ b/packages/inventory-general-info/src/SystemCard.js
@@ -6,7 +6,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { propertiesSelector } from './selectors';
 import { editDisplayName, editAnsibleHost, systemProfile } from './redux/actions';
 import TextInputModal from './TextInputModal';
-import { loadEntity } from '@redhat-cloud-services/frontend-components-inventory/actions';
+import { loadEntity } from '@redhat-cloud-services/frontend-components-inventory';
 import { Popover, Button } from '@patternfly/react-core';
 import EditButton from './EditButton';
 import { generalMapper } from './dataMapper';

--- a/packages/inventory/config/rollup.config.js
+++ b/packages/inventory/config/rollup.config.js
@@ -1,0 +1,68 @@
+/* eslint-disable camelcase */
+import nodeResolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from 'rollup-plugin-babel';
+import nodeGlobals from 'rollup-plugin-node-globals';
+import { terser } from 'rollup-plugin-terser';
+import postcss from 'rollup-plugin-postcss';
+import json from '@rollup/plugin-json';
+import { dependencies, peerDependencies, name } from '../package.json';
+import {
+    rollupConfig,
+    externalDeps,
+    external,
+    globals
+} from '../../../config/rollup-contants';
+import rollupPlugins from '../../../config/rollup-plugins';
+
+const commonjsOptions = {
+    ignoreGlobal: true,
+    include: /node_modules/,
+    namedExports: {
+        '../../node_modules/@patternfly/react-table/node_modules/lodash/lodash.js': [
+            'mergeWith',
+            'isFunction',
+            'isArray',
+            'isEqualWith',
+            'isEqual'
+        ]
+    }
+};
+
+const babelOptions = {
+    exclude: /node_modules/,
+    runtimeHelpers: true,
+    configFile: './babel.config'
+};
+
+const plugins = [
+    ...rollupPlugins,
+    nodeResolve({
+        browser: true
+    }),
+    babel(babelOptions),
+    commonjs(commonjsOptions),
+    nodeGlobals(),
+    terser({
+        keep_classnames: true,
+        keep_fnames: true
+    }),
+    postcss({
+        minimize: true,
+        extract: true
+    }),
+    json()
+];
+
+export default rollupConfig(
+    external(externalDeps({ ...dependencies, ...peerDependencies })),
+    plugins,
+    globals,
+    name,
+    [{
+        index: 'src/index.js',
+        actions: 'src/redux/actions.js',
+        filters: 'src/components/filters/index.js'
+    }],
+    './'
+);

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -3,12 +3,19 @@
     "version": "2.4.28",
     "description": "Inventory components for RedHat Cloud Services project.",
     "browser": "index.js",
+    "module": "esm/index.js",
     "publishConfig": {
         "access": "public"
     },
     "scripts": {
-        "build": "NODE_ENV=production webpack --config config/webpack.config.js",
-        "start": "webpack --watch --config config/webpack.config.js"
+        "build": "npm run build:js && npm run build:esm && npm run build:umd",
+        "build:js": "BABEL_ENV=cjs rollup -c ./config/rollup.config.js --format=cjs --environment NODE_ENV:production,FORMAT:cjs",
+        "build:esm": "BABEL_ENV=esm rollup -c ./config/rollup.config.js --environment NODE_ENV:production,FORMAT:esm",
+        "build:umd": "NODE_ENV=production webpack --config config/webpack.config.js",
+        "start": "rollup -c ./config/rollup.config.js -w",
+        "start:js": "BABEL_ENV=cjs rollup -c ./config/rollup.config.js -w --format=cjs --environment FORMAT:cjs",
+        "start:esm": "BABEL_ENV=esm rollup -c ./config/rollup.config.js -w --environment FORMAT:esm",
+        "start:umd": "webpack --watch --config config/webpack.config.js"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Add new build modules to inventory

With the migration to chrome-2.0 and using fed modules we can fully utilize esm/cjs builds. For consistency reasons we have to keep the webpack build (we'll log in chrome not to use this).