### PR TITLE
Allow to preselect source type and remove type selection

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -64,6 +64,7 @@ import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sour
 |disableAppSelection|bool|`false`|Flag to disable appSelection.|
 |hideSourcesButton|bool|`false`|hide 'Take me to sources' button.|
 |returnButtonTitle|node|`'Go back to sources'`|Title of the button shown after success submit. Put your own application name if you neeed.|
+|selectedType|string|`undefined`|A name of source type preselected - this will remove the source type selection. (Only for Cloud types.)|
 
 If you need to set up and **support only one application** you can provide filtered `applicationTypes` with the only one application, set up `disableAppSelection` to `false` and `initialValues` to:
 

--- a/packages/sources/src/addSourceWizard/SourceAddModal.js
+++ b/packages/sources/src/addSourceWizard/SourceAddModal.js
@@ -18,7 +18,7 @@ const initialValues = {
     isLoading: true
 };
 
-const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection, intl }) => {
+const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType }) => {
     switch (type) {
         case 'loaded':
             return {
@@ -28,7 +28,8 @@ const reducer = (state, { type, sourceTypes, applicationTypes, container, disabl
                     applicationTypes.filter(filterApps).filter(filterVendorAppTypes(sourceTypes)),
                     disableAppSelection,
                     container,
-                    intl
+                    intl,
+                    selectedType
                 ),
                 isLoading: false,
                 sourceTypes
@@ -43,7 +44,8 @@ const SourceAddModal = ({
     isCancelling,
     onCancel,
     values,
-    onSubmit
+    onSubmit,
+    selectedType
 }) => {
     const [{ schema, sourceTypes: stateSourceTypes, isLoading }, dispatch ] = useReducer(reducer, initialValues);
     const isMounted = useRef(false);
@@ -73,7 +75,8 @@ const SourceAddModal = ({
                     applicationTypes: applicationTypes || applicationTypesOut.applicationTypes,
                     disableAppSelection,
                     container: container.current,
-                    intl
+                    intl,
+                    selectedType
                 });
             }
         });
@@ -103,7 +106,10 @@ const SourceAddModal = ({
 
     return (
         <SourcesFormRenderer
-            initialValues={ values }
+            initialValues={ {
+                ...values,
+                ...(selectedType && { source_type: selectedType })
+            } }
             schema={ schema }
             onSubmit={ (values) => onSubmit(values, stateSourceTypes) }
             onCancel={ onCancel }
@@ -130,7 +136,8 @@ SourceAddModal.propTypes = {
     })),
     values: PropTypes.object,
     disableAppSelection: PropTypes.bool,
-    isCancelling: PropTypes.bool
+    isCancelling: PropTypes.bool,
+    selectedType: PropTypes.string
 };
 
 SourceAddModal.defaultProps = {

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -179,6 +179,41 @@ const redhatTypes = ({ intl, sourceTypes, applicationTypes, disableAppSelection 
     }
 ]);
 
+export const applicationStep = (applicationTypes, selectedType, intl) => ({
+    name: 'types_step',
+    title: intl.formatMessage({
+        id: 'wizard.Application',
+        defaultMessage: 'Application'
+    }),
+    nextStep,
+    fields: [{
+        component: componentTypes.PLAIN_TEXT,
+        name: 'app-description',
+        label: intl.formatMessage({
+            id: 'wizard.applicationDescription',
+            defaultMessage: 'Select an application to configure this source. You can connect additional applications after source creation.'
+        })
+    }, {
+        component: 'enhanced-select',
+        name: 'application.application_type_id',
+        label: intl.formatMessage({
+            id: 'wizard.selectYourApplicationNoPoint',
+            defaultMessage: 'Select an application'
+        }),
+        options: compileAllApplicationComboOptions(
+            applicationTypes.filter(({ supported_source_types }) => supported_source_types.includes(selectedType)),
+            intl
+        ),
+        mutator: appMutator(applicationTypes),
+        placeholder: intl.formatMessage({ id: 'wizard.chooseApp', defaultMessage: 'Choose application' }),
+        menuIsPortal: true
+    }, {
+        component: componentTypes.TEXT_FIELD,
+        name: 'source_type',
+        hideField: true
+    }]
+});
+
 export const typesStep = (sourceTypes, applicationTypes, disableAppSelection, intl) => ({
     title: intl.formatMessage({
         id: 'wizard.chooseAppAndType',
@@ -282,7 +317,7 @@ const summaryStep = (sourceTypes, applicationTypes, intl) => ({
     })
 });
 
-export default (sourceTypes, applicationTypes, disableAppSelection, container, intl) => {
+export default (sourceTypes, applicationTypes, disableAppSelection, container, intl, selectedType) => {
     setFirstValidated(true);
 
     return ({
@@ -315,7 +350,9 @@ export default (sourceTypes, applicationTypes, disableAppSelection, container, i
             crossroads: [ 'application.application_type_id', 'source_type', 'auth_select' ],
             fields: [
                 nameStep(intl),
-                typesStep(sourceTypes, applicationTypes, disableAppSelection, intl),
+                selectedType
+                    ? applicationStep(applicationTypes, selectedType, intl)
+                    : typesStep(sourceTypes, applicationTypes, disableAppSelection, intl),
                 ...schemaBuilder(sourceTypes, applicationTypes),
                 summaryStep(sourceTypes, applicationTypes, intl)
             ]

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -58,7 +58,8 @@ const AddSourceWizard = ({
     returnButtonTitle,
     initialValues,
     onClose,
-    afterSuccess
+    afterSuccess,
+    selectedType
 }) => {
     const [
         { isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, ...state },
@@ -107,6 +108,7 @@ const AddSourceWizard = ({
                 sourceTypes={ sourceTypes }
                 applicationTypes={ applicationTypes }
                 disableAppSelection={ disableAppSelection }
+                selectedType={selectedType}
             />
         </React.Fragment>
         );
@@ -153,7 +155,8 @@ AddSourceWizard.propTypes = {
     }),
     disableAppSelection: PropTypes.bool,
     hideSourcesButton: PropTypes.bool,
-    returnButtonTitle: PropTypes.node
+    returnButtonTitle: PropTypes.node,
+    selectedType: PropTypes.string
 };
 
 AddSourceWizard.defaultProps = {

--- a/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
@@ -8,7 +8,8 @@ import {
     appMutator,
     typesStep,
     compileAllApplicationComboOptions,
-    appMutatorRedHat
+    appMutatorRedHat,
+    applicationStep
 } from '../../addSourceWizard/SourceAddSchema';
 import sourceTypes, { OPENSHIFT_TYPE } from '../helpers/sourceTypes';
 import applicationTypes from '../helpers/applicationTypes';
@@ -19,6 +20,8 @@ import mount from '../__mocks__/mount';
 import { CLOUD_VENDOR, REDHAT_VENDOR } from '../../utilities/stringConstants';
 
 describe('Add source schema', () => {
+    const INTL = { formatMessage: ({ defaultMessage }) => defaultMessage };
+
     describe('nextStep', () => {
         const OPENSHIFT = 'openshift';
         const APP_ID = '666';
@@ -189,8 +192,6 @@ describe('Add source schema', () => {
     describe('typesStep', () => {
         let tmpLocation;
 
-        const INTL = { formatMessage: ({ defaultMessage }) => defaultMessage };
-
         beforeEach(() => {
             tmpLocation = Object.assign({}, window.location);
 
@@ -235,6 +236,23 @@ describe('Add source schema', () => {
             expect(result.fields[1].placeholder).toEqual(undefined);
             expect(result.fields[1].condition).toEqual({ isNotEmpty: true, when: 'source_type' });
             expect(result.fields[1].mutator.toString()).toEqual(appMutatorRedHat(applicationTypes).toString());
+        });
+    });
+
+    describe('application step', () => {
+        it('generate steps and filters application not belonging to the type', () => {
+            const result = applicationStep(applicationTypes, 'amazon', INTL);
+
+            expect(result.title).toEqual('Application');
+            expect(result.fields.map(({ name }) => name)).toEqual([
+                'app-description', 'application.application_type_id', 'source_type'
+            ]);
+            expect(result.fields[1].options).toEqual([
+                { key: 'none', label: 'None' },
+                { label: 'Cost Management', value: '2' },
+                { label: 'Subscription Watch', value: '5' },
+                { label: 'Topological Inventory', value: '3' }
+            ]);
         });
     });
 

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -16,6 +16,7 @@ import CloseModal from '../../addSourceWizard/CloseModal';
 import LoadingStep from '../../addSourceWizard/steps/LoadingStep';
 
 import mount from '../__mocks__/mount';
+import SourcesFormRenderer from '../../sourceFormRenderer';
 
 describe('AddSourceWizard', () => {
     let initialProps;
@@ -44,6 +45,8 @@ describe('AddSourceWizard', () => {
 
         expect(wrapper.find(Form)).toHaveLength(1);
         expect(wrapper.find(Modal)).toHaveLength(1);
+
+        expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[1].title).toEqual('Source type and application');
     });
 
     it('renders correctly without sourceTypes', async () => {
@@ -263,5 +266,14 @@ describe('AddSourceWizard', () => {
         expect(wrapper.find(ErroredStep)).toHaveLength(1);
 
         jest.useRealTimers();
+    });
+
+    it('show application step when selectedType is set', async () => {
+        await act(async() => {
+            wrapper = mount(<AddSourceWizard { ...initialProps } selectedType="amazon" />);
+        });
+        wrapper.update();
+
+        expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[1].title).toEqual('Application');
     });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-11431

|selectedType|string|`undefined`|A name of source type preselected - this will remove the source type selection. (Only for Cloud types.)|

**After**

![sourcetypeset](https://user-images.githubusercontent.com/32869456/103894775-b17b8480-50ef-11eb-80f6-2f9e7d5429a4.gif)
