### PR TITLE
Add callback function for Sources wizard submit

### DIFF
--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -65,6 +65,8 @@ import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sour
 |hideSourcesButton|bool|`false`|hide 'Take me to sources' button.|
 |returnButtonTitle|node|`'Go back to sources'`|Title of the button shown after success submit. Put your own application name if you neeed.|
 |selectedType|string|`undefined`|A name of source type preselected - this will remove the source type selection. (Only for Cloud types.)|
+|initialWizardState|object|`undefined`|An initial state passed to the wizard component. See [here](https://data-driven-forms.org/mappers/wizard?mapper=pf4#heading-pf4wizard#initialstate).|
+|submitCallback|function|`undefined`|An function that is always called when the submit finishes. `(state) => ...` In case of success, the state is a following object: `{createdSource, sourceTypes, isSubmitted: true}`, in case of any unhandled error: `{values, sourceTypes, isErrored, wizardState, error }` |
 
 If you need to set up and **support only one application** you can provide filtered `applicationTypes` with the only one application, set up `disableAppSelection` to `false` and `initialValues` to:
 

--- a/packages/sources/src/addSourceWizard/FinalWizard.js
+++ b/packages/sources/src/addSourceWizard/FinalWizard.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Wizard, Button, Text } from '@patternfly/react-core';
+import { Wizard, Button, Text, TextContent } from '@patternfly/react-core';
 import { useIntl } from 'react-intl';
 
 import FinishedStep from './steps/FinishedStep';
@@ -130,10 +130,24 @@ const FinalWizard = ({
                 id: 'wizard.loadingText',
                 defaultMessage: 'Validating credentials'
             })}
-            description={intl.formatMessage({
-                id: 'wizard.loadingDescription',
-                defaultMessage: 'This could take a minute. If you prefer not to wait, close this dialog and the process will continue.'
-            })}
+            description={
+                <TextContent>
+                    <Text className="pf-u-mb-md">{
+                        intl.formatMessage({
+                            id: 'wizard.loadingDescription-a',
+                            defaultMessage:
+                            // eslint-disable-next-line max-len
+                            'This might take some time. You\'ll receive a notification if you are still in the Sources application when the process completes. Otherwise, you can check the status in the main sources table at any time.'
+                        })
+                    }</Text>
+                    <Text>{
+                        intl.formatMessage({
+                            id: 'wizard.loadingDescription-b',
+                            defaultMessage: 'In the meantime, you can close this window while the validation process continues.'
+                        })
+                    }</Text>
+                </TextContent>
+            }
             onClose={afterError}
             cancelTitle={intl.formatMessage({ id: 'wizard.close', defaultMessage: 'Close' })}
         />;

--- a/packages/sources/src/addSourceWizard/SourceAddModal.js
+++ b/packages/sources/src/addSourceWizard/SourceAddModal.js
@@ -18,7 +18,7 @@ const initialValues = {
     isLoading: true
 };
 
