### PR TITLE
feat: Introduce TableTools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7712,6 +7712,37 @@
                 "@scalprum/core": "*"
             }
         },
+        "@testing-library/react-hooks": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz",
+            "integrity": "sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "@types/react": ">=16.9.0",
+                "@types/react-dom": ">=16.9.0",
+                "@types/react-test-renderer": ">=16.9.0",
+                "filter-console": "^0.1.1",
+                "react-error-boundary": "^3.1.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.13.10",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+                    "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                }
+            }
+        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -7871,11 +7902,46 @@
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
             "dev": true
         },
+        "@types/prop-types": {
+            "version": "15.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+            "dev": true
+        },
         "@types/q": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
             "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
+        },
+        "@types/react": {
+            "version": "17.0.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+            "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
+            "dev": true,
+            "requires": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/react-dom": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.2.tgz",
+            "integrity": "sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/react-test-renderer": {
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+            "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
         },
         "@types/resolve": {
             "version": "0.0.8",
@@ -7885,6 +7951,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/scheduler": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+            "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+            "dev": true
         },
         "@types/stack-utils": {
             "version": "1.0.1",
@@ -12783,6 +12855,12 @@
             "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
             "dev": true
         },
+        "csstype": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+            "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==",
+            "dev": true
+        },
         "currently-unhandled": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -15045,6 +15123,12 @@
                     }
                 }
             }
+        },
+        "filter-console": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz",
+            "integrity": "sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==",
+            "dev": true
         },
         "finalhandler": {
             "version": "1.1.1",
@@ -25690,6 +25774,32 @@
                 "file-selector": "^0.1.8",
                 "prop-types": "^15.6.2",
                 "prop-types-extra": "^1.1.0"
+            }
+        },
+        "react-error-boundary": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz",
+            "integrity": "sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.13.10",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+                    "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+                    "dev": true
+                }
             }
         },
         "react-intl": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@rollup/pluginutils": "^3.0.8",
         "@scalprum/core": "0.0.8",
         "@scalprum/react-core": "0.0.7",
+        "@testing-library/react-hooks": "^5.1.0",
         "axios-mock-adapter": "^1.17.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^24.1.0",

--- a/packages/utils/doc/useTableTools.md
+++ b/packages/utils/doc/useTableTools.md
@@ -1,0 +1,131 @@
+# useTableTools
+
+`useTableTools` is a hook combining several hooks to built a PatternFly `Table` with the platform `PrimaryToolbar` component.
+Each hook can also be used on their own to only leverage a specific functionality.
+
+There is also a `TableToolsTable` component that is already setup with a table and invokes the `useTableTools` hook.
+
+Both the hook and the component take at least an `items` and `columns` argument/prop.
+
+## Items
+
+Items can be an array of any object.
+
+
+## Columns
+
+Columns are defined similar to the default way of defining columns for the `Table` component,
+but allow passing additional properties
+
+* `key`
+* `renderFunc`
+
+## Hooks
+
+All Hooks will return an object with two properties `toolbarProps` and/or `tableProps`,
+both of them are meant to be spread as props for either the `PrimaryToolbar` or the `Table` component.
+
+### useTableTools
+
+```javascript
+const items = [{
+  name: 'Item #1'
+}];
+const columns = [{
+  title: 'Name',
+  key: 'name',
+  transforms: [ sortable ],
+  renderFunc: (name) => (
+      name
+  )
+}]
+const { toolbarProps, tableProps } = useTableTools(items, columns)
+```
+
+### useRowsBuilder
+
+This hook takes `columns` and `options` and returns a function
+which takes items and returns `rows` to use in a `Table` component
+and optionally `pagination` to be passed to the `PrimaryToolbar` component.
+
+#### Arguments
+
+ * **columns** - an array of column objects with additional properties (see below)
+ * **options** - see below
+
+##### Options
+
+ * **filter** - a function by which the items should be filtered by
+ * **sorter** - a function by which the items should be sorted by
+ * **paginate** - an object with
+   * **paginator** - a function by which the items should be paginated by
+   * **pagination** - an object with page, perPage
+
+#### rowBuilder
+
+The function return by `useRowsBuilder`.
+
+##### Arguments
+
+ * **items** - an array of object to render as rows
+
+#### Return
+
+ * **rows** - an array of rows for the `Table` component
+ * **pagination** - a pagination object for the `PrimaryToolbar` component
+
+### usePaginate
+
+THe `usePaginate` hook takes an object with options and returns an object
+
+#### Arguments
+
+ * **options**
+   * **perPage** - items per page
+   * **itemsCount** - Number of items in the whole table
+
+#### Returns
+
+ * **paginator** - a function to paginate an array of items
+ * **setPage** - a function to call to set a page
+ * **pagination** - a pagination object to be used with the `PrimaryToolbar` (Or `Pagination` component)
+
+### useTableSort
+
+#### Arguments
+
+ * **columns** - an array of column objects
+
+
+### Additional column properties
+
+ * **sortByProperty** - set the property by which the items should be sorted by
+ * **sortByFunction** - allows to provide a function returning a comparable value
+ * **sortByArray** - allows to provide an array by which the items should be sorted by
+
+### useFilterConfig
+
+ *
+### useBulkSelect
+
+## Basic component
+
+For a basic table with the `useTableTools` hook invoked there is a `TableToolsTable` component that accepts a `items` and `columns` prop to build a table
+
+## Arguments
+
+## Additional cell object properties for columns:
+
+ * **key** - sets the property of the object to be rendered (By default the whole object will be used)
+ * **rednerFunc** - Function/Component to render a cell for the column
+
+
+## Options:
+
+ * **filterConfig** - configuration for the useFilterConfig hook
+ * **detailsComponent** - component render a details row for each item
+
+## Future feature ideas/plan:
+
+ * Allow async loading of items via an async function
+ * Integrate with REST APIs

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -14,3 +14,5 @@ export * from './Registry';
 export { default as routerParams } from './RouterParams';
 export { default as RowLoader } from './RowLoader';
 export { useInventory } from './useInventory';
