### PR TITLE
Hot fix PDF chart renderer

### DIFF
--- a/packages/pdf-generator/rollup.config.js
+++ b/packages/pdf-generator/rollup.config.js
@@ -13,14 +13,13 @@ import json from '@rollup/plugin-json';
 import rollupPlugins from '../../config/rollup-plugins';
 
 const external = createFilter(
-    Object.keys(dependencies).map(item => item.includes('@patternfly') ? `${item}/**` : item),
+    Object.keys(dependencies).map(item => item.includes('@patternfly') ? `${item}/**` : item)
+    .filter(item => item !== 'react' && item !== 'react-dom'),
     null,
     { resolve: false }
 );
 
 const globals = {
-    react: 'React',
-    'react-dom': 'ReactDOM',
     '@patternfly/react-core': '@patternfly/react-core',
     '@patternfly/react-icons': '@patternfly/react-icons'
 };

--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { CircleIconConfig } from '@patternfly/react-icons/dist/js/icons/circle-icon';
 import PropTypes from 'prop-types';
@@ -37,7 +37,7 @@ const chartMapper = {
     }
 };
 
-class Chart extends Component {
+class Chart extends React.Component {
     getChartData = (currChart) => {
         const { data, chartType, colorSchema, ...props } = this.props;
         const Chart = currChart.component;


### PR DESCRIPTION
### Missing charts when renderring PDF with new react

Due to changes in react-dom and how it handles blocking/non-blocking render we have to include react-dom as internal dependency and ship the PDF renderer with it. This is just a hotfix, proper fix can be managed by changing how each children mounts because we have to wait for charts to render. But this would require a big overhaul of how children are rendered.