### PR TITLE
Update html-webpack-plugin to latest

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,7 +27,7 @@
         "file-loader": "^6.2.0",
         "git-revision-webpack-plugin": "^3.0.6",
         "html-replace-webpack-plugin": "^2.6.0",
-        "html-webpack-plugin": "^4.5.0",
+        "html-webpack-plugin": "^5.1.0",
         "koa-connect": "^2.1.0",
         "mini-css-extract-plugin": "^1.3.1",
         "node-sass": "^5.0.0",

--- a/packages/config/src/plugins.test.js
+++ b/packages/config/src/plugins.test.js
@@ -11,7 +11,7 @@ describe('plugins generations, no option', () => {
     });
 
     it('should generate correct template path for HtmlWebpackPlugin', () => {
-        expect(enabledPlugins[HTML_WEBPACK].options.template).toBe('/src/index.html');
+        expect(enabledPlugins[HTML_WEBPACK].userOptions.template).toBe('/src/index.html');
     });
 });
 
@@ -19,7 +19,7 @@ describe('rootFolder', () => {
     const enabledPlugins = plugins({ rootFolder: '/test/folder' });
 
     it('should generate correct template path for HtmlWebpackPlugin', () => {
-        expect(enabledPlugins[HTML_WEBPACK].options.template).toBe('/test/folder/src/index.html');
+        expect(enabledPlugins[HTML_WEBPACK].userOptions.template).toBe('/test/folder/src/index.html');
     });
 });
 
@@ -36,7 +36,7 @@ describe('appDeployment', () => {
 
 it('htmlPlugin should update', () => {
     const enabledPlugins = plugins({ htmlPlugin: { title: 'myTitle' } });
-    expect(enabledPlugins[HTML_WEBPACK].options.title).toBe('myTitle');
+    expect(enabledPlugins[HTML_WEBPACK].userOptions.title).toBe('myTitle');
 });
 
 it('replacePlugin should update', () => {


### PR DESCRIPTION
When updating Sources UI to the latest config, the HTML plugin was returning error:

```
Error: The loader "/Users/rvsiansk/insights-project/sources-ui/node_modules/html-webpack-plugin/lib/loader.  js!/Users/rvsiansk/insights-project/sources-ui/src/index.html" didn't return html.
```

The latest version fixed that.

Changelog: [here](https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#-breaking-changes)