### PR TITLE
fix(unsupported text): RHICOMPL-1207 Darker yellow

### DIFF
--- a/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
@@ -18,7 +18,7 @@ const UnsupportedSSGVersion = ({ ssgVersion }) => {
 
     return <div className='pf-c-alert pf-m-warning pf-m-inline' style={ divStyle }>
         <ExclamationTriangleIcon className='ins-u-warning' style={ { marginRight: '.25em' } } />
-        <Text component={ 'strong' } className='ins-u-warning' style={ { color: 'var(--pf-global--palette--gold-500)' } }>
+        <Text component={ 'strong' } className='ins-c-warning-text'>
             Unsupported SSG version ({ ssgVersion })
         </Text>
         <Popover position='right' { ...{ bodyContent, footerContent } }>

--- a/packages/inventory-compliance/src/compliance.scss
+++ b/packages/inventory-compliance/src/compliance.scss
@@ -26,6 +26,10 @@
     color: var(--pf-global--warning-color--100);
 }
 
+.ins-c-warning-text {
+    color: var(--pf-global--warning-color--200);
+}
+
 .ins-c-compliance-system-rule-check {
     color: var(--pf-global--success-color--200)
 }


### PR DESCRIPTION
Unsupported text next to the warning icon should be
--pf-global--warning-color--200 to match the mocks

System details cards:
![image](https://user-images.githubusercontent.com/761923/102374047-dec09100-3f8e-11eb-911e-9ea3ece3a6b4.png)


Signed-off-by: Andrew Kofink <akofink@redhat.com>