### PR TITLE
fix(tagsModal): skeleton flash

### DIFF
--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -168,6 +168,7 @@ export function showTags(state, { payload, meta }) {
     const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity || {};
     return {
         ...state,
+        tagModalLoaded: true,
         activeSystemTag: {
             ...activeSystemTag,
             tags: Object.values(payload.results)[0],
@@ -183,6 +184,7 @@ export function showTagsPending(state, { meta }) {
     const { tags, ...activeSystemTag } = state.rows ? state.rows.find(({ id }) => meta.systemId === id) : state.entity || {};
     return {
         ...state,
+        tagModalLoaded: false,
         activeSystemTag: {
             ...activeSystemTag,
             tagsCount: meta.tagsCount,

--- a/packages/inventory/src/redux/entityDetails.js
+++ b/packages/inventory/src/redux/entityDetails.js
@@ -32,12 +32,21 @@ function toggleDrawer(state, { payload }) {
     };
 }
 
+function showTagsPending(state) {
+    return {
+        ...state,
+        tagModalLoaded: false
+    };
+}
+
 export default {
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: () => defaultState,
     [ACTION_TYPES.LOAD_ENTITY_PENDING]: entityDetailPending,
     [ACTION_TYPES.LOAD_ENTITY_FULFILLED]: entityDetailLoaded,
     [APPLICATION_SELECTED]: onApplicationSelected,
     [ACTION_TYPES.LOAD_TAGS]: showTags,
+    [ACTION_TYPES.LOAD_TAGS_PENDING]: showTagsPending,
+    [ACTION_TYPES.LOAD_TAGS_FULFILLED]: showTags,
     [TOGGLE_TAG_MODAL]: toggleTagModal,
     [TOGGLE_DRAWER]: toggleDrawer,
     ...systemIssuesReducer

--- a/packages/inventory/src/shared/TagsModal.js
+++ b/packages/inventory/src/shared/TagsModal.js
@@ -31,13 +31,8 @@ const TagsModal = ({
         return entities?.allTagsPagination || statePagination;
     }, shallowEqual);
 
-    const loaded = useSelector(({ entities, entityDetails }) => {
-        if (entityDetails?.entity) {
-            return entityDetails?.loaded;
-        }
+    const loaded = useSelector(({ entities, entityDetails }) => entities?.tagModalLoaded || entityDetails?.tagModalLoaded);
 
-        return entities?.activeSystemTag?.tagsLoaded || (entities || entityDetails)?.allTagsLoaded;
-    });
     const activeSystemTag = useSelector(({ entities, entityDetails }) => entities?.activeSystemTag || entityDetails?.entity);
     const tags = useSelector(({ entities, entityDetails }) => {
         const activeTags = entities?.activeSystemTag?.tags || entityDetails?.entity?.tags;

--- a/packages/inventory/src/shared/TagsModal.test.js
+++ b/packages/inventory/src/shared/TagsModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import promiseMiddleware from 'redux-promise-middleware';
 import { Provider } from 'react-redux';
@@ -18,7 +18,8 @@ describe('TagsModal', () => {
         mockStore = configureStore([ promiseMiddleware() ]);
         initialState = {
             entities: {
-                showTagDialog: true
+                showTagDialog: true,
+                tagModalLoaded: true
             }
         };
     });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-11854

The problem is that the `loaded` flag was basically a random value. There were so many edge cases and fallbacks that the value was almost always true.

The solution is easy, reduce the condition complexity by adding a dedicated loader flag for the tag modal.

### Before
![tags-modal-before](https://user-images.githubusercontent.com/22619452/109786078-185b7c80-7c0d-11eb-854f-b2c5641bbf65.gif)

### After
![fixed-tag-loader](https://user-images.githubusercontent.com/22619452/109786063-142f5f00-7c0d-11eb-92c9-7679966b637d.gif)

