### PR TITLE
chore(docs): ignore docs package from "start" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "scripts": {
         "clean": "lerna clean -y && rm -rf node_modules",
         "bootstrap": "lerna bootstrap --hoist",
-        "start": "lerna run --parallel start",
+        "start": "lerna run --parallel start --ignore=docs",
         "build": "lerna run build --stream --no-private --ignore=@redhat-cloud-services/frontend-components-config",
         "generate-translations": "npm run build && node packages/utils/src/mergeMessages.js",
         "test": "jest",


### PR DESCRIPTION
The docs "start" command should not trigger. It starts server instead of watching build files.