### PR TITLE
fix(remediations): RHICOMPL-1292 for supported systems only

### DIFF
--- a/packages/inventory-compliance/src/ComplianceRemediationButton/ComplianceRemediationButton.js
+++ b/packages/inventory-compliance/src/ComplianceRemediationButton/ComplianceRemediationButton.js
@@ -43,7 +43,8 @@ class ComplianceRemediationButton extends React.Component {
         const { allSystems, selectedRules } = this.props;
         const result = { systems: [], issues: [] };
         allSystems.forEach(async (system) => {
-            result.systems.push(system.id);
+            system.supported === true && result.systems.push(system.id);
+
             if (selectedRules.length !== 0) {
                 result.issues.push(this.rulesWithRemediations(selectedRules, system));
             } else {


### PR DESCRIPTION
This covers the case when both supported and unsupported systems are
selected in the report details page. Unsupported systems should never be
included in remediation playbooks.

Signed-off-by: Andrew Kofink <akofink@redhat.com>