### PR TITLE
Fix review steps by moving selector to bottom

### DIFF
--- a/packages/remediations/src/steps/reviewSystems.js
+++ b/packages/remediations/src/steps/reviewSystems.js
@@ -22,21 +22,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import './reviewSystems.scss';
 
-const ReviewSystems = (props) => {
-    const { issues, systems, registry } = props;
-
+const ReviewSystems = ({ issues, systems, registry, ...props }) => {
     let dispatch = useDispatch();
     const inventory = useRef(null);
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
 
     const inventoryApi = useRef({});
-
-    const { selected, loaded, rows } = useSelector(({ entities }) => ({
-        selected: entities?.selected || [],
-        loaded: entities?.loaded,
-        rows: entities?.rows || []
-    }));
 
     const formValues = formOptions.getState().values;
     const error = formOptions.getState().errors?.systems;
@@ -70,6 +62,12 @@ const ReviewSystems = (props) => {
             payload: value
         });
     };
+
+    const { selected, loaded, rows } = useSelector(({ entities }) => ({
+        selected: entities?.selected || [],
+        loaded: entities?.loaded,
+        rows: entities?.rows || []
+    }));
 
     return (
         <Stack hasGutter>


### PR DESCRIPTION
### Error while loading ReviewSystems step

When rendering review system step there is error about accessing store too soon this is caused by how store is created and when reducer is registered. This PR fixes such issue by moving the selector right before the render which rearranges the hooks and the selector is correctly used.