### PR TITLE
Provide defaultGetEntities function in custom getEntities

### DIFF
--- a/packages/inventory/doc/custom_fetch.md
+++ b/packages/inventory/doc/custom_fetch.md
@@ -2,6 +2,7 @@
   - [getEntities](#getentities)
     - [items](#items)
     - [config](#config)
+    - [defaultGetEntities](#defaultgetentities)
     - [result](#result)
       - [results](#results)
       - [total](#total)
@@ -22,7 +23,7 @@ Inventory components provides a simple way for changing its loading function. Th
 ## getEntities
 
 ```tsx
-getEntities = (items: array, config: Config, showTags: boolean) => result as Result
+getEntities = (items: array, config: Config, showTags: boolean, defaultGetEntities: function) => result as Result
 ```
 
 ### items
@@ -64,6 +65,19 @@ example:
       "direction":"asc"
    },
    "hasItems":false
+}
+```
+
+### defaultGetEntities
+
+As the 4th argument, the default `getEntities` function is passed, so you can grab it and enhance it.
+
+```jsx
+customGetEntities = async (_items, config, showTags, defaultGetEntities) => {
+    const items = await getCustomItems(config); // load your items and data
+    const result = await defaultGetEntities(items, config, showTags); // merge them with default api
+
+    return result;
 }
 ```
 

--- a/packages/inventory/src/redux/actions.js
+++ b/packages/inventory/src/redux/actions.js
@@ -57,7 +57,7 @@ export const loadEntities = (items = [], { filters, ...config }, { showTags } = 
             ...config,
             orderBy,
             orderDirection
-        }, showTags).then(({ results, ...data }) => ({
+        }, showTags, defaultGetEntities).then(({ results, ...data }) => ({
             ...data,
             filters,
             sortBy: { key: orderBy, direction: orderDirection },


### PR DESCRIPTION
### defaultGetEntities

As the 4th argument, the default `getEntities` function is passed, so you can grab it and enhance it.

```jsx
customGetEntities = async (_items, config, showTags, defaultGetEntities) => {
    const items = await getCustomItems(config); // load your items and data
    const result = await defaultGetEntities(items, config, showTags); // merge them with default api
    return result;
}
```