### PR TITLE
Fix InventoryList prop typo s/guttter/gutter/

### DIFF
--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -60,7 +60,7 @@ class ContextInventoryList extends Component {
     render() {
         const { showHealth, ...props } = this.props;
         return (
-            <Grid guttter="sm" className="ins-inventory-list">
+            <Grid gutter="sm" className="ins-inventory-list">
                 <GridItem span={ 12 }>
                     <InventoryEntityTable { ...props } />
                 </GridItem>

--- a/packages/inventory/src/components/table/__snapshots__/InventoryList.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryList.test.js.snap
@@ -46,7 +46,7 @@ exports[`InventoryList should render correctly - with no access 1`] = `
 exports[`InventoryList should render correctly 1`] = `
 <div
   class="pf-l-grid ins-inventory-list"
-  guttter="sm"
+  gutter="sm"
 >
   <div
     class="pf-l-grid__item pf-m-12-col"


### PR DESCRIPTION
https://www.patternfly.org/2020.04/documentation/react/layouts/grid#props

This doesn't appear to change anything with the way the table looks; perhaps there's some css workaround somewhere?

Signed-off-by: Andrew Kofink <akofink@redhat.com>