### PR TITLE
Update async inventory component ErrorComponents.

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,7 +47,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0",
         "@scalprum/core": "0.0.8",
-        "@scalprum/react-core": "0.0.7"
+        "@scalprum/react-core": "0.0.10"
     },
     "devDependencies": {
         "node-sass-package-importer": "^5.3.2",

--- a/packages/components/src/Components/Inventory/AppInfo.js
+++ b/packages/components/src/Components/Inventory/AppInfo.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const AppInfo = ({ fallback, ...props }) => {
+const AppInfo = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./AppInfo"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="AppInfo"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./AppInfo"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="AppInfo" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 AppInfo.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <AppInfo {...props} ref={ref} />);
+AppInfo.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default AppInfo;

--- a/packages/components/src/Components/Inventory/AsyncInventory.js
+++ b/packages/components/src/Components/Inventory/AsyncInventory.js
@@ -23,8 +23,7 @@ const AsyncInventory = ({ fallback, onLoad, component, ...props }) => {
         })();
     }, []);
 
-    const Fallback = fallback || Fragment;
-    return InvCmp ? <InvCmp {...props} /> : <Fallback />;
+    return InvCmp ? <InvCmp {...props} /> : fallback || <Fragment />;
 };
 
 AsyncInventory.propTypes = {

--- a/packages/components/src/Components/Inventory/DetailWrapper.js
+++ b/packages/components/src/Components/Inventory/DetailWrapper.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const DetailWrapper = ({ fallback, ...props }) => {
+const DetailWrapper = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./DetailWrapper"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="DetailWrapper"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./DetailWrapper"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="DetailWrapper" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 DetailWrapper.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <DetailWrapper {...props} ref={ref} />);
+DetailWrapper.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default DetailWrapper;

--- a/packages/components/src/Components/Inventory/InventoryDetail.js
+++ b/packages/components/src/Components/Inventory/InventoryDetail.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InventoryDetail = ({ fallback, ...props }) => {
+const InventoryDetail = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./InventoryDetail"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="InventoryDetail"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./InventoryDetail"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="InventoryDetail" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 InventoryDetail.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <InventoryDetail {...props} ref={ref} />);
+InventoryDetail.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default InventoryDetail;

--- a/packages/components/src/Components/Inventory/InventoryDetailHead.js
+++ b/packages/components/src/Components/Inventory/InventoryDetailHead.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InventoryDetailHead = ({ fallback, ...props }) => {
+const InventoryDetailHead = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./InventoryDetailHead"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="InventoryDetailHead"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./InventoryDetailHead"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="InventoryDetailHead" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 InventoryDetailHead.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <InventoryDetailHead {...props} ref={ref} />);
+InventoryDetailHead.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default InventoryDetailHead;

--- a/packages/components/src/Components/Inventory/InventoryTable.js
+++ b/packages/components/src/Components/Inventory/InventoryTable.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InvTable = ({ fallback, ...props }) => {
+const InvTable = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./InventoryTable"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="InventoryTable"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./InventoryTable"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="InventoryTable" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 InvTable.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <InvTable {...props} ref={ref} />);
+InvTable.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default InvTable;

--- a/packages/components/src/Components/Inventory/TagWithDialog.js
+++ b/packages/components/src/Components/Inventory/TagWithDialog.js
@@ -4,29 +4,33 @@ const AsyncInventory = React.lazy(() => import('./AsyncInventory'));
 import { ScalprumComponent } from '@scalprum/react-core';
 import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
+import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const TagWithDialog = ({ fallback, ...props }) => {
+const TagWithDialog = React.forwardRef((props, ref) => {
     const history = useHistory();
     const store = useStore();
-    return <ScalprumComponent
-        history={history}
-        store={store}
-        fallback={fallback}
-        appName="chrome"
-        module="./TagWithDialog"
-        scope="chrome"
-        ErrorComponent={() => <Suspense fallback={fallback}>
-            <AsyncInventory
-                component="TagWithDialog"
+    return (
+        <Suspense fallback={props.fallback}>
+            <ScalprumComponent
+                history={history}
+                store={store}
+                appName="chrome"
+                module="./TagWithDialog"
+                scope="chrome"
+                ErrorComponent={<AsyncInventory ref={ref} component="TagWithDialog" {...props} />}
+                ref={ref}
                 {...props}
-                fallback={fallback} />
-        </Suspense>}
-        {...props}
-    />;
-};
+            />
+        </Suspense>
+    );
+});
 
 TagWithDialog.propTypes = {
-    fallback: PropTypes.any
+    fallback: PropTypes.node
 };
 
-export default React.forwardRef((props, ref) => <TagWithDialog {...props} ref={ref} />);
+TagWithDialog.defaultProps = {
+    fallback: <Bullseye><Spinner size="xl" /></Bullseye>
+};
+
+export default TagWithDialog;


### PR DESCRIPTION
### Changes
- async inventory error components are now nodes
- Moved forward ref to the const declaration to prevent obscuring displayName
- added fallback as a required node prop

Pr is required for successful inventory migration to chrome 2