### PR TITLE
fix(Remediations): RHICOMPL-1124 available only for supported

### DIFF
--- a/packages/inventory-compliance/src/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton.js
@@ -30,7 +30,11 @@ class ComplianceRemediationButton extends React.Component {
     )
 
     rulesWithRemediations = (rules, system) => {
-        return rules.filter(rule => rule.remediationAvailable).map(
+        return rules.filter((rule) => (
+            rule.remediationAvailable &&
+            this.ruleProfile(rule, system).supported &&
+            rule.compliant === false
+        )).map(
             rule => this.formatRule(rule, this.ruleProfile(rule, system).refId, system.id)
         );
     }
@@ -53,9 +57,17 @@ class ComplianceRemediationButton extends React.Component {
         });
     }
 
-    noRemediationAvailable = () => {
+    remediationAvailable = () => {
         const { allSystems, selectedRules } = this.props;
-        return selectedRules.length === 0 && !allSystems.some((system) => system.ruleObjectsFailed.some((rule) => rule.remediationAvailable && system.supported));
+        let rules = selectedRules.length ? selectedRules : allSystems.flatMap((system) => system.ruleObjectsFailed);
+        return rules.some((rule) => (
+            rule.remediationAvailable &&
+            (
+                rule.profiles?.some((profile) => profile.supported) ||
+                allSystems.some((system) => this.ruleProfile(rule, system).supported)
+            ) &&
+            rule.compliant === false
+        ));
     }
 
     render() {
@@ -64,7 +76,7 @@ class ComplianceRemediationButton extends React.Component {
         return (
             <React.Fragment>
                 <RemediationButton
-                    isDisabled={ this.noRemediationAvailable() }
+                    isDisabled={ !this.remediationAvailable() }
                     onRemediationCreated={ result => addNotification(result.getNotification()) }
                     dataProvider={ this.dataProvider }
                 >


### PR DESCRIPTION
Remediations are only available for rules which have failed against a
supported OS/SSG configuration.

This ComplianceRemediationButton needs to be refactored IMO because it makes a lot of assumptions about the data based on the two states it can be in (either a systems list or a rules list). It works for the system details page (i.e. rules table) when `system.ruleObjectsFailed == [] && selectedRules == []`, and it works for the policy details page (i.e. systems table) when `system.ruleObjectsFailed.length > 0`. It'd be way better if we just pass in `selectedRules` in the latter case and stop using `ruleObjectsFailed` completely. Just some (frustrated) thoughts after working through this fix :)

As you can see from the fix itself, there's a lot of different checks and, well nonsense, we have to include to allow the button to work in both contexts, now checking if (1) a rule is selected, (2) is not compliant, (3) has a remediation available, and (4) is part of a supported report.

**Testing hints**:

Please check both pages (system details and policy details), for supported and unsupported systems/rules, for systems/rules with and without remediations available, and for systems/rules that have both passed and failed results.

For all these combinations, please check that the button enables/disables properly and that the correct issues are sent to the remediations service and are able to be saved to a playbook.

Signed-off-by: Andrew Kofink <akofink@redhat.com>