### PR TITLE
Add settings for proxy

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -14,3 +14,79 @@ You'll also have to update your `webpack-cli` dependency to `>=4.2.0`, this pack
 ### Removed features with webpack 5
 
 The new version of webpack 5 changed plyfills and plugin configs, some packages are outdated, one example is `lodash-webpack-plugin` this plugin is no longer maintain anyways. You should be just fine by installing `lodash` directly, imports can stay the same as before `import get from 'lodash/get`.
+
+
+## useProxy
+
+The config provide a way to run your applications without using insights-proxy. Just add `useProxy: true` to your configuration.
+
+```jsx
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
+});
+```
+
+And run your application with following command:
+
+```shell
+NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js
+```
+
+*Path to config can be different*
+
+Then you will find your application running on `https://ci.foo.redhat.com:1337/beta/...`. This works only with **Chrome 2** ready applications.
+
+You can change the environment by setting `betaEnv`, but unless the targeted environment is using Chrome 2.0, it won't work correctly.
+
+### localChrome
+
+You can also easily run you application with a local build of Chrome by adding `localChrome: <absolute_path_to_chrome_build_folder>`.
+
+```jsx
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
+  localChrome: process.env.INSIGHTS_CHROME,
+});
+```
+
+```shell
+INSIGHTS_CHROME=/Users/rvsiansk/insights-project/insights-chrome/build/
+```
+
+To check what the proxy is doing with your local chrome settings you can set `proxyVerbose: true`.
+
+### Custom proxy settings
+
+You can add any additional custom proxy configuration. See [Webpack documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy). Please, provide your configuration as an array of object containing `context` property.
+
+*Example*:
+
+```jsx
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
+  localChrome: process.env.INSIGHTS_CHROME,
+  customProxy: [
+    {
+      context: (path) => path.includes('/api/'),
+      target: 'https://qa.cloud.redhat.com',
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+    },
+  ],
+});
+```
+
+This configuration will redirect all API requests to QA environment, so you can check CI UI with QA data.

--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -40,6 +40,8 @@ module.exports = (configurations) => {
         console.log(`Using deployments: ${appDeployment}`);
         console.log(`Public path: ${publicPath}`);
         console.log(`App entry: ${appEntry}`);
+        console.log(`Use proxy: ${configurations.useProxy ? 'true' : 'false'}`);
+        !configurations.useProxy && console.log('You can use webpack proxy (instead of using insights-proxy) by setting "useProxy". Check config documentation to see more details.');
         console.log('~~~~~~~~~~~~~~~~~~~~~');
     }
     /* eslint-enable no-console */

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
 const path = require('path');
