### PR TITLE
Set page to first one when filtering

### DIFF
--- a/packages/inventory-general-info/src/InfoTable.js
+++ b/packages/inventory-general-info/src/InfoTable.js
@@ -42,12 +42,15 @@ class InfoTable extends Component {
     setFilter = (key, value, label) => {
         const { activeFilters } = this.state;
         const { [key]: currFilter, ...restFilter } = activeFilters;
-        this.setState({ activeFilters: {
-            ...restFilter,
-            ...value.length !== 0 && {
-                [key]: { key, value, label }
-            }
-        } });
+        this.setState({
+            activeFilters: {
+                ...restFilter,
+                ...value.length !== 0 && {
+                    [key]: { key, value, label }
+                }
+            },
+            pagination: { ...this.state.pagination, page: 1 }
+        });
     }
 
     onDeleteFilter = (_e, [ deleted ], deleteAll) => {
@@ -56,7 +59,8 @@ class InfoTable extends Component {
                 deleted,
                 deleteAll,
                 this.state.activeFilters
-            )
+            ),
+            pagination: { ...this.state.pagination, page: 1 }
         });
     }
 

--- a/packages/inventory-general-info/src/InfoTable.test.js
+++ b/packages/inventory-general-info/src/InfoTable.test.js
@@ -3,6 +3,7 @@ import { shallow, mount } from 'enzyme';
 import toJson, { shallowToJson } from 'enzyme-to-json';
 import InfoTable from './InfoTable';
 import { sortable } from '@patternfly/react-table';
+import { Pagination } from '@patternfly/react-core';
 
 describe('InfoTable', () => {
     describe('should render', () => {
@@ -140,6 +141,48 @@ describe('InfoTable', () => {
             wrapper.find('nav.pf-c-pagination__nav [data-action="next"]').first().simulate('click');
             expect(wrapper.find('table tbody tr').length).toBe(10);
             expect(toJson(wrapper.find('table tbody tr').first())).toMatchSnapshot();
+        });
+
+        it('should paginate to 1 when filtering', () => {
+            const wrapper = mount(<InfoTable
+                cells={ [{ title: 'One cell' }, 'Second one' ] }
+                rows={
+                    [ ...new Array(50) ]
+                    .map(
+                        (_e, index) => ([ ...new Array(2) ].map((_e, cell) =>`${index}-${cell}`))
+                    )
+                }
+                filters={[{ index: 0 }, { index: 1 }]}
+            />);
+
+            wrapper.find('nav.pf-c-pagination__nav [data-action="next"]').first().simulate('click');
+
+            expect(wrapper.find(Pagination).first().props().page).toEqual(2);
+
+            wrapper.find('input.ins-c-conditional-filter').first().simulate('change', { target: { value: '10-0' } });
+
+            expect(wrapper.find(Pagination).first().props().page).toEqual(1);
+        });
+
+        it('should paginate to 1 when removing filters', () => {
+            const wrapper = mount(<InfoTable
+                cells={ [{ title: 'One cell' }, 'Second one' ] }
+                rows={
+                    [ ...new Array(50) ].map(
+                        () => ([ ...new Array(2) ].map((_e, cell) =>`item-${cell}`))
+                    )
+                }
+                filters={[{ index: 0 }, { index: 1 }]}
+            />);
+
+            wrapper.find('input.ins-c-conditional-filter').first().simulate('change', { target: { value: 'item' } });
+            wrapper.find('nav.pf-c-pagination__nav [data-action="next"]').first().simulate('click');
+
+            expect(wrapper.find(Pagination).first().props().page).toEqual(2);
+
+            wrapper.find('.ins-c-chip-filters ul.pf-c-chip-group__list .pf-c-chip-group__list-item button').first().simulate('click');
+
+            expect(wrapper.find(Pagination).first().props().page).toEqual(1);
         });
 
         it('should change per page count', () => {

--- a/packages/inventory-general-info/src/__snapshots__/InfoTable.test.js.snap
+++ b/packages/inventory-general-info/src/__snapshots__/InfoTable.test.js.snap
@@ -6787,7 +6787,7 @@ exports[`InfoTable api expandable should open 1`] = `
 exports[`InfoTable api should paginate to last page 1`] = `
 <tr
   className=""
-  data-ouia-component-id="OUIA-Generated-TableRow-71"
+  data-ouia-component-id="OUIA-Generated-TableRow-93"
   data-ouia-component-type="PF4/TableRow"
   data-ouia-safe={true}
   hidden={false}
@@ -6867,7 +6867,7 @@ exports[`InfoTable api should paginate to last page 1`] = `
 exports[`InfoTable api should paginate to last page 2`] = `
 <tr
   className=""
-  data-ouia-component-id="OUIA-Generated-TableRow-71"
+  data-ouia-component-id="OUIA-Generated-TableRow-93"
   data-ouia-component-type="PF4/TableRow"
   data-ouia-safe={true}
   hidden={false}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10631

**Description**

When filtering, pagination is not being reset - this could lead to no results, when you paginate from a higher page than number of filtered results.

**Before**

![before](https://user-images.githubusercontent.com/32869456/105004770-b2d47780-5a34-11eb-8178-2396f16fa6da.gif)

**After**

![after](https://user-images.githubusercontent.com/32869456/105004778-b5cf6800-5a34-11eb-968f-4b1420c6d851.gif)