### PR TITLE
feat(RulesTable): RHICOMPL-1550 selected filter switch

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable/SystemRulesTable.test.js
+++ b/packages/inventory-compliance/src/SystemRulesTable/SystemRulesTable.test.js
@@ -263,10 +263,9 @@ describe('SystemRulesTable component', () => {
                     ] }
                 />
             );
-            const instance = wrapper.instance();
-            await instance.onFilterUpdate('selected', [ 'selected' ]);
+            expect(wrapper.state.selectedOnly === true);
             expect(toJson(wrapper)).toMatchSnapshot();
-            await instance.onFilterUpdate('selected', undefined);
+            wrapper.setState({ selectedOnly: false });
             expect(toJson(wrapper)).toMatchSnapshot();
         });
     });

--- a/packages/inventory-compliance/src/SystemRulesTable/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/SystemRulesTable/__snapshots__/SystemRulesTable.test.js.snap
@@ -5742,16 +5742,7 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
   <PrimaryToolbar
     activeFiltersConfig={
       Object {
-        "filters": Array [
-          Object {
-            "category": "Selected",
-            "chips": Array [
-              Object {
-                "name": "Show selected rules",
-              },
-            ],
-          },
-        ],
+        "filters": Array [],
         "onDelete": [Function],
       }
     }
