### PR TITLE
Enable option to pass sass prefix

### DIFF
--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -92,7 +92,7 @@ module.exports = ({
                                  * Context class is equal to app name and that class ass added to root element via the chrome-render-loader.
                                  */
                                 if (relativePath.match(/^src/)) {
-                                    return `.${appName}${sassPrefix ? `, .${sassPrefix}` : ''}{\n${content}\n}`;
+                                    return `${sassPrefix || `.${appName}`}{\n${content}\n}`;
                                 }
 
                                 return content;

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -12,7 +12,8 @@ module.exports = ({
     mode,
     appName,
     useFileHash = true,
-    betaEnv = 'ci'
+    betaEnv = 'ci',
+    sassPrefix
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     return {
@@ -91,7 +92,7 @@ module.exports = ({
                                  * Context class is equal to app name and that class ass added to root element via the chrome-render-loader.
                                  */
                                 if (relativePath.match(/^src/)) {
-                                    return `.${appName}{\n${content}\n}`;
+                                    return `.${appName}${sassPrefix ? `, .${sassPrefix}` : ''}{\n${content}\n}`;
                                 }
 
                                 return content;


### PR DESCRIPTION
### Sass prefix missing

Some apps have different class on main element and styles are not applied. This PR fixes such issue by allowing to pass custom sass prefix when using shared config.