### PR TITLE
Remove additional beta from not auth component

### DIFF
--- a/packages/components/src/Components/NotAuthorized/NotAuthorized.js
+++ b/packages/components/src/Components/NotAuthorized/NotAuthorized.js
@@ -16,7 +16,7 @@ import './NotAuthorized.scss';
 
 const ContactBody = () => <React.Fragment>
   Contact your organization administrator(s) for more information or visit&nbsp;
-    <a href={`./${window.insights.chrome.isBeta() ? 'beta/' : ''}settings/my-user-access`}>My User Access</a>&nbsp;
+    <a href={`./settings/my-user-access`}>My User Access</a>&nbsp;
   to learn more about your permissions.
 </React.Fragment>;
 


### PR DESCRIPTION
### No need to have two `beta`s

Since we are using meta tag the notAuth component leads to `/beta/beta/` when clicked on beta env. This PR fixes such thing by removing manually calculated beta.

Fixes #892 