### PR TITLE
Change perPage to per_page to fix getEntities

### DIFF
--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -65,8 +65,9 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
                 ...item.id ? item : { id: item },
                 ...results.find(({ id }) => id === item || id === item.id) || {}
             })) : results,
-            page: config.page || (data && data.page),
-            perPage: config.perPage || (data && data.perPage),
+            page: config.page || (data?.page),
+            // eslint-disable-next-line camelcase
+            per_page: config.per_page || (data?.per_page),
             hideFilters: config.hideFilters
         })),
         meta: {


### PR DESCRIPTION
This fixes a bug, when the table couldn't be loaded without returning per_page in getEntities function.

(I think we should unify using of camelCase and snake_case across inventory app. :thinking: )

cc @bastilian 
