### PR TITLE
Inventory bug fixing

### DIFF
--- a/packages/inventory/doc/props.md
+++ b/packages/inventory/doc/props.md
@@ -15,6 +15,7 @@
   - [paginationProps](#paginationprops)
   - [autoRefresh](#autorefresh)
   - [initialLoading](#initialloading)
+  - [ignoreRefresh](#ignorerefresh)
 
 # Props
 
@@ -105,3 +106,9 @@ When `true`, the table is refreshed when `customFilters` are changed.
 *boolean*
 
 When `true`, the table is in loading state on mount until `entities.loaded` is set to `false` (and from that point, `loaded` is the only determinator.). Use when users can go back to already loaded table, this prop ensures that there will be no change from `loaded` > `loading` > `loaded`.
+
+## ignoreRefresh
+
+*boolean = true*
+
+On the initial mount and when items/sortBy are changed, the inventoryTable ignores `onRefresh` prop. By setting the prop to false, you can control this behavior.

--- a/packages/inventory/src/api/api.js
+++ b/packages/inventory/src/api/api.js
@@ -101,7 +101,7 @@ export async function getEntities(items, {
                     results: mergeArraysByKey([
                         data?.results,
                         result?.results || []
-                    ])
+                    ], 'id')
                 };
             } catch (e) {
                 console.error(e);

--- a/packages/inventory/src/components/table/EntityTableToolbar.js
+++ b/packages/inventory/src/components/table/EntityTableToolbar.js
@@ -316,8 +316,8 @@ const EntityTableToolbar = ({
                 itemCount: !hasAccess ? 0 : total,
                 isDisabled: !hasAccess,
                 perPage,
-                onSetPage: (_e, newPage) => updateData({ page: newPage }),
-                onPerPageSelect: (_e, newPerPage) => updateData({ page: 1, per_page: newPerPage }),
+                onSetPage: (_e, newPage) => onRefreshData({ page: newPage }),
+                onPerPageSelect: (_e, newPerPage) => onRefreshData({ page: 1, per_page: newPerPage }),
                 ...paginationProps
             } : <Skeleton size={SkeletonSize.lg} />}
         >

--- a/packages/inventory/src/components/table/InventoryList.js
+++ b/packages/inventory/src/components/table/InventoryList.js
@@ -7,16 +7,18 @@ import './InventoryList.scss';
 import isEqual from 'lodash/isEqual';
 import AccessDenied from '../../shared/AccessDenied';
 
+const convertItem = ({ children, isOpen, ...item }) => item;
+
 /**
  * Component that works as a side channel for consumers to notify inventory of new data changes.
  */
-const ContextInventoryList = ({ showHealth, onRefreshData, ...props }) => {
+const ContextInventoryList = ({ showHealth, onRefreshData, ignoreRefresh, ...props }) => {
     const prevItems = useRef(props.items);
     const prevSortBy = useRef(props.sortBy);
 
     useEffect(() => {
         if (props.hasItems) {
-            onRefreshData();
+            onRefreshData({}, ignoreRefresh);
         }
     }, []);
 
@@ -27,14 +29,14 @@ const ContextInventoryList = ({ showHealth, onRefreshData, ...props }) => {
      * @param {*} prevProps previous props - items, hasItems, sortBy.
      */
     useEffect(() => {
-        if (props.hasItems && !isEqual(prevItems.current, props.items)) {
+        if (props.hasItems && !isEqual(prevItems.current.map(convertItem), props.items.map(convertItem))) {
             prevItems.current = props.items;
-            onRefreshData();
+            onRefreshData({}, ignoreRefresh);
         }
 
         if (!props.hasItems && !isEqual(prevSortBy.current, props.sortBy)) {
             prevSortBy.current = props.sortBy;
-            onRefreshData();
+            onRefreshData({}, ignoreRefresh);
         }
     });
 
@@ -73,11 +75,13 @@ const InventoryList = React.forwardRef(({ hasAccess, onRefreshData, ...props }, 
 ContextInventoryList.propTypes = {
     ...InventoryList.propTypes,
     setRefresh: PropTypes.func,
-    onRefreshData: PropTypes.func
+    onRefreshData: PropTypes.func,
+    ignoreRefresh: PropTypes.bool
 };
 ContextInventoryList.defaultProps = {
     perPage: 50,
-    page: 1
+    page: 1,
+    ignoreRefresh: true
 };
 InventoryList.propTypes = {
     showTags: PropTypes.bool,

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -9,6 +9,7 @@ import Pagination from './Pagination';
 import AccessDenied from '../../shared/AccessDenied';
 import { loadSystems } from '../../shared';
 import isEqual from 'lodash/isEqual';
+import { entitiesLoading } from '../../redux/actions';
 
 /**
  * A helper function to store props and to always return the latest state.
@@ -54,6 +55,7 @@ const InventoryTable = forwardRef(({
     autoRefresh,
     isLoaded,
     initialLoading,
+    ignoreRefresh,
     ...props
 }, ref) => {
     const hasItems = Boolean(items);
@@ -112,7 +114,8 @@ const InventoryTable = forwardRef(({
         hideFilters,
         showTags,
         getEntities,
-        customFilters
+        customFilters,
+        hasItems
     });
 
     /**
@@ -133,11 +136,13 @@ const InventoryTable = forwardRef(({
             sortBy: cachedProps.sortBy,
             hideFilters: cachedProps.hideFilters,
             filters: activeFilters,
+            hasItems: cachedProps.hasItems,
             ...cachedProps.customFilters,
             ...options
         };
 
         if (onRefresh && !disableOnRefresh) {
+            dispatch(entitiesLoading());
             onRefresh(params, (options) => {
                 dispatch(
                     loadSystems(
@@ -207,6 +212,7 @@ const InventoryTable = forwardRef(({
                     showTags={ showTags }
                     onRefreshData={onRefreshData}
                     loaded={loaded}
+                    ignoreRefresh={ignoreRefresh}
                 />
                 <TableToolbar isFooter className="ins-c-inventory__table--toolbar">
                     <Pagination

--- a/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
+++ b/packages/inventory/src/components/table/__snapshots__/InventoryTable.test.js.snap
@@ -22,6 +22,7 @@ exports[`InventoryTable should render correctly - no data 1`] = `
   >
     <ContextInventoryList
       hasItems={false}
+      ignoreRefresh={true}
       onRefreshData={[Function]}
       page={1}
       perPage={50}
@@ -158,6 +159,7 @@ exports[`InventoryTable should render correctly 1`] = `
         ]
       }
       hasItems={false}
+      ignoreRefresh={true}
       loaded={true}
       onRefreshData={[Function]}
       page={1}
@@ -280,6 +282,7 @@ exports[`InventoryTable should render correctly with items 1`] = `
         ]
       }
       hasItems={true}
+      ignoreRefresh={true}
       items={
         Array [
           Object {
@@ -386,6 +389,7 @@ exports[`InventoryTable should render correctly with items no totla 1`] = `
         ]
       }
       hasItems={true}
+      ignoreRefresh={true}
       items={
         Array [
           Object {


### PR DESCRIPTION
- ignore onRefresh on mount (the same behavior as before)
- add hasItems to cache
- use onRefreshData in upper pagination
- connect entities by ID key