### PR TITLE
Allow using onClick to show modals for extra items

### DIFF
--- a/packages/inventory-general-info/src/BiosCard/BiosCard.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.js
@@ -18,11 +18,7 @@ const BiosCard = ({ bios, detailLoaded, hasVendor, hasVersion, handleClick, hasR
         ) }] : [],
         ...extra.map(({ onClick, ...item }) => ({
             ...item,
-            ...onClick && {
-                onClick: () => {
-                    handleClick(...onClick() || []);
-                }
-            }
+            ...onClick && { onClick: (e) => onClick(e, handleClick) }
         }))
     ] }
 />);

--- a/packages/inventory-general-info/src/BiosCard/BiosCard.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.js
@@ -6,7 +6,7 @@ import { biosSelector } from '../selectors';
 import DateFormat from '@redhat-cloud-services/frontend-components/DateFormat';
 import { extraShape, isDate } from '../constants';
 
-const BiosCard = ({ bios, detailLoaded, hasVendor, hasVersion, hasReleaseDate, extra }) => (<LoadingCard
+const BiosCard = ({ bios, detailLoaded, hasVendor, hasVersion, handleClick, hasReleaseDate, extra }) => (<LoadingCard
     title="BIOS"
     isLoading={ !detailLoaded }
     items={ [
@@ -16,7 +16,14 @@ const BiosCard = ({ bios, detailLoaded, hasVendor, hasVersion, hasReleaseDate, e
             <DateFormat date={ new Date(bios.releaseDate) } type="onlyDate" /> :
             'Not available'
         ) }] : [],
-        ...extra
+        ...extra.map(({ onClick, ...item }) => ({
+            ...item,
+            ...onClick && {
+                onClick: () => {
+                    handleClick(...onClick() || []);
+                }
+            }
+        }))
     ] }
 />);
 

--- a/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
@@ -58,7 +58,7 @@ describe('BiosCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<BiosCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
+++ b/packages/inventory-general-info/src/BiosCard/BiosCard.test.js
@@ -57,7 +57,8 @@ describe('BiosCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<BiosCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/BiosCard/__snapshots__/BiosCard.test.js.snap
+++ b/packages/inventory-general-info/src/BiosCard/__snapshots__/BiosCard.test.js.snap
@@ -472,6 +472,22 @@ exports[`BiosCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
@@ -59,11 +59,7 @@ const CollectionCard = ({
         ...hasMachineId ? [{ title: 'RHEL machine id', value: entity && entity.rhel_machine_id }] : [],
         ...extra.map(({ onClick, ...item }) => ({
             ...item,
-            ...onClick && {
-                onClick: () => {
-                    handleClick(...onClick() || []);
-                }
-            }
+            ...onClick && { onClick: (e) => onClick(e, handleClick) }
         }))
     ] }
 />);

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.js
@@ -31,6 +31,7 @@ const CollectionCard = ({
     detailLoaded,
     collectionInformation,
     entity,
+    handleClick,
     hasClient,
     hasLastCheckIn,
     hasRegistered,
@@ -56,7 +57,14 @@ const CollectionCard = ({
         ...hasInsightsId ? [{ title: 'Insights id', value: entity && entity.insights_id }] : [],
         ...hasReporter ? [{ title: 'Reporter', value: entity && entity.reporter }] : [],
         ...hasMachineId ? [{ title: 'RHEL machine id', value: entity && entity.rhel_machine_id }] : [],
-        ...extra
+        ...extra.map(({ onClick, ...item }) => ({
+            ...item,
+            ...onClick && {
+                onClick: () => {
+                    handleClick(...onClick() || []);
+                }
+            }
+        }))
     ] }
 />);
 
@@ -66,6 +74,7 @@ CollectionCard.propTypes = {
         updated: PropTypes.string,
         created: PropTypes.string
     }),
+    handleClick: PropTypes.func,
     collectionInformation: PropTypes.shape({
         client: PropTypes.string,
         egg: PropTypes.string
@@ -80,6 +89,7 @@ CollectionCard.propTypes = {
 };
 CollectionCard.defaultProps = {
     detailLoaded: false,
+    handleClick: () => undefined,
     hasClient: true,
     hasEgg: true,
     hasLastCheckIn: true,

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
@@ -70,7 +70,7 @@ describe('CollectionCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<CollectionCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
+++ b/packages/inventory-general-info/src/CollectionCard/CollectionCard.test.js
@@ -69,7 +69,8 @@ describe('CollectionCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<CollectionCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/CollectionCard/__snapshots__/CollectionCard.test.js.snap
+++ b/packages/inventory-general-info/src/CollectionCard/__snapshots__/CollectionCard.test.js.snap
@@ -940,6 +940,22 @@ exports[`CollectionCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
@@ -77,7 +77,14 @@ const ConfigurationCard = ({
                 );
             }
         }] : [],
-        ...extra
+        ...extra.map(({ onClick, ...item }) => ({
+            ...item,
+            ...onClick && {
+                onClick: () => {
+                    handleClick(...onClick() || []);
+                }
+            }
+        }))
     ] }
 />);
 

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.js
@@ -79,11 +79,7 @@ const ConfigurationCard = ({
         }] : [],
         ...extra.map(({ onClick, ...item }) => ({
             ...item,
-            ...onClick && {
-                onClick: () => {
-                    handleClick(...onClick() || []);
-                }
-            }
+            ...onClick && { onClick: (e) => onClick(e, handleClick) }
         }))
     ] }
 />);

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
@@ -113,7 +113,7 @@ describe('ConfigurationCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<ConfigurationCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
+++ b/packages/inventory-general-info/src/ConfigurationCard/ConfigurationCard.test.js
@@ -112,7 +112,8 @@ describe('ConfigurationCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<ConfigurationCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
+++ b/packages/inventory-general-info/src/ConfigurationCard/__snapshots__/ConfigurationCard.test.js.snap
@@ -1025,6 +1025,22 @@ exports[`ConfigurationCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
@@ -60,7 +60,14 @@ const InfrastructureCard = ({
                 );
             }
         }] : [],
-        ...extra
+        ...extra.map(({ onClick, ...item }) => ({
+            ...item,
+            ...onClick && {
+                onClick: () => {
+                    handleClick(...onClick() || []);
+                }
+            }
+        }))
     ] }
 />);
 

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.js
@@ -62,11 +62,7 @@ const InfrastructureCard = ({
         }] : [],
         ...extra.map(({ onClick, ...item }) => ({
             ...item,
-            ...onClick && {
-                onClick: () => {
-                    handleClick(...onClick() || []);
-                }
-            }
+            ...onClick && { onClick: (e) => onClick(e, handleClick) }
         }))
     ] }
 />);

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
@@ -118,7 +118,7 @@ describe('InfrastructureCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<InfrastructureCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
+++ b/packages/inventory-general-info/src/InfrastructureCard/InfrastructureCard.test.js
@@ -117,7 +117,8 @@ describe('InfrastructureCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<InfrastructureCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
+++ b/packages/inventory-general-info/src/InfrastructureCard/__snapshots__/InfrastructureCard.test.js.snap
@@ -990,6 +990,22 @@ exports[`InfrastructureCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
@@ -44,11 +44,7 @@ const OperatingSystemCard = ({
             }] : [],
             ...extra.map(({ onClick, ...item }) => ({
                 ...item,
-                ...onClick && {
-                    onClick: () => {
-                        handleClick(...onClick() || []);
-                    }
-                }
+                ...onClick && { onClick: (e) => onClick(e, handleClick) }
             }))
         ] }
     />

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.js
@@ -42,7 +42,14 @@ const OperatingSystemCard = ({
                     );
                 }
             }] : [],
