### PR TITLE
fix(Compliance SystemRulesTable): RHICOMPL-1183 dupe policies on filter

### DIFF
--- a/packages/inventory-compliance/src/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance.js
@@ -18,7 +18,7 @@ query System($systemId: String!){
     system(id: $systemId) {
         id
         name
-        profiles {
+        testResultProfiles {
             id
             name
             policyType
@@ -52,12 +52,12 @@ query System($systemId: String!){
 
 const SystemQuery = ({ data: { system }, loading, hidePassed }) => (
     <React.Fragment>
-        <SystemPolicyCards policies={ system?.profiles } loading={ loading } />
+        <SystemPolicyCards policies={ system?.testResultProfiles } loading={ loading } />
         <br/>
         <SystemRulesTable hidePassed={ hidePassed }
             system={ system }
             columns={ columns }
-            profileRules={ system?.profiles.map(profile => ({
+            profileRules={ system?.testResultProfiles.map(profile => ({
                 system: system.id,
                 profile,
                 rules: profile.rules

--- a/packages/inventory-compliance/src/Fixtures.js
+++ b/packages/inventory-compliance/src/Fixtures.js
@@ -6,7 +6,7 @@ export const remediationsResponse = {
 export const system = {
     id: 'aa9c4497-5707-4233-9e9b-1fded5423ef3',
     name: '3.example.com',
-    profiles: [{
+    testResultProfiles: [{
         id: '99a661a8-8cb2-4adf-bf01-62f186493c04',
         refId: 'xccdf_org.ssgproject.content_profile_pci-dss',
         name: 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7',

--- a/packages/inventory-compliance/src/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable.js
@@ -345,7 +345,7 @@ class SystemRulesTable extends React.Component {
                     { remediationsEnabled &&
                         <ToolbarItem>
                             <ComplianceRemediationButton
-                                allSystems={ [{ id: system.id, profiles: system.profiles, ruleObjectsFailed: [] }] }
+                                allSystems={ [{ id: system.id, profiles: system.testResultProfiles, ruleObjectsFailed: [] }] }
                                 selectedRules={ selectedRulesWithRemediations } />
                         </ToolbarItem>
                     }


### PR DESCRIPTION
Pull testResultProfiles instead of composite where all policy profiles
are returned.
This will deduplicate listed policies on the SystemRulesTable filter,
with the assumption that a system has only one test result/profile per
policy.