### PR TITLE
fix(components): removed unused PF css import

### DIFF
--- a/packages/components/src/Input/input.scss
+++ b/packages/components/src/Input/input.scss
@@ -1,2 +1,0 @@
-@import '~@patternfly/patternfly/components/FormControls/form-control.css';
-@import '~@patternfly/patternfly/components/Check/check.scss';

--- a/packages/components/src/index.scss
+++ b/packages/components/src/index.scss
@@ -7,7 +7,6 @@
 @import './FilterChips/filter-chips.scss';
 @import './FilterHooks/tagFilterHook.scss';
 @import './Filters/filters.scss';
-@import './Input/input.scss';
 @import './InsightsLabel/critical-icon.scss';
 @import './InsightsLabel/labels.scss';
 @import './InvalidObject/icon-404.scss';


### PR DESCRIPTION
`@patternfly/patternfly/components/FormControls/form-control.css` CSS file is no longer provided in the current PF version and it is killing builds when trying to build the CSS.