### PR TITLE
fix(docs): wrap mdlinks in router Link

### DIFF
--- a/packages/docs/components/layout/mdx-provider-components.js
+++ b/packages/docs/components/layout/mdx-provider-components.js
@@ -1,6 +1,7 @@
 import { Title, Card, CardBody } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 import classnames from 'classnames';
+import Link from 'next/link';
 
 const useTableStyles = createUseStyles({
     card: {
@@ -8,6 +9,7 @@ const useTableStyles = createUseStyles({
     }
 });
 
+const A = ({ children, target,  ...props }) => <Link {...props}><a target={target}>{children}</a></Link>;
 const H1 = ({ className, ...props }) => <Title className="pf-u-mb-lg" headingLevel="h1" {...props} />;
 const H2 = ({ className, ...props }) => <Title className="pf-u-mb-lg" headingLevel="h2" {...props} />;
 const H3 = ({ className, ...props }) => <Title className="pf-u-mb-lg" headingLevel="h2" {...props} />;
@@ -17,6 +19,7 @@ const Table = props => {
 };
 
 const components = {
+    a: A,
     h1: H1,
     h2: H2,
     h3: H3,

--- a/packages/utils/src/debounce/debounce.js
+++ b/packages/utils/src/debounce/debounce.js
@@ -4,7 +4,7 @@ import awesomeDebouncePromise from 'awesome-debounce-promise';
  * Async debounce factory functions.
  * @param {Function} asyncFunction async function to be debounced
  * @param {number} time delay in ms
- * @param {Object} config additional config. See <a href="https://github.com/slorber/awesome-debounce-promise#options">for more details</a>.
+ * @param {Object} config additional config. See <a target="_blank" href="https://github.com/slorber/awesome-debounce-promise#options">for more details</a>.
  */
 export const debounceFunction = (asyncFunction, time = 800, config = { onlyResolvesLast: true }) => awesomeDebouncePromise(
     asyncFunction,


### PR DESCRIPTION
Links generated from MD files used normal HTML `a` tag which caused full page refreshes. It has to be wrapped in next `Link` component to trigger the client-side routing.