### PR TITLE
Use value instead of label for app mutator

### DIFF
--- a/packages/sources/src/addSourceWizard/SourceAddSchema.js
+++ b/packages/sources/src/addSourceWizard/SourceAddSchema.js
@@ -95,7 +95,7 @@ export const compileAllApplicationComboOptions = (applicationTypes, intl) => (
 
 export const appMutatorRedHat = (appTypes) => (option, formOptions) => {
     const selectedSourceType = formOptions.getState().values.source_type;
-    const appType = appTypes.find(app => app.display_name === option.label);
+    const appType = appTypes.find(app => app.id === option.value);
     const isEnabled = selectedSourceType && appType ? appType.supported_source_types.includes(selectedSourceType) : true;
 
     if (!isEnabled) {

--- a/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
+++ b/packages/sources/src/tests/addSourceWizard/addSourceSchema.test.js
@@ -116,10 +116,12 @@ describe('Add source schema', () => {
     describe('mutators', () => {
         const sourceTypes = [{
             product_name: 'Amazon',
-            name: 'amazon'
+            name: 'amazon',
+            id: 'amazon'
         }, {
             product_name: 'differen type',
-            name: 'ops'
+            name: 'ops',
+            id: 'openshift'
         }];
         const applicationTypes = [{
             id: 'selected',
@@ -166,7 +168,7 @@ describe('Add source schema', () => {
             expect(mutator({ label: 'catalog', value: 'selected' }, formOptions)).toEqual(
                 { label: 'catalog', value: 'selected' }
             );
-            expect(mutator({ label: 'cost', value: 'cost' }, formOptions)).toEqual(undefined);
+            expect(mutator({ label: 'cost this is label', value: 'cost' }, formOptions)).toEqual(undefined);
         });
     });
 


### PR DESCRIPTION
Labels can be translated so they don't have to correspond to the names.

**After**

![fixbug](https://user-images.githubusercontent.com/32869456/106494199-6bc99600-64ba-11eb-94d6-14cc61fce616.gif)

