### PR TITLE
Add temporary beta rewrite.

### DIFF
--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -76,7 +76,8 @@ describe('should create dummy config with no options', () => {
             inline: true,
             disableHostCheck: true,
             historyApiFallback: true,
-            writeToDisk: true
+            writeToDisk: true,
+            proxy: expect.any(Object)
         });
     });
 });


### PR DESCRIPTION
There is a bug with the Insights proxy. It serves HTML (and other static assets by extensions) to beta env, even though webpack deployment is not set to `beta`.

However, when making an XHR request for the `fed-mods.json` it responds as 404 (which it should). This PR adds a temporary proxy rewrite from beta to stable with a warning and link to an example of how to use beta env properly.

The proxy rewrite can be turned off.

part of: https://github.com/RedHatInsights/insights-chrome/issues/1199