### PR TITLE
Convert pagination to functional component

### DIFF
--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -60,6 +60,7 @@ const EntityTableToolbar = ({
     bulkSelect,
     getEntities,
     hideFilters,
+    paginationProps,
     ...props
 }) => {
     const dispatch = useDispatch();
@@ -337,7 +338,8 @@ const EntityTableToolbar = ({
                 isDisabled: !hasAccess,
                 perPage,
                 onSetPage: (_e, newPage) => updateData({ page: newPage, per_page: perPage, filters }),
-                onPerPageSelect: (_e, newPerPage) => updateData({ page: 1, per_page: newPerPage, filters })
+                onPerPageSelect: (_e, newPerPage) => updateData({ page: 1, per_page: newPerPage, filters }),
+                ...paginationProps
             } : <Skeleton size={SkeletonSize.lg} />}
         >
             { children }
@@ -382,7 +384,8 @@ EntityTableToolbar.propTypes = {
         name: PropTypes.bool,
         registeredWith: PropTypes.bool,
         stale: PropTypes.bool
-    })
+    }),
+    paginationProps: PropTypes.object
 };
 
 EntityTableToolbar.defaultProps = {

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -29,6 +29,7 @@ const InventoryTable = forwardRef(({
     isFullView = false,
     getEntities,
     hideFilters,
+    paginationProps,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
@@ -80,6 +81,7 @@ const InventoryTable = forwardRef(({
                     getEntities={ getEntities }
                     sortBy={ sortBy }
                     hideFilters={hideFilters}
+                    paginationProps={paginationProps}
                 >
                     { children }
                 </EntityTableToolbar>
@@ -113,6 +115,7 @@ const InventoryTable = forwardRef(({
                         getEntities={ getEntities }
                         sortBy={ sortBy }
                         hideFilters={ hideFilters }
+                        paginationProps={paginationProps}
                     />
                 </TableToolbar>
             </Fragment>

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -24,7 +24,8 @@ const FooterPagination = ({
     customFilters,
     hideFilters,
     showTags,
-    getEntities
+    getEntities,
+    paginationProps
 }) => {
     const dispatch = useDispatch();
     const loaded = useSelector(store => store?.entities?.loaded);
@@ -97,6 +98,7 @@ const FooterPagination = ({
             dropDirection={ direction }
             onSetPage={ onSetPage }
             onPerPageSelect={ onPerPageSelect }
+            {...paginationProps}
         />
     ) : null;
 };
@@ -121,7 +123,8 @@ FooterPagination.propTypes = {
         name: PropTypes.bool,
         registeredWith: PropTypes.bool,
         stale: PropTypes.bool
-    })
+    }),
+    paginationProps: PropTypes.object
 };
 
 FooterPagination.defaultProps = {

--- a/packages/inventory/src/components/table/Pagination.test.js
+++ b/packages/inventory/src/components/table/Pagination.test.js
@@ -5,11 +5,17 @@ import { render, mount } from 'enzyme';
 import configureStore from 'redux-mock-store';
 import promiseMiddleware from 'redux-promise-middleware';
 import toJson from 'enzyme-to-json';
+import { Provider } from 'react-redux';
+
 import { mock } from '../../__mock__/hostApi';
 
 describe('Pagination', () => {
     let initialState;
     let mockStore;
+
+    const WrappedPagination = ({ store, ...props }) => <Provider store={store}>
+        <Pagination {...props}/>
+    </Provider>;
 
     beforeEach(() => {
         mockStore = configureStore([ promiseMiddleware() ]);
@@ -24,40 +30,40 @@ describe('Pagination', () => {
     describe('render', () => {
         it('should render correctly - no data', () => {
             const store = mockStore({ entities: {} });
-            const wrapper = render(<Pagination store={ store } />);
+            const wrapper = render(<WrappedPagination store={ store } />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
         it('should render correctly with data', () => {
             const store = mockStore(initialState);
-            const wrapper = render(<Pagination store={ store } />);
+            const wrapper = render(<WrappedPagination store={ store } />);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('button[disabled=""]').length).toBe(5);
         });
 
         it('should render correctly - with no access', () => {
             const store = mockStore(initialState);
-            const wrapper = render(<Pagination store={ store } hasAccess={false} />);
+            const wrapper = render(<WrappedPagination store={ store } hasAccess={false} />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
         it('should render correctly with data and props', () => {
             const store = mockStore(initialState);
-            const wrapper = render(<Pagination store={ store } page={1} perPage={50} total={500} />);
+            const wrapper = render(<WrappedPagination store={ store } page={1} perPage={50} total={500} />);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('button[disabled=""]').length).toBe(2);
         });
 
         it('should render correctly with data and isFull', () => {
             const store = mockStore(initialState);
-            const wrapper = render(<Pagination store={ store } page={1} perPage={50} total={500} isFull />);
+            const wrapper = render(<WrappedPagination store={ store } page={1} perPage={50} total={500} isFull />);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('button[disabled=""]').length).toBe(2);
         });
 
         it('should render correctly with hasItems and isLoaded false', () => {
             const store = mockStore(initialState);
-            const wrapper = render(<Pagination store={ store } hasItems isLoaded={false} />);
+            const wrapper = render(<WrappedPagination store={ store } hasItems isLoaded={false} />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
     });
@@ -66,12 +72,11 @@ describe('Pagination', () => {
         it('should call perPage change without onRefresh', () => {
             mock.onGet('/api/inventory/v1/hosts').reply(200, {});
             const store = mockStore(initialState);
-            const wrapper = mount(<Pagination store={ store } page={1} perPage={50} total={500} />);
+            const wrapper = mount(<WrappedPagination store={ store } page={1} perPage={50} total={500} />);
             wrapper.find('.pf-c-options-menu__toggle button').first().simulate('click');
             wrapper.update();
             wrapper.find('ul.pf-c-options-menu__menu li button').first().simulate('click');
             const actions = store.getActions();
-            expect(wrapper.find('FooterPagination').instance().state).toMatchObject({ page: 1 });
             expect(actions[0].meta).toMatchObject({ showTags: undefined });
             expect(actions[0].type).toBe('LOAD_ENTITIES_PENDING');
         });
@@ -79,7 +84,7 @@ describe('Pagination', () => {
         it('should call perPage change with onRefresh', () => {
             const onRefresh = jest.fn();
             const store = mockStore(initialState);
-            const wrapper = mount(<Pagination store={ store } page={1} perPage={50} total={500} onRefresh={onRefresh} />);
+            const wrapper = mount(<WrappedPagination store={ store } page={1} perPage={50} total={500} onRefresh={onRefresh} />);
             wrapper.find('.pf-c-options-menu__toggle button').first().simulate('click');
             wrapper.update();
             wrapper.find('ul.pf-c-options-menu__menu li button').first().simulate('click');
@@ -94,11 +99,10 @@ describe('Pagination', () => {
         it('should call onSetPage change without onRefresh - button', () => {
             mock.onGet('/api/inventory/v1/hosts').reply(200, {});
             const store = mockStore(initialState);
-            const wrapper = mount(<Pagination store={ store } page={1} perPage={50} total={500} />);
+            const wrapper = mount(<WrappedPagination store={ store } page={1} perPage={50} total={500} />);
             wrapper.find('.pf-c-pagination__nav-control button[data-action="next"]').first().simulate('click');
             wrapper.update();
             const actions = store.getActions();
-            expect(wrapper.find('FooterPagination').instance().state).toMatchObject({ page: undefined });
             expect(actions[0].meta).toMatchObject({ showTags: undefined });
             expect(actions[0].type).toBe('LOAD_ENTITIES_PENDING');
         });
@@ -106,7 +110,7 @@ describe('Pagination', () => {
         it('should call onSetPage change with onRefresh - button', () => {
             const onRefresh = jest.fn();
             const store = mockStore(initialState);
-            const wrapper = mount(<Pagination store={ store } page={1} perPage={50} total={500} onRefresh={onRefresh} />);
+            const wrapper = mount(<WrappedPagination store={ store } page={1} perPage={50} total={500} onRefresh={onRefresh} />);
             wrapper.find('.pf-c-pagination__nav-control button[data-action="next"]').first().simulate('click');
             wrapper.update();
             const actions = store.getActions();


### PR DESCRIPTION
- refactors pagination to functional component
- removed unnecessary debounce from it
- allows to pass `paginationProps` to add props to the pagination components