### PR TITLE
Use relative PF import in inventory list

### DIFF
--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import InventoryEntityTable from './EntityTable';
-import { Grid, GridItem } from '@patternfly/react-core/dist/js/layouts/Grid';
+import { Grid, GridItem } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import './InventoryList.scss';
 import { loadSystems } from '../../shared';


### PR DESCRIPTION
This absolute import path was corrupting the imported Grid styles module in the vulnerabilities app (possibly others?). After subsequent imports, the module had a double nested structure like this:
```
{
  default: {
    default: {
      __esModule: true,
      ...actualModule
    }
  }
}
```
JS expects only the second object

That obviously caused runtime crashes. I don't know why. The error was occurring only in the vulnerabilities application. Using relative import fixed the issue locally. It was only reproducible with running local chrome after prod build and installing dependencies with `npm ci` and running vulnerabilities app in prod mode.

We will have to update the dependency version in Chrome to see if it fixes the issue while deployed.

cc @katerinapat