### PR TITLE
Add initialLoading for inventory table

### DIFF
--- a/packages/inventory/doc/props.md
+++ b/packages/inventory/doc/props.md
@@ -13,6 +13,7 @@
   - [tableProps](#tableprops)
   - [paginationProps](#paginationprops)
   - [autoRefresh](#autorefresh)
+  - [initialLoading](#initialloading)
 
 # Props
 
@@ -91,3 +92,9 @@ Props passed to paginations components.
 *boolean*
 
 When `true`, the table is refreshed when `customFilters` are changed.
+
+## initialLoading
+
+*boolean*
+
+When `true`, the table is in loading state on mount until `entities.loaded` is set to `false` (and from that point, `loaded` is the only determinator.). Use when users can go back to already loaded table, this prop ensures that there will be no change from `loaded` > `loading` > `loaded`.

--- a/packages/inventory/src/components/table/EntityTable.js
+++ b/packages/inventory/src/components/table/EntityTable.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { selectEntity, setSort } from '../../redux/actions';
-import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import {
     Table as PfTable,
@@ -23,7 +23,6 @@ import { defaultColumns } from '../../redux/entities';
  */
 const EntityTable = ({
     hasItems,
-    isLoaded,
     expandable,
     onExpandClick,
     hasCheckbox,
@@ -38,14 +37,12 @@ const EntityTable = ({
     noSystemsTable = <NoSystemsTable />,
     showTags,
     columns: columnsProp,
-    disableDefaultColumns
+    disableDefaultColumns,
+    loaded
 }) => {
     const dispatch = useDispatch();
     const history = useHistory();
     const location = useLocation();
-    const loaded = useSelector(({ entities: { loaded } }) => (
-        hasItems && isLoaded !== undefined ? (isLoaded && loaded) : loaded
-    ), shallowEqual);
     const rows = useSelector(({ entities: { rows } }) => rows);
     const columnsRedux = useSelector(
         ({ entities: { columns } }) => columns,
@@ -169,7 +166,8 @@ EntityTable.propTypes = {
     onRowClick: PropTypes.func,
     showTags: PropTypes.bool,
     noSystemsTable: PropTypes.node,
-    disableDefaultColumns: PropTypes.oneOfType([ PropTypes.bool, PropTypes.arrayOf(PropTypes.string) ])
+    disableDefaultColumns: PropTypes.oneOfType([ PropTypes.bool, PropTypes.arrayOf(PropTypes.string) ]),
+    loaded: PropTypes.bool
 };
 
 EntityTable.defaultProps = {

--- a/packages/inventory/src/components/table/EntityTable.test.js
+++ b/packages/inventory/src/components/table/EntityTable.test.js
@@ -48,7 +48,7 @@ describe('EntityTable', () => {
             });
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable disableDefaultColumns loaded={false}/>
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('EntityTable'), { mode: 'shallow' })).toMatchSnapshot();
@@ -64,7 +64,7 @@ describe('EntityTable', () => {
             });
             const wrapper = render(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable disableDefaultColumns loaded/>
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper)).toMatchSnapshot();
@@ -80,7 +80,7 @@ describe('EntityTable', () => {
             });
             const wrapper = render(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable noSystemsTable={ <div>NO SYSTEMS</div> } />
+                    <EntityTable loaded noSystemsTable={ <div>NO SYSTEMS</div> } />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper)).toMatchSnapshot();
@@ -95,7 +95,7 @@ describe('EntityTable', () => {
             });
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable loaded disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('Table'), { mode: 'shallow' })).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable hasCheckbox={false} disableDefaultColumns />
+                    <EntityTable loaded hasCheckbox={false} disableDefaultColumns />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('Table'), { mode: 'shallow' })).toMatchSnapshot();
@@ -115,7 +115,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable expandable disableDefaultColumns />
+                    <EntityTable loaded expandable disableDefaultColumns />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('Table'), { mode: 'shallow' })).toMatchSnapshot();
@@ -125,7 +125,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable actions={[]} disableDefaultColumns />
+                    <EntityTable loaded actions={[]} disableDefaultColumns />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('Table'), { mode: 'shallow' })).toMatchSnapshot();
@@ -136,7 +136,7 @@ describe('EntityTable', () => {
                 const store = mockStore(initialState);
                 const wrapper = mount(<MemoryRouter>
                     <Provider store={ store }>
-                        <EntityTable disableDefaultColumns sortBy={{
+                        <EntityTable loaded disableDefaultColumns sortBy={{
                             key: 'one',
                             directions: 'asc'
                         }} />
@@ -150,6 +150,7 @@ describe('EntityTable', () => {
                 const wrapper = mount(<MemoryRouter>
                     <Provider store={ store }>
                         <EntityTable
+                            loaded
                             hasCheckbox={false}
                             disableDefaultColumns
                             sortBy={{
@@ -167,6 +168,7 @@ describe('EntityTable', () => {
                 const wrapper = mount(<MemoryRouter>
                     <Provider store={ store }>
                         <EntityTable
+                            loaded
                             expandable
                             disableDefaultColumns
                             sortBy={{
@@ -184,7 +186,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = render(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns variant="compact" />
+                    <EntityTable loaded disableDefaultColumns variant="compact" />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper)).toMatchSnapshot();
@@ -194,7 +196,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = render(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns hasItems isLoaded={false} />
+                    <EntityTable loaded disableDefaultColumns hasItems isLoaded={false} />
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper.find('EntityTable'), { mode: 'shallow' })).toMatchSnapshot();
@@ -204,7 +206,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = render(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable/>
+                    <EntityTable loaded/>
                 </Provider>
             </MemoryRouter>);
             expect(toJson(wrapper)).toMatchSnapshot();
@@ -228,7 +230,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable loaded disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
 
@@ -259,6 +261,7 @@ describe('EntityTable', () => {
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
                     <EntityTable
+                        loaded
                         columns={
                             [
                                 {
@@ -304,6 +307,7 @@ describe('EntityTable', () => {
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
                     <EntityTable
+                        loaded
                         columns={[]}
                         disableDefaultColumns={[ 'display_name' ]}
                     />
@@ -335,6 +339,7 @@ describe('EntityTable', () => {
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
                     <EntityTable
+                        loaded
                         columns={[]}
                         disableDefaultColumns={[ 'display_name' ]}
                         showTags
@@ -355,7 +360,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable loaded disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table tbody tr a[widget="col"]').first().simulate('click');
@@ -367,7 +372,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns onRowClick={onRowClick} />
+                    <EntityTable loaded disableDefaultColumns onRowClick={onRowClick} />
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table tbody tr a[widget="col"]').first().simulate('click');
@@ -387,7 +392,7 @@ describe('EntityTable', () => {
             });
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns expandable />
+                    <EntityTable loaded disableDefaultColumns expandable />
                 </Provider>
             </MemoryRouter>);
             wrapper.find('.pf-c-table__toggle button').first().simulate('click');
@@ -407,7 +412,7 @@ describe('EntityTable', () => {
             });
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns expandable onExpandClick={onExpand} />
+                    <EntityTable loaded disableDefaultColumns expandable onExpandClick={onExpand} />
                 </Provider>
             </MemoryRouter>);
             wrapper.find('.pf-c-table__toggle button').first().simulate('click');
@@ -418,7 +423,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable expandable disableDefaultColumns/>
+                    <EntityTable loaded expandable disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table tbody tr .pf-c-table__check input').first().simulate('change', {
@@ -435,7 +440,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable expandable disableDefaultColumns/>
+                    <EntityTable loaded expandable disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table tbody tr .pf-c-table__check input').first().simulate('change', {
@@ -452,7 +457,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable loaded disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table thead input[name="check-all"]').first().simulate('change', {
@@ -469,7 +474,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable disableDefaultColumns/>
+                    <EntityTable loaded disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table thead th.pf-c-table__sort button').first().simulate('click');
@@ -486,7 +491,7 @@ describe('EntityTable', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable onSort={onSort} disableDefaultColumns/>
+                    <EntityTable loaded onSort={onSort} disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table thead th.pf-c-table__sort button').first().simulate('click');
@@ -503,7 +508,7 @@ describe('EntityTable', () => {
             });
             const wrapper = mount(<MemoryRouter>
                 <Provider store={ store }>
-                    <EntityTable onSort={onSort} disableDefaultColumns/>
+                    <EntityTable loaded onSort={onSort} disableDefaultColumns/>
                 </Provider>
             </MemoryRouter>);
             wrapper.find('table thead th.pf-c-table__sort button').first().simulate('click');

--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -59,6 +59,7 @@ const EntityTableToolbar = ({
     hideFilters,
     paginationProps,
     onRefreshData,
+    loaded,
     ...props
 }) => {
     const dispatch = useDispatch();
@@ -74,9 +75,6 @@ const EntityTableToolbar = ({
         ...tagsFilterState
     });
     const filters = useSelector(({ entities: { activeFilters } }) => activeFilters);
-    const loaded = useSelector(({ entities: { loaded } }) => !hasAccess || (
-        hasItems && isLoaded !== undefined ? (isLoaded && loaded) : loaded
-    ));
     const allTagsLoaded = useSelector(({ entities: { allTagsLoaded } }) => allTagsLoaded);
     const allTags = useSelector(({ entities: { allTags } }) => allTags);
     const additionalTagsCount = useSelector(({ entities: { additionalTagsCount } }) => additionalTagsCount);
@@ -365,7 +363,8 @@ EntityTableToolbar.propTypes = {
         registeredWith: PropTypes.bool,
         stale: PropTypes.bool
     }),
-    paginationProps: PropTypes.object
+    paginationProps: PropTypes.object,
+    loaded: PropTypes.bool
 };
 
 EntityTableToolbar.defaultProps = {

--- a/packages/inventory/src/components/table/EntityTableToolbar.test.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.test.js
@@ -70,7 +70,7 @@ describe('EntityTableToolbar', () => {
                 }
             });
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData}/>
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded={false}/>
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -78,7 +78,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with tags', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar showTags onRefreshData={onRefreshData}/>
+                <EntityTableToolbar showTags onRefreshData={onRefreshData} loaded/>
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
             expect(toJson(wrapper.find('TagsModal'), { mode: 'shallow' })).toMatchSnapshot();
@@ -87,7 +87,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with no access', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar hasAccess={false} onRefreshData={onRefreshData}/>
+                <EntityTableToolbar hasAccess={false} onRefreshData={onRefreshData} loaded/>
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
             expect(toJson(wrapper.find('TagsModal'), { mode: 'shallow' })).toMatchSnapshot();
@@ -96,7 +96,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with items', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar hasItems onRefreshData={onRefreshData}/>
+                <EntityTableToolbar hasItems onRefreshData={onRefreshData} loaded/>
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -104,7 +104,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with custom filters', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData} filterConfig={{
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded filterConfig={{
                     items: [{ label: 'Filter by text' }]
                 }} />
             </Provider>);
@@ -114,7 +114,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with custom activeFilters', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData} activeFiltersConfig={{
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded activeFiltersConfig={{
                     filters: [{
                         category: 'Some',
                         chips: [{
@@ -136,7 +136,7 @@ describe('EntityTableToolbar', () => {
                 }
             });
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData} />
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded />
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -157,7 +157,7 @@ describe('EntityTableToolbar', () => {
                 }
             });
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData} />
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded />
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -165,7 +165,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly - with children', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar onRefreshData={onRefreshData}><div>something</div></EntityTableToolbar>
+                <EntityTableToolbar onRefreshData={onRefreshData} loaded><div>something</div></EntityTableToolbar>
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -173,7 +173,7 @@ describe('EntityTableToolbar', () => {
         it('should render correctly', () => {
             const store = mockStore(initialState);
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
             </Provider>);
             expect(toJson(wrapper.find('PrimaryToolbar'), { mode: 'shallow' })).toMatchSnapshot();
         });
@@ -185,7 +185,7 @@ describe('EntityTableToolbar', () => {
                 mockTags.onGet(/\/api\/inventory\/v1.*/).reply(200, { results: [] });
                 const store = mockStore(initialState);
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 wrapper.find('button[data-action="next"]').first().simulate('click');
 
@@ -196,7 +196,7 @@ describe('EntityTableToolbar', () => {
                 mockTags.onGet(/\/api\/inventory\/v1.*/).reply(200, { results: [] });
                 const store = mockStore(initialState);
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 wrapper.find('.pf-c-options-menu__toggle button.pf-c-options-menu__toggle-button').first().simulate('click');
                 wrapper.update();
@@ -212,7 +212,7 @@ describe('EntityTableToolbar', () => {
                 mockTags.onGet(/\/api\/inventory\/v1.*/).reply(200, { results: [] });
                 const store = mockStore(initialState);
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 onRefreshData.mockClear();
 
@@ -244,7 +244,7 @@ describe('EntityTableToolbar', () => {
                     }
                 });
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 onRefreshData.mockClear();
                 await act(async () => {
@@ -274,7 +274,7 @@ describe('EntityTableToolbar', () => {
                     }
                 });
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} showTags onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} showTags onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 onRefreshData.mockClear();
                 await act(async () => {
@@ -290,7 +290,7 @@ describe('EntityTableToolbar', () => {
                 mockTags.onGet(/\/api\/inventory\/v1.*/).reply(200, { results: [] });
                 const store = mockStore(initialState);
                 const wrapper = mount(<Provider store={store}>
-                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                    <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 wrapper.find('.ins-c-chip-filters button.pf-m-link').last().simulate('click');
                 const actions = store.getActions();
@@ -306,7 +306,7 @@ describe('EntityTableToolbar', () => {
                 const wrapper = mount(<Provider store={store}>
                     <EntityTableToolbar page={1} total={500} perPage={50} activeFiltersConfig={{
                         onDelete
-                    }} onRefreshData={onRefreshData} />
+                    }} onRefreshData={onRefreshData} loaded />
                 </Provider>);
                 wrapper.find('.pf-c-chip-group__list li div button').first().simulate('click');
                 expect(onDelete).toHaveBeenCalled();
@@ -320,7 +320,7 @@ describe('EntityTableToolbar', () => {
             const store = mockStore(initialState);
 
             const wrapper = mount(<Provider store={store}>
-                <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} />
+                <EntityTableToolbar page={1} total={500} perPage={50} onRefreshData={onRefreshData} loaded />
             </Provider>);
 
             await act(async () => {

--- a/packages/inventory/src/components/table/InventoryList.test.js
+++ b/packages/inventory/src/components/table/InventoryList.test.js
@@ -36,7 +36,7 @@ describe('InventoryList', () => {
         const store = mockStore(initialState);
         const wrapper = render(<MemoryRouter>
             <Provider store={ store }>
-                <InventoryList ref={ref} onRefreshData={onRefreshData} />
+                <InventoryList ref={ref} onRefreshData={onRefreshData} loaded />
             </Provider>
         </MemoryRouter>);
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -46,7 +46,7 @@ describe('InventoryList', () => {
         const store = mockStore(initialState);
         const wrapper = render(<MemoryRouter>
             <Provider store={ store }>
-                <InventoryList hasAccess={false} ref={ref} onRefreshData={onRefreshData} />
+                <InventoryList hasAccess={false} ref={ref} onRefreshData={onRefreshData} loaded />
             </Provider>
         </MemoryRouter>);
         expect(toJson(wrapper)).toMatchSnapshot();
@@ -63,7 +63,7 @@ describe('InventoryList', () => {
             const store = mockStore(initialState);
             const Cmp = (props) => <MemoryRouter>
                 <Provider store={ store }>
-                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} />
+                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} loaded />
                 </Provider>
             </MemoryRouter>;
             const wrapper = mount(<Cmp sortBy={sortBy} />);
@@ -90,7 +90,7 @@ describe('InventoryList', () => {
             const store = mockStore(initialState);
             const Cmp = (props) => <MemoryRouter>
                 <Provider store={ store }>
-                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} />
+                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} loaded />
                 </Provider>
             </MemoryRouter>;
             const wrapper = mount(<Cmp sortBy={sortBy} />);
@@ -107,7 +107,7 @@ describe('InventoryList', () => {
             const store = mockStore(initialState);
             const Cmp = (props) => <MemoryRouter>
                 <Provider store={ store }>
-                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} />
+                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} loaded />
                 </Provider>
             </MemoryRouter>;
             const wrapper = mount(<Cmp items={[{ children: () => <div>test</div>, isOpen: false, id: 'fff' }]} hasItems />);
@@ -124,7 +124,7 @@ describe('InventoryList', () => {
             const store = mockStore(initialState);
             const Cmp = (props) => <MemoryRouter>
                 <Provider store={ store }>
-                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} />
+                    <InventoryList {...props} ref={ref} onRefreshData={onRefreshData} loaded />
                 </Provider>
             </MemoryRouter>;
             const wrapper = mount(<Cmp items={[{ children: () => <div>test</div>, isOpen: false, id: 'fff' }]} hasItems />);

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -86,7 +86,7 @@ const InventoryTable = forwardRef(({
 
     const reduxLoaded = useSelector(({ entities }) => (
         hasItems && isLoaded !== undefined ? (isLoaded && entities?.loaded) : entities?.loaded
-    ), shallowEqual);
+    ));
 
     /**
      * If initialLoading is set to true, then the component should be in loading state until

--- a/packages/inventory/src/components/table/InventoryTable.test.js
+++ b/packages/inventory/src/components/table/InventoryTable.test.js
@@ -11,7 +11,7 @@ import toJson from 'enzyme-to-json';
 import { ConditionalFilter } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import * as actions from '../../shared/constants';
 
-describe('NoSystemsTable', () => {
+describe('InventoryTable', () => {
     let initialState;
     let mockStore;
     let spy;

--- a/packages/inventory/src/components/table/InventoryTableInitialLoading.test.js
+++ b/packages/inventory/src/components/table/InventoryTableInitialLoading.test.js
@@ -1,0 +1,85 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import InventoryTable from './InventoryTable';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { BrowserRouter as Router } from 'react-router-dom';
+import * as actions from '../../shared/constants';
+import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { Pagination } from '@patternfly/react-core';
+
+import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
+import promise from 'redux-promise-middleware';
+import entitiesReducer from '../../redux/entities';
+import debounce from 'lodash/debounce';
+
+jest.mock('lodash/debounce');
+
+describe('InventoryTable - initial loading', () => {
+    let initialState;
+    let spy;
+
+    beforeEach(() => {
+        debounce.mockImplementation(fn => fn);
+        initialState = {
+            entities: {
+                activeFilters: [{}],
+                loaded: true,
+                rows: [{ name: 'abc', display_name: 'result_origina', id: '1', system_profile: {} }],
+                columns: [{ key: 'one', title: 'One' }],
+                page: 1,
+                perPage: 50,
+                total: 500,
+                sortBy: {
+                    index: 1,
+                    key: 'one',
+                    direction: 'asc'
+                }
+            }
+        };
+        spy = jest.spyOn(actions, 'loadSystems').mockImplementation(() => ({ type: 'reload' }));
+    });
+
+    afterEach(() => {
+        spy.mockRestore();
+    });
+
+    it('should render loading state when initialLoading set', async () => {
+        spy.mockRestore();
+        jest.useFakeTimers();
+
+        const registry = new ReducerRegistry({}, [ promise() ]);
+        registry.register({
+            entities: applyReducerHash(entitiesReducer, initialState.entities)
+        });
+        const store = registry.getStore();
+
+        // eslint-disable-next-line no-import-assign
+        const getEntities = jest.fn().mockImplementation(() =>  Promise.resolve({
+            results: [{ name: '123', display_name: 'result_1', id: '123', system_profile: {} }],
+            total: 12
+        }));
+
+        let wrapper;
+
+        await act(async () => {
+            wrapper = mount(<Provider store={ store }>
+                <Router>
+                    <InventoryTable initialLoading getEntities={getEntities}/>
+                </Router>
+            </Provider>);
+        });
+
+        expect(wrapper.find(SkeletonTable)).toHaveLength(1);
+        expect(wrapper.find(Pagination)).toHaveLength(0);
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        wrapper.update();
+
+        expect(wrapper.find(SkeletonTable)).toHaveLength(0);
+        expect(wrapper.find(Pagination)).toHaveLength(2);
+    });
+});

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
@@ -11,16 +10,13 @@ const FooterPagination = ({
     total,
     page,
     perPage,
-    isLoaded,
     direction,
     isFull,
-    hasItems,
     hasAccess,
     paginationProps,
-    onRefreshData
+    onRefreshData,
+    loaded
 }) => {
-    const loaded = useSelector(store => store?.entities?.loaded);
-
     /**
      * Thi method sets new page and combines previous props to apply sort, filters etc.
      * @param {*} event html event to figure if target was input.
@@ -36,9 +32,7 @@ const FooterPagination = ({
      */
     const onPerPageSelect = (_event, perPageArg) => onRefreshData({ page: 1, per_page: perPageArg });
 
-    const finalIsLoaded = hasItems && isLoaded !== undefined ? (isLoaded && loaded) : loaded;
-
-    return (finalIsLoaded || !hasAccess) ? (
+    return (loaded || !hasAccess) ? (
         <Pagination
             { ...isFull && {
                 variant: PaginationVariant.bottom
@@ -59,17 +53,15 @@ FooterPagination.propTypes = {
     perPage: PropTypes.number,
     total: PropTypes.number,
     page: PropTypes.number,
-    isLoaded: PropTypes.bool,
     isFull: PropTypes.bool,
     hasAccess: PropTypes.bool,
-    hasItems: PropTypes.bool,
     direction: PropTypes.string,
-    paginationProps: PropTypes.object
+    paginationProps: PropTypes.object,
+    loaded: PropTypes.object
 };
 
 FooterPagination.defaultProps = {
     total: 0,
-    isLoaded: false,
     isFull: false,
     direction: 'up',
     hasAccess: true

--- a/packages/inventory/src/components/table/Pagination.js
+++ b/packages/inventory/src/components/table/Pagination.js
@@ -57,7 +57,7 @@ FooterPagination.propTypes = {
     hasAccess: PropTypes.bool,
     direction: PropTypes.string,
     paginationProps: PropTypes.object,
-    loaded: PropTypes.object
+    loaded: PropTypes.bool
 };
 
 FooterPagination.defaultProps = {

--- a/packages/inventory/src/components/table/Pagination.test.js
+++ b/packages/inventory/src/components/table/Pagination.test.js
@@ -28,14 +28,14 @@ describe('Pagination', () => {
 
         // eslint-disable-next-line react/display-name
         WrappedPagination = ({ store, ...props }) => <Provider store={store}>
-            <Pagination {...props} onRefreshData={onRefreshData}/>
+            <Pagination loaded {...props} onRefreshData={onRefreshData}/>
         </Provider>;
     });
 
     describe('render', () => {
         it('should render correctly - no data', () => {
             const store = mockStore({ entities: {} });
-            const wrapper = render(<WrappedPagination store={ store } />);
+            const wrapper = render(<WrappedPagination store={ store } loaded={false} />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
@@ -64,12 +64,6 @@ describe('Pagination', () => {
             const wrapper = render(<WrappedPagination store={ store } page={1} perPage={50} total={500} isFull />);
             expect(toJson(wrapper)).toMatchSnapshot();
             expect(wrapper.find('button[disabled=""]').length).toBe(2);
-        });
-
-        it('should render correctly with hasItems and isLoaded false', () => {
-            const store = mockStore(initialState);
-            const wrapper = render(<WrappedPagination store={ store } hasItems isLoaded={false} />);
-            expect(toJson(wrapper)).toMatchSnapshot();
         });
     });
 

--- a/packages/inventory/src/components/table/__snapshots__/EntityTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/EntityTable.test.js.snap
@@ -595,7 +595,7 @@ exports[`EntityTable DOM should render correctly 1`] = `
   >
     <tr
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-53"
+      data-ouia-component-id="OUIA-Generated-TableRow-39"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >
@@ -658,7 +658,7 @@ exports[`EntityTable DOM should render correctly 1`] = `
   >
     <tr
       class=""
-      data-ouia-component-id="OUIA-Generated-TableRow-54"
+      data-ouia-component-id="OUIA-Generated-TableRow-40"
       data-ouia-component-type="PF4/TableRow"
       data-ouia-safe="true"
     >

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NoSystemsTable should render correctly - no data 1`] = `
+exports[`InventoryTable should render correctly - no data 1`] = `
 <ForwardRef>
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
@@ -34,7 +34,7 @@ exports[`NoSystemsTable should render correctly - no data 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly - with no access 1`] = `
+exports[`InventoryTable should render correctly - with no access 1`] = `
 <ForwardRef
   hasAccess={false}
 >
@@ -44,6 +44,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
     hasAccess={false}
     hasItems={false}
     hideFilters={Object {}}
+    loaded={true}
     onRefreshData={[Function]}
     page={1}
     perPage={50}
@@ -60,6 +61,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
   <ForwardRef
     hasAccess={false}
     hasItems={false}
+    loaded={true}
     onRefreshData={[Function]}
     page={1}
     perPage={50}
@@ -92,7 +94,7 @@ exports[`NoSystemsTable should render correctly - with no access 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly - with no access and full view 1`] = `
+exports[`InventoryTable should render correctly - with no access and full view 1`] = `
 <ForwardRef
   hasAccess={false}
   isFullView={true}
@@ -108,7 +110,7 @@ exports[`NoSystemsTable should render correctly - with no access and full view 1
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly 1`] = `
+exports[`InventoryTable should render correctly 1`] = `
 <ForwardRef>
   <EntityTableToolbar
     activeFiltersConfig={Object {}}
@@ -116,6 +118,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
     hasAccess={true}
     hasItems={false}
     hideFilters={Object {}}
+    loaded={true}
     onRefreshData={[Function]}
     page={1}
     perPage={50}
@@ -132,6 +135,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
   <ForwardRef
     hasAccess={true}
     hasItems={false}
+    loaded={true}
     onRefreshData={[Function]}
     page={1}
     perPage={50}
@@ -154,6 +158,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
         ]
       }
       hasItems={false}
+      loaded={true}
       onRefreshData={[Function]}
       page={1}
       perPage={50}
@@ -173,7 +178,7 @@ exports[`NoSystemsTable should render correctly 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly with custom error 1`] = `
+exports[`InventoryTable should render correctly with custom error 1`] = `
 <ForwardRef
   errorState={
     <div>
@@ -187,7 +192,7 @@ exports[`NoSystemsTable should render correctly with custom error 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly with error 1`] = `
+exports[`InventoryTable should render correctly with error 1`] = `
 <ForwardRef>
   <ErrorState
     errorTitle="Something went wrong"
@@ -195,7 +200,7 @@ exports[`NoSystemsTable should render correctly with error 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly with items 1`] = `
+exports[`InventoryTable should render correctly with items 1`] = `
 <ForwardRef
   items={
     Array [
@@ -228,6 +233,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
         },
       ]
     }
+    loaded={true}
     onRefreshData={[Function]}
     page={5}
     perPage={20}
@@ -251,6 +257,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
         },
       ]
     }
+    loaded={true}
     onRefreshData={[Function]}
     page={5}
     perPage={20}
@@ -280,6 +287,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
           },
         ]
       }
+      loaded={true}
       onRefreshData={[Function]}
       page={5}
       perPage={20}
@@ -299,7 +307,7 @@ exports[`NoSystemsTable should render correctly with items 1`] = `
 </ForwardRef>
 `;
 
-exports[`NoSystemsTable should render correctly with items no totla 1`] = `
+exports[`InventoryTable should render correctly with items no totla 1`] = `
 <ForwardRef
   items={
     Array [
@@ -331,6 +339,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
         },
       ]
     }
+    loaded={true}
     onRefreshData={[Function]}
     page={5}
     perPage={20}
@@ -354,6 +363,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
         },
       ]
     }
+    loaded={true}
     onRefreshData={[Function]}
     page={5}
     perPage={20}
@@ -383,6 +393,7 @@ exports[`NoSystemsTable should render correctly with items no totla 1`] = `
           },
         ]
       }
+      loaded={true}
       onRefreshData={[Function]}
       page={5}
       perPage={20}

--- a/packages/inventory/src/components/table/__snapshots__/Pagination.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/Pagination.test.js.snap
@@ -833,5 +833,3 @@ exports[`Pagination render should render correctly with data and props 1`] = `
   </nav>
 </div>
 `;
-
-exports[`Pagination render should render correctly with hasItems and isLoaded false 1`] = `null`;


### PR DESCRIPTION
## initialLoading

*boolean*

When `true`, the table is in loading state on mount until `entities.loaded` is set to `false` (and from that point, `loaded` is the only determinator.). Use when users can go back to already loaded table, this prop ensures that there will be no change from `loaded` > `loading` > `loaded`.

Also moves all loading logic to one place.

**Before**

![Kapture 2021-05-05 at 13 46 46](https://user-images.githubusercontent.com/32869456/117136472-b3f1a080-ada8-11eb-91d8-94c70500160d.gif)

**After**

![Kapture 2021-05-05 at 13 47 35](https://user-images.githubusercontent.com/32869456/117136490-ba801800-ada8-11eb-98ee-934f4c84b1a7.gif)

