### PR TITLE
Allow to set columns as function

### DIFF
--- a/packages/inventory/doc/props.md
+++ b/packages/inventory/doc/props.md
@@ -2,6 +2,7 @@
   - [getEntities](#getentities)
   - [hideFilters](#hidefilters)
   - [columns](#columns)
+    - [columns as function](#columns-as-function)
   - [disableDefaultColumns](#disabledefaultcolumns)
   - [ref](#ref)
   - [onLoad](#onload)
@@ -35,9 +36,15 @@ An object allowing to hide default filters.
 
 ## columns
 
-*array*
+*array | (defaultColumns) => array*
 
 An array of columns definitions. They are merged with default columns by their keys.
+
+### columns as function
+
+You can use a function as `columns` prop. This function receives the default columns array as the first attribute, so you can do any modification you need.
+
+**note: this function is called only 1x to keep a good performance. If you need to call it after the initial render (for example, some outside variable is changing the results) change `columnsCounter`<number> prop.**
 
 ## disableDefaultColumns
 

--- a/packages/inventory/src/components/table/EntityTable.js
+++ b/packages/inventory/src/components/table/EntityTable.js
@@ -38,7 +38,8 @@ const EntityTable = ({
     showTags,
     columns: columnsProp,
     disableDefaultColumns,
-    loaded
+    loaded,
+    columnsCounter
 }) => {
     const dispatch = useDispatch();
     const history = useHistory();
@@ -66,7 +67,9 @@ const EntityTable = ({
 
     const columns = useRef([]);
     useMemo(() => {
-        if (columnsProp) {
+        if (typeof columnsProp === 'function') {
+            columns.current = columnsProp(defaultColumns);
+        } else if (columnsProp) {
             const disabledColumns = Array.isArray(disableDefaultColumns) ? disableDefaultColumns : [];
             const defaultColumnsFiltered = defaultColumns.filter(({ key }) =>
                 (key === 'tags' && showTags) || (key !== 'tags' && !disabledColumns.includes(key))
@@ -81,8 +84,9 @@ const EntityTable = ({
     }, [
         showTags,
         Array.isArray(disableDefaultColumns) ? disableDefaultColumns.join() : disableDefaultColumns,
-        Array.isArray(columnsProp) ? columnsProp.map(({ key }) => key).join() : columnsProp,
-        Array.isArray(columnsRedux) ? columnsRedux.map(({ key }) => key).join() : columnsRedux
+        Array.isArray(columnsProp) ? columnsProp.map(({ key }) => key).join() : typeof columnsProp === 'function' ? 'function' : columnsProp,
+        Array.isArray(columnsRedux) ? columnsRedux.map(({ key }) => key).join() : columnsRedux,
+        columnsCounter
     ]);
 
     const cells = loaded && createColumns(columns.current, hasItems, rows, isExpandable);
@@ -167,7 +171,9 @@ EntityTable.propTypes = {
     showTags: PropTypes.bool,
     noSystemsTable: PropTypes.node,
     disableDefaultColumns: PropTypes.oneOfType([ PropTypes.bool, PropTypes.arrayOf(PropTypes.string) ]),
-    loaded: PropTypes.bool
+    loaded: PropTypes.bool,
+    columnsCounter: PropTypes.number,
+    columns: PropTypes.oneOfType([ PropTypes.array, PropTypes.func ])
 };
 
 EntityTable.defaultProps = {


### PR DESCRIPTION
# columns as function

You can use a function as `columns` prop. This function receives the default columns array as the first attribute, so you can do any modification you need.

**note: this function is called only 1x to keep a good performance. If you need to call it after the initial render (for example, some outside variable is changing the results) change `columnsCounter`<number> prop.**

cc @bastilian 