### PR TITLE
fix(Compliance SystemRulesTable): RHICOMPL-1032 filtering by policy and unique policies

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -19,6 +19,7 @@ query System($systemId: String!){
         id
         name
         profiles {
+            id
             name
             policyType
             refId
@@ -56,9 +57,9 @@ const SystemQuery = ({ data: { system }, loading, hidePassed }) => (
         <SystemRulesTable hidePassed={ hidePassed }
             system={ system }
             columns={ columns }
-            profileRules={ system?.profiles.map((profile) => ({
+            profileRules={ system?.profiles.map(profile => ({
                 system: system.id,
-                profile: { refId: profile.refId, name: profile.name },
+                profile,
                 rules: profile.rules
             })) }
             loading={ loading } />

--- a/packages/inventory-compliance/src/Fixtures.js
+++ b/packages/inventory-compliance/src/Fixtures.js
@@ -7,8 +7,12 @@ export const system = {
     id: 'aa9c4497-5707-4233-9e9b-1fded5423ef3',
     name: '3.example.com',
     profiles: [{
+        id: '99a661a8-8cb2-4adf-bf01-62f186493c04',
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
+        policy: {
+            id: 'ddf5aefb-ecc8-491a-a2ba-81bf17076361'
+        },
         rules: [
             {
                 title: 'Use direct-lvm with the Device Mapper Storage Driver',
@@ -56,8 +60,12 @@ export const profileRules = [
     {
         system: 'aa9c4497-5707-4233-9e9b-1fded5423ef3',
         profile: {
+            id: '99a661a8-8cb2-4adf-bf01-62f186493c04',
             refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
-            name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
+            name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',
+            policy: {
+                id: 'ddf5aefb-ecc8-491a-a2ba-81bf17076361'
+            }
         },
         rulesFailed: 31,
         rulesPassed: 19,

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -52,7 +52,7 @@ class SystemRulesTable extends React.Component {
 
     parentRowForRule = (rule) => {
         const {
-            title, identifier, policies, severity, compliant, rowKey,
+            title, identifier, profiles, severity, compliant, rowKey,
             remediationAvailable, refId, isOpen, isSelected
         } = rule;
         const cells = this.props.columns.map((column) => {
@@ -63,7 +63,7 @@ class SystemRulesTable extends React.Component {
                     cell = <RuleTitle title={ title } identifier={ identifier } />;
                     break;
                 case 'Policy':
-                    cell = policies.map((p) => p.name).slice(0, 1).join(', ');
+                    cell = profiles.map((p) => p.name).slice(0, 1).join(', ');
                     break;
                 case 'Severity':
                     cell = (severity.toLowerCase() === 'high' ? HIGH_SEVERITY :

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -184,9 +184,12 @@ class SystemRulesTable extends React.Component {
     }
 
     updatePolicyFilterConfig = () => {
-        const policies = this.props.profileRules.map((p) => (
-            p.profile
-        )).filter((p) => !!p);
+        let policies = this.props.profileRules.filter(({ profile }) => !!profile).map(({ profile }) => (
+            {
+                id: profile.policy ? profile.policy.id : profile.id,
+                name: profile.name
+            }
+        ));
 
         if (policies.length > 1) {
             this.filterConfigBuilder.addConfigItem(POLICIES_FILTER_CONFIG(policies));

--- a/packages/inventory-compliance/src/SystemRulesTable.test.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.test.js
@@ -54,6 +54,54 @@ describe('SystemRulesTable component', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render filtered rows by policy', async () => {
+        let profileRulesWithExternal = [
+            ...profileRules,
+            {
+                system: 'aa9c4497-5707-4233-9e9b-1fded5423ef3',
+                profile: {
+                    id: 'f685817e-69d2-44af-96de-bd5944c4dbd3',
+                    refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
+                    name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7'
+                },
+                rulesFailed: 0,
+                rulesPassed: 1,
+                rules: [
+                    {
+                        title: 'Use direct-lvm with the Device Mapper Storage Driver',
+                        severity: 'low',
+                        rationale: 'foorationale',
+                        refId: 'xccdf_org.ssgproject.content_rule_docker_storage_configured',
+                        description: 'foodescription',
+                        compliant: true,
+                        identifier: JSON.stringify({
+                            label: 'CCE-80441-9',
+                            system: 'https://nvd.nist.gov/cce/index.cfm'
+                        }),
+                        references: JSON.stringify([])
+                    }
+                ]
+            }
+        ];
+
+        const wrapper = shallow(
+            <SystemRulesTable
+                profileRules={ profileRulesWithExternal }
+                loading={ false }
+                system={ system }
+                itemsPerPage={ 100 }
+                columns={ columns }
+            />
+        );
+        const instance = wrapper.instance();
+        expect(instance.getRules().length).toEqual(53);
+        instance.updatePolicyFilterConfig();
+        await instance.onFilterUpdate('policy', [ 'ddf5aefb-ecc8-491a-a2ba-81bf17076361' ]);
+        expect(instance.getRules().length).toEqual(52);
+        await instance.onFilterUpdate('policy', [ 'f685817e-69d2-44af-96de-bd5944c4dbd3' ]);
+        expect(instance.getRules().length).toEqual(1);
+    });
+
     it('should render filtered rows by severity', async () => {
         const wrapper = shallow(
             <SystemRulesTable

--- a/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
+++ b/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
@@ -72,7 +72,7 @@ export const POLICIES_FILTER_CONFIG = (policies) => ({
         { label: policy.name, value: policy.refId }
     )),
     filter: (rules, values) => filterRulesWithAllValues(rules, values, (rule, value) => (
-        rule.policies.filter((policy) => policy.refId === value).length > 0
+        rule.profiles.filter((profile) => profile.refId === value).length > 0
     ))
 });
 

--- a/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
+++ b/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
@@ -69,10 +69,12 @@ export const POLICIES_FILTER_CONFIG = (policies) => ({
     type: conditionalFilterType.checkbox,
     label: 'Policy',
     items: policies.map(policy => (
-        { label: policy.name, value: policy.refId }
+        { label: policy.name, value: policy.id }
     )),
     filter: (rules, values) => filterRulesWithAllValues(rules, values, (rule, value) => (
-        rule.profiles.filter((profile) => profile.refId === value).length > 0
+        rule.profiles.filter((profile) =>
+            profile.policy ? profile.policy.id === value : profile.id === value
+        ).length > 0
     ))
 });
 

--- a/packages/inventory-compliance/src/Utilities/RulesHelper.js
+++ b/packages/inventory-compliance/src/Utilities/RulesHelper.js
@@ -1,15 +1,14 @@
-export const toRulesArray = (policiesWithRules) => {
-    const rules = policiesWithRules.flatMap((policy) => (
-        policy.rules.map((rule) => {
+export const toRulesArray = (profilesWithRules) => (
+    profilesWithRules.flatMap((profileWithRules) => (
+        profileWithRules.rules.map((rule) => {
             const identifier = rule.identifier && JSON.parse(rule.identifier);
             return {
                 ...rule,
-                rowKey: `${rule.refId}${policy.profile ? `-${policy.profile.refId}` : '' }`,
+                rowKey: `${rule.refId}${profileWithRules.profile ? `-${profileWithRules.profile.refId}` : '' }`,
                 references: rule.references ? JSON.parse(rule.references) : [],
                 identifier: identifier && identifier.label ? identifier : null,
-                policies: [ policy.profile ]
+                profiles: [ profileWithRules.profile ]
             };
         })
-    ));
-    return rules;
-};
+    ))
+);

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -134,7 +134,11 @@ exports[`SystemRulesTable component should render 1`] = `
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -301,7 +305,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -371,7 +379,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -441,7 +453,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -531,7 +547,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -600,7 +620,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -670,7 +694,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -740,7 +768,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -810,7 +842,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -880,7 +916,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -950,7 +990,11 @@ exports[`SystemRulesTable component should render 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -1270,7 +1314,11 @@ exports[`SystemRulesTable component should render filtered and search mixed resu
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -1631,7 +1679,11 @@ exports[`SystemRulesTable component should render search results by rule name 1`
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -1806,7 +1858,11 @@ exports[`SystemRulesTable component should render search results by rule name 1`
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2042,7 +2098,11 @@ exports[`SystemRulesTable component should render search results on any page, re
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -2217,7 +2277,11 @@ exports[`SystemRulesTable component should render search results on any page, re
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2444,7 +2508,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -2611,7 +2679,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2681,7 +2753,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2751,7 +2827,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2841,7 +2921,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2910,7 +2994,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -2980,7 +3068,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3050,7 +3142,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3120,7 +3216,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3190,7 +3290,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3260,7 +3364,11 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3488,7 +3596,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -3655,7 +3767,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3725,7 +3841,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3795,7 +3915,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3865,7 +3989,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -3935,7 +4063,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4005,7 +4137,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4075,7 +4211,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4145,7 +4285,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4215,7 +4359,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4285,7 +4433,11 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4634,7 +4786,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4704,7 +4860,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4774,7 +4934,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4864,7 +5028,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -4933,7 +5101,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5003,7 +5175,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5073,7 +5249,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5143,7 +5323,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5213,7 +5397,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5283,7 +5471,11 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -5518,7 +5710,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -5831,7 +6027,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {
@@ -5952,7 +6152,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6011,7 +6215,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6070,7 +6278,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6149,7 +6361,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6207,7 +6423,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6266,7 +6486,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6325,7 +6549,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6384,7 +6612,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6443,7 +6675,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6502,7 +6738,11 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "isSelected": false,
                     "profiles": Array [
                       Object {
+                        "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                        "policy": Object {
+                          "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                        },
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                       },
                     ],
@@ -6737,7 +6977,11 @@ exports[`SystemRulesTable component tailoring rules should be able to show all s
               "id": "aa9c4497-5707-4233-9e9b-1fded5423ef3",
               "profiles": Array [
                 Object {
+                  "id": "99a661a8-8cb2-4adf-bf01-62f186493c04",
                   "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
+                  "policy": Object {
+                    "id": "ddf5aefb-ecc8-491a-a2ba-81bf17076361",
+                  },
                   "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
                   "rules": Array [
                     Object {

--- a/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/__snapshots__/SystemRulesTable.test.js.snap
@@ -299,7 +299,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -369,7 +369,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -439,7 +439,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -529,7 +529,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -598,7 +598,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -668,7 +668,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -738,7 +738,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -808,7 +808,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -878,7 +878,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -948,7 +948,7 @@ exports[`SystemRulesTable component should render 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -1804,7 +1804,7 @@ exports[`SystemRulesTable component should render search results by rule name 1`
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2215,7 +2215,7 @@ exports[`SystemRulesTable component should render search results on any page, re
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2609,7 +2609,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2679,7 +2679,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2749,7 +2749,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2839,7 +2839,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2908,7 +2908,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -2978,7 +2978,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3048,7 +3048,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3118,7 +3118,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3188,7 +3188,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3258,7 +3258,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3653,7 +3653,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3723,7 +3723,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3793,7 +3793,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3863,7 +3863,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -3933,7 +3933,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4003,7 +4003,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4073,7 +4073,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4143,7 +4143,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4213,7 +4213,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4283,7 +4283,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4632,7 +4632,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4702,7 +4702,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4772,7 +4772,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4862,7 +4862,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -4931,7 +4931,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5001,7 +5001,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5071,7 +5071,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5141,7 +5141,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5211,7 +5211,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5281,7 +5281,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -5950,7 +5950,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6009,7 +6009,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6068,7 +6068,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6147,7 +6147,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     },
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6205,7 +6205,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6264,7 +6264,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6323,7 +6323,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6382,7 +6382,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6441,7 +6441,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",
@@ -6500,7 +6500,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
                     "identifier": null,
                     "isOpen": false,
                     "isSelected": false,
-                    "policies": Array [
+                    "profiles": Array [
                       Object {
                         "name": "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
                         "refId": "xccdf_org.ssgproject.content_profile_pci-dss",


### PR DESCRIPTION
Fixes filter by policy on SystemRulesTable:
* filtering is done by policy id (or by external profile id) instead of ref_id

![Screenshot_2020-11-30 Compliance](https://user-images.githubusercontent.com/7695766/100630811-49d15d00-332b-11eb-92da-ca74e8bde694.png)
(Note, the one with a custom name is a policy and the other is an external profile/policy.)