### PR TITLE
chore(InventoryDetail): display custom app children components

### DIFF
--- a/packages/inventory/src/components/detail/InventoryDetail.js
+++ b/packages/inventory/src/components/detail/InventoryDetail.js
@@ -25,7 +25,8 @@ const InventoryDetail = ({
     onBackToListClick,
     showDelete,
     appList,
-    showInventoryDrawer
+    showInventoryDrawer,
+    children
 }) => {
     const { inventoryId } = useParams();
     const dispatch = useDispatch();
@@ -60,6 +61,7 @@ const InventoryDetail = ({
                 showTags={ showTags }
             />
             <FactsInfo loaded={ loaded } entity={ entity } />
+            {children}
         </Fragment>
         }
         <ApplicationDetails onTabSelect={ onTabSelect } appList={ appList } />
@@ -83,7 +85,8 @@ InventoryDetail.propTypes = {
         pageId: PropTypes.string
     })),
     onTabSelect: PropTypes.func,
-    onBackToListClick: PropTypes.func
+    onBackToListClick: PropTypes.func,
+    children: PropTypes.element
 };
 InventoryDetail.defaultProps = {
     actions: [],

--- a/packages/inventory/src/components/detail/InventoryDetail.js
+++ b/packages/inventory/src/components/detail/InventoryDetail.js
@@ -86,7 +86,7 @@ InventoryDetail.propTypes = {
     })),
     onTabSelect: PropTypes.func,
     onBackToListClick: PropTypes.func,
-    children: PropTypes.element
+    children: PropTypes.node
 };
 InventoryDetail.defaultProps = {
     actions: [],


### PR DESCRIPTION
We need to add more info to the Patch system details page header and I am able to add custom components to Inventory Header after this change in InventoryDetail.js.  Please feel free to ping me if my PR needs some changes :).

![image](https://user-images.githubusercontent.com/59481011/109671330-43de5880-7b74-11eb-9272-88ad55fd90bb.png)