@@ -5844,24 +5835,6 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
             "filterValues": Object {
               "items": Array [
                 Object {
-                  "label": "Show selected rules",
-                  "value": "selected",
-                },
-              ],
-              "onChange": [Function],
-              "value": Array [
-                "selected",
-              ],
-            },
-            "id": "selected",
-            "label": "Selected",
-            "placeholder": "Filter by selected",
-            "type": "checkbox",
-          },
-          Object {
-            "filterValues": Object {
-              "items": Array [
-                Object {
                   "label": "Remediation available",
                   "value": "true",
                 },
@@ -5943,6 +5916,15 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
           ]
         }
         selectedRules={Array []}
+      />
+    </ToolbarItem>
+    <ToolbarItem>
+      <Switch
+        aria-label=""
+        isChecked={true}
+        isDisabled={false}
+        label="Selected only"
+        onChange={[Function]}
       />
     </ToolbarItem>
     <ToolbarItem>
@@ -6187,22 +6169,6 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
             "filterValues": Object {
               "items": Array [
                 Object {
-                  "label": "Show selected rules",
-                  "value": "selected",
-                },
-              ],
-              "onChange": [Function],
-              "value": undefined,
-            },
-            "id": "selected",
-            "label": "Selected",
-            "placeholder": "Filter by selected",
-            "type": "checkbox",
-          },
-          Object {
-            "filterValues": Object {
-              "items": Array [
-                Object {
                   "label": "Remediation available",
                   "value": "true",
                 },
@@ -6284,6 +6250,15 @@ exports[`SystemRulesTable component tailoring rules should be able to filter by 
           ]
         }
         selectedRules={Array []}
+      />
+    </ToolbarItem>
+    <ToolbarItem>
+      <Switch
+        aria-label=""
+        isChecked={false}
+        isDisabled={false}
+        label="Selected only"
+        onChange={[Function]}
       />
     </ToolbarItem>
     <ToolbarItem>
@@ -7057,16 +7032,7 @@ exports[`SystemRulesTable component tailoring rules should be able to show all s
   <PrimaryToolbar
     activeFiltersConfig={
       Object {
-        "filters": Array [
-          Object {
-            "category": "Selected",
-            "chips": Array [
-              Object {
-                "name": "Show selected rules",
-              },
-            ],
-          },
-        ],
+        "filters": Array [],
         "onDelete": [Function],
       }
     }
@@ -7159,24 +7125,6 @@ exports[`SystemRulesTable component tailoring rules should be able to show all s
             "filterValues": Object {
               "items": Array [
                 Object {
-                  "label": "Show selected rules",
-                  "value": "selected",
-                },
-              ],
-              "onChange": [Function],
-              "value": Array [
-                "selected",
-              ],
-            },
-            "id": "selected",
-            "label": "Selected",
-            "placeholder": "Filter by selected",
-            "type": "checkbox",
-          },
-          Object {
-            "filterValues": Object {
-              "items": Array [
-                Object {
                   "label": "Remediation available",
                   "value": "true",
                 },
@@ -7258,6 +7206,15 @@ exports[`SystemRulesTable component tailoring rules should be able to show all s
           ]
         }
         selectedRules={Array []}
+      />
+    </ToolbarItem>
+    <ToolbarItem>
+      <Switch
+        aria-label=""
+        isChecked={true}
+        isDisabled={false}
+        label="Selected only"
+        onChange={[Function]}
       />
     </ToolbarItem>
     <ToolbarItem>

--- a/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
+++ b/packages/inventory-compliance/src/Utilities/FilterBuilderConfigBuilder.js
@@ -54,17 +54,6 @@ const PASS_FILTER_CONFIG = {
     ))
 };
 
-const SELECTED_FILTER_CONFIG = {
-    type: conditionalFilterType.checkbox,
-    label: 'Selected',
-    items: [
-        { label: 'Show selected rules', value: 'selected' }
-    ],
-    filter: (rules, value) => rules.filter((rule) => (
-        value[0] === 'selected' ? rule.isSelected === true : true
-    ))
-};
-
 export const POLICIES_FILTER_CONFIG = (policies) => ({
     type: conditionalFilterType.checkbox,
     label: 'Policy',
@@ -85,15 +74,11 @@ export const REMEDIATION_AVAILABLE_FILTER_CONFIG = {
     filter: (rules, value) => rules.filter(rule => rule.remediationAvailable)
 };
 
-const buildFilterConfig = ({ showPassFailFilter, policies, selectedFilter, remediationAvailableFilter }) => {
+const buildFilterConfig = ({ showPassFailFilter, policies, remediationAvailableFilter }) => {
     const config = [ ...BASE_FILTER_CONFIGURATION ];
 
     if (showPassFailFilter) {
         config.push(PASS_FILTER_CONFIG);
-    }
-
-    if (selectedFilter) {
-        config.push(SELECTED_FILTER_CONFIG);
     }
 
     if (policies && policies.length > 1) {

--- a/packages/inventory-compliance/src/Utilities/FilterConfigBuilder.test.js
+++ b/packages/inventory-compliance/src/Utilities/FilterConfigBuilder.test.js
@@ -12,7 +12,7 @@ describe('FilterConfigBuilder', () => {
             ],
             filter: () => ([])
         },
-        ...buildFilterConfig({ selectedFilter: true, showPassFailFilter: true, policies: [] })
+        ...buildFilterConfig({ showPassFailFilter: true, policies: [] })
     ];
     let builder;
 

--- a/packages/inventory-compliance/src/Utilities/__snapshots__/ChipBuilder.test.js.snap
+++ b/packages/inventory-compliance/src/Utilities/__snapshots__/ChipBuilder.test.js.snap
@@ -20,13 +20,5 @@ Array [
       },
     ],
   },
-  Object {
-    "category": "Selected",
-    "chips": Array [
-      Object {
-        "name": "all",
-      },
-    ],
-  },
 ]
 `;

--- a/packages/inventory-compliance/src/Utilities/__snapshots__/FilterConfigBuilder.test.js.snap
+++ b/packages/inventory-compliance/src/Utilities/__snapshots__/FilterConfigBuilder.test.js.snap
@@ -11,7 +11,6 @@ Object {
   "filterwithmultiplespaces": Array [],
   "name": "",
   "passed": undefined,
-  "selected": Array [],
   "severity": Array [],
 }
 `;
@@ -143,22 +142,6 @@ Object {
       "label": "Passed",
       "placeholder": "Filter by passed",
       "type": "radio",
-    },
-    Object {
-      "filterValues": Object {
-        "items": Array [
-          Object {
-            "label": "Show selected rules",
-            "value": "selected",
-          },
-        ],
-        "onChange": [Function],
-        "value": undefined,
-      },
-      "id": "selected",
-      "label": "Selected",
-      "placeholder": "Filter by selected",
-      "type": "checkbox",
     },
   ],
   "name": "",


### PR DESCRIPTION
Add a Switch for selected rules vs. filter + filter chip

According to UX, this fixes an inconsistency with the selected filter:
>"selected" isn't really an aspect of the object (its a state) so the filter is not 100% appropriate.

This work is not behind any feature flag.

![image](https://user-images.githubusercontent.com/761923/112905671-c8ab8c00-90b8-11eb-9574-3ae8bd2f01e3.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>