### PR TITLE
Add prepublish script to utils package

### DIFF
--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -11,3 +11,4 @@
 !LICENSE
 !package.json
 !README.md
+!postinstall.js

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -6,3 +6,4 @@ doc/
 config/
 !Styles.css
 !helpers.css
+!postinstall.js

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
         "build:esm": "BABEL_ENV=esm babel src --out-dir ./esm --ignore '**/*.test.js'",
         "build:css": "node ../../scripts/build-styles.js",
         "build:packages": "node ../../scripts/build-packages.js",
-        "postinstall": "node ./postinstall.js",
+        "prepublishOnly": "node ./postinstall.js",
         "start": "concurrently \"npm run build:esm -- --watch\" \"npm run build:js -- --watch\" \"npm run build:css -- --watch\""
     },
     "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,6 +13,7 @@
         "build:esm": "BABEL_ENV=esm babel src --out-dir ./esm --ignore '**/*.test.js'",
         "build:css": "node ../../scripts/build-styles.js",
         "build:packages": "node ../../scripts/build-packages.js",
+        "postinstall": "node ./postinstall.js",
         "start": "concurrently \"npm run build:esm -- --watch\" \"npm run build:js -- --watch\" \"npm run build:css -- --watch\""
     },
     "repository": {

--- a/packages/utils/postinstall.js
+++ b/packages/utils/postinstall.js
@@ -1,0 +1,16 @@
+const { readdirSync } = require('fs');
+const { copySync } = require('fs-extra');
+
+const getDirectories = source => readdirSync(source, { withFileTypes: true })
+.filter(dirent => dirent.isDirectory())
+.map(dirent => dirent.name);
+
+copySync('./styles', './Utilities');
+
+const files = getDirectories('./').filter(item => ![ 'esm', 'files', 'doc', 'src', 'node_modules' ].includes(item));
+
+files.map(file => copySync(`./${file}`, `./files/${file}`));
+files.map(file => copySync(`./${file}`, `./files/cjs/${file}`));
+copySync('./esm', './files/esm');
+copySync('./index.js', './files/index.js');
+copySync('./index.js', './files/cjs/index.js');

--- a/packages/utils/postinstall.js
+++ b/packages/utils/postinstall.js
@@ -5,7 +5,7 @@ const getDirectories = source => readdirSync(source, { withFileTypes: true })
 .filter(dirent => dirent.isDirectory())
 .map(dirent => dirent.name);
 
-copySync('./styles', './Utilities');
+copySync('./styles', './Utilities', (err) => err && console.log(err));
 
 const files = getDirectories('./').filter(item => ![ 'esm', 'files', 'doc', 'src', 'node_modules' ].includes(item));
 


### PR DESCRIPTION
### Prevent breaking of partially migrated apps

If an app doesn't migrate all packages to v3, they can experience missing files in utils package. This PR fixes such issue by introducing postinstall script.