### PR TITLE
Remove deprecated boundary prop from shield

### DIFF
--- a/packages/components/src/Shield/Shield.js
+++ b/packages/components/src/Shield/Shield.js
@@ -20,7 +20,7 @@ const Shield = ({ impact, hasLabel, hasTooltip, size }) => {
     return (
         <span>
             {hasTooltip ?
-                <Tooltip content={<div>{attributes.message}</div>} position={'bottom'} boundary={'viewport'}>
+                <Tooltip content={<div>{attributes.message}</div>} position={'bottom'}>
                     {body}
                 </Tooltip>
                 : body}

--- a/packages/components/src/Shield/__snapshots__/Shield.test.js.snap
+++ b/packages/components/src/Shield/__snapshots__/Shield.test.js.snap
@@ -18,7 +18,6 @@ exports[`Shield component should render where hasTooltip is false 1`] = `
 exports[`Shield component should render where impact value is 1 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to all other issues that have a security         impact. These are the types of vulnerabilities that are believed to         require unlikely circumstances to be able to be exploited, or where         a successful exploit would give minimal consequences. 
@@ -43,7 +42,6 @@ exports[`Shield component should render where impact value is 1 1`] = `
 exports[`Shield component should render where impact value is 2 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to flaws that may be more difficult to exploit         but could still lead to some compromise of the confidentiality,         integrity, or availability of resources, under certain circumstances.         These are the types of vulnerabilities that could have had a Critical         impact or Important impact but are less easily exploited based on a         technical evaluation of the flaw, or affect unlikely configurations. 
@@ -68,7 +66,6 @@ exports[`Shield component should render where impact value is 2 1`] = `
 exports[`Shield component should render where impact value is 3 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to flaws that can easily compromise the     confidentiality, integrity, or availability of resources. These are the     types of vulnerabilities that allow local users to gain privileges, allow     unauthenticated remote users to view resources that should otherwise be     protected by authentication, allow authenticated remote users to execute     arbitrary code, or allow remote users to cause a denial of service.
@@ -93,7 +90,6 @@ exports[`Shield component should render where impact value is 3 1`] = `
 exports[`Shield component should render where impact value is 4 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to flaws that could be easily exploited by a         remote unauthenticated attacker and lead to system compromise         (arbitrary code execution) without requiring user interaction. These         are the types of vulnerabilities that can be exploited by worms.         Flaws that require an authenticated remote user, a local user,         or an unlikely configuration are not classed as Critical impact.
@@ -118,7 +114,6 @@ exports[`Shield component should render where impact value is 4 1`] = `
 exports[`Shield component should render where impact value is Critical 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to flaws that could be easily exploited by a         remote unauthenticated attacker and lead to system compromise         (arbitrary code execution) without requiring user interaction. These         are the types of vulnerabilities that can be exploited by worms.         Flaws that require an authenticated remote user, a local user,         or an unlikely configuration are not classed as Critical impact.
@@ -143,7 +138,6 @@ exports[`Shield component should render where impact value is Critical 1`] = `
 exports[`Shield component should render where impact value is Low 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to all other issues that have a security         impact. These are the types of vulnerabilities that are believed to         require unlikely circumstances to be able to be exploited, or where         a successful exploit would give minimal consequences. 
@@ -168,7 +162,6 @@ exports[`Shield component should render where impact value is Low 1`] = `
 exports[`Shield component should render where impact value is NonExist 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={<div />}
     position="bottom"
   >
@@ -189,7 +182,6 @@ exports[`Shield component should render where impact value is NonExist 1`] = `
 exports[`Shield component should render where impact value is empty string 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={<div />}
     position="bottom"
   >
@@ -210,7 +202,6 @@ exports[`Shield component should render where impact value is empty string 1`] =
 exports[`Shield component should render where impact value is undefined 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={<div />}
     position="bottom"
   >
@@ -231,7 +222,6 @@ exports[`Shield component should render where impact value is undefined 1`] = `
 exports[`Shield component should render with label 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={
       <div>
         This rating is given to flaws that may be more difficult to exploit         but could still lead to some compromise of the confidentiality,         integrity, or availability of resources, under certain circumstances.         These are the types of vulnerabilities that could have had a Critical         impact or Important impact but are less easily exploited based on a         technical evaluation of the flaw, or affect unlikely configurations. 
@@ -257,7 +247,6 @@ exports[`Shield component should render with label 1`] = `
 exports[`Shield component should render without props 1`] = `
 <span>
   <Tooltip
-    boundary="viewport"
     content={<div />}
     position="bottom"
   >


### PR DESCRIPTION
Tooltip boundary is viewport by default. Fixes deprecated warning in console.