### PR TITLE
Include fed-mods file in assets so webpack actually includes them

### DIFF
--- a/packages/config/chunk-mapper.js
+++ b/packages/config/chunk-mapper.js
@@ -32,9 +32,10 @@ class ChunkMapper {
                 }
             });
 
-            const outputPath = this.options.output || compiler.options.output.path;
-            mkdirSync(resolve(outputPath), { recursive: true });
-            writeFileSync(`${resolve(outputPath, 'fed-mods.json')}`, JSON.stringify(this.config, null, 4));
+            compilation.assets['fed-mods.json'] = {
+                source: () => JSON.stringify(this.config, null, 4),
+                size: () => JSON.stringify(this.config, null, 4).length
+            };
         });
     }
 }


### PR DESCRIPTION
### No fed-mods.json in webpack-dev-server

When running webpack dev server the fed-mods.json is not included in the build when accessing localhost:8002/webpack-deve-server and is not served at all (accessing /apps/inventory/fed-mods.json results in 404), this is caused by not including this file in compilation assets (when running build it is OK as we are not really serving that file from webpack). This PR fixes such issue by using webpack's plugin `compilation.assets`