+export { default as useTableTools } from './useTableTools';
+export * from './useTableTools';

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/ChipBuilder.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/ChipBuilder.js
@@ -1,0 +1,52 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+class ChipBuilder {
+    constructor(filterConfig) {
+        this.filterConfig = filterConfig;
+        this.config = this.filterConfig.config;
+    }
+
+    textFilterChip = (category, currentValue) => (currentValue && currentValue !== '' ? {
+        category,
+        chips: [{ name: currentValue }]
+    } : null)
+
+    checkboxFilterChip = (category, currentValue) => (currentValue && currentValue.length > 0 ? {
+        category,
+        chips: currentValue.map((value) => (
+            { name: this.filterConfig.labelForValue(value, category) }
+        ))
+    } : null)
+
+    radioFilterChip = (category, currentValue) => (currentValue && currentValue !== '' ? {
+        category,
+        chips: [{ name: this.filterConfig.labelForValue(currentValue, category) }]
+    } : null)
+
+    chipFor = (filter, currentValue) => {
+        const categoryConfig = this.filterConfig.getCategoryForLabel(filter);
+        const { label, type } = categoryConfig ? categoryConfig : { label: filter, type: null };
+
+        switch (type) {
+            case conditionalFilterType.text:
+                return this.textFilterChip(label, currentValue);
+
+            case conditionalFilterType.checkbox:
+                return this.checkboxFilterChip(label, currentValue);
+
+            case conditionalFilterType.radio:
+                return this.radioFilterChip(label, currentValue);
+
+            default:
+                return null;
+        }
+    }
+
+    chipsFor = (filters) => (
+        Object.keys(filters).map((filter) => (
+            this.chipFor(filter, filters[filter])
+        )).filter((f) => (!!f))
+    )
+}
+
+export default ChipBuilder;

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/ChipBuilder.test.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/ChipBuilder.test.js
@@ -1,0 +1,23 @@
+import { exampleFilters } from '../__fixtures__/filters';
+import FilterConfigBuilder from './FilterConfigBuilder';
+
+import ChipBuilder from './ChipBuilder';
+
+describe('ChipBuilder#getChipsFor', () => {
+    const builder = new FilterConfigBuilder(exampleFilters);
+    let chipBuilder;
+
+    beforeEach(() => {
+        chipBuilder = new ChipBuilder(builder);
+    });
+
+    it('returns a filterConfig', () => {
+        const chips = chipBuilder.chipsFor({
+            passed: [ 'passed' ],
+            name: 'Text search',
+            selected: [ 'all' ],
+            invalidFilter: ''
+        });
+        expect(chips).toMatchSnapshot();
+    });
+});

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/FilterBuilder.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/FilterBuilder.js
@@ -1,0 +1,45 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+import { stringToId } from './Helpers';
+
+class FilterBuilder {
+    constructor(filterConfig) {
+        this.filterConfig = filterConfig;
+        this.config = this.filterConfig.config;
+    }
+
+    buildFilterFilterString = (configItem, value) => {
+        const { type, filterString } = configItem;
+
+        if (type !== 'hidden' && !value) { return []; }
+
+        switch (type) {
+            case conditionalFilterType.text:
+                return [ filterString(value) ];
+            case conditionalFilterType.checkbox:
+                return value.map((filter) => (filterString(filter)));
+
+            case conditionalFilterType.group:
+                return filterString(value);
+
+            case 'hidden':
+                return filterString();
+
+            default:
+                return [];
+        }
+    }
+
+    combineFilterStrings = (filterStringArray) => {
+        const moreThanTwo = filterStringArray.map((f) => (f.length)).filter((fl) => (fl > 0)).length >= 2;
+        return filterStringArray.map((fs) => (fs.join(' or '))).join(moreThanTwo ? ' and ' : '');
+    }
+
+    buildFilterString = (filters) => {
+        const filterStringArray = this.config.map((configItem) => (
+            this.buildFilterFilterString(configItem, filters[stringToId(configItem.label)])
+        )).filter((f) => (f.length > 0));
+        return this.combineFilterStrings(filterStringArray);
+    }
+}
+
+export default FilterBuilder;

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/FilterBuilder.test.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/FilterBuilder.test.js
@@ -1,0 +1,45 @@
+import FilterConfigBuilder from './FilterConfigBuilder';
+import FilterBuilder from './FilterBuilder';
+import { exampleFilters } from '../__fixtures__/filters';
+
+describe('buildFilterString', () => {
+    const configBuilder = new FilterConfigBuilder(exampleFilters);
+    let filterBuilder;
+
+    beforeEach(() => {
+        filterBuilder = new FilterBuilder(configBuilder);
+    });
+
+    it('returns a filterstring', () => {
+        const exampleActiveFilters = {
+            name: 'Name',
+            compliant: [ true ],
+            compliancescore: [ '0-49', '50-69' ]
+        };
+
+        expect(filterBuilder.buildFilterString(exampleActiveFilters)).toMatchSnapshot();
+    });
+
+    describe('filter building', () => {
+        it('returns a base filter for name when searching', () => {
+            const testExampleState = {
+                name: 'Name'
+            };
+            expect(filterBuilder.buildFilterString(testExampleState)).toMatchSnapshot();
+        });
+
+        it('returns a filter for compliant', () => {
+            const testExampleState = {
+                compliant: [ true ]
+            };
+            expect(filterBuilder.buildFilterString(testExampleState)).toMatchSnapshot();
+        });
+
+        it('returns a filter for scores', () => {
+            const testExampleState = {
+                systemsmeetingcompliance: [ '0-49', '50-69' ]
+            };
+            expect(filterBuilder.buildFilterString(testExampleState)).toMatchSnapshot();
+        });
+    });
+});

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/FilterConfigBuilder.js
@@ -1,0 +1,194 @@
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+import FilterBuilder from './FilterBuilder';
+import ChipBuilder from './ChipBuilder';
+import { stringToId } from './Helpers';
+
+const defaultPlaceholder = (label) => (`Filter by ${ label.toLowerCase() }`);
+
+class FilterConfigBuilder {
+    chipBuilder = null;
+    filterBuilder = null;
+
+    constructor(config) {
+        this.config = config;
+    }
+
+    addConfigItem = (item) => (
+        this.config = this.config.filter((i) => (
+            i.label !== item.label
+        )).concat(item)
+    )
+
+    getChipBuilder = () => (
+        this.chipBuilder = this.chipBuilder ? this.chipBuilder : new ChipBuilder(this)
+    )
+
+    getFilterBuilder = () => (
+        this.filterBuilder = this.filterBuilder ? this.filterBuilder : new FilterBuilder(this)
+    )
+
+    toTextFilterConfig = (item, handler, value) => ({
+        type: conditionalFilterType.text,
+        label: item.label,
+        placeholder: defaultPlaceholder(item.label),
+        id: stringToId(item.label),
+        filterValues: {
+            value,
+            [item.event || 'onChange']: (_event, selectedValues) => {
+                handler(stringToId(item.label), selectedValues);
+            }
+        }
+    });
+
+    toCheckboxFilterConfig = (item, handler, value) => ({
+        type: conditionalFilterType.checkbox,
+        label: item.label,
+        placeholder: defaultPlaceholder(item.label),
+        id: stringToId(item.label),
+        filterValues: {
+            value,
+            items: item.items,
+            onChange: (_event, selectedValues) => {
+                handler(stringToId(item.label), selectedValues);
+            }
+        }
+    });
+
+    toRadioFilterConfig = (item, handler, value) => ({
+        type: conditionalFilterType.radio,
+        label: item.label,
+        placeholder: defaultPlaceholder(item.label),
+        id: stringToId(item.label),
+        filterValues: {
+            value,
+            items: item.items,
+            onChange: (_event, selectedValues) => {
+                handler(stringToId(item.label), selectedValues);
+            }
+        }
+    });
+
+    toFilterConfigItem = (item, handler, value) => {
+        switch (item.type) {
+            case conditionalFilterType.text:
+                return this.toTextFilterConfig(item, handler, value);
+
+            case conditionalFilterType.checkbox:
+                return this.toCheckboxFilterConfig(item, handler, value);
+
+            case conditionalFilterType.radio:
+                return this.toRadioFilterConfig(item, handler, value);
+
+            default:
+                return null;
+        }
+    };
+
+    buildConfiguration = (handler, states, props = {}) => ({
+        ...props,
+        items: this.config.map((item) => (
+            this.toFilterConfigItem(item, handler, states[stringToId(item.label)])
+        )).filter((v) => (!!v))
+    });
+
+    defaultValueForFilter = (filter) => {
+        switch (filter.type) {
+            case conditionalFilterType.text:
+                return '';
+            case conditionalFilterType.checkbox:
+                return [];
+            default:
+                return;
+        }
+    }
+
+    initialDefaultState = (defaultStates = {}) => {
+        let initialState = {};
+        this.config.forEach((filter) => {
+            const filterStateName = stringToId(filter.label);
+            initialState[filterStateName] =
+                defaultStates[filterStateName] || this.defaultValueForFilter(filter);
+        });
+        return initialState;
+    }
+
+    categoryLabelForValue = (value) => {
+        const category = this.config.filter((category) => (
+            category.items ? category.items.map((item) => item.value).includes(value) : false
+        ))[0];
+
+        return category ? category.label : value;
+    };
+
+    getCategoryForLabel = (query) => (
+        this.config.filter((item) => (stringToId(item.label) === stringToId(query)))[0] || {}
+    )
+
+    getItemByLabelOrValue = (query, category) => {
+        const items = this.getCategoryForLabel(category).items;
+        const results = (items || []).filter((item) => (
+            item.value === query || item.label === query
+        ));
+
+        if (results.length === 1) {
+            return results[0];
+        } else if (results.length > 1) {
+            // eslint-disable-next-line no-console
+            console.info(`Multiple items found for ${query} in ${category}! Returning first one.`);
+            return results[0];
+        } else {
+            // eslint-disable-next-line no-console
+            console.info('No item found for ' + query + ' in ', category);
+        }
+    }
+
+    labelForValue = (value, category) => {
+        const item = this.getItemByLabelOrValue(value, category);
+        return item ? item.label : value;
+    };
+
+    valueForLabel = (label, category) => {
+        const item = this.getItemByLabelOrValue(label, category);
+        return item ? item.value : label;
+    };
+
+    applyFilterToObjectArray = (objects, activeFilters) => {
+        let filteredObjects = [ ...objects ];
+
+        Object.keys(activeFilters).forEach((filter) => {
+            const category = this.getCategoryForLabel(filter);
+            const value = activeFilters[filter];
+            if ((!category || !value) && category.type !== 'hidden') {
+                return;
+            }
+
+            if (value.length > 0 || category.type === 'hidden') {
+                filteredObjects = category.filter(filteredObjects, value);
+            }
+        });
+
+        return filteredObjects;
+    }
+
+    removeFilterFromFilterState = (currentState, filter) => (
+        (typeof(currentState) === 'string') ? '' :
+            currentState.filter((value) =>
+                value !== filter
+            )
+    )
+
+    removeFilterWithChip = (chips, activeFilters) => {
+        const chipCategory = chips.category;
+        const chipValue = this.valueForLabel(chips.chips[0].name, chipCategory);
+        const stateProp = stringToId(chipCategory);
+        const currentState = activeFilters[stateProp];
+        const newFilterState = this.removeFilterFromFilterState(currentState, chipValue);
+
+        return {
+            ...activeFilters,
+            [stateProp]: newFilterState
+        };
+    }
+}
+
+export default FilterConfigBuilder;

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/FilterConfigBuilder.test.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/FilterConfigBuilder.test.js
@@ -1,0 +1,50 @@
+import FilterConfigBuilder from './FilterConfigBuilder';
+import { exampleFilters } from '../__fixtures__/filters';
+
+describe('FilterConfigBuilder', () => {
+    let builder;
+
+    beforeEach(() => {
+        builder = new FilterConfigBuilder(exampleFilters);
+    });
+
+    it('returns a filterConfig', () => {
+        const states = {
+            name: '',
+            compliant: [],
+            compliancescore: []
+        };
+        const builtConfig = builder.buildConfiguration(exampleFilters, ()=> ({}), states);
+
+        expect(builtConfig).toMatchSnapshot();
+    });
+    describe('initialDefaultState', () => {
+        it('to return a matching category label', () => {
+            expect(builder.initialDefaultState()).toMatchSnapshot();
+        });
+    });
+
+    describe('categoryLabelForValue', () => {
+        it('to return a matching category label', () => {
+            expect(builder.categoryLabelForValue('true', 'compliant')).toMatchSnapshot();
+            expect(builder.categoryLabelForValue('0-49', 'compliancescore')).toMatchSnapshot();
+            expect(builder.categoryLabelForValue('Search term', 'name')).toMatchSnapshot();
+        });
+    });
+
+    describe('labelForValue', () => {
+        it('to return a matching label', () => {
+            expect(builder.labelForValue('true', 'compliant')).toMatchSnapshot();
+            expect(builder.labelForValue('0-49', 'compliancescore')).toMatchSnapshot();
+            expect(builder.labelForValue('Search term', 'name')).toMatchSnapshot();
+        });
+    });
+
+    describe('valueForLabel', () => {
+        it('to return a matching value', () => {
+            expect(builder.valueForLabel('Non-compliant', 'compliant')).toMatchSnapshot();
+            expect(builder.valueForLabel('50 - 69%', 'compliancescore')).toMatchSnapshot();
+            expect(builder.valueForLabel('Search term', 'name')).toMatchSnapshot();
+        });
+    });
+});

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/Helpers.js
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/Helpers.js
@@ -1,0 +1,3 @@
+export const stringToId = (string) => (
+    string.split(' ').join('').toLowerCase()
+);

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/ChipBuilder.test.js.snap
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/ChipBuilder.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ChipBuilder#getChipsFor returns a filterConfig 1`] = `
+Array [
+  Object {
+    "category": "Name",
+    "chips": Array [
+      Object {
+        "name": "Text search",
+      },
+    ],
+  },
+]
+`;

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/FilterBuilder.test.js.snap
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/FilterBuilder.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildFilterString filter building returns a base filter for name when searching 1`] = `"name ~ Name"`;
+
+exports[`buildFilterString filter building returns a filter for compliant 1`] = `"compliant = true"`;
+
+exports[`buildFilterString filter building returns a filter for scores 1`] = `"compliance_score >= 0 and compliance_score <= 49 or compliance_score >= 50 and compliance_score <= 69"`;
+
+exports[`buildFilterString returns a filterstring 1`] = `"name ~ Name and compliant = true"`;

