### PR TITLE
Add named remediation button to remediation package

### DIFF
--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -4,6 +4,7 @@
     "description": "Detail part of compliance for RedHat Cloud Services.",
     "browser": "index.js",
     "module": "esm/index.js",
+    "main": "cjs/main.js",
     "publishConfig": {
         "access": "public"
     },

--- a/packages/inventory-compliance/package.json
+++ b/packages/inventory-compliance/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-inventory-compliance",
-    "version": "2.2.20",
+    "version": "2.2.21",
     "description": "Detail part of compliance for RedHat Cloud Services.",
     "browser": "index.js",
     "module": "esm/index.js",

--- a/packages/remediations/config/webpack.config.js
+++ b/packages/remediations/config/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env) => ({
         minimizer: [ new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({}) ]
     },
     entry: {
-        index: './src/index.js',
+        index: [ './src/index.js', './src/RemediationButton.js' ],
         remediationsApi: './src/api/index.js'
     },
     output: {

--- a/packages/remediations/src/RemediationButton.js
+++ b/packages/remediations/src/RemediationButton.js
@@ -85,3 +85,5 @@ RemediationButton.defaultProps = {
 };
 
 export default RemediationButton;
+
+export { RemediationButton };


### PR DESCRIPTION
### No component found

When importing Remediation button from UMD package, there is an error with missing remediation button. This PR fixes such issue by exporting the button as named dependency as well.