### PR TITLE
Remove abbreviations in Remediations wizard tables

### DIFF
--- a/packages/remediations/src/steps/review.js
+++ b/packages/remediations/src/steps/review.js
@@ -110,7 +110,7 @@ const Review = (props) => {
                 onSort={ (event, index, direction) => setSortByState({ index, direction }) }
                 sortBy={ sortByState }
             >
-                <TableHeader />
+                <TableHeader noWrap />
                 <TableBody />
             </Table>
         </Stack >

--- a/packages/remediations/src/steps/reviewActions.js
+++ b/packages/remediations/src/steps/reviewActions.js
@@ -80,7 +80,7 @@ const ReviewActions = (props) => {
                 onSort={ (event, index, direction) => setSortByState({ index, direction }) }
                 sortBy={ sortByState }
             >
-                <TableHeader />
+                <TableHeader noWrap />
                 <TableBody />
             </Table>
             <StackItem>

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -65,7 +65,7 @@ export const buildRows = (records, sortByState, showAlternate) => sortRecords(re
                 )}
         </Fragment>,
         {
-            title: record.needsReboot ? <Fragment><RedoIcon/>{' Yes'}</Fragment> : <Fragment><CloseIcon/>{' No'}</Fragment>,
+            title: record.needsReboot ? <div><RedoIcon className="pf-u-mr-sm"/>Yes</div> : <div><CloseIcon className="pf-u-mr-sm"/>No</div>,
             value: record.needsReboot
         },
         record.systemsCount


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-13916
- removed abbreviations in wizard table headers
- removed wrapping of reboot-required icon & text on small screens

![fixed-1](https://user-images.githubusercontent.com/50696716/116531388-6922e500-a8df-11eb-9648-3046db7f21b7.png)
![fixed-2](https://user-images.githubusercontent.com/50696716/116531396-6a541200-a8df-11eb-8d9b-52da1d335b8b.png)
