### PR TITLE
fix(ComplianceRemediationButton): RHICOMPL-873 color

### DIFF
--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -28,7 +28,6 @@
         "@patternfly/react-core": ">=4.18.5",
         "@patternfly/react-icons": ">=4.3.5",
         "@patternfly/react-table": ">=4.5.7",
-        "@patternfly/react-tokens": ">=4.4.4",
         "react": ">=16.13.1",
         "react-dom": ">=16.13.1",
         "prop-types": ">=15.6.2",

--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -4,7 +4,6 @@ import { RemediationButton } from '@redhat-cloud-services/frontend-components-re
 import flatten from 'lodash/flatten';
 import { connect } from 'react-redux';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications';
-import globalBackgroundColor100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_100';
 import { AnsibeTowerIcon } from '@patternfly/react-icons';
 
 class ComplianceRemediationButton extends React.Component {
@@ -69,7 +68,7 @@ class ComplianceRemediationButton extends React.Component {
                     onRemediationCreated={ result => addNotification(result.getNotification()) }
                     dataProvider={ this.dataProvider }
                 >
-                    <AnsibeTowerIcon size='sm' color={globalBackgroundColor100.value} />
+                    <AnsibeTowerIcon size='sm' color='var(--pf-c-button--m-primary--Color)' />
                     &nbsp;Remediate
                 </RemediationButton>
             </React.Fragment>


### PR DESCRIPTION
Fixes color of ComplianceRemediationButton to match button primary color
(white).  The color is also used for on disabled state.

In general scenario the icon within a button would share the same color
as the text.  Unfortunately, this is not the case (?).

Use of direct CSS variables is deliberate for consistency.  Previously
used background color (provided from react-tokens) had a wrong color.

Drops unused patternfly/react-tokens from peer dependencies.

![Remediation Button-active](https://user-images.githubusercontent.com/7695766/102770850-19f30380-4385-11eb-87b9-b30aed1c2978.png) ![Remediation Button-disabled](https://user-images.githubusercontent.com/7695766/102770845-195a6d00-4385-11eb-8cf6-dbfc3865391b.png)
