### PR TITLE
Convert remediation wizard to a functional component

### DIFF
--- a/packages/remediations/src/NewRemediationWizard.js
+++ b/packages/remediations/src/NewRemediationWizard.js
@@ -1,10 +1,20 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useEffect, useReducer } from 'react';
+import PropTypes from 'prop-types';
 import keyBy from 'lodash/keyBy';
 import transform from 'lodash/transform';
 import FormRenderer from '@data-driven-forms/react-form-renderer/dist/esm/form-renderer';
 import Pf4FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/esm/form-template';
 import schemaBuilder from './schema';
+import * as api from './api';
+import Wizard from '@data-driven-forms/pf4-component-mapper/dist/esm/wizard';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/esm/component-types';
+import SelectPlaybook from './newSteps/selectPlaybook';
+import ReviewActions from './newSteps/reviewActions';
+import IssueResolution from './newSteps/issueResolution';
+import FetchError from './newSteps/fetchError';
+import Review from './newSteps/review';
 import {
+    getResolution,
     remediationUrl,
     AUTO_REBOOT,
     HAS_MULTIPLES,
@@ -14,14 +24,6 @@ import {
     EXISTING_PLAYBOOK,
     MANUAL_RESOLUTION
 } from './utils';
-import * as api from './api';
-import Wizard from '@data-driven-forms/pf4-component-mapper/dist/esm/wizard';
-import componentTypes from '@data-driven-forms/react-form-renderer/dist/esm/component-types';
-import SelectPlaybook from './newSteps/selectPlaybook';
-import ReviewActions from './newSteps/reviewActions';
-import IssueResolution from './newSteps/issueResolution';
-import FetchError from './newSteps/fetchError';
-import Review from './newSteps/review';
 
 function createNotification (id, name, isNewSwitch) {
     const verb = isNewSwitch ? 'created' : 'updated';
@@ -34,93 +36,44 @@ function createNotification (id, name, isNewSwitch) {
     };
 }
 
-class RemediationWizard extends Component {
+const initialState = {
+    open: false,
+    schema: {},
+    errors: []
+};
 
-    state = {
-        open: false,
-        schema: {},
-        errors: []
+function reducer(state, action) {
+    switch (action.type) {
+        case 'update':
+            return {
+                ...state,
+                ...action.payload
+            };
+        default:
+            throw new Error();
     }
+}
 
-    constructor() {
-        super();
-        this.container = React.createRef(document.createElement('div'));
-    }
+const RemediationWizard = ({
+    isOpen,
+    data,
+    basePath
+}) => {
 
-    setOpen = open => {
-        this.setState({ open });
-    }
+    const [ state, dispatch ] = useReducer(reducer, initialState);
 
-    getFormTemplate = (props) => <Pf4FormTemplate {...props} showFormControls={false} />;
-
-    getIssues = (data, issuesById, getResolution) =>
+    const getIssuesMultiple = (issuesById, resolutions) =>
         data.issues.map(issue => {
-            const resolutions = getResolution(issue.id);
-            const { description, needs_reboot: needsReboot  } = resolutions?.[0] || {};
             return {
                 action: issuesById[issue.id].description,
-                resolution: description,
-                needsReboot,
                 systemsCount: issue.systems ? issue.systems.length : data.systems.length,
                 id: issue.id,
                 shortId: issue?.id?.split('|')?.slice(-1)?.[0] || issue.id,
-                alternate: resolutions.length - 1
+                alternate: resolutions.find(r => r.id === issue.id).resolutions?.length - 1
             };
-        });
+        }).filter(record => record.alternate > 0);
 
-    openWizard = (data, basePath) => {
-        const issuesById = keyBy(data.issues, issue => issue.id);
-
-        this.loadResolutions(data.issues).then(
-            (values) => {
-                this.setState(values);
-                const issuesMultiple = this.getIssues(data, issuesById, this.getResolution).filter(record => record.alternate > 1);
-                this.setState({
-                    open: true,
-                    data,
-                    basePath,
-                    onRemediationCreated: data.onRemediationCreated,
-                    schema: schemaBuilder(this.container.current, issuesMultiple),
-
-                    mapperExtension: {
-                        'select-playbook': {
-                            component: this.state.errors.length > 0 ? FetchError : SelectPlaybook,
-                            issues: data.issues,
-                            systems: data.systems
-                        },
-                        'review-actions': {
-                            component: ReviewActions,
-                            issues: data.issues,
-                            issuesMultiple
-                        },
-                        'issue-resolution': {
-                            component: IssueResolution,
-                            systems: data.systems,
-                            getResolution: this.getResolution
-                        },
-                        review: {
-                            component: Review,
-                            data: data,
-                            issuesById,
-                            getIssues: this.getIssues,
-                            resolutions: this.state.resolutions
-                        }
-                    }
-                });
-            }
-        );
-    }
-
-    closeWizard = () => {
-        this.setOpen(false);
-    }
-
-    loadRemediations = async () => {
-        const { data: existingRemediations } = await api.getRemediations();
-        this.setState({ existingRemediations });
-    }
-
-    loadResolutions = async (issues) => {
+    const loadResolutions = async (issues) => {
         try {
             const result = await api.getResolutionsBatch(issues.map(i => i.id));
 
@@ -138,63 +91,109 @@ class RemediationWizard extends Component {
         } catch (e) {
             return { errors: [ 'Error obtaining resolution information. Please try again later.' ] };
         }
-    }
+    };
 
-    getResolution = issueId => this.state.resolutions.find(r => r.id === issueId)?.resolutions || [];
-
-    resolver = (id, name, isNewSwitch) => (
-        this.state.onRemediationCreated({
-            remediation: { id, name },
-            getNotification: () => createNotification(id, name, isNewSwitch)
-        })
-    );
-
-    onSubmit = (values) => {
-        const issues = this.state.data.issues.map(({ id }) => ({
-            id,
-            resolution: values[MANUAL_RESOLUTION] ? this.getResolution(id)?.[0]?.id : undefined,
-            systems: this.state.data.systems
-        }));
-        const add = { issues, systems: this.state.data.systems };
-        if (values[EXISTING_PLAYBOOK_SELECTED]) {
-            const { id, name } = values[EXISTING_PLAYBOOK];
-            // eslint-disable-next-line camelcase
-            api.patchRemediation(id, { add, auto_reboot: values[AUTO_REBOOT] }, this.state.basePath)
-            .then(() => this.resolver(id, name, false));
-        } else {
-        // eslint-disable-next-line camelcase
-            api.createRemediation({ name: values[SELECT_PLAYBOOK], add, auto_reboot: values[AUTO_REBOOT] }, this.state.basePath)
-            .then(({ id }) => this.resolver(id, values[SELECT_PLAYBOOK], true));
-        }
-    }
-
-    render () {
-        return (
-            this.state.open ?
-                <FormRenderer
-                    schema={this.state.schema}
-                    container={this.container}
-                    subscription={{ values: true }}
-                    FormTemplate={this.getFormTemplate}
-                    initialValues={{
-                        [HAS_MULTIPLES]: !!this.state.resolutions?.find(r => r.resolutions.length > 1),
-                        [MANUAL_RESOLUTION]: true,
-                        [SELECTED_RESOLUTIONS]: {},
-                        [EXISTING_PLAYBOOK_SELECTED]: false
-                    }}
-                    componentMapper={{
-                        [componentTypes.WIZARD]: Wizard,
-                        ...this.state.mapperExtension
-                    }}
-                    onSubmit={(_, formOptions) => {
-                        this.onSubmit(formOptions.getState().values);
-                        this.setOpen(false);
-                    }}
-                    onCancel={this.closeWizard}
-                />
-                : <Fragment/>
+    useEffect(() => {
+        const issuesById = keyBy(data.issues, issue => issue.id);
+        loadResolutions(data.issues).then(
+            (values) => {
+                const issuesMultiple = getIssuesMultiple(issuesById, values.resolutions);
+                dispatch({
+                    type: 'update',
+                    payload: {
+                        ...values,
+                        issuesById,
+                        issuesMultiple,
+                        basePath,
+                        onRemediationCreated: data.onRemediationCreated,
+                        schema: schemaBuilder(issuesMultiple),
+                        isOpen
+                    }
+                });
+            }
         );
-    }
-}
+    }, []);
+
+    const closeWizard = () => dispatch({ type: 'update', payload: { isOpen: false } });
+
+    const resolver = (id, name, isNewSwitch) => state.onRemediationCreated({
+        remediation: { id, name },
+        getNotification: () => createNotification(id, name, isNewSwitch)
+    });
+
+    const onSubmit = (formValues) => {
+        const issues = data.issues.map(({ id }) => ({
+            id,
+            resolution: getResolution(id, formValues, state.resolutions)?.[0]?.id,
+            systems: data.systems
+        }));
+        const add = { issues, systems: data.systems };
+        if (formValues[EXISTING_PLAYBOOK_SELECTED]) {
+            const { id, name } = formValues[EXISTING_PLAYBOOK];
+            // eslint-disable-next-line camelcase
+            api.patchRemediation(id, { add, auto_reboot: formValues[AUTO_REBOOT] }, state.basePath)
+            .then(() => resolver(id, name, false));
+        } else {
+            // eslint-disable-next-line camelcase
+            api.createRemediation({ name: formValues[SELECT_PLAYBOOK], add, auto_reboot: formValues[AUTO_REBOOT] }, state.basePath)
+            .then(({ id }) => resolver(id, formValues[SELECT_PLAYBOOK], true));
+        }
+    };
+
+    const mapperExtension = {
+        'select-playbook': {
+            component: state.errors.length > 0 ? FetchError : SelectPlaybook,
+            issues: data.issues,
+            systems: data.systems
+        },
+        'review-actions': {
+            component: ReviewActions,
+            issues: data.issues,
+            issuesMultiple: state.issuesMultiple
+        },
+        'issue-resolution': {
+            component: IssueResolution,
+            systems: data.systems,
+            resolutions: state.resolutions
+        },
+        review: {
+            component: Review,
+            data: data,
+            issuesById: state.issuesById,
+            resolutions: state.resolutions
+        }
+    };
+
+    return (
+        state.isOpen ?
+            <FormRenderer
+                schema={state.schema}
+                subscription={{ values: true }}
+                FormTemplate={(props) => <Pf4FormTemplate {...props} showFormControls={false} />}
+                initialValues={{
+                    [HAS_MULTIPLES]: !!state.resolutions?.find(r => r.resolutions.length > 1),
+                    [MANUAL_RESOLUTION]: true,
+                    [SELECTED_RESOLUTIONS]: {},
+                    [EXISTING_PLAYBOOK_SELECTED]: false
+                }}
+                componentMapper={{
+                    [componentTypes.WIZARD]: Wizard,
+                    ...mapperExtension
+                }}
+                onSubmit={(_, formOptions) => {
+                    onSubmit(formOptions.getState().values);
+                    closeWizard();
+                }}
+                onCancel={closeWizard}
+            />
+            : <Fragment/>
+    );
+};
+
+RemediationWizard.propTypes = {
+    isOpen: PropTypes.bool,
+    data: PropTypes.any,
+    basePath: PropTypes.any
+};
 
 export default RemediationWizard;

--- a/packages/remediations/src/NewRemediationWizard.js
+++ b/packages/remediations/src/NewRemediationWizard.js
@@ -7,6 +7,7 @@ import Pf4FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/esm/fo
 import schemaBuilder from './schema';
 import * as api from './api';
 import Wizard from '@data-driven-forms/pf4-component-mapper/dist/esm/wizard';
+import TextField from '@data-driven-forms/pf4-component-mapper/dist/esm/text-field';
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/esm/component-types';
 import SelectPlaybook from './newSteps/selectPlaybook';
 import ReviewActions from './newSteps/reviewActions';
@@ -160,10 +161,11 @@ const RemediationWizard = ({
                 }}
                 componentMapper={{
                     [componentTypes.WIZARD]: Wizard,
+                    [componentTypes.TEXT_FIELD]: TextField,
                     ...mapperExtension
                 }}
-                onSubmit={(_, formOptions) => {
-                    onSubmit(formOptions.getState().values);
+                onSubmit={(formValues) => {
+                    onSubmit(formValues);
                     setOpen(false);
                 }}
                 onCancel={() => setOpen(false)}

--- a/packages/remediations/src/NewRemediationWizardHelper.js
+++ b/packages/remediations/src/NewRemediationWizardHelper.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import RemediationWizard from './NewRemediationWizard';
 
 class NewRemediationWizard extends Component {
@@ -15,9 +15,18 @@ class NewRemediationWizard extends Component {
         });
     }
 
+    setOpen = (value) => {
+        this.setState({ isOpen: value });
+    }
+
     render () {
         return (
-            this.state.isOpen ? <RemediationWizard {...this.state}/> : <Fragment/>
+            this.state.isOpen
+                ? <RemediationWizard
+                    data={this.state.data}
+                    basePath={this.state.basePath}
+                    setOpen={this.setOpen}/>
+                : null
         );
     }
 }

--- a/packages/remediations/src/NewRemediationWizardHelper.js
+++ b/packages/remediations/src/NewRemediationWizardHelper.js
@@ -1,0 +1,25 @@
+import React, { Component, Fragment } from 'react';
+import RemediationWizard from './NewRemediationWizard';
+
+class NewRemediationWizard extends Component {
+
+    state = {
+        isOpen: false
+    }
+
+    openWizard = (data, basePath) => {
+        this.setState({
+            isOpen: true,
+            data,
+            basePath
+        });
+    }
+
+    render () {
+        return (
+            this.state.isOpen ? <RemediationWizard {...this.state}/> : <Fragment/>
+        );
+    }
+}
+
+export default NewRemediationWizard;

--- a/packages/remediations/src/index.js
+++ b/packages/remediations/src/index.js
@@ -1,7 +1,7 @@
 
 import validate from './validator';
 import RemediationWizard from './RemediationWizard';
-import NewRemediationWizard from './NewRemediationWizard';
+import NewRemediationWizard from './NewRemediationWizardHelper';
 export { RemediationWizard, NewRemediationWizard };
 
 export function openWizard(data, basePath, wizardRef) {

--- a/packages/remediations/src/newSteps/issueResolution.js
+++ b/packages/remediations/src/newSteps/issueResolution.js
@@ -14,12 +14,12 @@ import { SELECTED_RESOLUTIONS } from '../utils';
 import { RedoIcon, CloseIcon } from '@patternfly/react-icons';
 
 const IssueResolution = (props) => {
-    const { systems, getResolution, issue } = props;
+    const { systems, resolutions, issue } = props;
     const formOptions = useFormApi();
-    const [ resolutions, setResolutions ] = useState([]);
+    const [ issueResolutions, setIssueResolutions ] = useState([]);
 
     useEffect(() => {
-        setResolutions(getResolution(issue.id));
+        setIssueResolutions(resolutions.find(r => r.id === issue.id)?.resolutions || []);
     }, []);
 
     const pluralize = (count, str) => count > 1 ? str + 's' : str;
@@ -47,7 +47,7 @@ const IssueResolution = (props) => {
             <StackItem>
                 <div className="ins-c-resolution-container">
                     {
-                        resolutions.map((resolution, index) => (
+                        issueResolutions.map((resolution, index) => (
                             <div
                                 className="ins-c-resolution-option"
                                 sm={12}
@@ -98,11 +98,12 @@ IssueResolution.propTypes = {
         shortId: propTypes.string,
         action: propTypes.string,
         alternate: propTypes.number,
-        needsReboot: propTypes.bool,
-        resolution: propTypes.string,
         systemsCount: propTypes.number
     }).isRequired,
-    getResolution: propTypes.func.isRequired
+    resolutions: propTypes.arrayOf(propTypes.shape({
+        id: propTypes.string,
+        resolutions: propTypes.array
+    })).isRequired
 };
 
 export default IssueResolution;

--- a/packages/remediations/src/newSteps/review.js
+++ b/packages/remediations/src/newSteps/review.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import propTypes from 'prop-types';
+import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
 import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -13,7 +14,6 @@ import {
 import {
     buildRows,
     getResolution,
-    AUTO_REBOOT,
     EXISTING_PLAYBOOK,
     EXISTING_PLAYBOOK_SELECTED,
     SELECT_PLAYBOOK
@@ -22,13 +22,18 @@ import './review.scss';
 
 const Review = (props) => {
     const { data, issuesById, resolutions } = props;
+    const { input } = useFieldApi(props);
     const formOptions = useFormApi();
     const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
 
     const selectedPlaybook = formOptions.getState().values[EXISTING_PLAYBOOK];
 
     useEffect(() => {
-        formOptions.change(AUTO_REBOOT, formOptions.getState().values[EXISTING_PLAYBOOK_SELECTED] && selectedPlaybook.auto_reboot);
+        input.onChange(
+            input.value !== undefined
+                ? input.value
+                : formOptions.getState().values[EXISTING_PLAYBOOK_SELECTED] && selectedPlaybook.auto_reboot
+        );
     }, []);
 
     const records = data.issues.map(issue => {
@@ -67,7 +72,7 @@ const Review = (props) => {
                 <TextContent>
                     <Text>
                         The playbook <b>{formOptions.getState().values[SELECT_PLAYBOOK]}</b>
-                        { formOptions.getState().values[AUTO_REBOOT] ?
+                        { input.value ?
                             ' does' :
                             <span className="ins-c-remediation-danger-text"> does not</span>
                         } auto reboot systems.
@@ -78,9 +83,9 @@ const Review = (props) => {
                 <Button
                     variant="link"
                     isInline
-                    onClick={ () => formOptions.change(AUTO_REBOOT, !formOptions.getState().values[AUTO_REBOOT]) }
+                    onClick={ () => input.onChange(!input.value) }
                 >
-                    Turn {formOptions.getState().values[AUTO_REBOOT] ? 'off' : 'on'} autoreboot
+                    Turn {input.value ? 'off' : 'on'} autoreboot
                 </Button>
             </StackItem>
             <Table

--- a/packages/remediations/src/newSteps/reviewActions.js
+++ b/packages/remediations/src/newSteps/reviewActions.js
@@ -1,6 +1,8 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState } from 'react';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
+import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
 import {
     Radio,
     Text,
@@ -8,49 +10,25 @@ import {
     Stack,
     StackItem
 } from '@patternfly/react-core';
-import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
-import { CloseIcon, RedoIcon } from '@patternfly/react-icons';
+import {
+    buildRows,
+    pluralize,
+    EXISTING_PLAYBOOK,
+    EXISTING_PLAYBOOK_SELECTED
+} from '../utils';
 import './reviewActions.scss';
 
 const ReviewActions = (props) => {
     const { issues, issuesMultiple } = props;
     const { input } = useFieldApi(props);
+    const formOptions = useFormApi();
     const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
 
-    const sortedRecords = issuesMultiple.sort(
-        (a, b) => {
-            const key = Object.keys(a)[sortByState.index];
-            return (
-                (a[key] > b[key] ? 1 :
-                    a[key] < b[key] ? -1 : 0)
-                * (sortByState.direction === 'desc' ? -1 : 1)
-            );
-        }
-    );
+    const records = formOptions.getState().values[EXISTING_PLAYBOOK_SELECTED]
+        ? issuesMultiple.filter(issue => !formOptions.getState().values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
+        : issuesMultiple;
 
-    const rows = sortedRecords.map((record, index) => ({
-        cells: [
-            record.action,
-            <Fragment key={`${index}-description`}>
-                <p key={`${index}-resolution`}>
-                    {record.resolution}
-                </p>
-                {record.alternate > 0 &&
-                    (
-                        <p key={`${index}-alternate`}>{record.alternate} alternate resolution</p>
-                    )}
-            </Fragment>,
-            {
-                title: record.needsReboot ? <Fragment><RedoIcon/>{' Yes'}</Fragment> : <Fragment><CloseIcon/>{' No'}</Fragment>,
-                value: record.needsReboot
-            },
-            record.systemsCount
-        ]
-    }));
-
-    const onSort = (event, index, direction) => setSortByState({ index, direction });
-
-    const pluralize = (count, str) => count > 1 ? str + 's' : str;
+    const rows = buildRows(records, sortByState);
 
     return (
         <Stack hasGutter>
@@ -97,7 +75,7 @@ const ReviewActions = (props) => {
                     }]
                 }
                 rows={ rows }
-                onSort={ onSort }
+                onSort={ (event, index, direction) => setSortByState({ index, direction }) }
                 sortBy={ sortByState }
             >
                 <TableHeader />
@@ -129,8 +107,6 @@ ReviewActions.propTypes = {
         shortId: propTypes.string,
         action: propTypes.string,
         alternate: propTypes.number,
-        needsReboot: propTypes.bool,
-        resolution: propTypes.string,
         systemsCount: propTypes.number
     })).isRequired
 };

--- a/packages/remediations/src/newSteps/reviewActions.js
+++ b/packages/remediations/src/newSteps/reviewActions.js
@@ -24,8 +24,9 @@ const ReviewActions = (props) => {
     const formOptions = useFormApi();
     const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
 
-    const records = formOptions.getState().values[EXISTING_PLAYBOOK_SELECTED]
-        ? issuesMultiple.filter(issue => !formOptions.getState().values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
+    const values = formOptions.getState().values;
+    const records = values[EXISTING_PLAYBOOK_SELECTED]
+        ? issuesMultiple.filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
         : issuesMultiple;
 
     const rows = buildRows(records, sortByState);
@@ -106,6 +107,8 @@ ReviewActions.propTypes = {
         id: propTypes.string,
         shortId: propTypes.string,
         action: propTypes.string,
+        resolution: propTypes.string,
+        needsReboot: propTypes.bool,
         alternate: propTypes.number,
         systemsCount: propTypes.number
     })).isRequired

--- a/packages/remediations/src/newSteps/selectPlaybook.js
+++ b/packages/remediations/src/newSteps/selectPlaybook.js
@@ -16,8 +16,9 @@ import {
     Stack, StackItem
 } from '@patternfly/react-core';
 import {
-    EXISTING_PLAYBOOK_SELECTED,
-    EXISTING_PLAYBOOK
+    pluralize,
+    EXISTING_PLAYBOOK,
+    EXISTING_PLAYBOOK_SELECTED
 } from '../utils';
 import './selectPlaybook.scss';
 
@@ -26,12 +27,12 @@ const SelectPlaybook = (props) => {
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
     const values = formOptions.getState().values;
+
     const [ existingRemediations, setExistingRemediations ] = useState();
     const [ existingPlaybookSelected, setExistingPlaybookSelected ] = useState(values[EXISTING_PLAYBOOK_SELECTED]);
     const [ newPlaybookName, setNewPlaybookName ] = useState(values[EXISTING_PLAYBOOK_SELECTED] ? '' : input.value);
     const [ selectedPlaybook, setSelectedPlaybook ] = useState(values[EXISTING_PLAYBOOK]);
     const [ isLoadingRemediation, setIsLoadingRemediation ] = useState(false);
-    const nameValid = true;
 
     useEffect(() => {
         async function fetchData() {
@@ -41,8 +42,6 @@ const SelectPlaybook = (props) => {
 
         fetchData();
     }, []);
-
-    const pluralize = (count, str) => count > 1 ? str + 's' : str;
 
     return (
         <Stack hasGutter>
@@ -122,7 +121,6 @@ const SelectPlaybook = (props) => {
                     <GridItem sm={12} md={6} lg={4}>
                         <FormGroup
                             fieldId="remediation-name"
-                            validated={nameValid ? 'default' : 'error'}
                         >
                             <TextInput
                                 type="text"
@@ -133,7 +131,6 @@ const SelectPlaybook = (props) => {
                                 }}
                                 aria-label="Name your playbook"
                                 autoFocus
-                                validated={nameValid ? 'default' : 'error'}
                             />
                         </FormGroup>
                     </GridItem>

--- a/packages/remediations/src/schema.js
+++ b/packages/remediations/src/schema.js
@@ -5,7 +5,9 @@ import {
     SELECT_PLAYBOOK,
     MANUAL_RESOLUTION,
     EXISTING_PLAYBOOK,
-    EXISTING_PLAYBOOK_SELECTED
+    EXISTING_PLAYBOOK_SELECTED,
+    SELECTED_RESOLUTIONS,
+    AUTO_REBOOT
 } from './utils';
 
 export default issues => ({
@@ -32,6 +34,16 @@ export default issues => ({
                         {
                             type: validatorTypes.REQUIRED
                         }]
+                    },
+                    {
+                        name: EXISTING_PLAYBOOK_SELECTED,
+                        component: componentTypes.TEXT_FIELD,
+                        hideField: true
+                    },
+                    {
+                        name: EXISTING_PLAYBOOK,
+                        component: componentTypes.TEXT_FIELD,
+                        hideField: true
                     }],
                     nextStep: ({ values }) => values[HAS_MULTIPLES] ? 'actions' : 'review'
                 },
@@ -59,6 +71,11 @@ export default issues => ({
                                 name: issue.id,
                                 component: 'issue-resolution',
                                 issue
+                            },
+                            {
+                                name: SELECTED_RESOLUTIONS,
+                                component: componentTypes.TEXT_FIELD,
+                                hideField: true
                             }
                         ],
                         nextStep: ({ values }) => {
@@ -75,7 +92,7 @@ export default issues => ({
                     title: 'Remediation review',
                     fields: [
                         {
-                            name: 'review',
+                            name: AUTO_REBOOT,
                             component: 'review'
                         }
                     ]

--- a/packages/remediations/src/utils.js
+++ b/packages/remediations/src/utils.js
@@ -1,4 +1,16 @@
+import React, { Fragment } from 'react';
+import { CloseIcon, RedoIcon } from '@patternfly/react-icons';
 import urijs from 'urijs';
+
+export const CAN_REMEDIATE = 'remediations:remediation:write';
+
+export const AUTO_REBOOT = 'auto-reboot';
+export const HAS_MULTIPLES = 'has-multiples';
+export const SELECT_PLAYBOOK = 'select-playbook';
+export const SELECTED_RESOLUTIONS = 'selected-resolutions';
+export const MANUAL_RESOLUTION = 'manual-resolution';
+export const EXISTING_PLAYBOOK_SELECTED = 'existing-playbook-selected';
+export const EXISTING_PLAYBOOK = 'existing-playbook';
 
 // Get the current group since we can be mounted at two urls
 export function getGroup () {
@@ -15,12 +27,53 @@ export function remediationUrl (id) {
     return urijs(document.baseURI).segment(getGroup()).segment('remediations').segment(id).toString();
 }
 
-export const CAN_REMEDIATE = 'remediations:remediation:write';
+export const pluralize = (count, str) => count > 1 ? str + 's' : str;
 
-export const AUTO_REBOOT = 'auto-reboot';
-export const HAS_MULTIPLES = 'has-multiples';
-export const SELECT_PLAYBOOK = 'select-playbook';
-export const SELECTED_RESOLUTIONS = 'selected-resolutions';
-export const MANUAL_RESOLUTION = 'manual-resolution';
-export const EXISTING_PLAYBOOK_SELECTED = 'existing-playbook-selected';
-export const EXISTING_PLAYBOOK = 'existing-playbook';
+const sortRecords = (records, sortByState) => records.sort(
+    (a, b) => {
+        const key = Object.keys(a)[sortByState.index];
+        return (
+            (a[key] > b[key] ? 1 :
+                a[key] < b[key] ? -1 : 0)
+                * (sortByState.direction === 'desc' ? -1 : 1)
+        );
+    }
+);
+
+export const buildRows = (records, sortByState) => sortRecords(records, sortByState).map((record, index) => ({
+    cells: [
+        record.action,
+        <Fragment key={`${index}-description`}>
+            <p key={`${index}-resolution`}>
+                {record.resolution}
+            </p>
+            {record.alternate > 0 &&
+                (
+                    <p key={`${index}-alternate`}>{record.alternate} alternate {pluralize(record.alternate, 'resolution')}</p>
+                )}
+        </Fragment>,
+        {
+            title: record.needsReboot ? <Fragment><RedoIcon/>{' Yes'}</Fragment> : <Fragment><CloseIcon/>{' No'}</Fragment>,
+            value: record.needsReboot
+        },
+        record.systemsCount
+    ]
+}));
+
+export const getResolution = (issueId, formValues, resolutions) => {
+    const issueResolutions = resolutions.find(r => r.id === issueId)?.resolutions || [];
+
+    if (formValues[MANUAL_RESOLUTION] && issueId in formValues[SELECTED_RESOLUTIONS]) {
+        return issueResolutions.filter(r => r.id === formValues[SELECTED_RESOLUTIONS][issueId]);
+    }
+
+    if (formValues[EXISTING_PLAYBOOK_SELECTED]) {
+        const existing = formValues[EXISTING_PLAYBOOK]?.issues?.find(i => i.id === issueId);
+
+        if (existing) {
+            return issueResolutions.filter(r => r.id === existing.resolution.id);
+        }
+    }
+
+    return issueResolutions;
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-11793

- converted NewRemediationWizard to functional component + added a helper class component to preserve the API
- moved duplicate logic to `./utils`
- fixed bug showing resolution steps also for issues already present in the selected playbook
- did some more code cleaning

![010](https://user-images.githubusercontent.com/50696716/105381359-35b12a00-5c0f-11eb-8875-5097ff69491c.png)
