### PR TITLE
Add option to pass routes config or use direct routes

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -62,6 +62,49 @@ INSIGHTS_CHROME=/Users/rvsiansk/insights-project/insights-chrome/build/
 
 To check what the proxy is doing with your local chrome settings you can set `proxyVerbose: true`.
 
+### Custom routes
+
+If you want to serve files or api from different URL you can either pass `routes` to config or `routesPath` for file which exports these routes.
+
+#### routes
+
+```JS
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
+  routes: {
+      '/config/main.yml': { host: 'http://127.0.0.1:8889' }
+  },
+```
+
+#### routesPath
+
+```JS
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
+  routesPath: process.env.CONFIG_PATH
+```
+
+```shell
+CONFIG_PATH=/home/khala/Documents/git/RedHatInsights/spandx.config.js
+```
+
+```JS
+module.exports = {
+  routes: {
+    '/api': { host: 'PORTAL_BACKEND_MARKER' },
+    '/config': { host: 'http://127.0.0.1:8889' },
+    '/beta/config': { host: 'http://127.0.0.1:8889' },
+  }
+};
+
+``` 
+
 ### Custom proxy settings
 
 You can add any additional custom proxy configuration. See [Webpack documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy). Please, provide your configuration as an array of object containing `context` property.

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -19,7 +19,10 @@ module.exports = ({
     skipChrome2 = false,
     useProxy,
     localChrome,
-    customProxy
+    customProxy,
+    proxyVerbose,
+    routes,
+    routesPath
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     return {
@@ -152,7 +155,10 @@ module.exports = ({
             appName,
             publicPath,
             https,
-            port
+            port,
+            proxyVerbose,
+            routes,
+            routesPath
         }) : {
             contentBase: `${rootFolder || ''}/dist`,
             hot: true,

--- a/packages/config/src/proxy.js
+++ b/packages/config/src/proxy.js
@@ -75,6 +75,7 @@ function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [
             }] : []),
             ...proxyRoutes ? Object.entries(proxyRoutes).map(([ route, redirect ]) => {
                 const currTarget = redirect.host || redirect;
+                delete redirect.host;
                 return {
                     context: (path) => path.includes(route),
                     target: currTarget === 'PORTAL_BACKEND_MARKER' ? target : currTarget,
@@ -82,7 +83,7 @@ function createInsightsProxy({ betaEnv, rootFolder, localChrome, customProxy = [
                     changeOrigin: true,
                     autoRewrite: true,
                     ws: true,
-                    ...redirect
+                    ...typeof redirect === 'object' ? redirect : {}
                 };
             }) : [],
             ...customProxy


### PR DESCRIPTION
### Option to re-use old proxy config

Since we provide a new way of using proxy we should also allow passing old proxy config with routes. This PR adds 2 options
* pass in list of routes - simply use config and pass `routes` to it
```JS
  rootFolder: resolve(__dirname, '../'),
  debug: true,
  useFileHash: false,
  deployment: process.env.BETA ? 'beta/apps' : 'apps',
  useProxy: true,
  routes: {
      '/config/main.yml': { host: 'http://127.0.0.1:8889' }
  },
```
* pass in path to config - if you have old config stored on disk you can now pass `routesPath` to shared config
```JS
  rootFolder: resolve(__dirname, '../'),
  debug: true,
  useFileHash: false,
  deployment: process.env.BETA ? 'beta/apps' : 'apps',
  useProxy: true,
  routesPath: process.env.CONFIG_PATH
```

And when running start you can do `CONFIG_PATH=/home/khala/Documents/git/RedHatInsights/spandx.config.js npm start` the spandx.config.js is just regular config we used before.