+const proxy = require('./proxy');
+
 let rewriteLineCounter = 0;
 
 module.exports = ({
@@ -14,7 +16,10 @@ module.exports = ({
     betaEnv = 'ci',
     sassPrefix,
     deployment,
-    skipChrome2 = false
+    skipChrome2 = false,
+    useProxy,
+    localChrome,
+    customProxy
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     return {
@@ -139,7 +144,14 @@ module.exports = ({
                 process: 'process/browser.js'
             }
         },
-        devServer: {
+        devServer: useProxy ? proxy({
+            betaEnv,
+            rootFolder,
+            localChrome,
+            customProxy,
+            appName,
+            publicPath
+        }) : {
             contentBase: `${rootFolder || ''}/dist`,
             hot: true,
             port: port || 8002,

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -150,7 +150,9 @@ module.exports = ({
             localChrome,
             customProxy,
             appName,
-            publicPath
+            publicPath,
+            https,
+            port
         }) : {
             contentBase: `${rootFolder || ''}/dist`,
             hot: true,

--- a/packages/config/src/proxy.js
+++ b/packages/config/src/proxy.js
@@ -1,0 +1,62 @@
+const { readFileSync } = require('fs');
+const { sync } = require('glob');
+
+function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [], publicPath, proxyVerbose }) {
+    const target = betaEnv === 'prod' ? 'https://cloud.redhat.com/' : `https://${betaEnv}.cloud.redhat.com/`;
+
+    const isNotCustomContext = (path) => customProxy.length > 0 ? customProxy.reduce((acc, curr) => acc && !curr.context(path), true) : true;
+
+    return {
+        contentBase: `${rootFolder || ''}/dist`,
+        index: `${rootFolder || ''}/dist/index.html`,
+        host: `${betaEnv}.foo.redhat.com`,
+        port: 1337,
+        https: true,
+        inline: true,
+        disableHostCheck: true,
+        historyApiFallback: true,
+        writeToDisk: true,
+        publicPath,
+        proxy: [
+            {
+                context: (path) => localChrome
+                    ? isNotCustomContext(path) && !path.includes(process.env.BETA ? '/beta/apps/chrome/' : '/apps/chrome/') || path.includes('.svg')
+                    : isNotCustomContext(path),
+                target,
+                secure: false,
+                changeOrigin: true,
+                autoRewrite: true,
+                ws: true
+            },
+            ...(localChrome ? [{
+                context: (path) => path.includes(process.env.BETA ? '/beta/apps/chrome/' : '/apps/chrome/') && !path.includes('.svg'),
+                target,
+                secure: false,
+                changeOrigin: true,
+                autoRewrite: true,
+                ws: true,
+                // When running chrome locally, we have to redirect all requests and serve files locally
+                selfHandleResponse: true,
+                onProxyReq: (_proxyReq, req, res) => {
+                    const newPath = req.url
+                    .replace(/\.([a-z]|\d)+\.[a-z]+$/, '**') //removeHash and add wilcard
+                    .replace(process.env.BETA ? '/beta/apps/chrome/' : '/apps/chrome/', ''); //remove chrome URL
+
+                    const localPath = sync(`${localChrome}${newPath}`);
+
+                    // eslint-disable-next-line no-console
+                    proxyVerbose && console.log('serving locally', req.url, '--->', newPath, '------>', localPath[0], '\n\n');
+
+                    // if there is a local file with the same name, it's served
+                    if (localPath[0]) {
+                        const localFile = readFileSync(localPath[0]);
+                        res.end(localFile);
+                    }
+                }
+            }] : []),
+            ...customProxy
+        ]
+    };
+}
+
+module.exports = createInsightsProxy;

--- a/packages/config/src/proxy.js
+++ b/packages/config/src/proxy.js
@@ -1,7 +1,7 @@
 const { readFileSync } = require('fs');
 const { sync } = require('glob');
 
-function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [], publicPath, proxyVerbose }) {
+function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [], publicPath, proxyVerbose, https = true, port }) {
     const target = betaEnv === 'prod' ? 'https://cloud.redhat.com/' : `https://${betaEnv}.cloud.redhat.com/`;
 
     const isNotCustomContext = (path) => customProxy.length > 0 ? customProxy.reduce((acc, curr) => acc && !curr.context(path), true) : true;
@@ -10,8 +10,8 @@ function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [
         contentBase: `${rootFolder || ''}/dist`,
         index: `${rootFolder || ''}/dist/index.html`,
         host: `${betaEnv}.foo.redhat.com`,
-        port: 1337,
-        https: true,
+        port: port || 1337,
+        https,
         inline: true,
         disableHostCheck: true,
         historyApiFallback: true,


### PR DESCRIPTION
## useProxy

The config provide a way to run your applications without using insights-proxy. Just add `useProxy: true` to your configuration.

```jsx
const { config: webpackConfig, plugins } = config({
  rootFolder: resolve(__dirname, '../'),
  debug: true,
  useFileHash: false,
  deployment: process.env.BETA ? 'beta/apps' : 'apps',
  useProxy: true,
});
```

And run your application with following command:

```shell
NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js
```

*Path to config can be different*

Then you will find your application running on `https://ci.foo.redhat.com:1337/beta/...`. This works only with **Chrome 2** ready applications.

You can change the environment by setting `betaEnv`, but unless the targeted environment is using Chrome 2.0, it won't work correctly.

### localChrome

You can also easily run you application with a local build of Chrome by adding `localChrome: <absolute_path_to_chrome_build_folder>`.

```jsx
  rootFolder: resolve(__dirname, '../'),
  debug: true,
  useFileHash: false,
  deployment: process.env.BETA ? 'beta/apps' : 'apps',
  useProxy: true,
  localChrome: process.env.INSIGHTS_CHROME,
});
```

```shell
INSIGHTS_CHROME=/Users/rvsiansk/insights-project/insights-chrome/build/
```

To check what the proxy is doing with your local chrome settings you can set `proxyVerbose: true`.

### Custom proxy settings

You can add any additional custom proxy configuration. See [Webpack documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy). Please, provide your configuration as an array of object containing `context` property.

*Example*:

```jsx
const { config: webpackConfig, plugins } = config({
  rootFolder: resolve(__dirname, '../'),
  debug: true,
  useFileHash: false,
  deployment: process.env.BETA ? 'beta/apps' : 'apps',
  useProxy: true,
  localChrome: process.env.INSIGHTS_CHROME,
  customProxy: [
    {
      context: (path) => path.includes('/api/'),
      target: 'https://qa.cloud.redhat.com',
      secure: false,
      changeOrigin: true,
      autoRewrite: true,
      ws: true,
    },
  ],
});
```

This configuration will redirect all API requests to QA environment, so you can check CI UI with QA data.