### PR TITLE
Set tagsModalLoaded when fetching all tagts

### DIFF
--- a/packages/inventory/src/redux/entities.js
+++ b/packages/inventory/src/redux/entities.js
@@ -231,13 +231,14 @@ export function allTags(state, { payload: { results, total, page, per_page: perP
         },
         additionalTagsCount: total > perPage ? total - perPage : 0,
         allTagsTotal: total,
-        allTagsLoaded: true
+        allTagsLoaded: true,
+        tagModalLoaded: true
     };
 }
 
 export default {
     [ACTION_TYPES.ALL_TAGS_FULFILLED]: allTags,
-    [ACTION_TYPES.ALL_TAGS_PENDING]: (state) => ({ ...state, allTagsLoaded: false }),
+    [ACTION_TYPES.ALL_TAGS_PENDING]: (state) => ({ ...state, allTagsLoaded: false, tagModalLoaded: false }),
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
     [ACTION_TYPES.LOAD_ENTITIES_REJECTED]: loadingRejected,


### PR DESCRIPTION
Loading logic was changed in https://github.com/RedHatInsights/frontend-components/commit/f79e6966fadb63112eae90ae00f1f565da4abb05

This sets `tagsModalLoaded` also when loading allTags.

**Before**

![Screenshot 2021-05-05 at 8 35 21](https://user-images.githubusercontent.com/32869456/117104721-f3a29300-ad7c-11eb-9e89-eb6296d10d0c.png)

**After**

![ezgif com-gif-maker](https://user-images.githubusercontent.com/32869456/117105551-90196500-ad7e-11eb-85e1-c07ed7ba316c.gif)

We need this to backport to older environments as well @karelhala 

