### PR TITLE
Pass getEntities to connected inventory

### DIFF
--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -4,6 +4,7 @@ import { TagWithDialog, RenderWrapper } from './shared';
 import { InventoryTable } from './components/table';
 import * as inventoryFitlers from './components/filters';
 import DetailRenderer from './components/detail/DetailRenderer';
+import { getEntities } from './api';
 
 export function inventoryConnector(store, componentsMapper, Wrapper, isRbacEnabled = true) {
     const showInventoryDrawer = Boolean(Wrapper);
@@ -68,6 +69,7 @@ export function inventoryConnector(store, componentsMapper, Wrapper, isRbacEnabl
             showInventoryDrawer={ showInventoryDrawer }
             {...props}
         />,
-        ...inventoryFitlers
+        ...inventoryFitlers,
+        getEntities
     };
 }


### PR DESCRIPTION
### When using custom getEntities original one is missing

When I as a consumer want to use original getEntities and my custom one I would have to write it all, this PR changes such thing by passing down `getEntities` to connected components and this can be later consumed trough `onLoad` function.