### PR TITLE
Add support for PF expand all

### DIFF
--- a/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
@@ -1,4 +1,5 @@
-import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, Pagination } from '@patternfly/react-core';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, Pagination, Button, ToolbarExpandIconWrapper } from '@patternfly/react-core';
+import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import React, { Component } from 'react';
 
 import Actions from './Actions';
@@ -26,6 +27,7 @@ class PrimaryToolbar extends Component {
             activeFiltersConfig,
             children,
             exportConfig,
+            expandAll,
             ...props
         } = this.props;
         const overflowActions = [
@@ -53,11 +55,33 @@ class PrimaryToolbar extends Component {
             >
                 <ToolbarContent>
                     {
-                        (bulkSelect || filterConfig || dedicatedAction) &&
+                        (expandAll || bulkSelect || filterConfig || dedicatedAction) &&
                         <ToolbarGroup
                             className="ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
                             variant="filter-group"
                         >
+                            {
+                                expandAll &&
+                                <ToolbarItem>
+                                    {
+                                        React.isValidElement(expandAll) ? expandAll : (
+                                            expandAll.isAllExpanded ? (
+                                                <Button variant="plain" aria-label="Collapse all" onClick={() => expandAll.onClick(false)}>
+                                                    <ToolbarExpandIconWrapper>
+                                                        <AngleDownIcon />
+                                                    </ToolbarExpandIconWrapper>
+                                                </Button>
+                                            ) : (
+                                                <Button variant="plain" aria-label="Expand all" onClick={() => expandAll.onClick(true)}>
+                                                    <ToolbarExpandIconWrapper>
+                                                        <AngleRightIcon />
+                                                    </ToolbarExpandIconWrapper>
+                                                </Button>
+                                            )
+                                        )
+                                    }
+                                </ToolbarItem>
+                            }
                             {
                                 bulkSelect &&
                                 <ToolbarItem>
@@ -160,7 +184,14 @@ PrimaryToolbar.propTypes = {
         actions: Actions.propTypes.actions,
         dropdownProps: Actions.propTypes.dropdownProps,
         onSelect: Actions.propTypes.onSelect
-    })
+    }),
+    expandAll: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.shape({
+            onClick: PropTypes.func,
+            isAllExpanded: PropTypes.bool
+        })
+    ])
 };
 
 PrimaryToolbar.defaultProps = {

--- a/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
@@ -65,15 +65,15 @@ class PrimaryToolbar extends Component {
                                 <ToolbarItem>
                                     {
                                         React.isValidElement(expandAll) ? expandAll : (
-                                              <Button
+                                            <Button
                                                 variant="plain"
                                                 aria-label={`${expandAll.isAllExpanded ? 'Collapse' : 'Expand'} all`}
                                                 onClick={(e) => expandAll.onClick(e, !expandAll.isAllExpanded)}
-                                              >
-                                                  <ToolbarExpandIconWrapper>
-                                                      {expandAll.isAllExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
-                                                  </ToolbarExpandIconWrapper>
-                                              </Button>
+                                            >
+                                                <ToolbarExpandIconWrapper>
+                                                    {expandAll.isAllExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
+                                                </ToolbarExpandIconWrapper>
+                                            </Button>
                                         )
                                     }
                                 </ToolbarItem>

--- a/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
+++ b/packages/components/src/PrimaryToolbar/PrimaryToolbar.js
@@ -65,19 +65,15 @@ class PrimaryToolbar extends Component {
                                 <ToolbarItem>
                                     {
                                         React.isValidElement(expandAll) ? expandAll : (
-                                            expandAll.isAllExpanded ? (
-                                                <Button variant="plain" aria-label="Collapse all" onClick={() => expandAll.onClick(false)}>
-                                                    <ToolbarExpandIconWrapper>
-                                                        <AngleDownIcon />
-                                                    </ToolbarExpandIconWrapper>
-                                                </Button>
-                                            ) : (
-                                                <Button variant="plain" aria-label="Expand all" onClick={() => expandAll.onClick(true)}>
-                                                    <ToolbarExpandIconWrapper>
-                                                        <AngleRightIcon />
-                                                    </ToolbarExpandIconWrapper>
-                                                </Button>
-                                            )
+                                              <Button
+                                                variant="plain"
+                                                aria-label={`${expandAll.isAllExpanded ? 'Collapse' : 'Expand'} all`}
+                                                onClick={(e) => expandAll.onClick(e, !expandAll.isAllExpanded)}
+                                              >
+                                                  <ToolbarExpandIconWrapper>
+                                                      {expandAll.isAllExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
+                                                  </ToolbarExpandIconWrapper>
+                                              </Button>
                                         )
                                     }
                                 </ToolbarItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/VULN-1551
https://www.patternfly.org/v4/components/table/react-demos/expandcollapse-all/

Example usage:
```
<PrimaryToolbar
...
expandAll = {isAllExpanded ? (
      <Button variant="plain" aria-label="Collapse all" onClick={collapseAll}>
          <ToolbarExpandIconWrapper>
              <AngleDownIcon />
          </ToolbarExpandIconWrapper>
      </Button>
  ) : (
      <Button variant="plain" aria-label="Expand all" onClick={expandAll}>
          <ToolbarExpandIconWrapper>
              <AngleRightIcon />
          </ToolbarExpandIconWrapper>
      </Button>
  )}
...
/>
```

![1](https://user-images.githubusercontent.com/8426204/114864150-f26eed80-9df0-11eb-81f5-9fe3a2e6841b.png)
![2](https://user-images.githubusercontent.com/8426204/114864140-f0a52a00-9df0-11eb-964b-86c0ebf48194.png)