### PR TITLE
Transform jwt cookie to x-hr-identity header

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -16,6 +16,7 @@
       - [Multiple HTML entrypoints](#multiple-html-entrypoints)
       - [Exact URL](#exact-url)
     - [cookieTransform](#cookietransform)
+      - [custom entitlements](#custom-entitlements)
 
 ## Webpack 5
 
@@ -234,4 +235,12 @@ onProxyReq: (...args) => {
 },
 ```
 
-Routes passed via `routes` or `routesFile` attribute are using this transform automatically.
+Routes passed via `routes` or `routesFile` attributes are using this transform automatically. If you override the `onProxyReq` function, you have to add it back manually.
+
+#### custom entitlements
+
+By default, the same entitlements as in insights-proxy are provided. You can rewrite them via the options object:
+
+```jsx
+cookieTransform(proxyReq, req, res, { entitlements });
+```

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -244,3 +244,9 @@ By default, the same entitlements as in insights-proxy are provided. You can rew
 ```jsx
 cookieTransform(proxyReq, req, res, { entitlements });
 ```
+
+You can also modify the whole identity object:
+
+```jsx
+cookieTransform(proxyReq, req, res, { entitlements, identity, user, internal });
+```

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -11,10 +11,11 @@
       - [routes](#routes)
       - [routesPath](#routespath)
     - [Custom proxy settings](#custom-proxy-settings)
-    - [Chrome 1 environments](#chrome-1-environments)
+    - [Chrome 1 environments / application entry url](#chrome-1-environments--application-entry-url)
       - [Prod environment example](#prod-environment-example)
       - [Multiple HTML entrypoints](#multiple-html-entrypoints)
       - [Exact URL](#exact-url)
+    - [cookieTransform](#cookietransform)
 
 ## Webpack 5
 
@@ -148,7 +149,7 @@ const { config: webpackConfig, plugins } = config({
 
 This configuration will redirect all API requests to QA environment, so you can check CI UI with QA data.
 
-### Chrome 1 environments
+### Chrome 1 environments / application entry url
 
 To run your application in Chrome 1 environment, just add `appUrl` that contains entry url for your application.
 
@@ -220,3 +221,17 @@ const { config: webpackConfig, plugins } = config({
 `redhat.com/beta/app` won`t be redirect to any of your local files
 
 In both cases queries and hashes are ignored.
+
+### cookieTransform
+
+For running local services you can use `cookieTransform` ([original function](https://github.com/RedHatInsights/insights-standalone/blob/1eef6cfc21f96304275683d090c6b8178a4d386f/index.js#L8), you can also check [insights-proxy implementation](https://github.com/RedHatInsights/insights-proxy/blob/1cdbc597681eac51998d8c2dd2dd6b5a2d4d03d6/spandx.config.js#L101)) in `onProxyReq` function. This function transform `jwt` cookie to `x-hr-identity` header.
+
+```jsx
+const cookieTransform = require('@redhat-cloud-services/frontend-components-config/src/cookieTransform');
+
+onProxyReq: (...args) => {
+    cookieTransform(...args);
+},
+```
+
+Routes passed via `routes` or `routesFile` attribute are using this transform automatically.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,6 +27,7 @@
         "git-revision-webpack-plugin": "^3.0.6",
         "html-replace-webpack-plugin": "^2.6.0",
         "html-webpack-plugin": "^5.1.0",
+        "jws": "^4.0.0",
         "koa-connect": "^2.1.0",
         "mini-css-extract-plugin": "^1.3.1",
         "node-sass": "^5.0.0",

--- a/packages/config/src/cookieTransform.js
+++ b/packages/config/src/cookieTransform.js
@@ -11,7 +11,7 @@ const defaultEntitlements = {
     ansible: { is_entitled: true }
 };
 
-function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlements }) {
+function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlements, user, internal, identity: customIdentity }) {
     const cookie = req.headers.cookie;
     const match = cookie && cookie.match(/cs_jwt=([^;]+);/);
     if (match) {
@@ -24,6 +24,7 @@ function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlemen
                 type: 'User',
                 auth_type: 'basic-auth',
                 account_number: payload.account_number + '',
+                ...customIdentity,
                 user: {
                     username: payload.username,
                     email: payload.email,
@@ -33,11 +34,13 @@ function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlemen
                     is_org_admin: payload.is_org_admin,
                     is_internal: payload.is_internal,
                     locale: 'en-US',
-                    user_id: payload.account_id
+                    user_id: payload.account_id,
+                    ...user
                 },
                 internal: {
                     org_id: payload.org_id,
-                    auth_time: payload.auth_time
+                    auth_time: payload.auth_time,
+                    ...internal
                 }
             }
         };

--- a/packages/config/src/cookieTransform.js
+++ b/packages/config/src/cookieTransform.js
@@ -1,0 +1,46 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-console */
+const jws = require('jws');
+
+function cookieTransform(proxyReq, req) {
+    const cookie = req.headers.cookie;
+    const match = cookie && cookie.match(/cs_jwt=([^;]+);/);
+    if (match) {
+        const cs_jwt = match[1];
+        const { payload } = jws.decode(cs_jwt);
+        const identity = {
+            entitlements: {
+                insights: { is_entitled: true },
+                smart_management: { is_entitled: true },
+                openshift: { is_entitled: true },
+                hybrid: { is_entitled: true },
+                migrations: { is_entitled: true },
+                ansible: { is_entitled: true }
+            },
+            identity: {
+                type: 'User',
+                auth_type: 'basic-auth',
+                account_number: payload.account_number + '',
+                user: {
+                    username: payload.username,
+                    email: payload.email,
+                    first_name: payload.first_name,
+                    last_name: payload.last_name,
+                    is_active: true,
+                    is_org_admin: payload.is_org_admin,
+                    is_internal: payload.is_internal,
+                    locale: 'en-US',
+                    user_id: payload.account_id
+                },
+                internal: {
+                    org_id: payload.org_id,
+                    auth_time: payload.auth_time
+                }
+            }
+        };
+        const identityB64 = Buffer.from(JSON.stringify(identity), 'utf8').toString('base64');
+        proxyReq.setHeader('x-rh-identity', identityB64);
+    }
+}
+
+module.exports = cookieTransform;

--- a/packages/config/src/cookieTransform.js
+++ b/packages/config/src/cookieTransform.js
@@ -2,21 +2,24 @@
 /* eslint-disable no-console */
 const jws = require('jws');
 
-function cookieTransform(proxyReq, req) {
+const defaultEntitlements = {
+    insights: { is_entitled: true },
+    smart_management: { is_entitled: true },
+    openshift: { is_entitled: true },
+    hybrid: { is_entitled: true },
+    migrations: { is_entitled: true },
+    ansible: { is_entitled: true }
+};
+
+function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlements }) {
     const cookie = req.headers.cookie;
     const match = cookie && cookie.match(/cs_jwt=([^;]+);/);
     if (match) {
         const cs_jwt = match[1];
         const { payload } = jws.decode(cs_jwt);
+
         const identity = {
-            entitlements: {
-                insights: { is_entitled: true },
-                smart_management: { is_entitled: true },
-                openshift: { is_entitled: true },
-                hybrid: { is_entitled: true },
-                migrations: { is_entitled: true },
-                ansible: { is_entitled: true }
-            },
+            entitlements,
             identity: {
                 type: 'User',
                 auth_type: 'basic-auth',

--- a/packages/config/src/proxy.js
+++ b/packages/config/src/proxy.js
@@ -2,6 +2,7 @@
 const { readFileSync } = require('fs');
 const { sync } = require('glob');
 const ESI = require('nodesi');
+const cookieTransform = require('./cookieTransform');
 
 function createInsightsProxy({
     betaEnv,
@@ -165,6 +166,9 @@ function createInsightsProxy({
                     changeOrigin: true,
                     autoRewrite: true,
                     ws: true,
+                    onProxyReq: (...args) => {
+                        cookieTransform(...args);
+                    },
                     ...typeof redirect === 'object' ? redirect : {}
                 };
             }) : [],


### PR DESCRIPTION
### cookieTransform
For running local services you can use `cookieTransform` ([original function](https://github.com/RedHatInsights/insights-standalone/blob/1eef6cfc21f96304275683d090c6b8178a4d386f/index.js#L8), you can also check [insights-proxy implementation](https://github.com/RedHatInsights/insights-proxy/blob/1cdbc597681eac51998d8c2dd2dd6b5a2d4d03d6/spandx.config.js#L101)) in `onProxyReq` function. This function transform `jwt` cookie to `x-hr-identity` header.
```jsx
const cookieTransform = require('@redhat-cloud-services/frontend-components-config/src/cookieTransform');
onProxyReq: (...args) => {
    cookieTransform(...args);
},
```

Routes passed via `routes` or `routesFile` attributes are using this transform automatically. If you override the `onProxyReq` function, you have to add it back manually.

#### custom entitlements

By default, the same entitlements as in insights-proxy are provided. You can rewrite them via the options object:

```jsx
cookieTransform(proxyReq, req, res, { entitlements });
```

You can also modify the whole identity object:

```jsx
cookieTransform(proxyReq, req, res, { entitlements, identity, user, internal });
```