### PR TITLE
Add Remediations button to UMD output.

### DIFF
--- a/packages/remediations/config/webpack.config.js
+++ b/packages/remediations/config/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = (env) => ({
     },
     entry: {
         index: [ './src/index.js', './src/RemediationButton.js' ],
+        RemediationButton: './src/RemediationButton.js',
         remediationsApi: './src/api/index.js'
     },
     output: {


### PR DESCRIPTION
The webpack is not outputting the remediations button file.

fixes chrome issue:
```
ERROR in ./node_modules/@redhat-cloud-services/frontend-components-inventory-vulnerabilities/dist/index.js
Module not found: Error: Can't resolve '@redhat-cloud-services/frontend-components-remediations/RemediationButton' in '/home/martin/insights/insights-chrome/node_modules/@redhat-cloud-services/frontend-components-inventory-vulnerabilities/dist'
 @ ./node_modules/@redhat-cloud-services/frontend-components-inventory-vulnerabilities/dist/index.js 1:4011-4095
 @ ./src/js/inventory/details.js
 @ ./src/js/inventory/RenderWrapper.js
 @ ./src/js/inventory/index.js
 @ ./src/js/chrome/entry.js
 @ ./src/js/chrome.js

```