-            ...extra
+            ...extra.map(({ onClick, ...item }) => ({
+                ...item,
+                ...onClick && {
+                    onClick: () => {
+                        handleClick(...onClick() || []);
+                    }
+                }
+            }))
         ] }
     />
 );

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
@@ -115,7 +115,8 @@ describe('OperatingSystemCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<OperatingSystemCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
+++ b/packages/inventory-general-info/src/OperatingSystemCard/OperatingSystemCard.test.js
@@ -116,7 +116,7 @@ describe('OperatingSystemCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<OperatingSystemCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
+++ b/packages/inventory-general-info/src/OperatingSystemCard/__snapshots__/OperatingSystemCard.test.js.snap
@@ -906,6 +906,22 @@ exports[`OperatingSystemCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.js
@@ -144,7 +144,14 @@ class SystemCard extends Component {
                             onClick: () => handleClick('CPU flags', generalMapper(properties.cpuFlags, 'flag name'))
                         }] : [],
                         ...hasRAM ? [{ title: 'RAM', value: properties.ramSize }] : [],
-                        ...extra
+                        ...extra.map(({ onClick, ...item }) => ({
+                            ...item,
+                            ...onClick && {
+                                onClick: () => {
+                                    handleClick(...onClick() || []);
+                                }
+                            }
+                        }))
                     ] }
                 />
                 <TextInputModal

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.js
@@ -146,11 +146,7 @@ class SystemCard extends Component {
                         ...hasRAM ? [{ title: 'RAM', value: properties.ramSize }] : [],
                         ...extra.map(({ onClick, ...item }) => ({
                             ...item,
-                            ...onClick && {
-                                onClick: () => {
-                                    handleClick(...onClick() || []);
-                                }
-                            }
+                            ...onClick && { onClick: (e) => onClick(e, handleClick) }
                         }))
                     ] }
                 />

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
@@ -243,7 +243,8 @@ describe('SystemCard', () => {
     it('should render extra', () => {
         const store = mockStore(initialState);
         const wrapper = render(<SystemCard store={ store } extra={[
-            { title: 'something', value: 'test' }
+            { title: 'something', value: 'test' },
+            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
+++ b/packages/inventory-general-info/src/SystemCard/SystemCard.test.js
@@ -244,7 +244,7 @@ describe('SystemCard', () => {
         const store = mockStore(initialState);
         const wrapper = render(<SystemCard store={ store } extra={[
             { title: 'something', value: 'test' },
-            { title: 'with click', value: '1 tests', onClick: () => [ 'Something', {}, 'small' ] }
+            { title: 'with click', value: '1 tests', onClick: (_e, handleClick) => handleClick('Something', {}, 'small') }
         ]} />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });

--- a/packages/inventory-general-info/src/SystemCard/__snapshots__/SystemCard.test.js.snap
+++ b/packages/inventory-general-info/src/SystemCard/__snapshots__/SystemCard.test.js.snap
@@ -3333,6 +3333,22 @@ exports[`SystemCard should render extra 1`] = `
         >
           test
         </dd>
+        <dt
+          class=""
+          data-pf-content="true"
+        >
+          with click
+        </dt>
+        <dd
+          class=""
+          data-pf-content="true"
+        >
+          <a
+            href="http://localhost:5000//undefined"
+          >
+            1 tests
+          </a>
+        </dd>
       </dl>
     </div>
   </div>


### PR DESCRIPTION
### Onclick for extra items

Since we allow passing extra items to general information we should also reuse our modals if consumer wants to show tabled data. This PR introduces a check for onClick and if such callback is present it calls it and consumes array off of it.