### PR TITLE
Fix immutable error on sort in Remediations wizard

### DIFF
--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -41,7 +41,7 @@ export const dedupeArray = (array) => [ ...new Set(array) ];
 
 export const pluralize = (count, str, fallback) => count !== 1 ? (fallback || str + 's') : str;
 
-const sortRecords = (records, sortByState) => records.sort(
+const sortRecords = (records, sortByState) => [ ...records ].sort(
     (a, b) => {
         const key = Object.keys(a)[sortByState.index];
         return (


### PR DESCRIPTION
This should fix
`The sort method cannot be invoked on an Immutable data structure.`
error in Remediations wizard.

@karelhala 