### PR TITLE
Add import eslint rule for FEC modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+rulesDirPlugin.RULES_DIR = 'packages/eslint-config/lib/rules';
+
+module.exports = {
+  plugins: [
+    'rulesdir'
+  ],
+  extends: './config/.eslintrc.yml'
+}

--- a/config/.eslintrc.yml
+++ b/config/.eslintrc.yml
@@ -121,3 +121,5 @@ rules:
   yoda:
     - error
     - never
+#  following rule will be enable once we start with clean up pahse
+#  rulesdir/disallow-fec-relative-imports: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -14298,6 +14298,12 @@
                 "prop-types": "^15.6.2"
             }
         },
+        "eslint-plugin-rulesdir": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz",
+            "integrity": "sha1-rRRNfphGT9qClj7/P6szGuyyvwg=",
+            "dev": true
+        },
         "eslint-scope": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "eslint": "^5.6.0",
         "eslint-config-prettier": "^3.1.0",
         "eslint-plugin-react": "^7.11.1",
+        "eslint-plugin-rulesdir": "^0.1.0",
         "file-loader": "^1.1.11",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,3 +1,7 @@
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+const path = require('path');
+rulesDirPlugin.RULES_DIR = path.resolve(__dirname, './lib/rules');
+
 module.exports = {
     parser: '@babel/eslint-parser',
     env: {
@@ -13,7 +17,8 @@ module.exports = {
         }
     },
     plugins: [
-        'prettier'
+        'prettier',
+        'rulesdir'
     ],
     extends: [
         'eslint:recommended',
@@ -30,7 +35,8 @@ module.exports = {
         'prettier/prettier': [
             'error',
             { singleQuote: true }
-        ]
+        ],
+        'rulesdir/disallow-fec-relative-imports': 2
     },
     parserOptions: {
         ecmaVersion: 7,

--- a/packages/eslint-config/lib/rules/disallow-fec-relative-imports.js
+++ b/packages/eslint-config/lib/rules/disallow-fec-relative-imports.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Rule to disallow relative imports from FEC packages to improve treeskaing
+ * @author Martin Marosi
+ */
+
+const FECPackages = [
+    '@redhat-cloud-services/frontend-components-charts',
+    '@redhat-cloud-services/frontend-components',
+    '@redhat-cloud-services/frontend-components-config',
+    '@redhat-cloud-services/frontend-components-demo',
+    '@redhat-cloud-services/eslint-config-redhat-cloud-services',
+    '@redhat-cloud-services/frontend-components-inventory-compliance',
+    '@redhat-cloud-services/frontend-components-inventory-general-info',
+    '@redhat-cloud-services/frontend-components-inventory-insights',
+    '@redhat-cloud-services/frontend-components-inventory',
+    '@redhat-cloud-services/frontend-components-notifications',
+    '@redhat-cloud-services/frontend-components-pdf-generator',
+    '@redhat-cloud-services/frontend-components-remediations',
+    '@redhat-cloud-services/rule-components',
+    '@redhat-cloud-services/frontend-components-translations',
+    '@redhat-cloud-services/frontend-components-utilities'
+];
+
+module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'disallow relative imports from FEC packages',
+            category: 'Possible build errors',
+            recommended: true
+        },
+        fixable: 'code',
+        messages: {
+            avoidRelativeImport: 'Avoid using relative imports from {{ package }}. Use direct import path to {{ source }}. Module may be found at {{ hint }}.',
+            avoidImportingStyles: 'Avoid importing styles from {{ package }}. Styles are injected with components automatically.'
+        }
+    },
+    create: function(context) {
+        return {
+            ImportDeclaration: function (codePath) {
+                const importString = codePath.source.value;
+                const fecImport = FECPackages.find(pckg => importString.includes(pckg));
+                if (fecImport && importString.match(/(css|scss|sass)/gim)) {
+                    context.report({
+                        node: codePath,
+                        messageId: 'avoidImportingStyles',
+                        data: {
+                            package: importString
+                        },
+                        fix: function(fixer) {
+                            return fixer.remove(codePath.parent);
+                        }
+                    });
+                }
+
+                /**
+                 * Check if import is from FEC package and if it directly matches the package name which means its relative import
+                 */
+                if (fecImport && FECPackages.includes(importString)) {
+                    const fullImport = context.getSourceCode(codePath.parent).text;
+                    /**
+                     * Check if the import is not full import statement
+                     */
+                    if (!fullImport.includes('from')) {
+                        return;
+                    }
+                    /**
+                     * Determine correct variable for direct import
+                     */
+
+                    let variables = context.getDeclaredVariables(codePath);
+                    let varName = 'Unknown';
+                    if (variables.length > 0) {
+                        varName = variables[0].name;
+                    }
+
+                    context.report({
+                        node: codePath,
+                        messageId: 'avoidRelativeImport',
+                        data: {
+                            package: importString,
+                            source: varName,
+                            hint: `import ${varName} from '${importString}/${varName}'`
+
+                        },
+                        fix: function(fixer) {
+                            const newText = variables.map(function(data) {
+                                return `import ${data.name} from "${importString}/${data.name}"`;
+                            });
+                            return fixer.replaceText(codePath, newText.join('\n'));
+                        }
+                    });
+
+                }
+            }
+        };
+    }
+};

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/eslint-config-redhat-cloud-services",
-    "version": "1.0.0",
+    "version": "1.0.1-beta.4",
     "description": "Recommended eslint configuration used in cloud.redhat.com frontend apps.",
     "keywords": [
         "eslint",
@@ -14,6 +14,7 @@
         "eslint-config-prettier": "^6.12.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.21.4",
+        "eslint-plugin-rulesdir": "^0.1.0",
         "prettier": "^2.1.2"
     },
     "peerDependencies": {

--- a/packages/eslint-config/tests/lib/rules/disallow-fec-relative-imports.test.js
+++ b/packages/eslint-config/tests/lib/rules/disallow-fec-relative-imports.test.js
@@ -32,7 +32,7 @@ ruleTester.run('fec-direct-import', rule, {
                     message: `Avoid using relative imports from @redhat-cloud-services/frontend-components. Use direct import path to X. Module may be found at import X from '@redhat-cloud-services/frontend-components/X'.`
                 }
             ],
-            output: 'import X from "@redhat-cloud-services/frontend-components/X"'
+            output: 'import A from "@redhat-cloud-services/frontend-components/A"\nimport X from "@redhat-cloud-services/frontend-components/X"\nimport Y from "@redhat-cloud-services/frontend-components/Y"\nimport { B } from "@redhat-cloud-services/frontend-components/B"'
         },
         {
             code: 'import { X } from "@redhat-cloud-services/frontend-components"',
@@ -52,3 +52,4 @@ ruleTester.run('fec-direct-import', rule, {
         }
     ]
 });
