### PR TITLE
Add relative paths to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,10 @@
+const path = require('path');
 const rulesDirPlugin = require('eslint-plugin-rulesdir');
-rulesDirPlugin.RULES_DIR = 'packages/eslint-config/lib/rules';
+rulesDirPlugin.RULES_DIR = path.resolve(__dirname, './packages/eslint-config/lib/rules');
 
 module.exports = {
-  plugins: [
-    'rulesdir'
-  ],
-  extends: './config/.eslintrc.yml'
-}
+    plugins: [
+        'rulesdir'
+    ],
+    extends: path.resolve(__dirname, './config/.eslintrc.yml')
+};


### PR DESCRIPTION
This fixes eslint when not running project from root