### PR TITLE
Add ErrorState to InventoryTable

### DIFF
--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -2,6 +2,7 @@ import React, { Fragment, forwardRef } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import EntityTableToolbar from './EntityTableToolbar';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
 import InventoryList from './InventoryList';
 import Pagination from './Pagination';
 import AccessDenied from '../../shared/AccessDenied';
@@ -30,9 +31,13 @@ const InventoryTable = forwardRef(({
     getEntities,
     hideFilters,
     paginationProps,
+    errorState = <ErrorState />,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
+    const error = useSelector(({ entities }) => (
+        entities?.error
+    ));
     const page = useSelector(({ entities: { page: invPage } }) => (
         hasItems ? propsPage : (invPage || 1)
     )
@@ -65,7 +70,7 @@ const InventoryTable = forwardRef(({
                     To view the content of this page, you must be granted a minimum of inventory permissions from your Organization Administrator.
                 </div>}
             /> :
-            <Fragment>
+            !error ? <Fragment>
                 <EntityTableToolbar
                     { ...props }
                     customFilters={customFilters}
@@ -118,7 +123,7 @@ const InventoryTable = forwardRef(({
                         paginationProps={paginationProps}
                     />
                 </TableToolbar>
-            </Fragment>
+            </Fragment> : errorState
     );
 });
 

--- a/packages/inventory/src/components/table/InventoryTable.test.js
+++ b/packages/inventory/src/components/table/InventoryTable.test.js
@@ -52,6 +52,36 @@ describe('NoSystemsTable', () => {
         expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
     });
 
+    it('should render correctly with error', () => {
+        const store = mockStore({
+            entities: {
+                ...initialState.entities,
+                error: new Error('Loading error')
+            }
+        });
+        const wrapper = mount(<Provider store={ store }>
+            <Router>
+                <InventoryTable/>
+            </Router>
+        </Provider>);
+        expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
+    });
+
+    it('should render correctly with custom error', () => {
+        const store = mockStore({
+            entities: {
+                ...initialState.entities,
+                error: new Error('Loading error')
+            }
+        });
+        const wrapper = mount(<Provider store={ store }>
+            <Router>
+                <InventoryTable errorState={ <div>CUSTOM ERROR STATE</div> } />
+            </Router>
+        </Provider>);
+        expect(toJson(wrapper.find('ForwardRef').first(), { mode: 'shallow' })).toMatchSnapshot();
+    });
+
     it('should render correctly - with no access', () => {
         const store = mockStore(initialState);
         const wrapper = mount(<Provider store={ store }>

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -167,6 +167,28 @@ exports[`NoSystemsTable should render correctly 1`] = `
 </ForwardRef>
 `;
 
+exports[`NoSystemsTable should render correctly with custom error 1`] = `
+<ForwardRef
+  errorState={
+    <div>
+      CUSTOM ERROR STATE
+    </div>
+  }
+>
+  <div>
+    CUSTOM ERROR STATE
+  </div>
+</ForwardRef>
+`;
+
+exports[`NoSystemsTable should render correctly with error 1`] = `
+<ForwardRef>
+  <ErrorState
+    errorTitle="Something went wrong"
+  />
+</ForwardRef>
+`;
+
 exports[`NoSystemsTable should render correctly with items 1`] = `
 <ForwardRef
   items={

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -243,7 +243,7 @@ export default {
     [ACTION_TYPES.LOAD_ENTITIES_REJECTED]: loadingRejected,
     [ACTION_TYPES.LOAD_TAGS_PENDING]: showTagsPending,
     [ACTION_TYPES.LOAD_TAGS_FULFILLED]: showTags,
-    [ACTION_TYPES.LOAD_TAGS_REJECTED]: loadingRejected,
+    [ACTION_TYPES.ALL_TAGS_REJECTED]: loadingRejected,
     [UPDATE_ENTITIES]: entitiesLoaded,
     [SHOW_ENTITIES]: (state, action) => entitiesLoaded(state, {
         payload: {

--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -122,6 +122,13 @@ function entitiesLoaded(state, { payload: { results, per_page: perPage, page, co
     };
 }
 
+function loadingRejected(state, { payload }) {
+    return {
+        ...state,
+        error: payload
+    };
+}
+
 function selectEntity(state, { payload }) {
     const rows = [ ...state.rows ];
     const toSelect = [].concat(payload);
@@ -233,8 +240,10 @@ export default {
     [ACTION_TYPES.ALL_TAGS_PENDING]: (state) => ({ ...state, allTagsLoaded: false }),
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
+    [ACTION_TYPES.LOAD_ENTITIES_REJECTED]: loadingRejected,
     [ACTION_TYPES.LOAD_TAGS_PENDING]: showTagsPending,
     [ACTION_TYPES.LOAD_TAGS_FULFILLED]: showTags,
+    [ACTION_TYPES.LOAD_TAGS_REJECTED]: loadingRejected,
     [UPDATE_ENTITIES]: entitiesLoaded,
     [SHOW_ENTITIES]: (state, action) => entitiesLoaded(state, {
         payload: {


### PR DESCRIPTION
This adds an `ErrorState` for when a `LOAD_ENTITIES_REJECTED` is dispatched and allows to provide a custom component as an ErrorState if necessary.

https://user-images.githubusercontent.com/7757/116590329-e79e7780-a91d-11eb-91ef-bf0775def4a3.mp4

