### PR TITLE
Remove side effects from review systems steps

### DIFF
--- a/packages/remediations/src/steps/reviewSystems.js
+++ b/packages/remediations/src/steps/reviewSystems.js
@@ -29,14 +29,11 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
     const inventory = useRef(null);
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
-    const selectedRef = useRef();
     const inventoryApi = useRef({});
 
-    const { selected, loaded, rows } = useSelector(({ entities }) => ({
-        selected: entities?.selected || [],
-        loaded: entities?.loaded,
-        rows: entities?.rows || []
-    }));
+    const rowsLength = useSelector(({ entities }) => (entities?.rows || []).length);
+    const selected = useSelector(({ entities }) => entities?.selected || []);
+    const loaded = useSelector(({ entities }) => entities?.loaded);
 
     const formValues = formOptions.getState().values;
     const error = formOptions.getState().errors?.systems;
@@ -67,10 +64,11 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
         });
     };
 
-    if (!isEqual(selectedRef.current, selected)) {
-        selectedRef.current = selected;
-        input.onChange(selected);
-    }
+    useEffect(() => {
+        if (!isEqual(input.value, selected)) {
+            input.onChange(selected);
+        }
+    });
 
     return (
         <Stack hasGutter>
@@ -92,11 +90,10 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
                             onRefresh={onRefresh}
                             ref={inventory}
                             getEntities={(_i, config) => fetchSystemsInfo(config, allSystems, inventoryApi.current)}
-                            onLoad={({ mergeWithEntities, api }) => {
-                                registry.register(mergeWithEntities(entitiesReducer(input.value)));
+                            onLoad={({ mergeWithEntities, api, INVENTORY_ACTION_TYPES }) => {
+                                registry.register(mergeWithEntities(entitiesReducer(allSystems, INVENTORY_ACTION_TYPES)));
                                 inventoryApi.current = api;
-                            }
-                            }
+                            }}
                             bulkSelect={{
                                 id: 'select-systems',
                                 count: selected.length,
@@ -105,8 +102,8 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
                                     onClick: () => onSelectRows(false)
                                 },
                                 {
-                                    ...loaded && rows.length > 0 ? {
-                                        title: `Select page (${ rows.length })`,
+                                    ...loaded && rowsLength > 0 ? {
+                                        title: `Select page (${ rowsLength })`,
                                         onClick: () => onSelectRows(true)
                                     } : {}
                                 }],

--- a/packages/remediations/src/steps/reviewSystems.js
+++ b/packages/remediations/src/steps/reviewSystems.js
@@ -21,14 +21,22 @@ import { Provider, useDispatch, useSelector } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import './reviewSystems.scss';
+import isEqual from 'lodash/isEqual';
 
 const ReviewSystems = ({ issues, systems, registry, ...props }) => {
+
     let dispatch = useDispatch();
     const inventory = useRef(null);
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
-
+    const selectedRef = useRef();
     const inventoryApi = useRef({});
+
+    const { selected, loaded, rows } = useSelector(({ entities }) => ({
+        selected: entities?.selected || [],
+        loaded: entities?.loaded,
+        rows: entities?.rows || []
+    }));
 
     const formValues = formOptions.getState().values;
     const error = formOptions.getState().errors?.systems;
@@ -52,10 +60,6 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
         }
     };
 
-    const onSelect = (selected) => {
-        input.onChange(selected);
-    };
-
     const onSelectRows = (value) => {
         dispatch({
             type: TOGGLE_BULK_SELECT,
@@ -63,11 +67,10 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
         });
     };
 
-    const { selected, loaded, rows } = useSelector(({ entities }) => ({
-        selected: entities?.selected || [],
-        loaded: entities?.loaded,
-        rows: entities?.rows || []
-    }));
+    if (!isEqual(selectedRef.current, selected)) {
+        selectedRef.current = selected;
+        input.onChange(selected);
+    }
 
     return (
         <Stack hasGutter>
@@ -90,7 +93,7 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
                             ref={inventory}
                             getEntities={(_i, config) => fetchSystemsInfo(config, allSystems, inventoryApi.current)}
                             onLoad={({ mergeWithEntities, api }) => {
-                                registry.register(mergeWithEntities(entitiesReducer(onSelect, input.value)));
+                                registry.register(mergeWithEntities(entitiesReducer(input.value)));
                                 inventoryApi.current = api;
                             }
                             }

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -118,7 +118,7 @@ export const submitRemediation = (formValues, data, basePath, resolutions) => {
     }
 };
 
-const entitySelected = (state, { payload }, onSelect) => {
+const entitySelected = (state, { payload }) => {
     let selected = state.selected || [];
     if (payload.selected) {
         selected = [
@@ -134,21 +134,18 @@ const entitySelected = (state, { payload }, onSelect) => {
         }
     }
 
-    onSelect(selected);
-
     return {
         ...state,
         selected
     };
 };
 
-const loadEntitiesFulfilled = (state, onSelect, formValue) => {
+const loadEntitiesFulfilled = (state, formValue) => {
     let selected = state.selected || [];
     if (!state.selected) {
         selected = formValue ? formValue : state.rows.map(row => row.id);
     }
 
-    onSelect(selected);
     return ({
         ...state,
         selected,
@@ -160,17 +157,13 @@ const loadEntitiesFulfilled = (state, onSelect, formValue) => {
     });
 };
 
-const changeBulkSelect = (state, action, onSelect) => {
+const changeBulkSelect = (state, action) => {
     const removeSelected = !action.payload;
     if (!removeSelected) {
         state.selected = [
             ...state.selected,
             ...state.rows.map(row => row.id)
         ];
-
-        onSelect(state.selected);
-    } else {
-        onSelect([]);
     }
 
     return ({
@@ -196,8 +189,8 @@ export const fetchSystemsInfo = async (config, allSystems, { getEntities } = {})
     };
 };
 
-export const inventoryEntitiesReducer = (onSelect, formValue) => applyReducerHash({
-    SELECT_ENTITY: (state, action) => entitySelected(state, action, onSelect),
-    LOAD_ENTITIES_FULFILLED: (state) => loadEntitiesFulfilled(state, onSelect, formValue),
-    [TOGGLE_BULK_SELECT]: (state, action) => changeBulkSelect(state, action, onSelect)
+export const inventoryEntitiesReducer = (formValue) => applyReducerHash({
+    SELECT_ENTITY: (state, action) => entitySelected(state, action),
+    LOAD_ENTITIES_FULFILLED: (state) => loadEntitiesFulfilled(state, formValue),
+    [TOGGLE_BULK_SELECT]: (state, action) => changeBulkSelect(state, action)
 });

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -140,10 +140,10 @@ const entitySelected = (state, { payload }) => {
     };
 };
 
-const loadEntitiesFulfilled = (state, formValue) => {
+const loadEntitiesFulfilled = (state, allSystems) => {
     let selected = state.selected || [];
     if (!state.selected) {
-        selected = formValue ? formValue : state.rows.map(row => row.id);
+        selected = allSystems ? allSystems : state.rows.map(row => row.id);
     }
 
     return ({
@@ -189,8 +189,8 @@ export const fetchSystemsInfo = async (config, allSystems, { getEntities } = {})
     };
 };
 
-export const inventoryEntitiesReducer = (formValue) => applyReducerHash({
+export const inventoryEntitiesReducer = (allSystems, { LOAD_ENTITIES_FULFILLED }) => applyReducerHash({
     SELECT_ENTITY: (state, action) => entitySelected(state, action),
-    LOAD_ENTITIES_FULFILLED: (state) => loadEntitiesFulfilled(state, formValue),
-    [TOGGLE_BULK_SELECT]: (state, action) => changeBulkSelect(state, action)
+    [LOAD_ENTITIES_FULFILLED]: (state) => loadEntitiesFulfilled(state, allSystems),
+    [TOGGLE_BULK_SELECT]: changeBulkSelect
 });


### PR DESCRIPTION
### No side effects in reducers

There is an error in remediation wizard with reducers having side effects by calling `onSelect`. This PR fixes it by using ref to selected systems and when this ref differs from actual selected systems send them to form input.