### PR TITLE
Add aria-label to description filter text input

### DIFF
--- a/packages/rule-components/src/RuleFilters/description.js
+++ b/packages/rule-components/src/RuleFilters/description.js
@@ -3,6 +3,7 @@ export default ({ onChange, value, ...props } = { onChange: () => undefined }) =
     label: 'Description',
     value: 'description',
     filterValues: {
+        'aria-label': 'Description Filter Input',
         value,
         onChange
     }


### PR DESCRIPTION
All filters inside `RuleFilters/` with ` value: 'description'` that are rendered within `RuleTable` component (see `filters` property) generate error in the console: `Text input: Text input requires either an id or aria-label to be specified`.

This PR adds `aria-label` property to all of them (right now there is only one such filter -- `description`).