### PR TITLE
fix(notifications): remove duplicate filename

### DIFF
--- a/packages/notifications/src/NotificationPortal.js
+++ b/packages/notifications/src/NotificationPortal.js
@@ -1,1 +1,0 @@
-export * from './NotificationPortal';


### PR DESCRIPTION
### Changes
- removed v2 fallback `NotificationPortal.js` file from the build.
  - it was causing conflicts with the folder containing the module
  - the file is not required because apps using v2 will consume the module from the folder correctly
  - we only need fallback import names that are not present in v3