--- a/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/FilterConfigBuilder.test.js.snap
+++ b/packages/utils/src/useTableTools/FilterConfigBuilder/__snapshots__/FilterConfigBuilder.test.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterConfigBuilder categoryLabelForValue to return a matching category label 1`] = `"Compliant"`;
+
+exports[`FilterConfigBuilder categoryLabelForValue to return a matching category label 2`] = `"Systems meeting compliance"`;
+
+exports[`FilterConfigBuilder categoryLabelForValue to return a matching category label 3`] = `"Search term"`;
+
+exports[`FilterConfigBuilder initialDefaultState to return a matching category label 1`] = `
+Object {
+  "compliant": Array [],
+  "name": "",
+  "systemsmeetingcompliance": Array [],
+}
+`;
+
+exports[`FilterConfigBuilder labelForValue to return a matching label 1`] = `"Compliant"`;
+
+exports[`FilterConfigBuilder labelForValue to return a matching label 2`] = `"0-49"`;
+
+exports[`FilterConfigBuilder labelForValue to return a matching label 3`] = `"Search term"`;
+
+exports[`FilterConfigBuilder returns a filterConfig 1`] = `
+Object {
+  "compliancescore": Array [],
+  "compliant": Array [],
+  "items": Array [
+    Object {
+      "filterValues": Object {
+        "onChange": [Function],
+        "value": "",
+      },
+      "id": "name",
+      "label": "Name",
+      "placeholder": "Filter by name",
+      "type": "text",
+    },
+    Object {
+      "filterValues": Object {
+        "items": Array [
+          Object {
+            "label": "Compliant",
+            "value": "true",
+          },
+          Object {
+            "label": "Non-compliant",
+            "value": "false",
+          },
+        ],
+        "onChange": [Function],
+        "value": undefined,
+      },
+      "id": "compliant",
+      "label": "Compliant",
+      "placeholder": "Filter by compliant",
+      "type": "checkbox",
+    },
+    Object {
+      "filterValues": Object {
+        "items": Array [
+          Object {
+            "label": "90 - 100%",
+            "value": "90-100",
+          },
+          Object {
+            "label": "70 - 89%",
+            "value": "70-89",
+          },
+          Object {
+            "label": "50 - 69%",
+            "value": "50-69",
+          },
+          Object {
+            "label": "Less than 50%",
+            "value": "0-49",
+          },
+        ],
+        "onChange": [Function],
+        "value": undefined,
+      },
+      "id": "systemsmeetingcompliance",
+      "label": "Systems meeting compliance",
+      "placeholder": "Filter by systems meeting compliance",
+      "type": "checkbox",
+    },
+  ],
+  "name": "",
+}
+`;
+
+exports[`FilterConfigBuilder valueForLabel to return a matching value 1`] = `"false"`;
+
+exports[`FilterConfigBuilder valueForLabel to return a matching value 2`] = `"50 - 69%"`;
+
+exports[`FilterConfigBuilder valueForLabel to return a matching value 3`] = `"Search term"`;

--- a/packages/utils/src/useTableTools/NoResultsTable.js
+++ b/packages/utils/src/useTableTools/NoResultsTable.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+    Bullseye, EmptyState, EmptyStateBody, EmptyStateVariant, Title
+} from '@patternfly/react-core';
+import EmptyTable from '@redhat-cloud-services/frontend-components/EmptyTable';
+
+const NoResultsTable = () => (
+    <EmptyTable>
+        <Bullseye>
+            <EmptyState variant={ EmptyStateVariant.full }>
+                <Title headingLevel="h5" size="lg">
+                    No matching results found
+                </Title>
+                <EmptyStateBody>
+                    This filter criteria matches no results. <br /> Try changing your filter settings.
+                </EmptyStateBody>
+            </EmptyState>
+        </Bullseye>
+    </EmptyTable>
+);
+
+export const emptyRows = [{
+    cells: [
+        {
+            title: () => (<NoResultsTable />),  // eslint-disable-line
+            props: {
+                colSpan: 3
+            }
+        }
+    ]
+}];
+
+export default NoResultsTable;

--- a/packages/utils/src/useTableTools/TableToolsTable.js
+++ b/packages/utils/src/useTableTools/TableToolsTable.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Table, TableBody, TableHeader } from '@patternfly/react-table';
+import PrimaryToolbar from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import TableToolbar from '@redhat-cloud-services/frontend-components/TableToolbar';
+
+import useTableTools from './useTableTools';
+
+const TableToolsTable = ({
+    items = [], columns = [], filters = [], onSelect, ...tablePropsRest
+}) => {
+    const { toolbarProps, tableProps } = useTableTools(items, columns, {
+        filterConfig: filters,
+        onSelect
+    });
+
+    return <React.Fragment>
+
+        <PrimaryToolbar
+            { ...toolbarProps } />
+
+        <Table
+            { ...tableProps }
+            { ...tablePropsRest }>
+            <TableHeader />
+            <TableBody />
+        </Table>
+
+        <TableToolbar isFooter>
+            <Pagination
+                variant={ PaginationVariant.bottom }
+                { ...toolbarProps.pagination } />
+        </TableToolbar>
+
+    </React.Fragment>;
+};
+
+TableToolsTable.propTypes = {
+    items: propTypes.array.isRequired,
+    columns: propTypes.arrayOf(propTypes.shape({
+        title: propTypes.string,
+        transforms: propTypes.array,
+        sortByProperty: propTypes.string,
+        sortByArray: propTypes.array,
+        sortByFunction: propTypes.func,
+        renderFunc: propTypes.func
+    })).isRequired
+};
+
+export default TableToolsTable;

--- a/packages/utils/src/useTableTools/__fixtures__/columns.js
+++ b/packages/utils/src/useTableTools/__fixtures__/columns.js
@@ -1,0 +1,28 @@
+import { severityLevels } from './items';
+
+export default [
+    {
+        title: 'Name',
+        key: 'name',
+        sortByProperty: 'name',
+        renderFunc: (item) => (
+            item.name
+        )
+    }, {
+        title: 'Description',
+        key: 'description'
+    }, {
+        title: 'Severity sorted by function',
+        sortByFunction: (item) => (severityLevels.indexOf(item.severity)),
+        renderFunc: (item) => (
+            item.severity
+        )
+    }, {
+        title: 'Severity by Array',
+        sortByProperty: 'severity',
+        sortByArray: severityLevels,
+        renderFunc: (item) => (
+            item.severity
+        )
+    }
+];

--- a/packages/utils/src/useTableTools/__fixtures__/filters.js
+++ b/packages/utils/src/useTableTools/__fixtures__/filters.js
@@ -1,0 +1,45 @@
+export const exampleFilters = [{
+    type: 'text',
+    label: 'Name',
+    filterString: (value) => (`name ~ ${value}`)
+}, {
+    type: 'checkbox',
+    label: 'Compliant',
+    filterString: (value) => (`compliant = ${value}`),
+    items: [
+        { label: 'Compliant', value: 'true' },
+        { label: 'Non-compliant', value: 'false' }
+    ]
+}, {
+    type: 'checkbox',
+    label: 'Systems meeting compliance',
+    filterString: (value) => {
+        const scoreRange = value.split('-');
+        return `compliance_score >= ${scoreRange[0]} and compliance_score <= ${scoreRange[1]}`;
+    },
+    items: [
+        { label: '90 - 100%', value: '90-100' },
+        { label: '70 - 89%', value: '70-89' },
+        { label: '50 - 69%', value: '50-69' },
+        { label: 'Less than 50%', value: '0-49' }
+    ]
+}];
+
+export default [
+    {
+        type: 'text',
+        label: 'Name',
+        filter: (items, value) => (items.filter((item) => (
+            item?.name.includes(value)
+        )))
+    },
+    {
+        type: 'checkbox',
+        label: 'Chackbox Filter',
+        items: [ 'OPTION 1', 'OPTION 2', 'OPTION 3' ].map((option) => ({
+            label: option,
+            value: option
+        })),
+        filter: (items) => (items)
+    }
+];

--- a/packages/utils/src/useTableTools/__fixtures__/items.js
+++ b/packages/utils/src/useTableTools/__fixtures__/items.js
@@ -1,0 +1,14 @@
+export const severityLevels = [ 'high', 'medium', 'low', 'unknown' ];
+
+export default (count) => {
+    let currentCount = 0;
+    return [ ...new Array(count > 0 ? count : 1) ].map(() => {
+        currentCount++;
+        return {
+            id: currentCount,
+            severity: severityLevels[ currentCount % 4 ],
+            name: 'TEST ITEM #' + currentCount,
+            description: 'DESCRIPTION'
+        };
+    });
+};

--- a/packages/utils/src/useTableTools/__snapshots__/useBulkSelect.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/useBulkSelect.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useBulkSelect returns a bulk select configuration 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "clearSelection": [Function],
+      "tableProps": Object {
+        "canSelectAll": false,
+        "onSelect": [Function],
+      },
+      "toolbarProps": Object {
+        "bulkSelect": Object {
+          "checked": false,
+          "isDisabled": false,
+          "items": Array [
+            Object {
+              "onClick": [Function],
+              "props": Object {
+                "isDisabled": true,
+              },
+              "title": "Select none",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Select page 20",
+            },
+            Object {
+              "onClick": [Function],
+              "title": "Select all 20",
+            },
+          ],
+          "onSelect": [Function],
+          "toggleProps": Object {
+            "children": Array [
+              "0 selected",
+              " ",
+            ],
+          },
+        },
+      },
+      "transformer": [Function],
+    },
+  ],
+  "current": Object {
+    "clearSelection": [Function],
+    "tableProps": Object {
+      "canSelectAll": false,
+      "onSelect": [Function],
+    },
+    "toolbarProps": Object {
+      "bulkSelect": Object {
+        "checked": false,
+        "isDisabled": false,
+        "items": Array [
+          Object {
+            "onClick": [Function],
+            "props": Object {
+              "isDisabled": true,
+            },
+            "title": "Select none",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Select page 20",
+          },
+          Object {
+            "onClick": [Function],
+            "title": "Select all 20",
+          },
+        ],
+        "onSelect": [Function],
+        "toggleProps": Object {
+          "children": Array [
+            "0 selected",
+            " ",
+          ],
+        },
+      },
+    },
+    "transformer": [Function],
+  },
+  "error": undefined,
+}
+`;

