### PR TITLE
Use newest version of scalprum to use cjs build

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -46,8 +46,8 @@
     "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "sanitize-html": "^1.25.0",
-        "@scalprum/core": "0.0.8",
-        "@scalprum/react-core": "0.0.12"
+        "@scalprum/core": "0.0.10",
+        "@scalprum/react-core": "0.0.13"
     },
     "devDependencies": {
         "node-sass-package-importer": "^5.3.2",


### PR DESCRIPTION
### Fixes usage of CJS

Since many applications are using CJS we should start using new version of scalprum in order to fully use CJS builds.