### PR TITLE
Export api partials as seperate key

### DIFF
--- a/packages/inventory/src/Inventory.js
+++ b/packages/inventory/src/Inventory.js
@@ -4,7 +4,6 @@ import { TagWithDialog, RenderWrapper } from './shared';
 import { InventoryTable } from './components/table';
 import * as inventoryFitlers from './components/filters';
 import DetailRenderer from './components/detail/DetailRenderer';
-import { getEntities } from './api';
 
 export function inventoryConnector(store, componentsMapper, Wrapper, isRbacEnabled = true) {
     const showInventoryDrawer = Boolean(Wrapper);
@@ -69,7 +68,6 @@ export function inventoryConnector(store, componentsMapper, Wrapper, isRbacEnabl
             showInventoryDrawer={ showInventoryDrawer }
             {...props}
         />,
-        ...inventoryFitlers,
-        getEntities
+        ...inventoryFitlers
     };
 }

--- a/packages/inventory/src/index.js
+++ b/packages/inventory/src/index.js
@@ -4,3 +4,5 @@ export * from './redux/action-types';
 export * from './redux/actions';
 export { default as DeleteModal } from './shared/DeleteModal';
 export * from './components/filters';
+import * as api from './api';
+export { api };


### PR DESCRIPTION
### Export api requests from index

If someone would like to use any part of inventory API they would have to recreate it, this PR exports entire api under new key.