### PR TITLE
Visibility prop of delete button in filter chips

### DIFF
--- a/packages/components/src/FilterChips/FilterChips.js
+++ b/packages/components/src/FilterChips/FilterChips.js
@@ -4,7 +4,7 @@ import { Badge, Chip, ChipGroup, Button } from '@patternfly/react-core';
 import classNames from 'classnames';
 import './filter-chips.scss';
 
-const FilterChips = ({ className, filters, onDelete, deleteTitle, onDeleteGroup }) => {
+const FilterChips = ({ className, filters, onDelete, deleteTitle, showDeleteButton, onDeleteGroup }) => {
     const groups = filters.filter(group => group.category);
     const groupedFilters = groups.map((group, groupKey) =>  (
         <ChipGroup
@@ -50,7 +50,8 @@ const FilterChips = ({ className, filters, onDelete, deleteTitle, onDeleteGroup 
                     </Chip>
                 </ChipGroup>
             )) }
-            { filters.length > 0 && <Button variant="link" onClick={ (event) => onDelete(event, filters, true) }>{deleteTitle}</Button> }
+            { (showDeleteButton === true || (showDeleteButton === undefined && filters.length > 0)) &&
+                <Button variant="link" onClick={ (event) => onDelete(event, filters, true) }>{deleteTitle}</Button> }
         </span>
     );
 };
@@ -78,7 +79,8 @@ FilterChips.propTypes = {
     ),
     onDelete: PropTypes.func,
     onDeleteGroup: PropTypes.func,
-    deleteTitle: PropTypes.node
+    deleteTitle: PropTypes.node,
+    showDeleteButton: PropTypes.bool
 };
 
 FilterChips.defaultProps = {

--- a/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
@@ -128,7 +128,7 @@ class PrimaryToolbar extends Component {
                         <ToolbarContent>
                             <ToolbarItem>{activeFiltersConfig}</ToolbarItem>
                         </ToolbarContent>
-                        : activeFiltersConfig !== undefined && activeFiltersConfig.filters.length > 0 &&
+                        : activeFiltersConfig !== undefined && (activeFiltersConfig.filters.length > 0 || activeFiltersConfig.showDeleteButton === true) &&
                         <ToolbarContent>
                             <ToolbarItem><FilterChips {...activeFiltersConfig} /></ToolbarItem>
                         </ToolbarContent>


### PR DESCRIPTION
This change is backwards compatible.
Added `showDeleteButton` prop, which is necessary for [reset filters functionality](https://issues.redhat.com/browse/VULN-1512) in case no filters applied is not the default state.

Example in Vulnerability -- default filter state is `{ systemsExposed: '1 or more' }` so delete (reset) button is shown only if chips are not in a default state
![resetFilters](https://user-images.githubusercontent.com/8426204/113296605-f9c6cf00-92f9-11eb-8f45-5ee3266e7ea7.gif)
