### PR TITLE
Add option to pass custom delete node and func to remove group

### DIFF
--- a/packages/components/src/FilterChips/FilterChips.js
+++ b/packages/components/src/FilterChips/FilterChips.js
@@ -4,9 +4,19 @@ import { Badge, Chip, ChipGroup, Button } from '@patternfly/react-core';
 import classNames from 'classnames';
 import './filter-chips.scss';
 
-const FilterChips = ({ className, filters, onDelete }) => {
-    const groupedFilters = filters.filter(group => group.category).map(group =>  (
-        <ChipGroup key={ `group_${group.category}` } categoryName={group.category}>
+const FilterChips = ({ className, filters, onDelete, deleteTitle, onDeleteGroup }) => {
+    const groups = filters.filter(group => group.category);
+    const groupedFilters = groups.map((group, groupKey) =>  (
+        <ChipGroup
+            key={ `group_${group.category}` }
+            categoryName={group.category}
+            {...onDeleteGroup && {
+                isClosable: true,
+                onClick: (event) => {
+                    event.stopPropagation();
+                    onDeleteGroup(event, [ group ], groups.filter((_item, key) => key !== groupKey));
+                } }}
+        >
             {group.chips.map(chip => (
                 <Chip
                     key={chip.name}
@@ -40,7 +50,7 @@ const FilterChips = ({ className, filters, onDelete }) => {
                     </Chip>
                 </ChipGroup>
             )) }
-            { filters.length > 0 && <Button variant="link" onClick={ (event) => onDelete(event, filters, true) }>Clear filters</Button> }
+            { filters.length > 0 && <Button variant="link" onClick={ (event) => onDelete(event, filters, true) }>{deleteTitle}</Button> }
         </span>
     );
 };
@@ -66,12 +76,15 @@ FilterChips.propTypes = {
             })
         ])
     ),
-    onDelete: PropTypes.func
+    onDelete: PropTypes.func,
+    onDeleteGroup: PropTypes.func,
+    deleteTitle: PropTypes.node
 };
 
 FilterChips.defaultProps = {
     filters: [],
-    onDelete: () => undefined
+    onDelete: () => undefined,
+    deleteTitle: 'Clear filters'
 };
 
 export default FilterChips;

--- a/packages/components/src/FilterChips/FilterChips.test.js
+++ b/packages/components/src/FilterChips/FilterChips.test.js
@@ -39,6 +39,20 @@ describe('FilterChips component', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render with custom delete message', () => {
+        const wrapper = shallow(
+            <FilterChips filters={ filters } deleteTitle={<div>Some delete title</div>} />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('should render group delete', () => {
+        const wrapper = shallow(
+            <FilterChips filters={ filters } onDeleteGroup={ () => undefined } />
+        );
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     describe('API', () => {
         it('should have default onDelete handle', () => {
             const onDelete = FilterChips.defaultProps.onDelete;
@@ -84,6 +98,43 @@ describe('FilterChips component', () => {
 
             wrapper.find(ChipGroup).forEach(group => group.simulate('click'));
             expect(onDelete).not.toHaveBeenCalled();
+        });
+
+        it('should have default onDeleteGroup handle', () => {
+            const onDelete = FilterChips.defaultProps.onDeleteGroup;
+            expect(onDelete).not.toBeDefined();
+        });
+
+        it('should call onDelete when deleting a single chip', () => {
+            const onDelete = jest.fn();
+            const newGroup = {
+                category: 'Group 2',
+                chips: [
+                    {
+                        name: 'Chip 1'
+                    }
+                ]
+            };
+            const wrapper = mount(<FilterChips filters={ [ ...filters, newGroup ] } onDeleteGroup={ onDelete } />);
+            wrapper.find('.pf-c-chip-group__close button').last().simulate('click');
+            expect(onDelete).toHaveBeenCalledWith(
+                expect.anything(),
+                [ newGroup ],
+                [{
+                    category: 'Group 1',
+                    chips: [
+                        {
+                            name: 'Chip 1',
+                            isRead: true
+                        },
+                        {
+                            name: 'Chip 2',
+                            count: 3
+                        }
+                    ]
+                }]
+            );
+            expect(onDelete).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/components/src/FilterChips/__snapshots__/FilterChips.test.js.snap
+++ b/packages/components/src/FilterChips/__snapshots__/FilterChips.test.js.snap
@@ -111,3 +111,217 @@ exports[`FilterChips component should render 1`] = `
   </Button>
 </span>
 `;
+
+exports[`FilterChips component should render group delete 1`] = `
+<span
+  className="ins-c-chip-filters"
+>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName="Group 1"
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={true}
+    key="group_Group 1"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      key="Chip 1"
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 1
+    </Chip>
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      key="Chip 2"
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 2
+      <Badge
+        key="chip_badge_undefined"
+      >
+        3
+      </Badge>
+    </Chip>
+  </ChipGroup>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName=""
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={false}
+    key="group_plain_chip_Chip 3"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 3
+    </Chip>
+  </ChipGroup>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName=""
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={false}
+    key="group_plain_chip_Chip 4"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 4
+    </Chip>
+  </ChipGroup>
+  <Button
+    onClick={[Function]}
+    variant="link"
+  >
+    Clear filters
+  </Button>
+</span>
+`;
+
+exports[`FilterChips component should render with custom delete message 1`] = `
+<span
+  className="ins-c-chip-filters"
+>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName="Group 1"
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={false}
+    key="group_Group 1"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      key="Chip 1"
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 1
+    </Chip>
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      key="Chip 2"
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 2
+      <Badge
+        key="chip_badge_undefined"
+      >
+        3
+      </Badge>
+    </Chip>
+  </ChipGroup>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName=""
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={false}
+    key="group_plain_chip_Chip 3"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 3
+    </Chip>
+  </ChipGroup>
+  <ChipGroup
+    aria-label="Chip group category"
+    categoryName=""
+    closeBtnAriaLabel="Close chip group"
+    collapsedText="\${remaining} more"
+    defaultIsOpen={false}
+    expandedText="Show Less"
+    isClosable={false}
+    key="group_plain_chip_Chip 4"
+    numChips={3}
+    onClick={[Function]}
+    tooltipPosition="top"
+  >
+    <Chip
+      className=""
+      closeBtnAriaLabel="close"
+      component="div"
+      isOverflowChip={false}
+      isReadOnly={false}
+      onClick={[Function]}
+      tooltipPosition="top"
+    >
+      Chip 4
+    </Chip>
+  </ChipGroup>
+  <Button
+    onClick={[Function]}
+    variant="link"
+  >
+    <div>
+      Some delete title
+    </div>
+  </Button>
+</span>
+`;

--- a/packages/components/src/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
+++ b/packages/components/src/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
@@ -285,6 +285,7 @@ exports[`PrimaryToolbar should render with data full config 1`] = `
   >
     <ToolbarItem>
       <FilterChips
+        deleteTitle="Clear filters"
         filters={
           Array [
             Object {
@@ -566,6 +567,7 @@ exports[`PrimaryToolbar should render wrong actionsConfig 1`] = `
   >
     <ToolbarItem>
       <FilterChips
+        deleteTitle="Clear filters"
         filters={
           Array [
             Object {


### PR DESCRIPTION
### Option to pass custom node to delete msg

We have to support custom strings in `Clear all` button, there is requirements from UX to allow on some tables to have `Reset filters`. This is good for translation purposes as well.

### Option to pass `onDeleteGroup`

Consumers should be able to pass in callback to remove entire group. This should be done in a way that it won't break current API.