--- a/packages/utils/src/useTableTools/__snapshots__/useFilterConfig.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/useFilterConfig.test.js.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useFilterConfig returns a filter config configuration 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "activeFilters": Object {},
+      "addConfigItem": [Function],
+      "buildFilterString": [Function],
+      "filter": [Function],
+      "filterConfigBuilder": FilterConfigBuilder {
+        "addConfigItem": [Function],
+        "applyFilterToObjectArray": [Function],
+        "buildConfiguration": [Function],
+        "categoryLabelForValue": [Function],
+        "chipBuilder": ChipBuilder {
+          "checkboxFilterChip": [Function],
+          "chipFor": [Function],
+          "chipsFor": [Function],
+          "config": Array [],
+          "filterConfig": [Circular],
+          "radioFilterChip": [Function],
+          "textFilterChip": [Function],
+        },
+        "config": Array [
+          Object {
+            "filter": [Function],
+            "items": Array [
+              Object {
+                "label": "Show ",
+                "value": "show",
+              },
+            ],
+            "label": "Filter with multiple spaces",
+            "type": "checkbox",
+          },
+          Object {
+            "filter": [Function],
+            "label": "Name",
+            "type": "text",
+          },
+        ],
+        "defaultValueForFilter": [Function],
+        "filterBuilder": null,
+        "getCategoryForLabel": [Function],
+        "getChipBuilder": [Function],
+        "getFilterBuilder": [Function],
+        "getItemByLabelOrValue": [Function],
+        "initialDefaultState": [Function],
+        "labelForValue": [Function],
+        "removeFilterFromFilterState": [Function],
+        "removeFilterWithChip": [Function],
+        "toCheckboxFilterConfig": [Function],
+        "toFilterConfigItem": [Function],
+        "toRadioFilterConfig": [Function],
+        "toTextFilterConfig": [Function],
+        "valueForLabel": [Function],
+      },
+      "toolbarProps": Object {
+        "activeFiltersConfig": Object {
+          "filters": Array [],
+          "onDelete": [Function],
+        },
+        "filterConfig": Object {
+          "items": Array [],
+        },
+      },
+    },
+  ],
+  "current": Object {
+    "activeFilters": Object {},
+    "addConfigItem": [Function],
+    "buildFilterString": [Function],
+    "filter": [Function],
+    "filterConfigBuilder": FilterConfigBuilder {
+      "addConfigItem": [Function],
+      "applyFilterToObjectArray": [Function],
+      "buildConfiguration": [Function],
+      "categoryLabelForValue": [Function],
+      "chipBuilder": ChipBuilder {
+        "checkboxFilterChip": [Function],
+        "chipFor": [Function],
+        "chipsFor": [Function],
+        "config": Array [],
+        "filterConfig": [Circular],
+        "radioFilterChip": [Function],
+        "textFilterChip": [Function],
+      },
+      "config": Array [
+        Object {
+          "filter": [Function],
+          "items": Array [
+            Object {
+              "label": "Show ",
+              "value": "show",
+            },
+          ],
+          "label": "Filter with multiple spaces",
+          "type": "checkbox",
+        },
+        Object {
+          "filter": [Function],
+          "label": "Name",
+          "type": "text",
+        },
+      ],
+      "defaultValueForFilter": [Function],
+      "filterBuilder": null,
+      "getCategoryForLabel": [Function],
+      "getChipBuilder": [Function],
+      "getFilterBuilder": [Function],
+      "getItemByLabelOrValue": [Function],
+      "initialDefaultState": [Function],
+      "labelForValue": [Function],
+      "removeFilterFromFilterState": [Function],
+      "removeFilterWithChip": [Function],
+      "toCheckboxFilterConfig": [Function],
+      "toFilterConfigItem": [Function],
+      "toRadioFilterConfig": [Function],
+      "toTextFilterConfig": [Function],
+      "valueForLabel": [Function],
+    },
+    "toolbarProps": Object {
+      "activeFiltersConfig": Object {
+        "filters": Array [],
+        "onDelete": [Function],
+      },
+      "filterConfig": Object {
+        "items": Array [],
+      },
+    },
+  },
+  "error": undefined,
+}
+`;

--- a/packages/utils/src/useTableTools/__snapshots__/usePaginate.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/usePaginate.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`usePaginate returns a paginate configuration 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "pagination": Object {
+        "itemCount": undefined,
+        "onPerPageSelect": [Function],
+        "onSetPage": [Function],
+        "page": 1,
+        "perPage": 10,
+      },
+      "paginator": [Function],
+      "setPage": [Function],
+    },
+  ],
+  "current": Object {
+    "pagination": Object {
+      "itemCount": undefined,
+      "onPerPageSelect": [Function],
+      "onSetPage": [Function],
+      "page": 1,
+      "perPage": 10,
+    },
+    "paginator": [Function],
+    "setPage": [Function],
+  },
+  "error": undefined,
+}
+`;
+
+exports[`usePaginate returns a paginate configuration 2`] = `
+Array [
+  Object {
+    "description": "DESCRIPTION",
+    "id": 6,
+    "name": "TEST ITEM #6",
+    "severity": "low",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 7,
+    "name": "TEST ITEM #7",
+    "severity": "unknown",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 8,
+    "name": "TEST ITEM #8",
+    "severity": "high",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 9,
+    "name": "TEST ITEM #9",
+    "severity": "medium",
+  },
+  Object {
+    "description": "DESCRIPTION",
+    "id": 10,
+    "name": "TEST ITEM #10",
+    "severity": "low",
+  },
+]
+`;

--- a/packages/utils/src/useTableTools/__snapshots__/useRowsBuilder.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/useRowsBuilder.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRowsBuilder returns a rows configuration 1`] = `
+Object {
+  "all": Array [
+    [Function],
+  ],
+  "current": [Function],
+  "error": undefined,
+}
+`;

