### PR TITLE
Allow passing custom props to BulkSelect items

### DIFF
--- a/packages/components/src/BulkSelect/BulkSelect.js
+++ b/packages/components/src/BulkSelect/BulkSelect.js
@@ -72,6 +72,7 @@ visible unless you update it.');
                             component="button"
                             key={ oneItem.key || key }
                             onClick={ (event) => oneItem.onClick && oneItem.onClick(event, oneItem, key) }
+                            { ...oneItem?.props }
                         >
                             { oneItem.title }
                         </DropdownItem>)

--- a/packages/components/src/BulkSelect/BulkSelect.test.js
+++ b/packages/components/src/BulkSelect/BulkSelect.test.js
@@ -40,6 +40,23 @@ describe('BulkSelect', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
+    it('should render custom props', () => {
+        const wrapper = shallow(<BulkSelect items={ [
+            {
+                title: 'Select none',
+                onClick: jest.fn(),
+                props: {
+                    isDisabled: true
+                }
+            },
+            {
+                title: 'Select all',
+                onClick: jest.fn()
+            }
+        ] } />);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
     describe('API', () => {
         it('should call on select with no items', () => {
             const onSelect = jest.fn();

--- a/packages/components/src/BulkSelect/__snapshots__/BulkSelect.test.js.snap
+++ b/packages/components/src/BulkSelect/__snapshots__/BulkSelect.test.js.snap
@@ -148,3 +148,53 @@ exports[`BulkSelect should render correctly 2`] = `
   />
 </Fragment>
 `;
+
+exports[`BulkSelect should render custom props 1`] = `
+<Fragment>
+  <Dropdown
+    className="ins-c-bulk-select"
+    dropdownItems={
+      Array [
+        <DropdownItem
+          component="button"
+          isDisabled={true}
+          onClick={[Function]}
+        >
+          Select none
+        </DropdownItem>,
+        <DropdownItem
+          component="button"
+          onClick={[Function]}
+        >
+          Select all
+        </DropdownItem>,
+      ]
+    }
+    isOpen={false}
+    onSelect={[Function]}
+    toggle={
+      <DropdownToggle
+        isDisabled={false}
+        onToggle={[Function]}
+        splitButtonItems={
+          Array [
+            <React.Fragment>
+              <DropdownToggleCheckbox
+                aria-label="Select all"
+                className=""
+                id="toggle-checkbox"
+                isChecked={false}
+                isDisabled={false}
+                isValid={true}
+                onChange={[Function]}
+              >
+                
+              </DropdownToggleCheckbox>
+            </React.Fragment>,
+          ]
+        }
+      />
+    }
+  />
+</Fragment>
+`;


### PR DESCRIPTION
This is just a nicety. When working on the BulkSelect integration for compliance (via https://github.com/RedHatInsights/frontend-components/pull/919) I thought it would be nice to be able and disable the "Select none" if none are selected, but there wasn't a way yet to pass in the necessary prop. 

![Screenshot 2021-04-28 at 05 15 57](https://user-images.githubusercontent.com/7757/116373584-c6e6fc80-a80d-11eb-9fb4-8325d6c19a8c.png)
