### PR TITLE
Reexport actions as default

### DIFF
--- a/packages/notifications/src/redux/actions/action-types.js
+++ b/packages/notifications/src/redux/actions/action-types.js
@@ -2,3 +2,9 @@ const notificationsPrefix = '@@INSIGHTS-CORE/NOTIFICATIONS/';
 export const ADD_NOTIFICATION = `${notificationsPrefix}ADD_NOTIFICATION`;
 export const REMOVE_NOTIFICATION = `${notificationsPrefix}REMOVE_NOTIFICATION`;
 export const CLEAR_NOTIFICATIONS = `${notificationsPrefix}CLEAR_NOTIFICATIONS`;
+
+export default {
+    ADD_NOTIFICATION,
+    REMOVE_NOTIFICATION,
+    CLEAR_NOTIFICATIONS
+};

--- a/packages/notifications/src/redux/actions/notifications.js
+++ b/packages/notifications/src/redux/actions/notifications.js
@@ -13,3 +13,9 @@ export const removeNotification = index => ({
 export const clearNotifications = () => ({
     type: CLEAR_NOTIFICATIONS
 });
+
+export default {
+    addNotification,
+    removeNotification,
+    clearNotifications
+};


### PR DESCRIPTION
Should fix these errors:

```js
WARNING in ./node_modules/@redhat-cloud-services/frontend-components-notifications/esm/redux/index.js 1:0-64
export 'default' (reexported as 'actionTypes') was not found in './actions/action-types' (possible exports: ADD_NOTIFICATION, CLEAR_NOTIFICATIONS, REMOVE_NOTIFICATION)

WARNING in ./node_modules/@redhat-cloud-services/frontend-components-notifications/esm/redux/index.js 3:0-73
export 'default' (reexported as 'notificationActions') was not found in './actions/notifications' (possible exports: addNotification, clearNotifications, removeNotification)
```