--- a/packages/utils/src/useTableTools/__snapshots__/useTableSort.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/useTableSort.test.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useTableSort returns a table sort configuration 1`] = `
+Object {
+  "all": Array [
+    Object {
+      "columns": Array [
+        Object {
+          "key": "name",
+          "renderFunc": [Function],
+          "sortByProperty": "name",
+          "title": "Name",
+        },
+        Object {
+          "key": "description",
+          "title": "Description",
+        },
+        Object {
+          "renderFunc": [Function],
+          "sortByFunction": [Function],
+          "title": "Severity sorted by function",
+          "transforms": Array [
+            [Function],
+          ],
+        },
+        Object {
+          "renderFunc": [Function],
+          "sortByArray": Array [
+            "high",
+            "medium",
+            "low",
+            "unknown",
+          ],
+          "sortByProperty": "severity",
+          "title": "Severity by Array",
+        },
+      ],
+      "sorter": [Function],
+      "tableProps": Object {
+        "onSort": [Function],
+        "sortBy": Object {
+          "direction": "desc",
+          "index": 0,
+        },
+      },
+    },
+  ],
+  "current": Object {
+    "columns": Array [
+      Object {
+        "key": "name",
+        "renderFunc": [Function],
+        "sortByProperty": "name",
+        "title": "Name",
+      },
+      Object {
+        "key": "description",
+        "title": "Description",
+      },
+      Object {
+        "renderFunc": [Function],
+        "sortByFunction": [Function],
+        "title": "Severity sorted by function",
+        "transforms": Array [
+          [Function],
+        ],
+      },
+      Object {
+        "renderFunc": [Function],
+        "sortByArray": Array [
+          "high",
+          "medium",
+          "low",
+          "unknown",
+        ],
+        "sortByProperty": "severity",
+        "title": "Severity by Array",
+      },
+    ],
+    "sorter": [Function],
+    "tableProps": Object {
+      "onSort": [Function],
+      "sortBy": Object {
+        "direction": "desc",
+        "index": 0,
+      },
+    },
+  },
+  "error": undefined,
+}
+`;

--- a/packages/utils/src/useTableTools/__snapshots__/useTableTools.test.js.snap
+++ b/packages/utils/src/useTableTools/__snapshots__/useTableTools.test.js.snap
@@ -1,0 +1,230 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useTableTools returns default pagintated rows 1`] = `
+Array [
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #9",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "medium",
+      },
+      Object {
+        "title": "medium",
+      },
+    ],
+    "itemId": 9,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #8",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "high",
+      },
+      Object {
+        "title": "high",
+      },
+    ],
+    "itemId": 8,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #7",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "unknown",
+      },
+      Object {
+        "title": "unknown",
+      },
+    ],
+    "itemId": 7,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #6",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "low",
+      },
+      Object {
+        "title": "low",
+      },
+    ],
+    "itemId": 6,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #5",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "medium",
+      },
+      Object {
+        "title": "medium",
+      },
+    ],
+    "itemId": 5,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #4",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "high",
+      },
+      Object {
+        "title": "high",
+      },
+    ],
+    "itemId": 4,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #30",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "low",
+      },
+      Object {
+        "title": "low",
+      },
+    ],
+    "itemId": 30,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #3",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "unknown",
+      },
+      Object {
+        "title": "unknown",
+      },
+    ],
+    "itemId": 3,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #29",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "medium",
+      },
+      Object {
+        "title": "medium",
+      },
+    ],
+    "itemId": 29,
+  },
+  Object {
+    "cells": Array [
+      Object {
+        "title": "TEST ITEM #28",
+      },
+      Object {
+        "title": "DESCRIPTION",
+      },
+      Object {
+        "title": "high",
+      },
+      Object {
+        "title": "high",
+      },
+    ],
+    "itemId": 28,
+  },
+]
+`;
+
+exports[`useTableTools returns toolbarProps and tableProps for filters when a filter config is passed 1`] = `
+Object {
+  "activeFiltersConfig": Object {
+    "filters": Array [],
+    "onDelete": [Function],
+  },
+  "filterConfig": Object {
+    "items": Array [
+      Object {
+        "filterValues": Object {
+          "onChange": [Function],
+          "value": undefined,
+        },
+        "id": "name",
+        "label": "Name",
+        "placeholder": "Filter by name",
+        "type": "text",
+      },
+      Object {
+        "filterValues": Object {
+          "items": Array [
+            Object {
+              "label": "OPTION 1",
+              "value": "OPTION 1",
+            },
+            Object {
+              "label": "OPTION 2",
+              "value": "OPTION 2",
+            },
+            Object {
+              "label": "OPTION 3",
+              "value": "OPTION 3",
+            },
+          ],
+          "onChange": [Function],
+          "value": undefined,
+        },
+        "id": "chackboxfilter",
+        "label": "Chackbox Filter",
+        "placeholder": "Filter by chackbox filter",
+        "type": "checkbox",
+      },
+    ],
+  },
+  "pagination": Object {
+    "itemCount": 30,
+    "onPerPageSelect": [Function],
+    "onSetPage": [Function],
+    "page": 1,
+    "perPage": 10,
+  },
+}
+`;

