### PR TITLE
Improve Chart component in the pdf-generator

### DIFF
--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -100,7 +100,7 @@ class Chart extends React.Component {
     }
 
     render() {
-        const { data, chartType, colorSchema, ...props } = this.props;
+        const { data, chartType, colorSchema, legendHeader, ...props } = this.props;
         const currChart = chartMapper[chartType] || chartMapper.pie;
 
         const colors = currChart.colorScale
@@ -200,7 +200,7 @@ class Chart extends React.Component {
                         ...appliedStyles.compactCellPadding
                     }}
                     rows={[
-                        [ 'Legend' ],
+                        [ legendHeader ],
                         ...(Array.isArray(data) ? data : [ data ]).map(({ x, y }, key) => [
                             <Canvas
                                 key={`${key}-bullet`}
@@ -238,11 +238,14 @@ Chart.propTypes = {
         'multiUnordered',
         'orange',
         'purple'
-    ])
+    ]),
+    legend: PropTypes.bool,
+    legendHeader: PropTypes.string
 };
 Chart.defaultProps = {
     colorSchema: 'multiOrdered',
-    legend: true
+    legend: true,
+    legendHeader: 'Legend'
 };
 
 export default Chart;

--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -35,7 +35,7 @@ const chartMapper = {
     bar: {
         component: ChartBar,
         width: 200,
-        height: 200,
+        height: 100,
         scale: 0.34,
         lineChart: true,
         translate: {
@@ -165,8 +165,9 @@ class Chart extends React.Component {
                         let xshift = 35;
                         let yshift = -35;
                         const total = data.length;
-                        const [ maxY ] = data.sort((a, b) => b.y - a.y);
-                        const stepper = Math.floor(maxY.y / total);
+                        const [ maxY ] = [ ...data ].sort((a, b) => b.y - a.y);
+                        let stepper = maxY.y < total ? parseFloat(maxY.y / total).toFixed(1) : Math.ceil(maxY.y / total);
+                        stepper = stepper === 0 ? total : stepper;
 
                         moveTo(0, 0);
                         lineTo(0, 250);
@@ -176,12 +177,12 @@ class Chart extends React.Component {
                         fillColor(globalPaletteBlack700.value);
 
                         for (let i = 0; i < total; i++) {
-                            let valueY = String(i * stepper);
+                            let valueY = String(Number.isInteger(i * stepper) ? i * stepper : (i * stepper).toFixed(1));
                             let valueX = String(data[i].name);
 
                             xshift += i === 0 ? 0 : 120;
                             // y-axis labels
-                            text(valueY, yshift - valueY.length, 240 - (Math.floor(240 / total) * i));
+                            text(valueY, yshift - valueY.length, 240 - (Math.ceil(240 / total) * i));
                             // x-axis labels
                             text(valueX, xshift, 260);
                         }

--- a/packages/pdf-generator/src/components/PDFDocument.js
+++ b/packages/pdf-generator/src/components/PDFDocument.js
@@ -39,13 +39,16 @@ const PDFDocument = ({
                         </Text>
                     </View>
                     <View style={appliedStyles.reportNameWrapper}>
-                        <Text style={ appliedStyles.groupName }>
-                            {groupName}
-                        </Text>
+
                         {(allPagesHaveTitle || key === 0) && (
-                            <Text style={[ appliedStyles.reportName, appliedStyles.displayFont ]}>
-                                {reportName} {type}
-                            </Text>
+                            <React.Fragment>
+                                <Text style={ appliedStyles.groupName }>
+                                    {groupName}
+                                </Text>
+                                <Text style={[ appliedStyles.reportName, appliedStyles.displayFont ]}>
+                                    {reportName} {type}
+                                </Text>
+                            </React.Fragment>
                         )}
                     </View>
                     <View>


### PR DESCRIPTION
Handle the cases where the data for the y label are either 0 or less than the total number of the bars(decimal) and display them nicely.

1. in case of 0: display a default stepper
2. in case of > total:  parse the float as stepper 

Ability to customize chart's legend

![Screenshot from 2021-03-10 19-42-40](https://user-images.githubusercontent.com/3369346/110680509-fc417780-81d8-11eb-9125-714cbb6936f0.png)
 
