### PR TITLE
Remove button focus outline none

### DIFF
--- a/packages/utils/src/styles/_helpers.scss
+++ b/packages/utils/src/styles/_helpers.scss
@@ -1,3 +1,0 @@
-button:focus {
-    outline:none;
-}


### PR DESCRIPTION
### No focus on buttons

PF raised a bug that some of our buttons had no outline set-up. This was caused by setting outline to none for all buttons, if the outline set by PF was not strong enough it wouldn't override this rule and no outline was visible. This PR fixes such issue by removing our custom button focus outline.