--- a/packages/utils/src/useTableTools/index.js
+++ b/packages/utils/src/useTableTools/index.js
@@ -1,0 +1,3 @@
+export { default } from './useTableTools';
+export { usePaginate } from './usePaginate';
+export { default as TableToolsTable } from './TableToolsTable';

--- a/packages/utils/src/useTableTools/useBulkSelect.js
+++ b/packages/utils/src/useTableTools/useBulkSelect.js
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+const compileTitle = (itemsTotal, titleOption) => {
+    if (typeof titleOption === 'string') {
+        return titleOption;
+    } else if (typeof titleOption === 'function') {
+        return titleOption(itemsTotal);
+    } else {
+        return `${ itemsTotal } selected`;
+    }
+};
+
+const checkboxState = (selectedItemsTotal, itemsTotal) => {
+    if (selectedItemsTotal === 0) {
+        return false;
+    } else if (selectedItemsTotal === itemsTotal) {
+        return true;
+    } else {
+        return null;
+    }
+};
+
+const allItemsIncluded = (items, selection) => (
+    items.filter((item) => (
+        selection.includes(item)
+    )).length === items.length
+);
+
+const selectOrUnselect = (selected) => (
+    selected ? 'Unselect' : 'Select'
+);
+
+const checkCurrentPageSelected = (items, selectedItems) => {
+    if (items.length === 0) {
+        return false;
+    } else {
+        return allItemsIncluded(items, selectedItems);
+    }
+};
+
+const itemIds = (items) => (items.map((item) => (item.itemId)));
+const mergeArraysUniqly = (arrayA, arrayB) => (
+    Array.from(new Set([ ...arrayA, ...arrayB ]))
+);
+
+const SELECTED_FILTER =  {
+    type: conditionalFilterType.checkbox,
+    label: 'Selected only',
+    items: [
+        { label: 'Show selected only', value: true }
+    ]
+};
+
+const filterSelected = (items, selectedIds) => (
+    items.filter((item) => (
+        selectedIds.includes(item.id)
+    ))
+);
+
+const useSelectedFilter = (addFilterConfigItem, selectedIds) => {
+    const filterItem = {
+        ...SELECTED_FILTER,
+        filter: (items) => (
+            filterSelected(items, selectedIds)
+        )
+    };
+
+    if (addFilterConfigItem) {
+        addFilterConfigItem(filterItem);
+    }
+};
+
+const useBulkSelect = ({
+    onSelect,
+    items: propItems,
+    filter,
+    addFilterConfigItem,
+    paginate: {
+        paginator
+    } = {},
+    sorter,
+    preselectedIds,
+    selectFilter = false
+} = {}) => {
+    const [ selectedIds, setSelectedItemIds ] = useState(preselectedIds || []);
+    useSelectedFilter(selectFilter ? addFilterConfigItem : undefined, selectedIds);
+
+    const items = sorter ? sorter(propItems) : propItems;
+    const total = items.length;
+
+    const selectedItems = filterSelected(items, selectedIds);
+    const selectedItemsTotal = selectedItems.length;
+    const noneSelected = selectedItemsTotal === 0;
+
+    const filteredItems = filter ? filter(items) : items;
+    const filteredTotal = filteredItems.length;
+    const filtered = filteredTotal < total;
+    const allFiltertedSelected = allItemsIncluded(itemIds(filteredItems), selectedIds);
+
+    const paginatedItems = paginator ? paginator(filteredItems) : filteredItems;
+    const paginatedTotal = paginatedItems.length;
+
+    const currentPageSelected = checkCurrentPageSelected(
+        itemIds(paginatedItems), selectedIds
+    );
+
+    const allSelected = selectedItemsTotal === total;
+    const title = compileTitle(selectedItemsTotal);
+    const checked = checkboxState(selectedItemsTotal, total);
+
+    const onSelectCallback = (func) => {
+        const newSelectedItems = filterSelected(items, func());
+        onSelect && onSelect(newSelectedItems);
+    };
+
+    const selectNone = () => onSelectCallback(() => {
+        setSelectedItemIds([]);
+        return [];
+    });
+
+    const selectOne = (_, selected, key, row) => onSelectCallback(() => {
+        const newItemIds = selected ?
+            [ ...selectedIds, row.itemId ] :
+            selectedIds.filter((rowId) => (rowId !== row.itemId));
+
+        setSelectedItemIds(newItemIds);
+
+        return newItemIds;
+    });
+
+    const selectPage = () => onSelectCallback(() => {
+        const currentPageIds = itemIds(paginatedItems);
+        const newItemIds = currentPageSelected ? selectedIds.filter((itemId) => (
+            !currentPageIds.includes(itemId)
+        )) : mergeArraysUniqly(selectedIds, currentPageIds);
+        setSelectedItemIds(newItemIds);
+
+        return newItemIds;
+    });
+
+    const selectFiltered = () => {
+        const currentFilteredIds = itemIds(filteredItems);
+        const newItemIds = allFiltertedSelected ? selectedIds.filter((itemId) => (
+            !currentFilteredIds.includes(itemId)
+        )) : mergeArraysUniqly(selectedIds, currentFilteredIds);
+        setSelectedItemIds(newItemIds);
+
+        return newItemIds;
+    };
+
+    const selectFilteredOrAll = () => (
+        filtered ? selectFiltered() : setSelectedItemIds(
+            itemIds(items)
+        )
+    );
+
+    const selectAll = () => onSelectCallback(() => (
+        allSelected ? selectNone() : selectFilteredOrAll()
+    ));
+
+    const onSelectBulkSelect = selectPage;
+
+    const allCount = filtered ? filteredTotal : total;
+
+    const selectItemTransformer = (item) => ({
+        ...item,
+        rowProps: {
+            selected: selectedIds.includes(item.itemId)
+        }
+    });
+
+    const clearSelection = () => setSelectedItemIds([]);
+
+    return {
+        transformer: selectItemTransformer,
+        tableProps: {
+            onSelect: paginatedTotal > 0 ? selectOne : undefined,
+            canSelectAll: false
+        },
+        clearSelection,
+        toolbarProps: {
+            bulkSelect: {
+                toggleProps: { children: [ title, ' ' ] },
+                isDisabled: paginatedTotal === 0,
+                items: [{
+                    title: 'Select none',
+                    onClick: selectNone,
+                    props: {
+                        isDisabled: noneSelected
+                    }
+                }, {
+                    title: `${ selectOrUnselect(currentPageSelected) } page ${ paginatedTotal }`,
+                    onClick: selectPage
+                }, {
+                    title: `${ selectOrUnselect(allSelected) } all ${ allCount }`,
+                    onClick: selectAll
+                }],
+                checked,
+                onSelect: paginatedTotal > 0 ? () => onSelectBulkSelect() : undefined
+            }
+        }
+    };
+};
+
+export default useBulkSelect;

