### PR TITLE
Filter apps that do not belong to any source type

### DIFF
--- a/packages/sources/src/tests/utilities/filterApps.spec.js
+++ b/packages/sources/src/tests/utilities/filterApps.spec.js
@@ -50,6 +50,22 @@ describe('filterApps', () => {
             ]);
         });
 
+        it('filters CLOUD source types when only cloud source types - when type is not, filter the app', () => {
+            const onlyCloudTypes = [
+                { id: '1', name: 'azure', vendor: 'Microsoft' },
+                { id: '2', name: 'aws', vendor: 'amazon' },
+                { id: '4', name: 'vmware', vendor: 'vmware' }
+            ];
+
+            window.location.search = `activeVendor=${CLOUD_VENDOR}`;
+
+            expect(appTypes.filter(filterVendorAppTypes(onlyCloudTypes))).toEqual([
+                { id: '123', name: 'cost', supported_source_types: [ 'aws' ] },
+                { id: '13', name: 'sub watch', supported_source_types: [ 'azure' ] },
+                { id: '9089', name: 'topology', supported_source_types: [ 'openshift', 'vmware' ] }
+            ]);
+        });
+
         it('filters RED HAT source types', () => {
             window.location.search = `activeVendor=${REDHAT_VENDOR}`;
 

--- a/packages/sources/src/utilities/filterApps.js
+++ b/packages/sources/src/utilities/filterApps.js
@@ -9,7 +9,7 @@ export const filterVendorAppTypes = (sourceTypes) => {
 
     return ({ supported_source_types }) => supported_source_types.find(type =>
         activeVendor === CLOUD_VENDOR
-            ? sourceTypes.find(({ name }) => type === name)?.vendor !== REDHAT_VENDOR
+            ? (sourceTypes.find(({ name }) => type === name)?.vendor || REDHAT_VENDOR) !== REDHAT_VENDOR
             : sourceTypes.find(({ name }) => type === name)?.vendor === REDHAT_VENDOR
     );
 };


### PR DESCRIPTION
This caused that the application selection for cloud types included all the applications - because `undefined !== RED_HAT_VENDOR` is always true. 🤦 