### PR TITLE
Fix invalid prop types and invalid keys.

### DIFF
--- a/packages/charts/src/SeverityLine/SeverityLine.js
+++ b/packages/charts/src/SeverityLine/SeverityLine.js
@@ -45,9 +45,9 @@ const SeverityLine = ({ title, value, className, tooltipMessage, config, chartPr
 
 SeverityLine.propTypes = {
     value: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
+    title: PropTypes.node.isRequired,
     className: PropTypes.string,
-    tooltipMessage: PropTypes.string,
+    tooltipMessage: PropTypes.node,
     config: PropTypes.shape({
         height: PropTypes.number,
         width: PropTypes.number

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -299,7 +299,7 @@ class Group extends Component {
                             {showMore.items[0].label}
                         </Button>
                     </SelectGroup>
-                    : <Fragment value="" />}
+                    : <span hidden value=""></span>}
             </Select> }
         </Fragment>);
     }

--- a/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
+++ b/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
@@ -241,6 +241,10 @@ exports[`Group - component render should render correctly placeholder 1`] = `
         </SelectOption>
       </SelectGroup>
     </div>
+    <span
+      hidden={true}
+      value=""
+    />
   </Select>
 </Fragment>
 `;
@@ -469,6 +473,10 @@ exports[`Group - component render should render correctly with items - isDisable
         </SelectOption>
       </SelectGroup>
     </div>
+    <span
+      hidden={true}
+      value=""
+    />
   </Select>
 </Fragment>
 `;
@@ -697,6 +705,10 @@ exports[`Group - component render should render correctly with items 1`] = `
         </SelectOption>
       </SelectGroup>
     </div>
+    <span
+      hidden={true}
+      value=""
+    />
   </Select>
 </Fragment>
 `;
@@ -925,6 +937,10 @@ exports[`Group - component render should render correctly with items and default
         </SelectOption>
       </SelectGroup>
     </div>
+    <span
+      hidden={true}
+      value=""
+    />
   </Select>
 </Fragment>
 `;
@@ -1153,6 +1169,10 @@ exports[`Group - component render should render correctly with items and selecte
         </SelectOption>
       </SelectGroup>
     </div>
+    <span
+      hidden={true}
+      value=""
+    />
   </Select>
 </Fragment>
 `;

--- a/packages/components/src/DownloadButton/DownloadButton.js
+++ b/packages/components/src/DownloadButton/DownloadButton.js
@@ -32,7 +32,7 @@ class DownloadButton extends Component {
 
     render() {
         const { isOpen } = this.state;
-        const { extraItems, onSelect, isDisabled, ...props } = this.props;
+        const { extraItems, onSelect, isDisabled, tooltipText, ...props } = this.props;
         return <React.Fragment>
             {this.conditionallyTooltip(<Dropdown
                 { ...props }

--- a/packages/components/src/FilterHooks/tagFilterHook.js
+++ b/packages/components/src/FilterHooks/tagFilterHook.js
@@ -67,7 +67,7 @@ export const useTagsFilter = (
                 {
                     value: '',
                     label: !state.loaded ?
-                        <span> <Spinner size="md" /> </span> :
+                        <span key="no-tags-tooltip"> <Spinner size="md" /> </span> :
                         <div className="ins-c-tagfilter__no-tags"> No tags available </div>,
                     isDisabled: true,
                     className: 'ins-c-tagfilter__tail'

--- a/packages/sources/package.json
+++ b/packages/sources/package.json
@@ -30,9 +30,9 @@
         "awesome-debounce-promise": "^2.1.0"
     },
     "devDependencies": {
-        "@data-driven-forms/pf4-component-mapper": "^2.8.3",
+        "@data-driven-forms/pf4-component-mapper": "~2.21.0",
         "@data-driven-forms/react-form-renderer": "^2.8.3",
-        "@patternfly/react-core": "^4.18.5",
+        "@patternfly/react-core": "^4.90.2",
         "@patternfly/react-icons": "^4.3.5",
         "prop-types": "^15.7.2",
         "react-intl": "^5.0.2",


### PR DESCRIPTION
Fixes multiple react warnings at runtime

A possible breaking change is replacing Fragment with span to remove the invalid prop warning. I have tried clicking in the chrome global filter and it was working. But if someone could double-check it would be grand.