### PR TITLE
Add missing index to remediations rollup config.

### DIFF
--- a/packages/remediations/config/rollup.config.js
+++ b/packages/remediations/config/rollup.config.js
@@ -60,9 +60,11 @@ export default rollupConfig(
     globals,
     name,
     [{
-        RemediationButton: 'src/RemediationButton.js'
+        RemediationButton: 'src/RemediationButton.js',
+        index: 'src/index.js'
     }, {
-        RemediationButton: 'src/RemediationButton.js'
+        RemediationButton: 'src/RemediationButton.js',
+        index: 'src/index.js'
     }],
     './'
 );

--- a/packages/remediations/package.json
+++ b/packages/remediations/package.json
@@ -3,6 +3,8 @@
     "version": "2.3.4",
     "description": "Remediations components for RedHat Cloud Services project.",
     "browser": "index.js",
+    "main": "cjs/index.js",
+    "module": "esm/index.js",
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
The remediations missed was missing from the rollup build. It did not include the remediations wizard and the open wizard function. Causing the UI to crash.

@fhlavac this should fix your issues with missing components/files in the index.js. Rebase your PR once this is merged.