### PR TITLE
Fix async inventory ref by introducing inner ref

### DIFF
--- a/packages/components/src/Components/Inventory/AppInfo.js
+++ b/packages/components/src/Components/Inventory/AppInfo.js
@@ -6,11 +6,6 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-/**
- * Inventory sub component.
- *
- * This component shows tab(s) with detail information about selected system.
- */
 const BaseAppInfo = (props) => {
     const history = useHistory();
     const store = useStore();
@@ -30,15 +25,20 @@ const BaseAppInfo = (props) => {
     );
 };
 
-BaseAppInfo.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component shows tab(s) with detail information about selected system.
+ */
+const AppInfo = React.forwardRef((props, ref) => <BaseAppInfo innerRef={ref} {...props} />);
+
+AppInfo.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseAppInfo.defaultProps = {
+AppInfo.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const AppInfo = React.forwardRef((props, ref) => <BaseAppInfo innerRef={ref} {...props} />);
 
 export default AppInfo;

--- a/packages/components/src/Components/Inventory/AppInfo.js
+++ b/packages/components/src/Components/Inventory/AppInfo.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const AppInfo = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component shows tab(s) with detail information about selected system.
+ */
+const BaseAppInfo = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const AppInfo = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./AppInfo"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="AppInfo" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="AppInfo" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-AppInfo.propTypes = {
+BaseAppInfo.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-AppInfo.defaultProps = {
+BaseAppInfo.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const AppInfo = React.forwardRef((props, ref) => <BaseAppInfo innerRef={ref} {...props} />);
 
 export default AppInfo;

--- a/packages/components/src/Components/Inventory/AsyncInventory.js
+++ b/packages/components/src/Components/Inventory/AsyncInventory.js
@@ -6,7 +6,7 @@ import * as reactRouterDom from 'react-router-dom';
 import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import { useStore } from 'react-redux';
 
-const AsyncInventory = ({ fallback, onLoad, component, ...props }) => {
+const AsyncInventory = ({ fallback, onLoad, innerRef, component, ...props }) => {
     const store = useStore();
     const [ InvCmp, setInvCmp ] = useState();
     useEffect(() => {
@@ -23,7 +23,7 @@ const AsyncInventory = ({ fallback, onLoad, component, ...props }) => {
         })();
     }, []);
 
-    return InvCmp ? <InvCmp {...props} /> : fallback || <Fragment />;
+    return InvCmp ? <InvCmp ref={innerRef} {...props} /> : fallback || <Fragment />;
 };
 
 AsyncInventory.propTypes = {
@@ -37,4 +37,4 @@ AsyncInventory.defaultProps = {
     component: ''
 };
 
-export default React.forwardRef((props, ref) => <AsyncInventory {...props} ref={ref}/>);
+export default AsyncInventory;

--- a/packages/components/src/Components/Inventory/DetailWrapper.js
+++ b/packages/components/src/Components/Inventory/DetailWrapper.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const DetailWrapper = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component wraps entire system detail in order to show loading state and drawer (if enabled).
+ */
+const BaseDetailWrapper = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const DetailWrapper = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./DetailWrapper"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="DetailWrapper" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="DetailWrapper" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-DetailWrapper.propTypes = {
+BaseDetailWrapper.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-DetailWrapper.defaultProps = {
+BaseDetailWrapper.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const DetailWrapper = React.forwardRef((props, ref) => <BaseDetailWrapper innerRef={ref} {...props} />);
 
 export default DetailWrapper;

--- a/packages/components/src/Components/Inventory/DetailWrapper.js
+++ b/packages/components/src/Components/Inventory/DetailWrapper.js
@@ -6,11 +6,6 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-/**
- * Inventory sub component.
- *
- * This component wraps entire system detail in order to show loading state and drawer (if enabled).
- */
 const BaseDetailWrapper = (props) => {
     const history = useHistory();
     const store = useStore();
@@ -30,15 +25,20 @@ const BaseDetailWrapper = (props) => {
     );
 };
 
-BaseDetailWrapper.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component wraps entire system detail in order to show loading state and drawer (if enabled).
+ */
+const DetailWrapper = React.forwardRef((props, ref) => <BaseDetailWrapper innerRef={ref} {...props} />);
+
+DetailWrapper.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseDetailWrapper.defaultProps = {
+DetailWrapper.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const DetailWrapper = React.forwardRef((props, ref) => <BaseDetailWrapper innerRef={ref} {...props} />);
 
 export default DetailWrapper;

--- a/packages/components/src/Components/Inventory/InventoryDetail.js
+++ b/packages/components/src/Components/Inventory/InventoryDetail.js
@@ -6,11 +6,6 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-/**
- * Inventory sub component.
- *
- * This component shows complete inventory detail with system info and app's detail in tab(s).
- */
 const BaseInventoryDetail = (props) => {
     const history = useHistory();
     const store = useStore();
@@ -30,15 +25,20 @@ const BaseInventoryDetail = (props) => {
     );
 };
 
-BaseInventoryDetail.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component shows complete inventory detail with system info and app's detail in tab(s).
+ */
+const InventoryDetail = React.forwardRef((props, ref) => <BaseInventoryDetail innerRef={ref} {...props} />);
+
+InventoryDetail.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseInventoryDetail.defaultProps = {
+InventoryDetail.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const InventoryDetail = React.forwardRef((props, ref) => <BaseInventoryDetail innerRef={ref} {...props} />);
 
 export default InventoryDetail;

--- a/packages/components/src/Components/Inventory/InventoryDetail.js
+++ b/packages/components/src/Components/Inventory/InventoryDetail.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InventoryDetail = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component shows complete inventory detail with system info and app's detail in tab(s).
+ */
+const BaseInventoryDetail = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const InventoryDetail = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./InventoryDetail"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="InventoryDetail" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="InventoryDetail" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-InventoryDetail.propTypes = {
+BaseInventoryDetail.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-InventoryDetail.defaultProps = {
+BaseInventoryDetail.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const InventoryDetail = React.forwardRef((props, ref) => <BaseInventoryDetail innerRef={ref} {...props} />);
 
 export default InventoryDetail;

--- a/packages/components/src/Components/Inventory/InventoryDetailHead.js
+++ b/packages/components/src/Components/Inventory/InventoryDetailHead.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InventoryDetailHead = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component shows system information (tags, facts and basic operations).
+ */
+const BaseInventoryDetailHead = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const InventoryDetailHead = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./InventoryDetailHead"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="InventoryDetailHead" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="InventoryDetailHead" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-InventoryDetailHead.propTypes = {
+BaseInventoryDetailHead.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-InventoryDetailHead.defaultProps = {
+BaseInventoryDetailHead.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const InventoryDetailHead = React.forwardRef((props, ref) => <BaseInventoryDetailHead innerProps={ref} {...props} />);
 
 export default InventoryDetailHead;

--- a/packages/components/src/Components/Inventory/InventoryDetailHead.js
+++ b/packages/components/src/Components/Inventory/InventoryDetailHead.js
@@ -6,11 +6,6 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-/**
- * Inventory sub component.
- *
- * This component shows system information (tags, facts and basic operations).
- */
 const BaseInventoryDetailHead = (props) => {
     const history = useHistory();
     const store = useStore();
@@ -30,15 +25,20 @@ const BaseInventoryDetailHead = (props) => {
     );
 };
 
-BaseInventoryDetailHead.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component shows system information (tags, facts and basic operations).
+ */
+const InventoryDetailHead = React.forwardRef((props, ref) => <BaseInventoryDetailHead innerProps={ref} {...props} />);
+
+InventoryDetailHead.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseInventoryDetailHead.defaultProps = {
+InventoryDetailHead.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const InventoryDetailHead = React.forwardRef((props, ref) => <BaseInventoryDetailHead innerProps={ref} {...props} />);
 
 export default InventoryDetailHead;

--- a/packages/components/src/Components/Inventory/InventoryTable.js
+++ b/packages/components/src/Components/Inventory/InventoryTable.js
@@ -6,11 +6,6 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-/**
- * Inventory sub component.
- *
- * This component shows systems table connected to redux.
- */
 const BaseInvTable = (props) => {
     const history = useHistory();
     const store = useStore();
@@ -30,15 +25,20 @@ const BaseInvTable = (props) => {
     );
 };
 
-BaseInvTable.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component shows systems table connected to redux.
+ */
+const InvTable = React.forwardRef((props, ref) => <BaseInvTable innerRef={ref} {...props} />);
+
+InvTable.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseInvTable.defaultProps = {
+InvTable.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const InvTable = React.forwardRef((props, ref) => <BaseInvTable innerRef={ref} {...props} />);
 
 export default InvTable;

--- a/packages/components/src/Components/Inventory/InventoryTable.js
+++ b/packages/components/src/Components/Inventory/InventoryTable.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const InvTable = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component shows systems table connected to redux.
+ */
+const BaseInvTable = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const InvTable = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./InventoryTable"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="InventoryTable" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="InventoryTable" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-InvTable.propTypes = {
+BaseInvTable.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-InvTable.defaultProps = {
+BaseInvTable.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const InvTable = React.forwardRef((props, ref) => <BaseInvTable innerRef={ref} {...props} />);
 
 export default InvTable;

--- a/packages/components/src/Components/Inventory/TagWithDialog.js
+++ b/packages/components/src/Components/Inventory/TagWithDialog.js
@@ -6,7 +6,12 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-const TagWithDialog = React.forwardRef((props, ref) => {
+/**
+ * Inventory sub component.
+ *
+ * This component is used to manipulate with inventory tags.
+ */
+const BaseTagWithDialog = (props) => {
     const history = useHistory();
     const store = useStore();
     return (
@@ -17,20 +22,23 @@ const TagWithDialog = React.forwardRef((props, ref) => {
                 appName="chrome"
                 module="./TagWithDialog"
                 scope="chrome"
-                ErrorComponent={<AsyncInventory ref={ref} component="TagWithDialog" {...props} />}
-                ref={ref}
+                ErrorComponent={<AsyncInventory component="TagWithDialog" {...props} />}
+                ref={props.innerRef}
                 {...props}
             />
         </Suspense>
     );
-});
+};
 
-TagWithDialog.propTypes = {
+BaseTagWithDialog.propTypes = {
+    /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-TagWithDialog.defaultProps = {
+BaseTagWithDialog.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
+
+const TagWithDialog = React.forwardRef((props, ref) => <BaseTagWithDialog innerRef={ref} {...props} />);
 
 export default TagWithDialog;

--- a/packages/components/src/Components/Inventory/TagWithDialog.js
+++ b/packages/components/src/Components/Inventory/TagWithDialog.js
@@ -30,15 +30,20 @@ const BaseTagWithDialog = (props) => {
     );
 };
 
-BaseTagWithDialog.propTypes = {
+/**
+ * Inventory sub component.
+ *
+ * This component shows systems table connected to redux.
+ */
+const TagWithDialog = React.forwardRef((props, ref) => <BaseTagWithDialog innerRef={ref} {...props} />);
+
+TagWithDialog.propTypes = {
     /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
     fallback: PropTypes.node
 };
 
-BaseTagWithDialog.defaultProps = {
+TagWithDialog.defaultProps = {
     fallback: <Bullseye><Spinner size="xl" /></Bullseye>
 };
-
-const TagWithDialog = React.forwardRef((props, ref) => <BaseTagWithDialog innerRef={ref} {...props} />);
 
 export default TagWithDialog;

--- a/packages/inventory/.gitignore
+++ b/packages/inventory/.gitignore
@@ -6,3 +6,4 @@
 /cjs
 /*.css
 *.txt
+/filters.js

--- a/packages/inventory/.npmignore
+++ b/packages/inventory/.npmignore
@@ -9,3 +9,4 @@ config/
 !/esm
 !/cjs
 !/*.css
+!/filters.js


### PR DESCRIPTION
### Align async inventory refs

When using new async inventory component on old chrome the refs are broken, because they are wrongly passed to error component. This PR fixes such thing by introducing `innerRef` prop to all async inventory components which is then consumed by Async inventory itself (when errored = no scalprum present) or used as `ref` for the new chrome.