### PR TITLE
Hot fix notifications by adding actions exporter

### DIFF
--- a/packages/notifications/.gitignore
+++ b/packages/notifications/.gitignore
@@ -1,6 +1,10 @@
 /index.js
 /index.css
 /index.scss
+/actions.js
+/notifications.js
+/notificationsReducer.js
+/NotificationPortal.js
 /esm
 /cjs
 /redux

--- a/packages/notifications/.npmignore
+++ b/packages/notifications/.npmignore
@@ -1,5 +1,9 @@
 !/index.js
 !/index.css
+!/actions.js
+!/notifications.js
+!/notificationsReducer.js
+!/NotificationPortal.js
 src/
 .babelrc
 babel.config.js

--- a/packages/notifications/src/NotificationPortal.js
+++ b/packages/notifications/src/NotificationPortal.js
@@ -1,0 +1,1 @@
+export * from './NotificationPortal';

--- a/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
+++ b/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
@@ -19,7 +19,7 @@ describe('Notification portal', () => {
         };
     });
 
-    it('should return no component when no notifications given', () => {
+    it.only('should return no component when no notifications given', () => {
         const t = () => {
             try {
                 new ReactWrapper(mount(<NotificationsPortal { ...initialProps } />));

--- a/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
+++ b/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
@@ -19,7 +19,7 @@ describe('Notification portal', () => {
         };
     });
 
-    it.only('should return no component when no notifications given', () => {
+    it('should return no component when no notifications given', () => {
         const t = () => {
             try {
                 new ReactWrapper(mount(<NotificationsPortal { ...initialProps } />));

--- a/packages/notifications/src/actions.js
+++ b/packages/notifications/src/actions.js
@@ -1,0 +1,1 @@
+export * from './redux';

--- a/packages/notifications/src/index.js
+++ b/packages/notifications/src/index.js
@@ -1,4 +1,4 @@
-export { default as NotificationsPortal } from './NotificationPortal';
+export { default as NotificationsPortal } from './NotificationPortal/index';
 export { default as notifications, notificationsReducers } from './redux/reducers/notifications';
 export {
     ADD_NOTIFICATION,

--- a/packages/notifications/src/notifications.js
+++ b/packages/notifications/src/notifications.js
@@ -1,0 +1,1 @@
+export { default as notifications } from './redux/reducers/notifications';

--- a/packages/notifications/src/notificationsMiddleware/index.js
+++ b/packages/notifications/src/notificationsMiddleware/index.js
@@ -1,2 +1,3 @@
-export { default } from './notificationsMiddleware';
+export { default as default } from './notificationsMiddleware';
+export { default as notificationsMiddleware } from './notificationsMiddleware';
 export * from './notificationsMiddleware';

--- a/packages/notifications/src/notificationsReducer.js
+++ b/packages/notifications/src/notificationsReducer.js
@@ -1,0 +1,1 @@
+export { default as notificationsReducer } from './redux/reducers/notifications';


### PR DESCRIPTION
### Broken builds with older version

Since we want to maintain slow and incremental upgrade we shouldn't break how actions were previously imported. This PR fixes potentional problems by re-exporting redux partials under specific filenames.