### PR TITLE
Fix inventory detail inifite load if no system found

### DIFF
--- a/packages/inventory/src/components/detail/AppInfo.js
+++ b/packages/inventory/src/components/detail/AppInfo.js
@@ -32,7 +32,7 @@ const AppInfo = ({ componentMapper, appList }) => {
                         { Cmp ?
                             <Cmp
                                 store={store}
-                                inventoryId={entity.id}
+                                inventoryId={entity?.id}
                                 appName={activeApp?.name}
                             /> :
                             'missing component'}

--- a/packages/inventory/src/shared/TagsModal.js
+++ b/packages/inventory/src/shared/TagsModal.js
@@ -86,11 +86,11 @@ const TagsModal = ({
                     ...pagination,
                     count: tagsCount
                 },
-                rows: tags.map(({ key, value, namespace }) => ({
+                rows: tags?.map(({ key, value, namespace }) => ({
                     id: `${namespace}/${key}=${value}`,
                     selected: selected.find(({ id }) => id === `${namespace}/${key}=${value}`),
                     cells: [ key, value, namespace ]
-                }))
+                })) || []
             }}
             loaded={ loaded }
             width="auto"


### PR DESCRIPTION
### Broken inv detail when incorrect UUID

When navigating to inv detail with incorrect UUID the UI ends in infinite loading state, because entity is not found

### Broken ui upon navigating back to list

When user navigates back to inventory list the UI breaks because it thinks that the tags were loaded, but no array of tags is actually passed in