### PR TITLE
Allow to use different modal variants in GeneralInfo

### DIFF
--- a/packages/inventory-general-info/src/ConfigurationCard.js
+++ b/packages/inventory-general-info/src/ConfigurationCard.js
@@ -60,7 +60,8 @@ const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<Lo
             onClick: () => {
                 handleClick(
                     'Repositories',
-                    repositoriesMapper(configuration.repositories)
+                    repositoriesMapper(configuration.repositories),
+                    'medium'
                 );
             }
         }

--- a/packages/inventory-general-info/src/GeneralInformation.js
+++ b/packages/inventory-general-info/src/GeneralInformation.js
@@ -22,7 +22,8 @@ import './general-information.scss';
 class GeneralInformation extends Component {
     state = {
         isModalOpen: false,
-        modalTitle: ''
+        modalTitle: '',
+        modalVariant: 'small'
     };
 
     onSort = (_event, index, direction, customRows) => {
@@ -39,14 +40,15 @@ class GeneralInformation extends Component {
         });
     }
 
-    handleModalToggle = (modalTitle = '', { cells, rows, expandable, filters } = {}) => {
+    handleModalToggle = (modalTitle = '', { cells, rows, expandable, filters } = {}, modalVariant = 'small') => {
         rows && this.onSort(undefined, expandable ? 1 : 0, SortByDirection.asc, rows);
         this.setState(({ isModalOpen }) => ({
             isModalOpen: !isModalOpen,
             modalTitle,
             cells,
             expandable,
-            filters
+            filters,
+            modalVariant
         }));
     };
 
@@ -55,7 +57,7 @@ class GeneralInformation extends Component {
     };
 
     render() {
-        const { isModalOpen, modalTitle, cells, rows, expandable, filters } = this.state;
+        const { isModalOpen, modalTitle, cells, rows, expandable, filters, modalVariant } = this.state;
         const { store, writePermissions } = this.props;
         const Wrapper = store ? Provider : Fragment;
         return (
@@ -80,12 +82,12 @@ class GeneralInformation extends Component {
                         <CollectionCard handleClick={ this.handleModalToggle } />
                     </GridItem>
                     <Modal
-                        width={ 'initial' }
                         title={ modalTitle || '' }
                         aria-label={`${modalTitle || ''} modal`}
                         isOpen={ isModalOpen }
                         onClose={ () => this.handleModalToggle() }
                         className="ins-c-inventory__detail--dialog"
+                        variant={ modalVariant }
                     >
                         <InfoTable
                             cells={ cells }

--- a/packages/inventory-general-info/src/InfrastructureCard.js
+++ b/packages/inventory-general-info/src/InfrastructureCard.js
@@ -40,7 +40,8 @@ const InfrastructureCard = ({ infrastructure, handleClick, detailLoaded }) => (<
             onClick: () => {
                 handleClick(
                     'Interfaces/NICs',
-                    interfaceMapper(infrastructure.nics)
+                    interfaceMapper(infrastructure.nics),
+                    'medium'
                 );
             }
         }


### PR DESCRIPTION
This PR allows to set specific modal variant for each type of info.

1. simple lists can be still shown in small modals

![image](https://user-images.githubusercontent.com/32869456/104714282-52d48d00-5725-11eb-95e0-ff0243ea3b20.png)

![fixedmodal](https://user-images.githubusercontent.com/32869456/104716062-aa73f800-5727-11eb-8c83-bcc268bf8b66.gif)

2. complex tables can be expanded to medium/large to show all the content

![image](https://user-images.githubusercontent.com/32869456/104714311-5b2cc800-5725-11eb-9986-bea47ede6dbe.png)
