### PR TITLE
Allow hiding cards and fields in general information

### DIFF
--- a/packages/inventory-general-info/src/BiosCard/BiosCard.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.js
@@ -4,18 +4,19 @@ import { connect } from 'react-redux';
 import LoadingCard from '../LoadingCard';
 import { biosSelector } from '../selectors';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
-import { isDate } from '../constants';
+import { extraShape, isDate } from '../constants';
 
-const BiosCard = ({ bios, detailLoaded }) => (<LoadingCard
+const BiosCard = ({ bios, detailLoaded, hasVendor, hasVersion, hasReleaseDate, extra }) => (<LoadingCard
     title="BIOS"
     isLoading={ !detailLoaded }
     items={ [
-        { title: 'Vendor', value: bios.vendor },
-        { title: 'Version', value: bios.version },
-        { title: 'Release date', value: (isDate(bios.releaseDate) ?
+        ...hasVendor ? [{ title: 'Vendor', value: bios.vendor }] : [],
+        ...hasVersion ? [{ title: 'Version', value: bios.version }] : [],
+        ...hasReleaseDate ? [{ title: 'Release date', value: (isDate(bios.releaseDate) ?
             <DateFormat date={ new Date(bios.releaseDate) } type="onlyDate" /> :
             'Not available'
-        ) }
+        ) }] : [],
+        ...extra
     ] }
 />);
 
@@ -27,11 +28,19 @@ BiosCard.propTypes = {
         version: PropTypes.string,
         releaseDate: PropTypes.string,
         csm: PropTypes.arrayOf(PropTypes.string)
-    })
+    }),
+    hasVendor: PropTypes.bool,
+    hasVersion: PropTypes.bool,
+    hasReleaseDate: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 BiosCard.defaultProps = {
     detailLoaded: false,
-    handleClick: () => undefined
+    handleClick: () => undefined,
+    extra: [],
+    hasVendor: true,
+    hasVersion: true,
+    hasReleaseDate: true
 };
 
 export default connect(({

--- a/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
@@ -47,4 +47,18 @@ describe('BiosCard', () => {
         const wrapper = render(<BiosCard store={ store } />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
+
+    [ 'hasVendor', 'hasVersion', 'hasReleaseDate' ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<BiosCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<BiosCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/BiosCard/__snapshots__/BiosCard.test.js.snap
+++ b/packages/inventory-general-info/src/BiosCard/__snapshots__/BiosCard.test.js.snap
@@ -1,5 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BiosCard should not render hasReleaseDate 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        BIOS
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Version
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-version
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`BiosCard should not render hasVendor 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        BIOS
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Version
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-version
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release date
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`BiosCard should not render hasVersion 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        BIOS
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release date
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`BiosCard should render correctly - no data 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
@@ -215,6 +389,88 @@ exports[`BiosCard should render correctly with data 1`] = `
           data-pf-content="true"
         >
           01 Apr 2014
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`BiosCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        BIOS
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Version
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-version
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release date
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
@@ -7,6 +7,7 @@ import { Tooltip } from '@patternfly/react-core';
 import LoadingCard from '../LoadingCard';
 import { collectionInformationSelector } from '../selectors';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
+import { extraShape } from '../constants';
 
 const VersionTooltip = ({ egg, client }) => (
     <Tooltip
@@ -26,24 +27,36 @@ VersionTooltip.propTypes = {
     client: PropTypes.string
 };
 
-const CollectionCard = ({ detailLoaded, collectionInformation, entity }) => (<LoadingCard
+const CollectionCard = ({
+    detailLoaded,
+    collectionInformation,
+    entity,
+    hasClient,
+    hasLastCheckIn,
+    hasRegistered,
+    hasInsightsId,
+    hasReporter,
+    hasMachineId,
+    extra
+}) => (<LoadingCard
     title="Collection information"
     isLoading={ !detailLoaded }
     items={ [
-        { title: 'Insights client', value: <VersionTooltip egg={collectionInformation.egg} client={collectionInformation.client}/> },
-        { title: 'Last check-in', value: entity && (
+        ...hasClient ? [{ title: 'Insights client', value: <VersionTooltip egg={collectionInformation.egg} client={collectionInformation.client}/> }] : [],
+        ...hasLastCheckIn ? [{ title: 'Last check-in', value: entity && (
             DateFormat ?
                 <DateFormat date={ entity.updated } type="onlyDate" /> :
                 new Date(entity.updated).toLocaleString()
-        ) },
-        { title: 'Registered', value: entity && (
+        ) }] : [],
+        ...hasRegistered ? [{ title: 'Registered', value: entity && (
             DateFormat ?
                 <DateFormat date={entity.created} type="onlyDate" /> :
                 new Date(entity.created).toLocaleString()
-        ) },
-        { title: 'Insights id', value: entity && entity.insights_id },
-        { title: 'Reporter', value: entity && entity.reporter },
-        { title: 'RHEL machine id', value: entity && entity.rhel_machine_id }
+        ) }] : [],
+        ...hasInsightsId ? [{ title: 'Insights id', value: entity && entity.insights_id }] : [],
+        ...hasReporter ? [{ title: 'Reporter', value: entity && entity.reporter }] : [],
+        ...hasMachineId ? [{ title: 'RHEL machine id', value: entity && entity.rhel_machine_id }] : [],
+        ...extra
     ] }
 />);
 
@@ -56,10 +69,25 @@ CollectionCard.propTypes = {
     collectionInformation: PropTypes.shape({
         client: PropTypes.string,
         egg: PropTypes.string
-    })
+    }),
+    hasClient: PropTypes.bool,
+    hasLastCheckIn: PropTypes.bool,
+    hasRegistered: PropTypes.bool,
+    hasInsightsId: PropTypes.bool,
+    hasReporter: PropTypes.bool,
+    hasMachineId: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 CollectionCard.defaultProps = {
-    detailLoaded: false
+    detailLoaded: false,
+    hasClient: true,
+    hasEgg: true,
+    hasLastCheckIn: true,
+    hasRegistered: true,
+    hasInsightsId: true,
+    hasReporter: true,
+    hasMachineId: true,
+    extra: []
 };
 
 export default connect(({

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
@@ -52,4 +52,25 @@ describe('CollectionCard', () => {
             'Dynamic update version: test-egg'
         );
     });
+
+    [
+        'hasClient',
+        'hasLastCheckIn',
+        'hasRegistered',
+        'hasInsightsId',
+        'hasReporter',
+        'hasMachineId'
+    ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<CollectionCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<CollectionCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/packages/inventory-general-info/src/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -1,5 +1,589 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CollectionCard should not render hasClient 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should not render hasInsightsId 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-5"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should not render hasLastCheckIn 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-3"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should not render hasMachineId 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-7"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should not render hasRegistered 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-4"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should not render hasReporter 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-6"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`CollectionCard should render correctly - no data 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
@@ -233,6 +817,128 @@ exports[`CollectionCard should render correctly with data 1`] = `
           data-pf-content="true"
         >
           Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollectionCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Collection information
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights client
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <span
+            aria-describedby="pf-tooltip-8"
+          >
+            test-client
+          </span>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last check-in
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Jun 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Registered
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          01 Apr 2014
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Insights id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Reporter
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RHEL machine id
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import LoadingCard from '../LoadingCard';
 import { generalMapper, repositoriesMapper } from '../dataMapper';
 import { configurationSelector } from '../selectors';
+import { extraShape } from '../constants';
 
 export function enabledRepos(repositories) {
     if (repositories) {
@@ -14,11 +15,20 @@ export function enabledRepos(repositories) {
     }
 }
 
-const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<LoadingCard
+const ConfigurationCard = ({
+    detailLoaded,
+    configuration,
+    handleClick,
+    hasPackages,
+    hasServices,
+    hasProcesses,
+    hasRepositories,
+    extra
+}) => (<LoadingCard
     title="Configuration"
     isLoading={ !detailLoaded }
     items={ [
-        {
+        ...hasPackages ? [{
             title: 'Installed packages',
             value: configuration.packages?.length,
             singular: 'package',
@@ -29,8 +39,8 @@ const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<Lo
                     generalMapper(configuration.packages, 'Package name')
                 );
             }
-        },
-        {
+        }] : [],
+        ...hasServices ? [{
             title: 'Services',
             value: configuration.services?.length,
             singular: 'service',
@@ -41,8 +51,8 @@ const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<Lo
                     generalMapper(configuration.services, 'Service name')
                 );
             }
-        },
-        {
+        }] : [],
+        ...hasProcesses ? [{
             title: 'Running processes',
             value: configuration.processes?.length,
             singular: 'process',
@@ -54,8 +64,8 @@ const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<Lo
                     generalMapper(configuration.processes, 'Process name')
                 );
             }
-        },
-        {
+        }] : [],
+        ...hasRepositories ? [{
             title: 'Repositories',
             value: enabledRepos(configuration.repositories),
             target: 'repositories',
@@ -66,7 +76,8 @@ const ConfigurationCard = ({ detailLoaded, configuration, handleClick }) => (<Lo
                     'medium'
                 );
             }
-        }
+        }] : [],
+        ...extra
     ] }
 />);
 
@@ -93,11 +104,21 @@ ConfigurationCard.propTypes = {
                 gpgcheck: PropTypes.bool
             }))
         })
-    })
+    }),
+    hasPackages: PropTypes.bool,
+    hasServices: PropTypes.bool,
+    hasProcesses: PropTypes.bool,
+    hasRepositories: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 ConfigurationCard.defaultProps = {
     detailLoaded: false,
-    handleClick: () => undefined
+    handleClick: () => undefined,
+    hasPackages: true,
+    hasServices: true,
+    hasProcesses: true,
+    hasRepositories: true,
+    extra: []
 };
 
 export default connect(({

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
@@ -97,4 +97,23 @@ describe('ConfigurationCard', () => {
             expect(onClick).toHaveBeenCalled();
         });
     });
+
+    [
+        'hasPackages',
+        'hasServices',
+        'hasProcesses',
+        'hasRepositories'
+    ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<ConfigurationCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<ConfigurationCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
+++ b/packages/inventory-general-info/src/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
@@ -40,7 +40,12 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
     }
     detailLoaded={true}
     dispatch={[Function]}
+    extra={Array []}
     handleClick={[Function]}
+    hasPackages={true}
+    hasProcesses={true}
+    hasRepositories={true}
+    hasServices={true}
     store={
       Object {
         "clearActions": [Function],
@@ -292,6 +297,334 @@ exports[`ConfigurationCard api should NOT call handleClick 1`] = `
     </LoadingCard>
   </ConfigurationCard>
 </ConnectFunction>
+`;
+
+exports[`ConfigurationCard should not render hasPackages 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Configuration
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Services
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//services"
+          >
+            1 service
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Running processes
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//running_processes"
+          >
+            1 process
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Repositories
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//repositories"
+          >
+            1 enabled
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConfigurationCard should not render hasProcesses 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Configuration
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Installed packages
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//installed_packages"
+          >
+            1 package
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Services
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//services"
+          >
+            1 service
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Repositories
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//repositories"
+          >
+            1 enabled
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConfigurationCard should not render hasRepositories 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Configuration
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Installed packages
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//installed_packages"
+          >
+            1 package
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Services
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//services"
+          >
+            1 service
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Running processes
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//running_processes"
+          >
+            1 process
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConfigurationCard should not render hasServices 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Configuration
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Installed packages
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//installed_packages"
+          >
+            1 package
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Running processes
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//running_processes"
+          >
+            1 process
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Repositories
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//repositories"
+          >
+            1 enabled
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`ConfigurationCard should render correctly - no data 1`] = `
@@ -581,6 +914,116 @@ exports[`ConfigurationCard should render enabled/disabled 1`] = `
           >
             1 enabled / 1 disabled
           </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ConfigurationCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Configuration
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Installed packages
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//installed_packages"
+          >
+            1 package
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Services
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//services"
+          >
+            1 service
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Running processes
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//running_processes"
+          >
+            1 process
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Repositories
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//repositories"
+          >
+            1 enabled
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/GeneralInformation/GeneralInformation.js
+++ b/packages/inventory-general-info/src/GeneralInformation/GeneralInformation.js
@@ -58,30 +58,41 @@ class GeneralInformation extends Component {
 
     render() {
         const { isModalOpen, modalTitle, cells, rows, expandable, filters, modalVariant } = this.state;
-        const { store, writePermissions } = this.props;
+        const {
+            store,
+            writePermissions,
+            SystemCardWrapper,
+            OperatingSystemCardWrapper,
+            BiosCardWrapper,
+            InfrastructureCardWrapper,
+            ConfigurationCardWrapper,
+            CollectionCardWrapper,
+            children
+        } = this.props;
         const Wrapper = store ? Provider : Fragment;
         return (
             <Wrapper {...(store && { store })}>
                 <div className="ins-c-general-information">
                     <Grid sm={ 12 } md={ 6 } hasGutter>
-                        <GridItem>
-                            <SystemCard handleClick={ this.handleModalToggle } writePermissions={writePermissions} />
-                        </GridItem>
-                        <GridItem>
-                            <OperatingSystemCard handleClick={ this.handleModalToggle } />
-                        </GridItem>
-                        <GridItem>
-                            <BiosCard handleClick={ this.handleModalToggle } />
-                        </GridItem>
-                        <GridItem>
-                            <InfrastructureCard handleClick={ this.handleModalToggle } />
-                        </GridItem>
-                        <GridItem>
-                            <ConfigurationCard handleClick={ this.handleModalToggle } />
-                        </GridItem>
-                        <GridItem>
-                            <CollectionCard handleClick={ this.handleModalToggle } />
-                        </GridItem>
+                        {SystemCardWrapper && <GridItem>
+                            <SystemCardWrapper handleClick={ this.handleModalToggle } writePermissions={writePermissions} />
+                        </GridItem>}
+                        {OperatingSystemCardWrapper && <GridItem>
+                            <OperatingSystemCardWrapper handleClick={ this.handleModalToggle } />
+                        </GridItem>}
+                        {BiosCardWrapper && <GridItem>
+                            <BiosCardWrapper handleClick={ this.handleModalToggle } />
+                        </GridItem>}
+                        {InfrastructureCardWrapper && <GridItem>
+                            <InfrastructureCardWrapper handleClick={ this.handleModalToggle } />
+                        </GridItem>}
+                        {ConfigurationCardWrapper && <GridItem>
+                            <ConfigurationCardWrapper handleClick={ this.handleModalToggle } />
+                        </GridItem>}
+                        {CollectionCardWrapper && <GridItem>
+                            <CollectionCardWrapper handleClick={ this.handleModalToggle } />
+                        </GridItem>}
+                        {children}
                         <Modal
                             title={ modalTitle || '' }
                             aria-label={`${modalTitle || ''} modal`}
@@ -111,10 +122,22 @@ GeneralInformation.propTypes = {
     }),
     loadSystemDetail: PropTypes.func,
     store: PropTypes.any,
-    writePermissions: PropTypes.bool
+    writePermissions: PropTypes.bool,
+    SystemCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ]),
+    OperatingSystemCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ]),
+    BiosCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ]),
+    InfrastructureCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ]),
+    ConfigurationCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ]),
+    CollectionCardWrapper: PropTypes.oneOfType([ PropTypes.node, PropTypes.bool ])
 };
 GeneralInformation.defaultProps = {
-    entity: {}
+    entity: {},
+    SystemCardWrapper: SystemCard,
+    OperatingSystemCardWrapper: OperatingSystemCard,
+    BiosCardWrapper: BiosCard,
+    InfrastructureCardWrapper: InfrastructureCard,
+    ConfigurationCardWrapper: ConfigurationCard,
+    CollectionCardWrapper: CollectionCard
 };
 
 const mapStateToProps = ({

--- a/packages/inventory-general-info/src/GeneralInformation/GeneralInformation.test.js
+++ b/packages/inventory-general-info/src/GeneralInformation/GeneralInformation.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 /* eslint-disable camelcase */
 import React from 'react';
 import { render, mount } from 'enzyme';
@@ -72,6 +73,33 @@ describe('GeneralInformation', () => {
             <GeneralInformation />
         </Provider>);
         expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    describe('custom components', () => {
+        [
+            'SystemCardWrapper',
+            'OperatingSystemCardWrapper',
+            'BiosCardWrapper',
+            'InfrastructureCardWrapper',
+            'ConfigurationCardWrapper',
+            'CollectionCardWrapper'
+        ].map((item) => {
+            it(`should not render ${item}`, () => {
+                const store = mockStore(initialState);
+                const wrapper = render(<Provider store={ store }>
+                    <GeneralInformation {...{ [item]: false }} />
+                </Provider>);
+                expect(toJson(wrapper)).toMatchSnapshot();
+            });
+
+            it(`should render custom ${item}`, () => {
+                const store = mockStore(initialState);
+                const wrapper = render(<Provider store={ store }>
+                    <GeneralInformation {...{ [item]: () => <div>test</div> }} />
+                </Provider>);
+                expect(toJson(wrapper)).toMatchSnapshot();
+            });
+        });
     });
 
     describe('API', () => {

--- a/packages/inventory-general-info/src/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
+++ b/packages/inventory-general-info/src/GeneralInformation/__snapshots__/GeneralInformation.test.js.snap
@@ -1,5 +1,7539 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GeneralInformation custom components should not render BiosCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-6"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should not render CollectionCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should not render ConfigurationCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-10"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should not render InfrastructureCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-8"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should not render OperatingSystemCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-4"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should not render SystemCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-2"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom BiosCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-7"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom CollectionCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom ConfigurationCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-11"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom InfrastructureCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-9"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom OperatingSystemCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              System properties
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Host name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Host name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Display name
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Display name"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//display_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                <span>
+                  Ansible hostname
+                </span>
+                <button
+                  aria-disabled="false"
+                  aria-label="Action for Ansible hostname"
+                  class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                    />
+                  </svg>
+                </button>
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-id
+                <a
+                  class="ins-c-inventory__detail--action"
+                  href="http://localhost:5000//ansible_name"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align:-0.125em"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+                    />
+                  </svg>
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                SAP
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Number of CPUs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Sockets
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Cores per socket
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                1
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                CPU flags
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 flags
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RAM
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                5 MB
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-5"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GeneralInformation custom components should render custom SystemCardWrapper 1`] = `
+<div
+  class="ins-c-general-information"
+>
+  <div
+    class="pf-l-grid pf-m-all-12-col-on-sm pf-m-all-6-col-on-md pf-m-gutter"
+  >
+    <div
+      class="pf-l-grid__item"
+    >
+      <div>
+        test
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Operating system
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-release
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel release
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-kernel
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Architecture
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-arch
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last boot time
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Kernel modules
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                0 modules
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              BIOS
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Version
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-version
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Release date
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                01 Apr 2014
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Infrastructure
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Type
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-type
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Vendor
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                test-vendor
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv4 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//ipv4"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                IPv6 addresses
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//undefined"
+                >
+                  2 addresses
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Interfaces/NICs
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//interfaces"
+                >
+                  2 NICs
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Configuration
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Installed packages
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//installed_packages"
+                >
+                  1 package
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Services
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//services"
+                >
+                  1 service
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Running processes
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//running_processes"
+                >
+                  1 process
+                </a>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Repositories
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <a
+                  href="http://localhost:5000//repositories"
+                >
+                  1 enabled
+                </a>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="pf-l-grid__item"
+    >
+      <div
+        class="pf-l-stack pf-m-gutter"
+      >
+        <div
+          class="pf-l-stack__item"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <h1
+              class=""
+              data-pf-content="true"
+            >
+              Collection information
+            </h1>
+          </div>
+        </div>
+        <div
+          class="pf-l-stack__item pf-m-fill"
+        >
+          <div
+            class="pf-c-content"
+          >
+            <dl
+              class=""
+              data-pf-content="true"
+            >
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights client
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                <span
+                  aria-describedby="pf-tooltip-3"
+                >
+                  test-client
+                </span>
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Last check-in
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Registered
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Invalid date
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Insights id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                Reporter
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+              <dt
+                class=""
+                data-pf-content="true"
+              >
+                RHEL machine id
+              </dt>
+              <dd
+                class=""
+                data-pf-content="true"
+              >
+                Not available
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`GeneralInformation should render correctly - no data 1`] = `
 <div
   class="ins-c-general-information"

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
@@ -4,14 +4,25 @@ import { connect } from 'react-redux';
 import LoadingCard from '../LoadingCard';
 import { generalMapper, interfaceMapper } from '../dataMapper';
 import { infrastructureSelector } from '../selectors';
+import { extraShape } from '../constants';
 
-const InfrastructureCard = ({ infrastructure, handleClick, detailLoaded }) => (<LoadingCard
+const InfrastructureCard = ({
+    infrastructure,
+    handleClick,
+    detailLoaded,
+    hasType,
+    hasVendor,
+    hasIPv4,
+    hasIPv6,
+    hasInterfaces,
+    extra
+}) => (<LoadingCard
     title="Infrastructure"
     isLoading={ !detailLoaded }
     items={ [
-        { title: 'Type', value: infrastructure.type },
-        { title: 'Vendor', value: infrastructure.vendor },
-        {
+        ...hasType ? [{ title: 'Type', value: infrastructure.type }] : [],
+        ...hasVendor ? [{ title: 'Vendor', value: infrastructure.vendor }] : [],
+        ...hasIPv4 ? [{
             title: 'IPv4 addresses',
             value: infrastructure.ipv4?.length,
             plural: 'addresses',
@@ -23,8 +34,8 @@ const InfrastructureCard = ({ infrastructure, handleClick, detailLoaded }) => (<
                     generalMapper(infrastructure.ipv4, 'IP address')
                 );
             }
-        },
-        {
+        }] : [],
+        ...hasIPv6 ? [{
             title: 'IPv6 addresses',
             value: infrastructure.ipv6?.length,
             plural: 'addresses',
@@ -35,8 +46,8 @@ const InfrastructureCard = ({ infrastructure, handleClick, detailLoaded }) => (<
                     generalMapper(infrastructure.ipv6, 'IP address')
                 );
             }
-        },
-        {
+        }] : [],
+        ...hasInterfaces ? [{
             title: 'Interfaces/NICs',
             value: infrastructure.nics?.length,
             singular: 'NIC',
@@ -48,7 +59,8 @@ const InfrastructureCard = ({ infrastructure, handleClick, detailLoaded }) => (<
                     'medium'
                 );
             }
-        }
+        }] : [],
+        ...extra
     ] }
 />);
 
@@ -61,11 +73,23 @@ InfrastructureCard.propTypes = {
         ipv4: PropTypes.array,
         ipv6: PropTypes.array,
         nics: PropTypes.array
-    })
+    }),
+    hasType: PropTypes.bool,
+    hasVendor: PropTypes.bool,
+    hasIPv4: PropTypes.bool,
+    hasIPv6: PropTypes.bool,
+    hasInterfaces: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 InfrastructureCard.defaultProps = {
     detailLoaded: false,
-    handleClick: () => undefined
+    handleClick: () => undefined,
+    hasType: true,
+    hasVendor: true,
+    hasIPv4: true,
+    hasIPv6: true,
+    hasInterfaces: true,
+    extra: []
 };
 
 export default connect(({

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
@@ -101,4 +101,24 @@ describe('InfrastructureCard', () => {
             expect(onClick).toHaveBeenCalled();
         });
     });
+
+    [
+        'hasType',
+        'hasVendor',
+        'hasIPv4',
+        'hasIPv6',
+        'hasInterfaces'
+    ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<InfrastructureCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<InfrastructureCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/packages/inventory-general-info/src/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -1,5 +1,463 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`InfrastructureCard should not render hasIPv4 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Type
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-type
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv6 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Interfaces/NICs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//interfaces"
+          >
+            1 NIC
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InfrastructureCard should not render hasIPv6 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Type
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-type
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv4 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//ipv4"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Interfaces/NICs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//interfaces"
+          >
+            1 NIC
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InfrastructureCard should not render hasInterfaces 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Type
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-type
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv4 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//ipv4"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv6 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 address
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InfrastructureCard should not render hasType 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv4 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//ipv4"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv6 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Interfaces/NICs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//interfaces"
+          >
+            1 NIC
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InfrastructureCard should not render hasVendor 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Type
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-type
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv4 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//ipv4"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv6 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Interfaces/NICs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//interfaces"
+          >
+            1 NIC
+          </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`InfrastructureCard should render correctly - no data 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
@@ -413,6 +871,124 @@ exports[`InfrastructureCard should render enabled/disabled 1`] = `
           >
             1 NIC
           </a>
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`InfrastructureCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Infrastructure
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Type
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-type
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Vendor
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-vendor
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv4 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//ipv4"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          IPv6 addresses
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 address
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Interfaces/NICs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//interfaces"
+          >
+            1 NIC
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
@@ -5,22 +5,32 @@ import LoadingCard from '../LoadingCard';
 import { generalMapper } from '../dataMapper';
 import { operatingSystem } from '../selectors';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
-import { isDate } from '../constants';
+import { extraShape, isDate } from '../constants';
 
-const OperatingSystemCard = ({ systemInfo, detailLoaded, handleClick }) => (
+const OperatingSystemCard = ({
+    systemInfo,
+    detailLoaded,
+    handleClick,
+    hasRelease,
+    hasKernelRelease,
+    hasArchitecture,
+    hasLastBoot,
+    hasKernelModules,
+    extra
+}) => (
     <LoadingCard
         title="Operating system"
         isLoading={ !detailLoaded }
         items={ [
-            { title: 'Release', value: systemInfo.release },
-            { title: 'Kernel release', value: systemInfo.kernelRelease },
-            { title: 'Architecture', value: systemInfo.architecture },
-            { title: 'Last boot time', value: (isDate(systemInfo.bootTime) ?
+            ...hasRelease ? [{ title: 'Release', value: systemInfo.release }] : [],
+            ...hasKernelRelease ? [{ title: 'Kernel release', value: systemInfo.kernelRelease }] : [],
+            ...hasArchitecture ? [{ title: 'Architecture', value: systemInfo.architecture }] : [],
+            ...hasLastBoot ? [{ title: 'Last boot time', value: (isDate(systemInfo.bootTime) ?
                 <DateFormat date={ systemInfo.bootTime } type="onlyDate" /> :
                 'Not available'
             )
-            },
-            {
+            }] : [],
+            ...hasKernelModules ? [{
                 title: 'Kernel modules',
                 value: systemInfo.kernelModules?.length,
                 singular: 'module',
@@ -31,7 +41,8 @@ const OperatingSystemCard = ({ systemInfo, detailLoaded, handleClick }) => (
                         generalMapper(systemInfo.kernelModules, 'Module')
                     );
                 }
-            }
+            }] : [],
+            ...extra
         ] }
     />
 );
@@ -45,11 +56,23 @@ OperatingSystemCard.propTypes = {
         kernelRelease: PropTypes.string,
         bootTime: PropTypes.string,
         kernelModules: PropTypes.arrayOf(PropTypes.string)
-    })
+    }),
+    hasRelease: PropTypes.bool,
+    hasKernelRelease: PropTypes.bool,
+    hasArchitecture: PropTypes.bool,
+    hasLastBoot: PropTypes.bool,
+    hasKernelModules: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 OperatingSystemCard.defaultProps = {
     detailLoaded: false,
-    handleClick: () => undefined
+    handleClick: () => undefined,
+    hasRelease: true,
+    hasKernelRelease: true,
+    hasArchitecture: true,
+    hasLastBoot: true,
+    hasKernelModules: true,
+    extra: []
 };
 
 export default connect(({

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
@@ -99,4 +99,24 @@ describe('OperatingSystemCard', () => {
             expect(onClick).toHaveBeenCalled();
         });
     });
+
+    [
+        'hasRelease',
+        'hasKernelRelease',
+        'hasArchitecture',
+        'hasLastBoot',
+        'hasKernelModules'
+    ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<OperatingSystemCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<OperatingSystemCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
+++ b/packages/inventory-general-info/src/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
@@ -1,5 +1,415 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OperatingSystemCard should not render hasArchitecture 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-release
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-kernel
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last boot time
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel modules
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 modules
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OperatingSystemCard should not render hasKernelModules 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-release
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-kernel
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Architecture
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-arch
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last boot time
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OperatingSystemCard should not render hasKernelRelease 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-release
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Architecture
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-arch
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last boot time
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel modules
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 modules
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OperatingSystemCard should not render hasLastBoot 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-release
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-kernel
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Architecture
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-arch
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel modules
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 modules
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OperatingSystemCard should not render hasRelease 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-kernel
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Architecture
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-arch
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last boot time
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel modules
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 modules
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`OperatingSystemCard should render correctly - no data 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
@@ -389,6 +799,112 @@ exports[`OperatingSystemCard should render enabled/disabled 1`] = `
           data-pf-content="true"
         >
           0 modules
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OperatingSystemCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        Operating system
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-release
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel release
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-kernel
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Architecture
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-arch
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Last boot time
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Kernel modules
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 modules
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.js
@@ -10,6 +10,7 @@ import { loadEntity } from '@redhat-cloud-services/frontend-components-inventory
 import { Popover, Button } from '@patternfly/react-core';
 import EditButton from '../EditButton';
 import { generalMapper } from '../dataMapper';
+import { extraShape } from '../constants';
 
 const TitleWithPopover = ({ title, content }) => (
     <React.Fragment>
@@ -66,7 +67,25 @@ class SystemCard extends Component {
     };
 
     render() {
-        const { detailLoaded, entity, properties, setDisplayName, setAnsibleHost, writePermissions, handleClick } = this.props;
+        const {
+            detailLoaded,
+            entity,
+            properties,
+            setDisplayName,
+            setAnsibleHost,
+            writePermissions,
+            handleClick,
+            hasHostName,
+            hasDisplayName,
+            hasAnsibleHostname,
+            hasSAP,
+            hasCPUs,
+            hasSockets,
+            hasCores,
+            hasCPUFlags,
+            hasRAM,
+            extra
+        } = this.props;
         const { isDisplayNameModalOpen, isAnsibleHostModalOpen } = this.state;
         return (
             <Fragment>
@@ -74,13 +93,13 @@ class SystemCard extends Component {
                     title="System properties"
                     isLoading={ !detailLoaded }
                     items={ [
-                        {
+                        ...hasHostName ? [{
                             title: <TitleWithPopover
                                 title='Host name'
                                 content='Name imported from the system.'/>,
                             value: entity.fqdn, size: 'md'
-                        },
-                        {
+                        }] : [],
+                        ...hasDisplayName ? [{
                             title: <TitleWithPopover
                                 title='Display name'
                                 content='System name displayed in an inventory list.'/>,
@@ -90,8 +109,8 @@ class SystemCard extends Component {
                                     <EditButton writePermissions={writePermissions} link="display_name" onClick={this.onShowDisplayModal} />
                                 </Fragment>
                             ), size: 'md'
-                        },
-                        {
+                        }] : [],
+                        ...hasAnsibleHostname ? [{
                             title: <TitleWithPopover
                                 title='Ansible hostname'
                                 content='Hostname that is used in playbooks by Remediations.'/>,
@@ -101,8 +120,8 @@ class SystemCard extends Component {
                                     <EditButton writePermissions={writePermissions} link="ansible_name" onClick={this.onShowAnsibleModal} />
                                 </Fragment>
                             ), size: 'md'
-                        },
-                        {
+                        }] : [],
+                        ...hasSAP ? [{
                             title: 'SAP',
                             value: properties.sapIds?.length,
                             singular: 'identifier',
@@ -113,19 +132,19 @@ class SystemCard extends Component {
                                     generalMapper(properties.sapIds, 'SID')
                                 );
                             }
-                        },
-                        { title: 'Number of CPUs', value: properties.cpuNumber },
-                        { title: 'Sockets', value: properties.sockets },
-                        { title: 'Cores per socket', value: properties.coresPerSocket },
-
-                        {
+                        }] : [],
+                        ...hasCPUs ? [{ title: 'Number of CPUs', value: properties.cpuNumber }] : [],
+                        ...hasSockets ? [{ title: 'Sockets', value: properties.sockets }] : [],
+                        ...hasCores ? [{ title: 'Cores per socket', value: properties.coresPerSocket }] : [],
+                        ...hasCPUFlags ? [{
                             title: 'CPU flags',
                             value: properties?.cpuFlags?.length,
                             singular: 'flag',
                             target: 'flag',
                             onClick: () => handleClick('CPU flags', generalMapper(properties.cpuFlags, 'flag name'))
-                        },
-                        { title: 'RAM', value: properties.ramSize }
+                        }] : [],
+                        ...hasRAM ? [{ title: 'RAM', value: properties.ramSize }] : [],
+                        ...extra
                     ] }
                 />
                 <TextInputModal
@@ -176,12 +195,32 @@ SystemCard.propTypes = {
     setDisplayName: PropTypes.func,
     setAnsibleHost: PropTypes.func,
     writePermissions: PropTypes.bool,
-    handleClick: PropTypes.func
+    handleClick: PropTypes.func,
+    hasHostName: PropTypes.bool,
+    hasDisplayName: PropTypes.bool,
+    hasAnsibleHostname: PropTypes.bool,
+    hasSAP: PropTypes.bool,
+    hasCPUs: PropTypes.bool,
+    hasSockets: PropTypes.bool,
+    hasCores: PropTypes.bool,
+    hasCPUFlags: PropTypes.bool,
+    hasRAM: PropTypes.bool,
+    extra: PropTypes.arrayOf(extraShape)
 };
 SystemCard.defaultProps = {
     detailLoaded: false,
     entity: {},
-    properties: {}
+    properties: {},
+    hasHostName: true,
+    hasDisplayName: true,
+    hasAnsibleHostname: true,
+    hasSAP: true,
+    hasCPUs: true,
+    hasSockets: true,
+    hasCores: true,
+    hasCPUFlags: true,
+    hasRAM: true,
+    extra: []
 };
 
 TitleWithPopover.propTypes = {

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
@@ -223,4 +223,28 @@ describe('SystemCard', () => {
             );
         });
     });
+
+    [
+        'hasHostName',
+        'hasDisplayName',
+        'hasAnsibleHostname',
+        'hasSAP',
+        'hasCPUs',
+        'hasSockets',
+        'hasCores',
+        'hasCPUFlags',
+        'hasRAM'
+    ].map((item) => it(`should not render ${item}`, () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<SystemCard store={ store } {...{ [item]: false }} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    }));
+
+    it('should render extra', () => {
+        const store = mockStore(initialState);
+        const wrapper = render(<SystemCard store={ store } extra={[
+            { title: 'something', value: 'test' }
+        ]} />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
 });

--- a/packages/inventory-general-info/src/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/packages/inventory-general-info/src/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -1,5 +1,2063 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SystemCard should not render hasAnsibleHostname 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-48"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-49"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasCPUFlags 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-62"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-63"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-64"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasCPUs 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-53"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-54"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-55"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasCores 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-59"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-60"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-61"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasDisplayName 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-46"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-47"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasHostName 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-44"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-45"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasRAM 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-65"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-66"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-67"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasSAP 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-50"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-51"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-52"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should not render hasSockets 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-56"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-57"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-58"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SystemCard should render correctly - no data 1`] = `
 <div
   class="pf-l-stack pf-m-gutter"
@@ -1009,6 +3067,271 @@ exports[`SystemCard should render correctly with rhsm facts 1`] = `
           data-pf-content="true"
         >
           2 GB
+        </dd>
+      </dl>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SystemCard should render extra 1`] = `
+<div
+  class="pf-l-stack pf-m-gutter"
+>
+  <div
+    class="pf-l-stack__item"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <h1
+        class=""
+        data-pf-content="true"
+      >
+        System properties
+      </h1>
+    </div>
+  </div>
+  <div
+    class="pf-l-stack__item pf-m-fill"
+  >
+    <div
+      class="pf-c-content"
+    >
+      <dl
+        class=""
+        data-pf-content="true"
+      >
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Host name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Host name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-68"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Display name
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Display name"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-69"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-display-name
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//display_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          <span>
+            Ansible hostname
+          </span>
+          <button
+            aria-disabled="false"
+            aria-label="Action for Ansible hostname"
+            class="pf-c-button pf-m-plain ins-active-general_information__popover-icon"
+            data-ouia-component-id="OUIA-Generated-Button-plain-70"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+              />
+            </svg>
+          </button>
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test-ansible-host
+          <a
+            class="ins-c-inventory__detail--action"
+            href="http://localhost:5000//ansible_name"
+          >
+            <svg
+              aria-hidden="true"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style="vertical-align:-0.125em"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
+              />
+            </svg>
+          </a>
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          SAP
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          Not available
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Number of CPUs
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Sockets
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          Cores per socket
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          1
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          CPU flags
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          0 flags
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          RAM
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          5 MB
+        </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          something
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          test
         </dd>
       </dl>
     </div>

--- a/packages/inventory-general-info/src/constants/constants.js
+++ b/packages/inventory-general-info/src/constants/constants.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 export const prepareRows = (rows = [], pagination = {}) => (
     rows
     .slice((pagination.page - 1) * pagination.perPage, pagination.page * pagination.perPage)
@@ -63,3 +65,11 @@ export const onDeleteFilter = (deleted = {}, deleteAll = false, activeFilters = 
         };
     }
 };
+
+export const extraShape = PropTypes.shape({
+    title: PropTypes.node,
+    value: PropTypes.node,
+    singular: PropTypes.node,
+    plural: PropTypes.node,
+    onClick: PropTypes.func
+});


### PR DESCRIPTION
### Hide cards on general info page

Since we have a way to fetch just a few fields from API we should also allow hiding certain parts of general info detail. This PR allows to do that by simply adding `Wrapper` prop for each card and if consumer passes `false` in it the card won't be shown. There is also option to pass in custom Wrapper for each card to hide certain fields or to render something completely different.

```JSX
<GeneralInformation
  store={useStore()}
  writePermissions={writePermissions}
  ConfigurationCardWrapper={false}
  SystemCardWrapper={(props) => (
    <Suspense>
      <SystemCard {...props} hasSAP={false} />
    </Suspense>
  )}
  OperatingSystemCardWrapper={(props) => (
    <Suspense fallback="">
      <OperatingSystemCard {...props} hasKernelModules={false} />
    </Suspense>
  )}
/>
```