### PR TITLE
fix(components): add missing ts module exports

### DIFF
--- a/packages/components/src/Dark/index.d.ts
+++ b/packages/components/src/Dark/index.d.ts
@@ -1,2 +1,3 @@
-export { default } from './Dark';
-export * from './Dark';
+export { default } from './DarkContext';
+export { default as Dark } from './DarkContext';
+export { default as DarkContext } from './configContext';

--- a/packages/components/src/Main/index.d.ts
+++ b/packages/components/src/Main/index.d.ts
@@ -1,3 +1,2 @@
 export { default } from './Main';
-export * from './Main';
-
+export { default as Main } from './Main';

--- a/packages/components/src/PageHeader/index.d.ts
+++ b/packages/components/src/PageHeader/index.d.ts
@@ -1,3 +1,3 @@
 export { default } from './PageHeader';
-export * from './PageHeader';
-
+export { default as PageHeader } from './PageHeader';
+export { default as PageHeaderTitle } from './PageHeaderTitle';

--- a/packages/components/src/Section/index.d.ts
+++ b/packages/components/src/Section/index.d.ts
@@ -1,2 +1,2 @@
 export { default } from './Section';
-export * from './Section';
+export { default as Section } from './Section';

--- a/packages/components/src/Skeleton/index.d.ts
+++ b/packages/components/src/Skeleton/index.d.ts
@@ -1,2 +1,2 @@
 export { default } from './Skeleton';
-export * from './Skeleton';
+export { default as Skeleton, SkeletonSize } from './Skeleton';

--- a/packages/components/src/Spinner/index.d.ts
+++ b/packages/components/src/Spinner/index.d.ts
@@ -1,2 +1,2 @@
 export { default } from './Spinner';
-export * from './Spinner';
+export { default as Spinner } from './Spinner';


### PR DESCRIPTION
Fixes missing exports in existing TS module definitions. It now properly duplicates `index.js` files.