### PR TITLE
Handle duplicate IDs in issue resolution step

### DIFF
--- a/packages/remediations/src/RemediationWizard/RemediationWizard.js
+++ b/packages/remediations/src/RemediationWizard/RemediationWizard.js
@@ -86,8 +86,7 @@ const RemediationWizard = ({
             issues: data.issues
         },
         'issue-resolution': {
-            component: IssueResolution,
-            systems: data.systems
+            component: IssueResolution
         },
         review: {
             component: Review,

--- a/packages/remediations/src/steps/issueResolution.js
+++ b/packages/remediations/src/steps/issueResolution.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { Fragment } from 'react';
 import propTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
 import './issueResolution.scss';
@@ -8,22 +8,25 @@ import {
     Stack,
     StackItem,
     Tile,
-    Title
+    Title,
+    Alert,
+    Popover,
+    Button
 } from '@patternfly/react-core';
-import { RESOLUTIONS, SELECTED_RESOLUTIONS } from '../utils';
+import { pluralize, RESOLUTIONS, SELECTED_RESOLUTIONS, SYSTEMS } from '../utils';
 import { RedoIcon, CloseIcon } from '@patternfly/react-icons';
+import uniqBy from 'lodash/uniqBy';
+import differenceWith from 'lodash/differenceWith';
+import isEqual from 'lodash/isEqual';
 
-const IssueResolution = (props) => {
-    const { systems, issue } = props;
+const IssueResolution = ({ issue }) => {
     const formOptions = useFormApi();
     const resolutions = formOptions.getState().values[RESOLUTIONS];
-    const [ issueResolutions, setIssueResolutions ] = useState([]);
+    const systems = formOptions.getState().values[SYSTEMS];
 
-    useEffect(() => {
-        setIssueResolutions(resolutions.find(r => r.id === issue.id)?.resolutions || []);
-    }, []);
-
-    const pluralize = (count, str) => count > 1 ? str + 's' : str;
+    const issueResolutions = resolutions.find(r => r.id === issue.id)?.resolutions || [];
+    const uniqueResolutions = uniqBy(issueResolutions, 'id');
+    const removedResolutions = differenceWith(issueResolutions, uniqueResolutions, isEqual);
 
     return (
         <Stack hasGutter>
@@ -33,6 +36,20 @@ const IssueResolution = (props) => {
                 </Title>
             </StackItem>
             <StackItem>
+                {removedResolutions.length > 0 && (
+                    <StackItem className="pf-u-mb-sm">
+                        <Alert variant="warning" isInline title={
+                            <Text>
+                                There {pluralize(removedResolutions.length, 'was', 'were')} <Popover
+                                    aria-label="Resolution duplicates popover"
+                                    bodyContent={<Fragment>
+                                        {removedResolutions.map((resolution, key) => <div key={key}>{resolution.description}</div>)}
+                                    </Fragment>}
+                                >
+                                    <b><Button variant="link" isInline>{removedResolutions.length}</Button> {pluralize(removedResolutions.length, 'resolution')}</b>
+                                </Popover> removed due to duplication</Text>} />
+                    </StackItem>
+                )}
                 <TextContent>
                     <Text>
                         Review the possible resolution steps and select which to add to your playbook.
@@ -48,7 +65,7 @@ const IssueResolution = (props) => {
             <StackItem>
                 <div className="ins-c-resolution-container">
                     {
-                        issueResolutions.map((resolution, index) => (
+                        uniqueResolutions.map((resolution, index) => (
                             <div
                                 className="ins-c-resolution-option"
                                 sm={12}
@@ -93,7 +110,6 @@ const IssueResolution = (props) => {
 };
 
 IssueResolution.propTypes = {
-    systems: propTypes.arrayOf(propTypes.string).isRequired,
     issue: propTypes.shape({
         id: propTypes.string,
         shortId: propTypes.string,

--- a/packages/remediations/src/steps/reviewActions.js
+++ b/packages/remediations/src/steps/reviewActions.js
@@ -52,10 +52,10 @@ const ReviewActions = (props) => {
                     isChecked={input.value}
                     onChange={() => input.onChange(true)}
                 />
-                <Text className="ins-c-remediations-choose-actions-description">
+                {issues.length - rows.length > 0 && <Text className="ins-c-remediations-choose-actions-description">
                     {`The ${issues.length - rows.length} other selected ${pluralize(issues.length - rows.length, 'issue')} 
                     ${issues.length - rows.length > 1 ? 'do' : 'does'} not have multiple resolution options.`}
-                </Text>
+                </Text>}
             </StackItem>
             <Table
                 aria-label='Actions'

--- a/packages/remediations/src/tests/steps/issueResolution.test.js
+++ b/packages/remediations/src/tests/steps/issueResolution.test.js
@@ -5,7 +5,7 @@ import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/esm/form-
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import IssueResolution from '../../steps/issueResolution';
-import { RESOLUTIONS, SELECTED_RESOLUTIONS } from '../../utils';
+import { RESOLUTIONS, SELECTED_RESOLUTIONS, SYSTEMS } from '../../utils';
 import { Tile } from '@patternfly/react-core';
 import { remediationWizardTestData } from '../testData';
 
@@ -16,15 +16,15 @@ const RendererWrapper = (props) => (
         componentMapper={{
             'issue-resolution': {
                 component: IssueResolution,
-                issues: remediationWizardTestData.issues,
-                systems: remediationWizardTestData.systems
+                issues: remediationWizardTestData.issues
             }
         }}
         initialValues={{
             [SELECTED_RESOLUTIONS]: {
                 testId: 'test2'
             },
-            [RESOLUTIONS]: remediationWizardTestData.resolutions
+            [RESOLUTIONS]: remediationWizardTestData.resolutions,
+            [SYSTEMS]: remediationWizardTestData.systems
         }}
         schema={{ fields: [] }}
         {...props}

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -39,7 +39,7 @@ export function remediationUrl (id) {
 
 export const dedupeArray = (array) => [ ...new Set(array) ];
 
-export const pluralize = (count, str, fallback) => count > 1 ? (fallback || str + 's') : str;
+export const pluralize = (count, str, fallback) => count !== 1 ? (fallback || str + 's') : str;
 
 const sortRecords = (records, sortByState) => records.sort(
     (a, b) => {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-13743

- This fixes the inability to select a resolution in case of two resolutions with the same ID occurring.
- Also fixed `pluralize` utils function for cases when count is 0 and hidden message about other issues in `reviewActions` if there are no other issues.
- Updated tests.

![duplicates1](https://user-images.githubusercontent.com/50696716/115551012-cb119800-a2aa-11eb-8b67-d3946e399b16.png)
![duplicates2](https://user-images.githubusercontent.com/50696716/115551015-cbaa2e80-a2aa-11eb-8401-e0d4d737520a.png)
