### PR TITLE
Refactor onRefreshData to be controlled from one place

### DIFF
--- a/packages/inventory/src/components/table/EntityTable.js
+++ b/packages/inventory/src/components/table/EntityTable.js
@@ -7,8 +7,7 @@ import {
     Table as PfTable,
     TableBody,
     TableHeader,
-    TableGridBreakpoint,
-    TableVariant
+    TableGridBreakpoint
 } from '@patternfly/react-table';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
 import NoSystemsTable from './NoSystemsTable';

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -1,10 +1,12 @@
+/* eslint-disable camelcase */
 import React, { Fragment, forwardRef } from 'react';
-import { useSelector, shallowEqual } from 'react-redux';
+import { useSelector, shallowEqual, useStore, useDispatch } from 'react-redux';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
 import InventoryList from './InventoryList';
 import Pagination from './Pagination';
 import AccessDenied from '../../shared/AccessDenied';
+import { loadSystems } from '../../shared';
 
 /**
  * This component is used to combine all essential components together:
@@ -56,6 +58,50 @@ const InventoryTable = forwardRef(({
     const sortBy = useSelector(({ entities: { sortBy: invSortBy } }) => (
         hasItems ? propsSortBy : invSortBy
     ), shallowEqual);
+    const dispatch = useDispatch();
+    const store = useStore();
+
+    /**
+     * If consumer wants to change data they can call this function via component ref.
+     * @param {*} options new options to be applied, like pagination, filters, etc.
+     */
+    const onRefreshData = (options = {}, disableOnRefresh) => {
+        const { activeFilters } = store.getState().entities;
+
+        // eslint-disable-next-line camelcase
+        const currPerPage = options?.per_page || options?.perPage || perPage;
+
+        const params = {
+            page,
+            per_page: currPerPage,
+            items,
+            sortBy,
+            hideFilters,
+            filters: activeFilters,
+            ...customFilters,
+            ...options
+        };
+
+        if (onRefresh && !disableOnRefresh) {
+            onRefresh(params, (options) => {
+                dispatch(
+                    loadSystems(
+                        { ...params, ...options },
+                        showTags,
+                        getEntities
+                    )
+                );
+            });
+        } else {
+            dispatch(
+                loadSystems(
+                    params,
+                    showTags,
+                    getEntities
+                )
+            );
+        }
+    };
 
     return (
         (hasAccess === false && isFullView) ?
@@ -71,14 +117,13 @@ const InventoryTable = forwardRef(({
                     customFilters={customFilters}
                     hasAccess={hasAccess}
                     items={ items }
-                    onRefresh={onRefresh}
                     filters={ filters }
                     hasItems={ hasItems }
                     total={ pagination.total }
                     page={ pagination.page }
                     perPage={ pagination.perPage }
                     showTags={ showTags }
-                    getEntities={ getEntities }
+                    onRefreshData={onRefreshData}
                     sortBy={ sortBy }
                     hideFilters={hideFilters}
                     paginationProps={paginationProps}
@@ -91,30 +136,22 @@ const InventoryTable = forwardRef(({
                     hasAccess={hasAccess}
                     ref={ref}
                     hasItems={ hasItems }
-                    onRefresh={ onRefresh }
                     items={ items }
                     page={ pagination.page }
                     sortBy={ sortBy }
                     perPage={ pagination.perPage }
                     showTags={ showTags }
-                    getEntities={ getEntities }
-                    hideFilters={ hideFilters }
+                    onRefreshData={onRefreshData}
                 />
                 <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
                     <Pagination
-                        customFilters={customFilters}
                         hasAccess={hasAccess}
                         isFull
-                        items={ items }
                         total={ pagination.total }
                         page={ pagination.page }
                         perPage={ pagination.perPage }
                         hasItems={ hasItems }
-                        onRefresh={ onRefresh }
-                        showTags={ showTags }
-                        getEntities={ getEntities }
-                        sortBy={ sortBy }
-                        hideFilters={ hideFilters }
+                        onRefreshData={onRefreshData}
                         paginationProps={paginationProps}
                     />
                 </TableToolbar>

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -1,10 +1,8 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { entitiesLoading } from '../../redux/actions';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { loadSystems } from '../../shared';
 
 /**
  * Bottom pagination used in table. It can remember what page user is on if user entered the page number in input.
@@ -18,63 +16,17 @@ const FooterPagination = ({
     isFull,
     hasItems,
     hasAccess,
-    sortBy,
-    items,
-    onRefresh,
-    customFilters,
-    hideFilters,
-    showTags,
-    getEntities,
-    paginationProps
+    paginationProps,
+    onRefreshData
 }) => {
-    const dispatch = useDispatch();
     const loaded = useSelector(store => store?.entities?.loaded);
-    const filters = useSelector(store => store?.entities?.activeFilters, shallowEqual);
-
-    const loadEntities = (config) => dispatch(
-        loadSystems(
-            {
-                orderBy: sortBy?.key,
-                orderDirection: sortBy?.direction,
-                ...config
-            },
-            showTags,
-            getEntities
-        )
-    );
-
-    /**
-     * Actual function called when updating any part of pagination.
-     * It either calls `onRefresh` from props if passed or dispatches new action `loadEntities`.
-     * @param {*} config contains new pagination config.
-     */
-    const updatePagination = (config) => {
-        const pagination = {
-            page, per_page: perPage, filters, sortBy, hasItems, items, ...config
-        };
-
-        if (onRefresh) {
-            dispatch(entitiesLoading());
-            onRefresh(pagination, (options) => loadEntities({
-                ...customFilters,
-                ...options,
-                hideFilters
-            }));
-        } else {
-            loadEntities({
-                ...customFilters,
-                ...pagination,
-                hideFilters
-            });
-        }
-    };
 
     /**
      * Thi method sets new page and combines previous props to apply sort, filters etc.
      * @param {*} event html event to figure if target was input.
      * @param {*} page current page to change to.
      */
-    const onSetPage = (_event, pageArg) => updatePagination({ page: pageArg });
+    const onSetPage = (_event, pageArg) => onRefreshData({ page: pageArg });
 
     /**
      * This method changes per page, it automatically sets page to first one.
@@ -82,7 +34,7 @@ const FooterPagination = ({
      * @param {*} _event event is now not used.
      * @param {*} perPage new perPage set by user.
      */
-    const onPerPageSelect = (_event, perPageArg) => updatePagination({ page: 1, per_page: perPageArg });
+    const onPerPageSelect = (_event, perPageArg) => onRefreshData({ page: 1, per_page: perPageArg });
 
     const finalIsLoaded = hasItems && isLoaded !== undefined ? (isLoaded && loaded) : loaded;
 
@@ -106,30 +58,18 @@ const FooterPagination = ({
 FooterPagination.propTypes = {
     perPage: PropTypes.number,
     total: PropTypes.number,
-    loaded: PropTypes.bool,
+    page: PropTypes.number,
+    isLoaded: PropTypes.bool,
     isFull: PropTypes.bool,
     hasAccess: PropTypes.bool,
-    onRefresh: PropTypes.func,
+    hasItems: PropTypes.bool,
     direction: PropTypes.string,
-    customFilters: PropTypes.shape({
-        tags: PropTypes.oneOfType([
-            PropTypes.object,
-            PropTypes.arrayOf(PropTypes.string)
-        ])
-    }),
-    getEntities: PropTypes.func,
-    hideFilters: PropTypes.shape({
-        tags: PropTypes.bool,
-        name: PropTypes.bool,
-        registeredWith: PropTypes.bool,
-        stale: PropTypes.bool
-    }),
     paginationProps: PropTypes.object
 };
 
 FooterPagination.defaultProps = {
     total: 0,
-    loaded: false,
+    isLoaded: false,
     isFull: false,
     direction: 'up',
     hasAccess: true

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -8,6 +8,7 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
     hasAccess={true}
     hasItems={false}
     hideFilters={Object {}}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
     showTags={false}
@@ -15,6 +16,7 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
   <ForwardRef
     hasAccess={true}
     hasItems={false}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
   >
@@ -42,6 +44,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
     hasAccess={false}
     hasItems={false}
     hideFilters={Object {}}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
     showTags={false}
@@ -57,6 +60,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
   <ForwardRef
     hasAccess={false}
     hasItems={false}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
     sortBy={
@@ -112,6 +116,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
     hasAccess={true}
     hasItems={false}
     hideFilters={Object {}}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
     showTags={false}
@@ -127,6 +132,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
   <ForwardRef
     hasAccess={true}
     hasItems={false}
+    onRefreshData={[Function]}
     page={1}
     perPage={50}
     sortBy={
@@ -200,6 +206,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
         },
       ]
     }
+    onRefreshData={[Function]}
     page={5}
     perPage={20}
     showTags={false}
@@ -222,6 +229,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
         },
       ]
     }
+    onRefreshData={[Function]}
     page={5}
     perPage={20}
     sortBy={
@@ -301,6 +309,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
         },
       ]
     }
+    onRefreshData={[Function]}
     page={5}
     perPage={20}
     showTags={false}
@@ -323,6 +332,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
         },
       ]
     }
+    onRefreshData={[Function]}
     page={5}
     perPage={20}
     sortBy={

--- a/packages/inventory/src/shared/constants.js
+++ b/packages/inventory/src/shared/constants.js
@@ -80,11 +80,8 @@ export function reduceFilters(filters = []) {
 }
 
 export const loadSystems = (options, showTags, getEntities) => {
-    // eslint-disable-next-line camelcase
-    const currPerPage = options?.perPage || options?.per_page;
-
-    const limitedItems = options?.items?.length > currPerPage ? options?.items?.slice(
-        (options?.page - 1) * currPerPage, options?.page * currPerPage
+    const limitedItems = options?.items?.length > options.per_page ? options?.items?.slice(
+        (options?.page - 1) * options.per_page, options?.page * options.per_page
     ) : options?.items;
 
     const config = {
@@ -93,8 +90,6 @@ export const loadSystems = (options, showTags, getEntities) => {
             orderDirection: options?.sortBy?.direction?.toUpperCase()
         },
         ...options,
-        // eslint-disable-next-line camelcase
-        per_page: currPerPage,
         filters: options?.filters || options?.activeFilters,
         orderBy: options?.orderBy || options?.sortBy?.key,
         orderDirection: options?.orderDirection?.toUpperCase() || options?.sortBy?.direction?.toUpperCase(),


### PR DESCRIPTION
onRefreshData is declared only on one place. This makes the function consistent (there should be no bugs that some attributes are missing when the function is called from different places) and it makes all future changes much more manageable.