+

--- a/packages/eslint-config/tests/lib/rules/disallow-fec-relative-imports.test.js
+++ b/packages/eslint-config/tests/lib/rules/disallow-fec-relative-imports.test.js
@@ -1,0 +1,54 @@
+/* eslint-disable max-len */
+let rule = require('../../../lib/rules/disallow-fec-relative-imports');
+let RuleTester = require('eslint').RuleTester;
+
+let ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015, sourceType: 'module' } });
+ruleTester.run('fec-direct-import', rule, {
+    valid: [
+        'import X from "@redhat-cloud-services/frontend-components/X"',
+        'import { X } from "@redhat-cloud-services/frontend-components/X"',
+        'import { X, Y, Z } from "@redhat-cloud-services/frontend-components/X"',
+        'import A, { X, Y, Z } from "@redhat-cloud-services/frontend-components/X"',
+        'const X = 2',
+        'import { X } from "@somePackage/frontend-components"',
+        'import "@redhat-cloud-services/frontend-components"',
+        'const X = require("@redhat-cloud-services/frontend-components")',
+        'import { Spinner } from "@redhat-cloud-services/frontend-components/Spinner";\nimport "./compliance.scss";'
+    ],
+    invalid: [
+        {
+            code: 'import "@redhat-cloud-services/frontend-components/foo/styles.css"\n//additional text that should stay\n//import X from "foo"',
+            errors: [
+                {
+                    message: `Avoid importing styles from @redhat-cloud-services/frontend-components/foo/styles.css. Styles are injected with components automatically.`
+                }
+            ],
+            output: '\n//additional text that should stay\n//import X from "foo"'
+        },
+        {
+            code: 'import A from "@redhat-cloud-services/frontend-components/A"\nimport X, { Y } from "@redhat-cloud-services/frontend-components"\nimport { B } from "@redhat-cloud-services/frontend-components/B"',
+            errors: [
+                {
+                    message: `Avoid using relative imports from @redhat-cloud-services/frontend-components. Use direct import path to X. Module may be found at import X from '@redhat-cloud-services/frontend-components/X'.`
+                }
+            ],
+            output: 'import X from "@redhat-cloud-services/frontend-components/X"'
+        },
+        {
+            code: 'import { X } from "@redhat-cloud-services/frontend-components"',
+            errors: [
+                {
+                    message: `Avoid using relative imports from @redhat-cloud-services/frontend-components. Use direct import path to X. Module may be found at import X from '@redhat-cloud-services/frontend-components/X'.`
+                }
+            ]
+        },
+        {
+            code: 'import { X, Y } from "@redhat-cloud-services/frontend-components"',
+            errors: [
+                {
+                    message: `Avoid using relative imports from @redhat-cloud-services/frontend-components. Use direct import path to X. Module may be found at import X from '@redhat-cloud-services/frontend-components/X'.`
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
This rule can help with migration and prevent relative import paths which will further improve build sizes and performance. It will also help guide developers which are not familiar with FEC.

The rule is disabled for now in this repository and will be enabled once we discontinue the legacy build outputs

![eslint-cleanup](https://user-images.githubusercontent.com/22619452/109495966-4cf5f980-7a90-11eb-8c31-c097a686d187.gif)
