### PR TITLE
Add option to skip chrome 2 wrapper in order to render non module apps

### DIFF
--- a/packages/config/src/chrome-render-loader.js
+++ b/packages/config/src/chrome-render-loader.js
@@ -2,7 +2,7 @@
 function chromeRenderLoader(source) {
     const loaderUtils = require('loader-utils');
     const options = loaderUtils.getOptions(this);
-    return `document.getElementById('root').classList.add('${options.appName}');var isChrome2 = window.insights && window.insights.chrome && window.insights.chrome.isChrome2 || false; if(!isChrome2){${source}}`;
+    return `document.getElementById('root').classList.add('${options.appName}');var isChrome2 = (!${options.skipChrome2} && window.insights && window.insights.chrome && window.insights.chrome.isChrome2) || false; if(!isChrome2){${source}}`;
 }
 
 module.exports = chromeRenderLoader;

--- a/packages/config/src/chrome-render-loader.test.js
+++ b/packages/config/src/chrome-render-loader.test.js
@@ -1,0 +1,44 @@
+import chromeRenderLoader from './chrome-render-loader';
+
+jest.mock('loader-utils', () => ({
+    getOptions: jest.fn().mockImplementation((that) => {
+        return that.options;
+    })
+}));
+
+describe.only('chromeRenderLoader', () => {
+    beforeAll(() => {
+        global.insights = {
+            chrome: {
+                isChrome2: true
+            }
+        };
+    });
+    test('add correct class', () => {
+        const result = chromeRenderLoader.bind({
+            options: {
+                appName: 'someName'
+            }
+        })('something');
+        expect(result.includes(`document.getElementById('root').classList.add('someName')`)).toBe(true);
+    });
+
+    test('calculate isChrome2 to be true', () => {
+        const result = chromeRenderLoader.bind({
+            options: {
+                appName: 'someName'
+            }
+        })('something');
+        expect(eval(result.match(/\((!.*(?=;))/)[0])).toBe(true);
+    });
+
+    test('calculate isChrome2 to be false', () => {
+        const result = chromeRenderLoader.bind({
+            options: {
+                appName: 'someName',
+                skipChrome2: true
+            }
+        })('something');
+        expect(eval(result.match(/\((!.*(?=;))/)[0])).toBe(false);
+    });
+});

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -13,7 +13,8 @@ module.exports = ({
     useFileHash = true,
     betaEnv = 'ci',
     sassPrefix,
-    deployment
+    deployment,
+    skipChrome2 = false
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     return {
@@ -59,7 +60,8 @@ module.exports = ({
                 test: new RegExp(appEntry),
                 loader: path.resolve(__dirname, './chrome-render-loader.js'),
                 options: {
-                    appName
+                    appName,
+                    skipChrome2
                 }
             }, {
                 test: /src\/.*\.js$/,

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -96,6 +96,31 @@ describe('rootFolder', () => {
     });
 });
 
+describe('module rules', () => {
+    test('length', () => {
+        const {
+            module
+        } = configBuilder({ appEntry: 'testEntry', appName: 'someName' });
+        expect(module.rules.length).toBe(6);
+    });
+
+    test('first to be chrome-render-loader', () => {
+        const {
+            module
+        } = configBuilder({ appEntry: 'testEntry', appName: 'someName' });
+        expect((new RegExp('packages/config/src/chrome-render-loader.js$')).test(module.rules[0].loader)).toBe(true);
+        expect((new RegExp(module.rules[0].rules)).test('testEntry')).toBe(true);
+        expect(module.rules[0].options.skipChrome2).toBe(false);
+    });
+
+    test('first to be chrome-render-loader', () => {
+        const {
+            module
+        } = configBuilder({ appEntry: 'testEntry', appName: 'someName', skipChrome2: true });
+        expect(module.rules[0].options.skipChrome2).toBe(true);
+    });
+});
+
 test('appEntry correctly set', () => {
     const {
         entry


### PR DESCRIPTION
### Non module apps are not rendered

Because we are expecting apps using newest config to also define module to load properly some apps can end up in infinite loading cycle, because the render part is not triggered. This PR adds option to skip chrome2 check so apps can trigger plain old render.