-const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType }) => {
+const reducer = (state, { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType, initialWizardState }) => {
     switch (type) {
         case 'loaded':
             return {
@@ -29,7 +29,8 @@ const reducer = (state, { type, sourceTypes, applicationTypes, container, disabl
                     disableAppSelection,
                     container,
                     intl,
-                    selectedType
+                    selectedType,
+                    initialWizardState
                 ),
                 isLoading: false,
                 sourceTypes
@@ -45,7 +46,8 @@ const SourceAddModal = ({
     onCancel,
     values,
     onSubmit,
-    selectedType
+    selectedType,
+    initialWizardState
 }) => {
     const [{ schema, sourceTypes: stateSourceTypes, isLoading }, dispatch ] = useReducer(reducer, initialValues);
     const isMounted = useRef(false);
@@ -76,7 +78,8 @@ const SourceAddModal = ({
                     disableAppSelection,
                     container: container.current,
                     intl,
-                    selectedType
+                    selectedType,
+                    initialWizardState
                 });
             }
         });
@@ -111,7 +114,7 @@ const SourceAddModal = ({
                 ...(selectedType && { source_type: selectedType })
             } }
             schema={ schema }
-            onSubmit={ (values) => onSubmit(values, stateSourceTypes) }
+            onSubmit={ (values, _formApi, wizardState) => onSubmit(values, stateSourceTypes, wizardState) }
             onCancel={ onCancel }
         />
     );
@@ -137,7 +140,8 @@ SourceAddModal.propTypes = {
     values: PropTypes.object,
     disableAppSelection: PropTypes.bool,
     isCancelling: PropTypes.bool,
-    selectedType: PropTypes.string
+    selectedType: PropTypes.string,
+    initialWizardState: PropTypes.object
 };
 
 SourceAddModal.defaultProps = {

--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -336,7 +336,7 @@ const summaryStep = (sourceTypes, applicationTypes, intl) => ({
     })
 });
 
-export default (sourceTypes, applicationTypes, disableAppSelection, container, intl, selectedType) => {
+export default (sourceTypes, applicationTypes, disableAppSelection, container, intl, selectedType, initialWizardState) => {
     setFirstValidated(true);
 
     return ({
@@ -366,6 +366,7 @@ export default (sourceTypes, applicationTypes, disableAppSelection, container, i
             },
             container,
             showTitles: true,
+            initialState: initialWizardState,
             crossroads: [ 'application.application_type_id', 'source_type', 'auth_select' ],
             fields: [
                 nameStep(intl),

--- a/packages/sources/src/addSourceWizard/index.js
+++ b/packages/sources/src/addSourceWizard/index.js
@@ -60,15 +60,15 @@ const AddSourceWizard = ({
     onClose,
     afterSuccess,
     selectedType,
-    initialState,
+    initialWizardState,
     submitCallback
 }) => {
     const [
         { isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, ...state },
         dispatch
-    ] = useReducer(reducer, { ...prepareInitialValues(initialValues), ...initialState });
+    ] = useReducer(reducer, prepareInitialValues(initialValues));
 
-    const onSubmit = (formValues, sourceTypes) => {
+    const onSubmit = (formValues, sourceTypes, wizardState) => {
         dispatch({ type: 'prepareSubmitState', values: formValues, sourceTypes });
 
         return doCreateSource(formValues, sourceTypes, timeoutedApps(applicationTypes)).then((data) => {
@@ -77,7 +77,7 @@ const AddSourceWizard = ({
             dispatch({ type: 'setSubmitted', data });
         })
         .catch((error) => {
-            submitCallback && submitCallback({ isErrored: true, error, values: formValues, sourceTypes });
+            submitCallback && submitCallback({ isErrored: true, error, values: formValues, sourceTypes, wizardState });
             dispatch({ type: 'setErrored', error });
         });
     };
@@ -113,6 +113,7 @@ const AddSourceWizard = ({
                 applicationTypes={ applicationTypes }
                 disableAppSelection={ disableAppSelection }
                 selectedType={selectedType}
+                initialWizardState={initialWizardState}
             />
         </React.Fragment>
         );
@@ -161,17 +162,7 @@ AddSourceWizard.propTypes = {
     hideSourcesButton: PropTypes.bool,
     returnButtonTitle: PropTypes.node,
     selectedType: PropTypes.string,
-    initialState: PropTypes.shape({
-        isSubmitted: PropTypes.bool,
-        isFinished: PropTypes.bool,
-        isErrored: PropTypes.bool,
-        isCancelling: PropTypes.bool,
-        values: PropTypes.shape({
-            [PropTypes.string]: PropTypes.oneOf([ PropTypes.string, PropTypes.array, PropTypes.number, PropTypes.bool ])
-        }),
-        createdSource: PropTypes.object,
-        error: PropTypes.node
-    }),
+    initialWizardState: PropTypes.object,
     submitCallback: PropTypes.func
 };
 

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -225,7 +225,10 @@ describe('AddSourceWizard', () => {
             values: { source: { name: 'somename' } },
             isErrored: true,
             sourceTypes,
-            error: 'Error - wrong name'
+            error: 'Error - wrong name',
+            // because we are using form.submit in test instead of the button,
+            // the state is not included
+            wizardState: expect.any(Function)
         });
 
         jest.useRealTimers();
@@ -360,5 +363,14 @@ describe('AddSourceWizard', () => {
         wrapper.update();
 
         expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[1].title).toEqual('Select application');
+    });
+
+    it('pass initialWizardState to wizard', async () => {
+        await act(async() => {
+            wrapper = mount(<AddSourceWizard { ...initialProps } initialWizardState={{ some: 'state' }} />);
+        });
+        wrapper.update();
+
+        expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].initialState).toEqual({ some: 'state' });
     });
 });

--- a/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceWizzard.test.js
@@ -146,6 +146,91 @@ describe('AddSourceWizard', () => {
         jest.useRealTimers();
     });
 
+    it('pass created source to submitCallback function when success', async () => {
+        jest.useFakeTimers();
+
+        const submitCallback = jest.fn();
+        createSource.doCreateSource = jest.fn(() => new Promise((resolve) => resolve({ name: 'source', applications: [] })));
+        dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
+
+        await act(async() => {
+            wrapper = mount(<AddSourceWizard { ...initialProps } submitCallback={ submitCallback } />);
+        });
+        wrapper.update();
+
+        await act(async () => {
+            wrapper.find('input').instance().value = 'somename';
+            wrapper.find('input').simulate('change');
+        });
+        wrapper.update();
+
+        await act(async () => {
+            jest.advanceTimersByTime(1000);
+        });
+        wrapper.update();
+
+        await act(async() => {
+            wrapper.find('form').simulate('submit');
+        });
+        wrapper.update();
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        wrapper.update();
+
+        expect(submitCallback).toHaveBeenCalledWith({
+            createdSource: { name: 'source', applications: [] },
+            isSubmitted: true,
+            sourceTypes
+        });
+
+        jest.useRealTimers();
+    });
+
+    it('pass values to submitCallback function when errors', async () => {
+        jest.useFakeTimers();
+
+        const submitCallback = jest.fn();
+        createSource.doCreateSource = jest.fn(() => new Promise((_, reject) => reject('Error - wrong name')));
+        dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
+
+        await act(async() => {
+            wrapper = mount(<AddSourceWizard { ...initialProps } submitCallback={ submitCallback } />);
+        });
+        wrapper.update();
+
+        await act(async () => {
+            wrapper.find('input').instance().value = 'somename';
+            wrapper.find('input').simulate('change');
+        });
+        wrapper.update();
+
+        await act(async () => {
+            jest.advanceTimersByTime(1000);
+        });
+        wrapper.update();
+
+        await act(async() => {
+            wrapper.find('form').simulate('submit');
+        });
+        wrapper.update();
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        wrapper.update();
+
+        expect(submitCallback).toHaveBeenCalledWith({
+            values: { source: { name: 'somename' } },
+            isErrored: true,
+            sourceTypes,
+            error: 'Error - wrong name'
+        });
+
+        jest.useRealTimers();
+    });
+
     it('pass values to onClose function', async () => {
         jest.useFakeTimers();
 

--- a/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
+++ b/packages/sources/src/tests/addSourceWizard/finalWizard.test.js
@@ -57,7 +57,8 @@ describe('Final wizard', () => {
         expect(wrapper.find(LoadingStep)).toHaveLength(1);
         expect(wrapper.find(EmptyState).find(Title).text()).toEqual('Validating credentials');
         expect(wrapper.find(EmptyState).find(EmptyStateBody).text()).toEqual(
-            'This could take a minute. If you prefer not to wait, close this dialog and the process will continue.'
+            // eslint-disable-next-line max-len
+            'This might take some time. You\'ll receive a notification if you are still in the Sources application when the process completes. Otherwise, you can check the status in the main sources table at any time.In the meantime, you can close this window while the validation process continues.'
         );
     });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-11916

TODO:
- [x] docs
- [x] wait how UI will handle retry action https://github.com/RedHatInsights/sources-ui/pull/558

**New loading:**

![image](https://user-images.githubusercontent.com/32869456/106457220-f09eba80-648e-11eb-9fe2-5806c0ff42ae.png)