### PR TITLE
fix(remediations): RHICOMPL-1303 Playbook with no issue IDs

### DIFF
--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -30,7 +30,7 @@ class ComplianceRemediationButton extends React.Component {
     )
 
     rulesWithRemediations = (rules, system) => {
-        return rules.filter(rule => rule.remediationAvailable && system.supported).map(
+        return rules.filter(rule => rule.remediationAvailable).map(
             rule => this.formatRule(rule, this.ruleProfile(rule, system).refId, system.id)
         );
     }


### PR DESCRIPTION
On system details page, the remediations sent have no issue IDs, even
for supported systems. This will allow remediation those systems, but we
need to revisit this code to never send unsupported rules

Signed-off-by: Andrew Kofink <akofink@redhat.com>