### PR TITLE
fix(RulesTable): Fix Ansible sorting with variable columns

### DIFF
--- a/packages/inventory-compliance/src/SystemRulesTable/SystemRulesTable.js
+++ b/packages/inventory-compliance/src/SystemRulesTable/SystemRulesTable.js
@@ -20,8 +20,12 @@ export const columns = [
     { title: 'Policy', transforms: [ sortable ] },
     { title: 'Severity', transforms: [ sortable, fitContent ] },
     { title: 'Passed', transforms: [ sortable, fitContent ] },
-    { title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>,
-        original: 'Ansible', props: { tooltip: 'Ansible' }, transforms: [ sortable, fitContent ] }
+    {
+        title: <React.Fragment><AnsibeTowerIcon /> Ansible</React.Fragment>,
+        original: 'Ansible',
+        props: { tooltip: 'Ansible', property: 'ansible' },
+        transforms: [ sortable, fitContent ]
+    }
 ];
 
 export const selectColumns = (columnTitles) => (
@@ -134,7 +138,7 @@ class SystemRulesTable extends React.Component {
             sortBy: {
                 index,
                 direction,
-                property: extraData.property
+                property: extraData?.column?.props?.property || extraData?.property
             }
         })
     )

--- a/packages/inventory-compliance/src/SystemRulesTable/__snapshots__/SystemRulesTable.test.js.snap
+++ b/packages/inventory-compliance/src/SystemRulesTable/__snapshots__/SystemRulesTable.test.js.snap
@@ -242,6 +242,7 @@ exports[`SystemRulesTable component should render 1`] = `
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -1144,6 +1145,7 @@ exports[`SystemRulesTable component should render a loading table 1`] = `
       Object {
         "original": "Ansible",
         "props": Object {
+          "property": "ansible",
           "tooltip": "Ansible",
         },
         "title": <React.Fragment>
@@ -1409,6 +1411,7 @@ exports[`SystemRulesTable component should render additional toolbar items 1`] =
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -2559,6 +2562,7 @@ exports[`SystemRulesTable component should render filtered and search mixed resu
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -2947,6 +2951,7 @@ exports[`SystemRulesTable component should render search results by rule name 1`
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -3389,6 +3394,7 @@ exports[`SystemRulesTable component should render search results on any page, re
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -3822,6 +3828,7 @@ exports[`SystemRulesTable component should render sorted rows 1`] = `
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -4933,6 +4940,7 @@ exports[`SystemRulesTable component should render sorted rows 2`] = `
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>
@@ -5974,6 +5982,7 @@ exports[`SystemRulesTable component should render without remediations if prop p
         Object {
           "original": "Ansible",
           "props": Object {
+            "property": "ansible",
             "tooltip": "Ansible",
           },
           "title": <React.Fragment>

--- a/packages/inventory-compliance/src/Utilities/Helpers.js
+++ b/packages/inventory-compliance/src/Utilities/Helpers.js
@@ -12,7 +12,7 @@ export const getSortable = (property, rule) => {
             return rule.severity;
         case 'passed':
             return rule.compliant;
-        case 'column-6':
+        case 'ansible':
             return rule.remediationAvailable;
         default:
             return rule.title;


### PR DESCRIPTION
The `property` property comes from PatternFly, which, due to the title being a React node, uses just `column-INDEX` for it.
Since the columns can be different the index of the column can vary, this works around the issue und fixes sorting for the Ansible column in rules tables.