### PR TITLE
fix(supported popover): RHICOMPL-1461 update docs link

### DIFF
--- a/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
@@ -3,12 +3,13 @@ import propTypes from 'prop-types';
 import { Popover, Alert } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
+export const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/' +
+    'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
+    'con-compl-assess-overview_compl-assess-overview#con-compl-assess-supported-configurations_compl-assess-overview';
+
 const UnsupportedSSGVersion = ({ ssgVersion, style }) => {
     const bodyContent = 'This system was using an incompatible version of the SSG at the time this report was generated.' +
         ' Assessment of rules failed/passed on this system is a best-guess effort and may not be accurate.';
-    const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/' +
-        'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
-        'compl-assess-overview-con#compl-assess-supported-configurations-con';
     const footerContent = <a target='_blank' rel='noopener noreferrer' href={ supportedConfigsLink }>Supported SSG versions</a>;
 
     return <Alert

--- a/packages/inventory-compliance/src/index.js
+++ b/packages/inventory-compliance/src/index.js
@@ -3,3 +3,4 @@ export { default as SystemRulesTable, selectColumns as selectRulesTableColumns }
 export { default as ComplianceRemediationButton } from './ComplianceRemediationButton';
 export { default as ComplianceEmptyState } from './ComplianceEmptyState';
 export { ChipBuilder, FilterBuilder, FilterConfigBuilder } from './Utilities';
+export { supportedConfigsLink } from './PresentationalComponents/UnsupportedSSGVersion';


### PR DESCRIPTION
Corresponds with https://github.com/RedHatInsights/compliance-frontend/pull/1018

Since we have to change the link in both places, we may as well export it here so it's not such a pain in the future. The UnsupportedSSGVersion components (one in each code base) are not the same, but that seems like n obvious refactor for the future.

Signed-off-by: Andrew Kofink <akofink@redhat.com>