--- a/packages/utils/src/useTableTools/useBulkSelect.test.js
+++ b/packages/utils/src/useTableTools/useBulkSelect.test.js
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useBulkSelect from './useBulkSelect';
+import items from './__fixtures__/items';
+
+describe('useBulkSelect', () => {
+    const exampleItems = items(20);
+
+    it('returns a bulk select configuration', () => {
+        const options = {
+            onSelect: () => ({}),
+            items: exampleItems
+        };
+
+        const { result } = renderHook(() => useBulkSelect(options));
+
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/utils/src/useTableTools/useConditionalTableHook.js
+++ b/packages/utils/src/useTableTools/useConditionalTableHook.js
@@ -1,0 +1,9 @@
+const useConditionalTableHook = (condition, hook, options) => {
+    if (condition) {
+        return hook(options);
+    } else {
+        return { };
+    }
+};
+
+export default useConditionalTableHook;

--- a/packages/utils/src/useTableTools/useFilterConfig.js
+++ b/packages/utils/src/useTableTools/useFilterConfig.js
@@ -1,0 +1,67 @@
+import { useState, useLayoutEffect } from 'react';
+import FilterConfigBuilder from './FilterConfigBuilder/FilterConfigBuilder';
+
+const filterConfigBuilder = new FilterConfigBuilder([]);
+
+const useFilterConfig = (initialConfig) => {
+    const [ activeFilters, setActiveFilters ] = useState(filterConfigBuilder.initialDefaultState(
+        initialConfig?.activeFilters || []
+    ));
+    const onFilterUpdate = (filter, value) => (
+        setActiveFilters({
+            ...activeFilters,
+            [filter]: value
+        })
+    );
+
+    const buildConfig = () => (
+        filterConfigBuilder.buildConfiguration(
+            onFilterUpdate,
+            activeFilters
+        )
+    );
+
+    const addConfigItem = (item) => {
+        filterConfigBuilder.addConfigItem(item);
+    };
+
+    const clearAllFilter = () => (
+        setActiveFilters(filterConfigBuilder.initialDefaultState())
+    );
+
+    const deleteFilter = (chips) => (
+        setActiveFilters(filterConfigBuilder.removeFilterWithChip(
+            chips, activeFilters
+        ))
+    );
+    const onFilterDelete = (_event, chips, clearAll = false) => (
+        clearAll ? clearAllFilter() : deleteFilter(chips[0])
+    );
+    const chipBuilder = filterConfigBuilder.getChipBuilder();
+    const filterChips = chipBuilder.chipsFor(activeFilters);
+
+    useLayoutEffect(() => {
+        initialConfig.forEach(addConfigItem);
+    }, []);
+
+    return {
+        filter: (items) => (
+            filterConfigBuilder.applyFilterToObjectArray(
+                items, activeFilters
+            )
+        ),
+        toolbarProps: {
+            filterConfig: buildConfig(),
+            activeFiltersConfig: {
+                filters: filterChips,
+                onDelete: onFilterDelete
+            }
+        },
+        addConfigItem,
+        filterConfigBuilder,
+        activeFilters,
+        buildFilterString: () => filterConfigBuilder.getFilterBuilder().buildFilterString(activeFilters)
+    };
+};
+
+export default useFilterConfig;

--- a/packages/utils/src/useTableTools/useFilterConfig.test.js
+++ b/packages/utils/src/useTableTools/useFilterConfig.test.js
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+import useFilterConfig from './useFilterConfig';
+const config = [
+    {
+        type: conditionalFilterType.checkbox,
+        label: 'Filter with multiple spaces',
+        items: [
+            { label: 'Show ', value: 'show' }
+        ],
+        filter: () => ([])
+    },
+    {
+        type: conditionalFilterType.text,
+        label: 'Name',
+        filter: () => ([])
+    }
+];
+
+describe('useFilterConfig', () => {
+    it('returns a filter config configuration', () => {
+        const { result } = renderHook(() => useFilterConfig(config));
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/utils/src/useTableTools/usePaginate.js
+++ b/packages/utils/src/useTableTools/usePaginate.js
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+export const usePaginate = ({ perPage = 10, itemCount } = {}) => {
+    const [ paginationState, setPaginationState ] = useState({
+        perPage: perPage,
+        page: 1
+    });
+    const setPagination = (newState) => {
+        setPaginationState({
+            ...paginationState,
+            ...newState
+        });
+    };
+
+    const onSetPage = (_, page) => (
+        setPagination({ ...paginationState, page })
+    );
+
+    const onPerPageSelect = (_, perPage) => (
+        setPagination({ page: 1, perPage })
+    );
+
+    const paginator = (items) => {
+        const { page, perPage } = paginationState;
+        const start = (page - 1) * perPage;
+        const end = start + perPage;
+
+        return items.slice(start, end);
+    };
+
+    return {
+        paginator,
+        setPage: (page) => {
+            setPaginationState({
+                ...paginationState,
+                page
+            });
+        },
+        pagination: {
+            ...paginationState,
+            itemCount,
+            onSetPage,
+            onPerPageSelect
+        }
+    };
+};
+
+export default usePaginate;

--- a/packages/utils/src/useTableTools/usePaginate.test.js
+++ b/packages/utils/src/useTableTools/usePaginate.test.js
@@ -1,0 +1,35 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import usePaginate from './usePaginate';
+import items from './__fixtures__/items';
+
+describe('usePaginate', () => {
+    it('returns a paginate configuration', () => {
+        const { result } = renderHook(() => usePaginate());
+        expect(result).toMatchSnapshot();
+    });
+
+    it('returns a paginate configuration', () => {
+        const { result } = renderHook(() => usePaginate());
+
+        act(() => {
+            result.current.setPage(2);
+        });
+
+        expect(result.current.pagination.page).toBe(2);
+    });
+
+    it('returns a paginate configuration', () => {
+        const exampleItems = items(40);
+        const { result } = renderHook(() => usePaginate({ perPage: 5 }));
+
+        act(() => {
+            result.current.setPage(2);
+        });
+
+        const paginatedItems = result.current.paginator(exampleItems);
+
+        expect(paginatedItems).toMatchSnapshot();
+        expect(paginatedItems.length).toBe(5);
+        expect(paginatedItems[4]).toBe(exampleItems[9]);
+    });
+});

--- a/packages/utils/src/useTableTools/useRowIdentify.js
+++ b/packages/utils/src/useTableTools/useRowIdentify.js
@@ -1,0 +1,24 @@
+export const useRowIdentify = (options = {}) => {
+    const getIdProp = (item, idProp = 'id') => (item[idProp]);
+    const identifier = options?.identifier || getIdProp;
+
+    const identify = (item) => {
+        if (typeof identifier === 'string') {
+            return {
+                ...item,
+                itemId: getIdProp(item, identifier)
+            };
+        } else {
+            return {
+                ...item,
+                itemId: identifier(item)
+            };
+        }
+    };
+
+    return (items) => (
+        items.map(identify)
+    );
+};
+
+export default useRowIdentify;

--- a/packages/utils/src/useTableTools/useRowsBuilder.js
+++ b/packages/utils/src/useTableTools/useRowsBuilder.js
@@ -1,0 +1,68 @@
+import { emptyRows } from './NoResultsTable';
+
+const columnProp = (column) => {
+    return column.key || column.original?.toLowerCase() || column.title?.toLowerCase();
+};
+
+const itemRow = (item, columns) => ({
+    ...item.rowProps,
+    itemId: item.itemId,
+    cells: columns.map((column) => ({
+        title: column.renderFunc ? column.renderFunc(item) : item[columnProp(column)]
+    }))
+});
+
+const primeItem = (item, transformers) => {
+    let newItem = item;
+
+    transformers.forEach((transformer) => {
+        if (transformer) {
+            newItem = transformer(newItem);
+        }
+    });
+
+    return newItem;
+};
+
+const applyTransformers = (items, transformers = []) => (
+    items.map((item) => (
+        primeItem(item, transformers)
+    ))
+);
+
+const buildRows = (items, columns, options) => {
+    const EmptyRowsComponent = options.emptyRows || emptyRows;
+    const transformedItems = options?.transformers ?
+        applyTransformers(items, options?.transformers) : items;
+
+    const filteredItems = options?.filter ?
+        options.filter(transformedItems) : items;
+
+    const sortedItems = options?.sorter ?
+        options.sorter(filteredItems) : filteredItems;
+
+    const paginatedItems = options?.paginate?.paginator ?
+        options?.paginate?.paginator(sortedItems) : sortedItems;
+
+    const rows = paginatedItems.length > 0 ? paginatedItems.map((item) => (
+        itemRow(item, columns)
+    )).filter((v) => (!!v)) : EmptyRowsComponent;
+
+    const pagination = options?.paginate?.pagination ? {
+        ...options.paginate.pagination,
+        itemCount: filteredItems.length
+    } : undefined ;
+
+    return {
+        rows,
+        pagination
+    };
+};
+
+const useRowsBuilder = (columns, options) => (
+    (items) => (
+        buildRows(items, columns, options)
+    )
+);
+
+export default useRowsBuilder;

--- a/packages/utils/src/useTableTools/useRowsBuilder.test.js
+++ b/packages/utils/src/useTableTools/useRowsBuilder.test.js
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useRowsBuilder from './useRowsBuilder';
+
+describe('useRowsBuilder', () => {
+    it('returns a rows configuration', () => {
+        const { result } = renderHook(() =>
+            useRowsBuilder([{ name: 'Item #1' }])
+        );
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/utils/src/useTableTools/useTableSort.js
+++ b/packages/utils/src/useTableTools/useTableSort.js
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { sortable } from '@patternfly/react-table';
+
+const getSortable = (property, item) => {
+    if (typeof(property) === 'function') {
+        return property(item);
+    } else {
+        return item[property];
+    }
+};
+
+const compareSortableAsStrings = (property, a, b) => (
+    String(getSortable(property, a))
+    .localeCompare(String(getSortable(property, b)))
+);
+
+export const orderArrayByProp = (property, objects, direction) => (
+    objects.sort((a, b) => {
+        if (direction === 'asc') {
+            return compareSortableAsStrings(property, a, b);
+        } else {
+            return -compareSortableAsStrings(property, a, b);
+        }
+    })
+);
+export const orderByArray = (objectArray, orderProp, orderArray, direction) => (
+    (direction !== 'asc' ? orderArray.reverse() : orderArray).flatMap((orderKey) => (
+        objectArray.filter((item) => (item[orderProp] === orderKey))
+    ))
+);
+
+const isSortable = (column) => (
+    column.sortByProp || column.sortByFunction
+);
+
+const addSortableTransform = (columns) => (
+    columns.map((column) => ({
+        ...column,
+        ...isSortable(column) ? { transforms: Array.from(new Set([
+            ...(column?.transforms || []),
+            sortable
+        ])) } : {}
+    }))
+);
+
+const columnOffset = (options = {}) => {
+    let offset = 0;
+
+    if (options.selectable) {
+        offset += 1;
+    }
+
+    if (typeof options.detailsComponent  !== 'undefined') {
+        offset += 1;
+    }
+
+    return offset;
+};
+
+const sorter = (columns, options, sortBy) => (
+    (items) => {
+        const offset = columnOffset(options);
+        const column = columns[sortBy.index - offset];
+        const sortedItems = column?.sortByArray ? orderByArray(
+            items, column?.sortByProperty, column?.sortByArray, sortBy.direction
+        ) : orderArrayByProp(
+            (column?.sortByProperty || column?.sortByFunction), items, sortBy.direction
+        );
+
+        return sortedItems;
+    }
+);
+
+const useTableSort = (columns, options = {}) => {
+    const [ sortBy, setSortBy ] = useState({
+        index: 0,
+        direction: 'desc'
+    });
+    const onSort = (_, index, direction) => {
+        setSortBy({
+            index,
+            direction
+        });
+    };
+
+    return {
+        sorter: sorter(columns, options, sortBy),
+        tableProps: {
+            onSort,
+            sortBy
+        },
+        columns: addSortableTransform(columns)
+    };
+};
+
+export default useTableSort;

--- a/packages/utils/src/useTableTools/useTableSort.test.js
+++ b/packages/utils/src/useTableTools/useTableSort.test.js
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useTableSort from './useTableSort';
+import items from './__fixtures__/items';
+import columns from './__fixtures__/columns';
+
+describe('useTableSort', () => {
+    const exampleItems = items(100);
+
+    it('returns a table sort configuration', () => {
+        const { result } = renderHook(() => useTableSort(columns));
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/packages/utils/src/useTableTools/useTableTools.js
+++ b/packages/utils/src/useTableTools/useTableTools.js
@@ -1,0 +1,86 @@
+import { useEffect } from 'react';
+import useFilterConfig from './useFilterConfig';
+import useTableSort from './useTableSort';
+import { default as usePaginate } from './usePaginate';
+import useRowsBuilder from './useRowsBuilder';
+import useBulkSelect from './useBulkSelect';
+import useRowIdentify from './useRowIdentify';
+import useConditionalTableHook from './useConditionalTableHook';
+
+const useTableTools = (items = [], columns = [], options = {}) => {
+    const enableFilters = !!options.filterConfig;
+    const enableBulkSelect = !!options.onSelect;
+    const enablePagination = options?.pagination !== false;
+    const perPage = options?.perPage || 10;
+
+    const identify = useRowIdentify(options);
+    const identifiedItems = identify(items);
+
+    const {
+        tableProps: sortableTableProps, columns: sortableColumns, sorter
+    } = useTableSort(columns, options);
+
+    const {
+        filter, toolbarProps: conditionalFilter, activeFilters, addConfigItem: addFilterConfigItem
+    } = useConditionalTableHook(enableFilters, useFilterConfig, options.filterConfig);
+
+    const paginate = useConditionalTableHook(enablePagination, usePaginate, {
+        ...options,
+        perPage,
+        itemCount: items.length
+    });
+
+    const {
+        transformer: selectItem, toolbarProps: bulkSelectToolbarProps,
+        tableProps: bulkSelectTableProps, clearSelection
+    } = useConditionalTableHook(enableBulkSelect, useBulkSelect, {
+        ...options,
+        items: identifiedItems,
+        filter,
+        addFilterConfigItem,
+        paginate,
+        sorter
+    });
+
+    const transformers = [
+        selectItem
+    ];
+
+    const rowBuilder = useRowsBuilder(columns, {
+        detailsComponent: options.detailsComponent,
+        emptyRows: options.emptyRows,
+        transformers,
+        filter,
+        paginate,
+        sorter
+    });
+    const { rows, pagination } = rowBuilder(identifiedItems);
+
+    useEffect(() => {
+        if (paginate.setPage) {
+            paginate.setPage(1);
+        }
+    }, [ activeFilters ]);
+
+    useEffect(() => {
+        if (clearSelection) {
+            clearSelection();
+        }
+    }, [ items ]);
+
+    return {
+        toolbarProps: {
+            pagination,
+            ...bulkSelectToolbarProps,
+            ...conditionalFilter
+        },
+        tableProps: {
+            rows,
+            cells: sortableColumns,
+            ...sortableTableProps,
+            ...bulkSelectTableProps
+        }
+    };
+};
+
+export default useTableTools;

--- a/packages/utils/src/useTableTools/useTableTools.test.js
+++ b/packages/utils/src/useTableTools/useTableTools.test.js
@@ -1,0 +1,54 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useTableTools from './useTableTools';
+import items from './__fixtures__/items';
+import columns from './__fixtures__/columns';
+import filters from './__fixtures__/filters';
+
+describe('useTableTools', () => {
+    const exampleItems = items(30).sort((item) => (item.name));
+    const defaultArguments = [ exampleItems, columns ];
+
+    it('returns a tableProps and toolbarProps', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments));
+        expect(result.current.tableProps).not.toBeUndefined();
+        expect(result.current.toolbarProps).not.toBeUndefined();
+    });
+
+    it('returns default pagintated rows', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments));
+        expect(result.current.tableProps.rows.length).toBe(10);
+        expect(result.current.tableProps.rows).toMatchSnapshot();
+    });
+
+    it('returns perPage amount of items as rows', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments, {
+            perPage: 20
+        }));
+        expect(result.current.tableProps.rows.length).toBe(20);
+    });
+
+    it('returns all items as rows with pagination disabled', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments, {
+            pagination: false
+        }));
+        expect(result.current.tableProps.rows.length).toBe(exampleItems.length);
+    });
+
+    it('returns toolbarProps and tableProps for bulk select when onSelect is passed', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments, {
+            onSelect: () => ({})
+        }));
+        expect(result.current.tableProps.onSelect).not.toBeUndefined();
+        expect(result.current.tableProps.canSelectAll).not.toBeUndefined();
+        expect(result.current.toolbarProps.bulkSelect).not.toBeUndefined();
+    });
+
+    it('returns toolbarProps and tableProps for filters when a filter config is passed', () => {
+        const { result } = renderHook(() => useTableTools(...defaultArguments, {
+            filterConfig: filters
+        }));
+        expect(result.current.toolbarProps).toMatchSnapshot();
+        expect(result.current.toolbarProps.filterConfig).not.toBeUndefined();
+        expect(result.current.toolbarProps.activeFiltersConfig).not.toBeUndefined();
+    });
+});


### PR DESCRIPTION
This introduces a collection of hooks aka. TableTools to the frontend-components-utilities package to control a PatternFly table and/or the Insights Frontend Components `PrimaryToolbar` component.

It allows passing in an array of items and a set of columns as well as filters. Hooks are meant to be usable in combination with the `useTableTools` hook as well as separately (they may not fully yet). There is also a `TableToolsTable` component that is already set up to use the hooks, an example for a use of it can be found in compliance-frontend[0]. 
The resulting table looks and works like this:

https://user-images.githubusercontent.com/7757/116374906-0a8e3600-a80f-11eb-9b18-e5fc7d0d821f.mp4

[0] https://github.com/RedHatInsights/compliance-frontend/pull/1192/files#diff-042375a49456c92f5d5f42c19fdaf1e81fd7156fe94eb71e8691eadf78ff2d02