### PR TITLE
Hide filters in Inventory

### DIFF
--- a/packages/inventory/README.md
+++ b/packages/inventory/README.md
@@ -22,4 +22,5 @@ This package is dependent on [@redhat-cloud-services/frontend-components-utiliti
 * Components
   * [inventory](https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/inventory.md)
     * [custom fetch function](https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/custom_fetch.md)
+    * [hide filters](https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/hide_filters.md)
   * [inventory_header](https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/inventory_header.md)

--- a/packages/inventory/doc/hide_filters.md
+++ b/packages/inventory/doc/hide_filters.md
@@ -1,0 +1,46 @@
+- [hideFilters](#hidefilters)
+  - [tags](#tags)
+  - [name](#name)
+  - [registeredWith](#registeredwith)
+  - [stale](#stale)
+
+# hideFilters
+
+You can disable default filters by using a `hideFilters` prop.
+
+```jsx
+    hideFilters: PropTypes.shape({
+        tags: PropTypes.bool,
+        name: PropTypes.bool,
+        registeredWith: PropTypes.bool,
+        stale: PropTypes.bool
+    })
+```
+
+By default all filters are set to `true`. You can override just part of it.
+
+```jsx
+<InventoryTable
+    hideFilters={{name: true}}
+/>
+```
+
+This props is also passed to [custom fetch](./custom_fetch.md).
+
+Hiding filters also removes their default values.
+
+## tags
+
+Similar to `showTags`, it hides the tags filter.
+
+## name
+
+Hides display name filter.
+
+## registeredWith
+
+Hides registered with filter.
+
+## stale
+
+Hides staleness filter.

--- a/packages/inventory/doc/hide_filters.md
+++ b/packages/inventory/doc/hide_filters.md
@@ -3,25 +3,27 @@
   - [name](#name)
   - [registeredWith](#registeredwith)
   - [stale](#stale)
+  - [all](#all)
 
 # hideFilters
 
 You can disable default filters by using a `hideFilters` prop.
 
 ```jsx
-    hideFilters: PropTypes.shape({
-        tags: PropTypes.bool,
-        name: PropTypes.bool,
-        registeredWith: PropTypes.bool,
-        stale: PropTypes.bool
-    })
+hideFilters: PropTypes.shape({
+    tags: PropTypes.bool,
+    name: PropTypes.bool,
+    registeredWith: PropTypes.bool,
+    stale: PropTypes.bool,
+    all: PropTypes.bool,
+})
 ```
 
 By default all filters are set to `true`. You can override just part of it.
 
 ```jsx
 <InventoryTable
-    hideFilters={{name: true}}
+    hideFilters={{ name: true }}
 />
 ```
 
@@ -44,3 +46,18 @@ Hides registered with filter.
 ## stale
 
 Hides staleness filter.
+
+## all
+
+Hides all the filters. It has a lower priority than specific keys. You can hide all filter and then turn on specific ones. This makes sure that there will be no additional filters in the future.
+
+**Example**
+
+- name is shown
+- all others are hidden
+
+```jsx
+<InventoryTable
+    hideFilters={{ all: true, name: false }}
+/>
+```

--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -117,6 +117,13 @@ const EntityTableToolbar = ({
         }
     }, [ customFilters?.tags ]);
 
+    const enabledFilters = {
+        name: !(hideFilters.all && hideFilters.name !== false) && !hideFilters.name,
+        stale: !(hideFilters.all && hideFilters.stale !== false) && !hideFilters.stale,
+        registeredWith: !(hideFilters.all && hideFilters.registeredWith !== false) && !hideFilters.registeredWith,
+        tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags
+    };
+
     /**
      * Function used to update data, it either calls `onRefresh` from props or dispatches `onRefreshData`.
      * `onRefresh` function takes two parameters
@@ -158,10 +165,10 @@ const EntityTableToolbar = ({
     useEffect(() => {
         const { textFilter, tagFilters, staleFilter, registeredWithFilter } = reduceFilters(filters);
         debouncedRefresh();
-        !hideFilters.name && setTextFilter(textFilter);
-        !hideFilters.stale && setStaleFilter(staleFilter);
-        !hideFilters.registeredWith && setRegisteredWithFilter(registeredWithFilter);
-        !hideFilters.tags && setSelectedTags(tagFilters);
+        enabledFilters.name && setTextFilter(textFilter);
+        enabledFilters.stale && setStaleFilter(staleFilter);
+        enabledFilters.registeredWith && setRegisteredWithFilter(registeredWithFilter);
+        enabledFilters.tags && setSelectedTags(tagFilters);
     }, []);
 
     /**
@@ -200,31 +207,31 @@ const EntityTableToolbar = ({
     const shouldReload = page && perPage && filters && (!hasItems || items) && loaded;
 
     useEffect(() => {
-        if (shouldReload && showTags && !hideFilters.tags) {
+        if (shouldReload && showTags && enabledFilters.tags) {
             debounceGetAllTags(filterTagsBy, { filters });
         }
     }, [ filterTagsBy, customFilters?.tags ]);
 
     useEffect(() => {
-        if (shouldReload && !hideFilters.name) {
+        if (shouldReload && enabledFilters.name) {
             onSetTextFilter(textFilter, true);
         }
     }, [ textFilter ]);
 
     useEffect(() => {
-        if (shouldReload && !hideFilters.stale) {
+        if (shouldReload && enabledFilters.stale) {
             onSetFilter(staleFilter, 'staleFilter', debouncedRefresh);
         }
     }, [ staleFilter ]);
 
     useEffect(() => {
-        if (shouldReload && !hideFilters.registeredWith) {
+        if (shouldReload && enabledFilters.registeredWith) {
             onSetFilter(registeredWithFilter, 'registeredWithFilter', debouncedRefresh);
         }
     }, [ registeredWithFilter ]);
 
     useEffect(() => {
-        if (shouldReload && showTags && !hideFilters.tags) {
+        if (shouldReload && showTags && enabledFilters.tags) {
             onSetFilter(mapGroups(selectedTags), 'tagFilters', debouncedRefresh);
         }
     }, [ selectedTags ]);
@@ -253,20 +260,20 @@ const EntityTableToolbar = ({
     const constructFilters = () => {
         return {
             filters: [
-                ...(showTags && !hasItems && !hideFilters.tags) ? tagsChip : [],
-                ...!hasItems && !hideFilters.name ? nameChip : [],
-                ...!hasItems && !hideFilters.stale ? stalenessChip : [],
-                ...!hasItems && !hideFilters.registeredWith ? registeredChip : [],
+                ...(showTags && !hasItems && enabledFilters.tags) ? tagsChip : [],
+                ...!hasItems && enabledFilters.name ? nameChip : [],
+                ...!hasItems && enabledFilters.stale ? stalenessChip : [],
+                ...!hasItems && enabledFilters.registeredWith ? registeredChip : [],
                 ...activeFiltersConfig?.filters || []
             ],
             onDelete: (e, [ deleted, ...restDeleted ], isAll) => {
                 if (isAll) {
                     updateData({ page: 1, perPage, filters: [] });
                     dispatch(clearFilters());
-                    !hideFilters.name && setTextFilter('');
-                    !hideFilters.stale && setStaleFilter([]);
-                    !hideFilters.registeredWith && setRegisteredWithFilter([]);
-                    !hideFilters.tags && setSelectedTags({});
+                    enabledFilters.name && setTextFilter('');
+                    enabledFilters.stale && setStaleFilter([]);
+                    enabledFilters.registeredWith && setRegisteredWithFilter([]);
+                    enabledFilters.tags && setSelectedTags({});
                 } else if (deleted.type) {
                     deleteMapper[deleted.type](deleted);
                 }
@@ -291,10 +298,10 @@ const EntityTableToolbar = ({
 
     const inventoryFilters = [
         ...!hasItems ? [
-            ...!hideFilters.name ? [ nameFilter ] : [],
-            ...!hideFilters.stale ? [ stalenessFilter ] : [],
-            ...!hideFilters.registeredWith ? [ registeredFilter ] : [],
-            ...showTags && !hideFilters.tags ? [ tagsFilter ] : []
+            ...enabledFilters.name ? [ nameFilter ] : [],
+            ...enabledFilters.stale ? [ stalenessFilter ] : [],
+            ...enabledFilters.registeredWith ? [ registeredFilter ] : [],
+            ...showTags && enabledFilters.tags ? [ tagsFilter ] : []
         ] : [],
         ...filterConfig?.items || []
     ];
@@ -336,7 +343,7 @@ const EntityTableToolbar = ({
             { children }
         </PrimaryToolbar>
         {
-            showTags && !hideFilters.tags &&
+            showTags && enabledFilters.tags &&
             <TagsModal
                 customFilters={customFilters}
                 filterTagsBy={filterTagsBy}

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import InventoryEntityTable from './EntityTable';
 import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid';
 import PropTypes from 'prop-types';
@@ -72,7 +72,7 @@ class ContextInventoryList extends Component {
 /**
  * Component that consumes active filters and passes them down to component.
  */
-const InventoryList = React.forwardRef(({ hasAccess, getEntities, ...props }, ref) => {
+const InventoryList = React.forwardRef(({ hasAccess, getEntities, hideFilters, ...props }, ref) => {
     const dispatch = useDispatch();
     const activeFilters = useSelector(({ entities: { activeFilters } }) => activeFilters);
     return !hasAccess ?
@@ -84,7 +84,7 @@ const InventoryList = React.forwardRef(({ hasAccess, getEntities, ...props }, re
                 { ...props }
                 ref={ref}
                 activeFilters={ activeFilters }
-                loadEntities={ (config, showTags) => dispatch(loadSystems(config, showTags, getEntities)) }
+                loadEntities={ (config, showTags) => dispatch(loadSystems({ ...config, hideFilters }, showTags, getEntities)) }
             />
         );
 });
@@ -126,7 +126,13 @@ InventoryList.propTypes = {
             PropTypes.arrayOf(PropTypes.string)
         ])
     }),
-    getEntities: PropTypes.func
+    getEntities: PropTypes.func,
+    hideFilters: PropTypes.shape({
+        tags: PropTypes.bool,
+        name: PropTypes.bool,
+        registeredWith: PropTypes.bool,
+        stale: PropTypes.bool
+    })
 };
 
 InventoryList.defaultProps = {

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -28,6 +28,7 @@ const InventoryTable = forwardRef(({
     hasAccess = true,
     isFullView = false,
     getEntities,
+    hideFilters,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
@@ -78,6 +79,7 @@ const InventoryTable = forwardRef(({
                     showTags={ showTags }
                     getEntities={ getEntities }
                     sortBy={ sortBy }
+                    hideFilters={hideFilters}
                 >
                     { children }
                 </EntityTableToolbar>
@@ -94,6 +96,7 @@ const InventoryTable = forwardRef(({
                     perPage={ pagination.perPage }
                     showTags={ showTags }
                     getEntities={ getEntities }
+                    hideFilters={ hideFilters }
                 />
                 <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
                     <Pagination
@@ -109,6 +112,7 @@ const InventoryTable = forwardRef(({
                         showTags={ showTags }
                         getEntities={ getEntities }
                         sortBy={ sortBy }
+                        hideFilters={ hideFilters }
                     />
                 </TableToolbar>
             </Fragment>

--- a/packages/inventory/src/components/table/InventoryTable.test.js
+++ b/packages/inventory/src/components/table/InventoryTable.test.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import { BrowserRouter as Router } from 'react-router-dom';
 import toJson from 'enzyme-to-json';
+import { ConditionalFilter } from '@redhat-cloud-services/frontend-components/components/cjs/ConditionalFilter';
 
 describe('NoSystemsTable', () => {
     let initialState;
@@ -108,5 +109,44 @@ describe('NoSystemsTable', () => {
             </Router>
         </Provider>);
         expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
+    });
+
+    describe('hideFilters', () => {
+        it('should disable all filters', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={ store }>
+                <Router>
+                    <InventoryTable hideFilters={{ all: true }} showTags/>
+                </Router>
+            </Provider>);
+
+            expect(wrapper.find(ConditionalFilter)).toHaveLength(0);
+        });
+
+        it('should disable only one filter', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={ store }>
+                <Router>
+                    <InventoryTable hideFilters={{ name: true }} showTags/>
+                </Router>
+            </Provider>);
+
+            expect(wrapper.find(ConditionalFilter).props().items.map(({ value }) => value)).toEqual(
+                [ 'stale-status', 'source-registered-with', 'tags' ]
+            );
+        });
+
+        it('should disable all and enable one', () => {
+            const store = mockStore(initialState);
+            const wrapper = mount(<Provider store={ store }>
+                <Router>
+                    <InventoryTable hideFilters={{ all: true, name: false }} showTags/>
+                </Router>
+            </Provider>);
+
+            expect(wrapper.find(ConditionalFilter).props().items.map(({ value }) => value)).toEqual(
+                [ 'name-filter' ]
+            );
+        });
     });
 });

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -21,17 +21,19 @@ class FooterPagination extends Component {
      * @param {*} pagination contains new pagination config.
      */
     updatePagination = (pagination) => {
-        const { onRefresh, dataLoading, loadEntities, showTags, customFilters } = this.props;
+        const { onRefresh, dataLoading, loadEntities, showTags, customFilters, hideFilters } = this.props;
         if (onRefresh) {
             dataLoading();
             onRefresh(pagination, (options) => loadEntities({
                 ...customFilters,
-                ...options
+                ...options,
+                hideFilters
             }, showTags));
         } else {
             loadEntities({
                 ...customFilters,
-                ...pagination
+                ...pagination,
+                hideFilters
             }, showTags);
         }
     }
@@ -111,7 +113,13 @@ const propTypes = {
             PropTypes.arrayOf(PropTypes.string)
         ])
     }),
-    getEntities: PropTypes.func
+    getEntities: PropTypes.func,
+    hideFilters: PropTypes.shape({
+        tags: PropTypes.bool,
+        name: PropTypes.bool,
+        registeredWith: PropTypes.bool,
+        stale: PropTypes.bool
+    })
 };
 
 FooterPagination.propTypes = propTypes;

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -7,6 +7,7 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
     filters={Array []}
     hasAccess={true}
     hasItems={false}
+    hideFilters={Object {}}
     page={1}
     perPage={50}
     showTags={false}
@@ -40,6 +41,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
     filters={Array []}
     hasAccess={false}
     hasItems={false}
+    hideFilters={Object {}}
     page={1}
     perPage={50}
     showTags={false}
@@ -109,6 +111,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
     filters={Array []}
     hasAccess={true}
     hasItems={false}
+    hideFilters={Object {}}
     page={1}
     perPage={50}
     showTags={false}
@@ -189,6 +192,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
     filters={Array []}
     hasAccess={true}
     hasItems={true}
+    hideFilters={Object {}}
     items={
       Array [
         Object {
@@ -289,6 +293,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
     filters={Array []}
     hasAccess={true}
     hasItems={true}
+    hideFilters={Object {}}
     items={
       Array [
         Object {

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -35,14 +35,16 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
         ]
     ), []).filter(Boolean);
 
+    const isFilterDisabled = (name) => config.hideFilters?.[name] || (config.hideFilters?.all && config.hideFilters?.[name] !== false);
+
     const updatedFilters = filters ? filters.reduce(filtersReducer, {
         ...defaultFilters,
         ...filters.length === 0 && { registeredWithFilter: [] },
-        ...(config.hideFilters?.stale && { staleFilter: undefined }),
-        ...(config.hideFilters?.registeredWith && { registeredWithFilter: undefined })
+        ...(isFilterDisabled('stale') && { staleFilter: undefined }),
+        ...(isFilterDisabled('registeredWith') && { registeredWithFilter: undefined })
     }) : { ...defaultFilters,
-        ...(config.hideFilters?.stale && { staleFilter: undefined }),
-        ...(config.hideFilters?.registeredWith && { registeredWithFilter: undefined })
+        ...(isFilterDisabled('stale') && { staleFilter: undefined }),
+        ...(isFilterDisabled('registeredWith') && { registeredWithFilter: undefined })
     };
 
     const orderBy = config.orderBy || 'updated';

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -37,8 +37,13 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
 
     const updatedFilters = filters ? filters.reduce(filtersReducer, {
         ...defaultFilters,
-        ...filters.length === 0 && { registeredWithFilter: [] }
-    }) : defaultFilters;
+        ...filters.length === 0 && { registeredWithFilter: [] },
+        ...(config.hideFilters?.stale && { staleFilter: undefined }),
+        ...(config.hideFilters?.registeredWith && { registeredWithFilter: undefined })
+    }) : { ...defaultFilters,
+        ...(config.hideFilters?.stale && { staleFilter: undefined }),
+        ...(config.hideFilters?.registeredWith && { registeredWithFilter: undefined })
+    };
 
     const orderBy = config.orderBy || 'updated';
     const orderDirection = config.orderDirection || 'DESC';
@@ -59,7 +64,8 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
                 ...results.find(({ id }) => id === item || id === item.id) || {}
             })) : results,
             page: config.page || (data && data.page),
-            perPage: config.perPage || (data && data.perPage)
+            perPage: config.perPage || (data && data.perPage),
+            hideFilters: config.hideFilters
         })),
         meta: {
             showTags


### PR DESCRIPTION
# hideFilters

You can disable default filters by using a `hideFilters` prop.

```jsx
hideFilters: PropTypes.shape({
    tags: PropTypes.bool,
    name: PropTypes.bool,
    registeredWith: PropTypes.bool,
    stale: PropTypes.bool,
    all: PropTypes.bool,
})
```

By default all filters are set to `true`. You can override just part of it.

```jsx
<InventoryTable
    hideFilters={{ name: true }}
/>
```

This props is also passed to [custom fetch](./custom_fetch.md).

Hiding filters also removes their default values.

## tags

Similar to `showTags`, it hides the tags filter.

## name

Hides display name filter.

## registeredWith

Hides registered with filter.

## stale

Hides staleness filter.

## all

Hides all the filters. It has a lower priority than specific keys. You can hide all filter and then turn on specific ones. This makes sure that there will be no additional filters in the future.

**Example**

- name is shown
- all others are hidden

```jsx
<InventoryTable
    hideFilters={{ all: true, name: false }}
/>
```