### PR TITLE
Fix systems seletion in Remediation Wizard

### DIFF
--- a/packages/remediations/src/RemediationWizard/RemediationWizard.js
+++ b/packages/remediations/src/RemediationWizard/RemediationWizard.js
@@ -73,12 +73,14 @@ const RemediationWizard = ({
         'select-playbook': {
             component: SelectPlaybook,
             issues: data.issues,
+            systems: data.systems,
             allSystems: allSystems.current
         },
         'review-systems': {
             component: ReviewSystems,
             issues: data.issues,
             systems: data.systems,
+            allSystems: allSystems.current,
             registry
         },
         'review-actions': {
@@ -97,7 +99,7 @@ const RemediationWizard = ({
 
     const validatorMapper = {
         'validate-systems': () => (value) => (
-            value && value.length > 0
+            value && Object.keys(value).length > 0
                 ? undefined
                 : 'At least one system must be selected. Actions must be associated to a system to be added to a playbook.')
     };
@@ -111,7 +113,7 @@ const RemediationWizard = ({
                 initialValues={{
                     [RESOLUTIONS]: [],
                     [ISSUES_MULTIPLE]: [],
-                    [SYSTEMS]: undefined,
+                    [SYSTEMS]: {},
                     [MANUAL_RESOLUTION]: true,
                     [SELECTED_RESOLUTIONS]: {},
                     [EXISTING_PLAYBOOK_SELECTED]: false

--- a/packages/remediations/src/RemediationWizard/RemediationWizard.js
+++ b/packages/remediations/src/RemediationWizard/RemediationWizard.js
@@ -99,7 +99,7 @@ const RemediationWizard = ({
 
     const validatorMapper = {
         'validate-systems': () => (value) => (
-            value && Object.keys(value).length > 0
+            value && Object.values(value).filter(value => typeof value !== undefined).length
                 ? undefined
                 : 'At least one system must be selected. Actions must be associated to a system to be added to a playbook.')
     };

--- a/packages/remediations/src/RemediationWizard/RemediationWizardHelper.js
+++ b/packages/remediations/src/RemediationWizard/RemediationWizardHelper.js
@@ -12,6 +12,21 @@ class RemediationWizard extends Component {
             isOpen: true,
             data: {
                 ...data,
+                issues: [{
+                    description: 'Bonding will not fail over to the backup link when bonding options are partially read',
+                    id: 'advisor:network_bond_opts_config_issue|NETWORK_BONDING_OPTS_DOUBLE_QUOTES_ISSUE',
+                    systems: [ '702502d2-1b72-472a-8b1c-bacfdd2ee8a4' ]
+                }, {
+                    description: 'Cluster nodes are frequently fenced as realtime is not enabled in corosync',
+                    id: 'advisor:corosync_enable_rt_schedule|COROSYNC_NOT_ENABLE_RT',
+                    systems: [ '335e6733-bab8-4696-8a0b-ff329eed4aea', 'da627f06-2a15-48b0-b5d9-55173e12a97d' ]
+                }, {
+                    description: 'Kernel vulnerable to local privilege escalation via DCCP module (CVE-2017-6074)',
+                    id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074',
+                    systems: [ '5f8b7586-bb74-4bf7-be15-1f258eb9e79d',
+                        '95fd611b-9d23-4713-b2f7-e577fde97d82',
+                        '702502d2-1b72-472a-8b1c-bacfdd2ee8a4' ]
+                }],
                 systems: data.systems || []
             },
             basePath

--- a/packages/remediations/src/RemediationWizard/RemediationWizardHelper.js
+++ b/packages/remediations/src/RemediationWizard/RemediationWizardHelper.js
@@ -12,21 +12,6 @@ class RemediationWizard extends Component {
             isOpen: true,
             data: {
                 ...data,
-                issues: [{
-                    description: 'Bonding will not fail over to the backup link when bonding options are partially read',
-                    id: 'advisor:network_bond_opts_config_issue|NETWORK_BONDING_OPTS_DOUBLE_QUOTES_ISSUE',
-                    systems: [ '702502d2-1b72-472a-8b1c-bacfdd2ee8a4' ]
-                }, {
-                    description: 'Cluster nodes are frequently fenced as realtime is not enabled in corosync',
-                    id: 'advisor:corosync_enable_rt_schedule|COROSYNC_NOT_ENABLE_RT',
-                    systems: [ '335e6733-bab8-4696-8a0b-ff329eed4aea', 'da627f06-2a15-48b0-b5d9-55173e12a97d' ]
-                }, {
-                    description: 'Kernel vulnerable to local privilege escalation via DCCP module (CVE-2017-6074)',
-                    id: 'advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074',
-                    systems: [ '5f8b7586-bb74-4bf7-be15-1f258eb9e79d',
-                        '95fd611b-9d23-4713-b2f7-e577fde97d82',
-                        '702502d2-1b72-472a-8b1c-bacfdd2ee8a4' ]
-                }],
                 systems: data.systems || []
             },
             basePath

--- a/packages/remediations/src/RemediationWizard/schema.js
+++ b/packages/remediations/src/RemediationWizard/schema.js
@@ -48,16 +48,16 @@ export const reviewActionsFields = [{
 export const reviewActionsNextStep = (values) => {
     const filteredIssues = values[EXISTING_PLAYBOOK_SELECTED]
         ? values[ISSUES_MULTIPLE].filter(
-            issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id)
+            issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id) && Object.keys(values[SYSTEMS]).includes(issue.id)
         )
-        : values[ISSUES_MULTIPLE];
-    return values[MANUAL_RESOLUTION] ? filteredIssues[0].id : 'review';
+        : values[ISSUES_MULTIPLE].filter(issue => Object.keys(values[SYSTEMS]).includes(issue.id));
+    return values[MANUAL_RESOLUTION] ? filteredIssues[0]?.id : 'review';
 };
 
 export const issueResolutionNextStep = (values, issue) => {
     const filteredIssues = values[EXISTING_PLAYBOOK_SELECTED]
-        ? values[ISSUES_MULTIPLE].filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
-        : values[ISSUES_MULTIPLE];
+        ? values[ISSUES_MULTIPLE].filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id && Object.keys(values[SYSTEMS]).includes(issue.id)))
+        : values[ISSUES_MULTIPLE].filter(issue => Object.keys(values[SYSTEMS]).includes(issue.id));
     return filteredIssues.slice(filteredIssues.findIndex(i => i.id === issue.id) + 1, filteredIssues.length)[0]?.id || 'review';
 };
 

--- a/packages/remediations/src/steps/issueResolution.js
+++ b/packages/remediations/src/steps/issueResolution.js
@@ -22,8 +22,8 @@ import isEqual from 'lodash/isEqual';
 const IssueResolution = ({ issue }) => {
     const formOptions = useFormApi();
     const resolutions = formOptions.getState().values[RESOLUTIONS];
-    const systems = formOptions.getState().values[SYSTEMS];
 
+    const systems = formOptions.getState().values[SYSTEMS][issue.id] || [];
     const issueResolutions = resolutions.find(r => r.id === issue.id)?.resolutions || [];
     const uniqueResolutions = uniqBy(issueResolutions, 'id');
     const removedResolutions = differenceWith(issueResolutions, uniqueResolutions, isEqual);
@@ -112,10 +112,9 @@ const IssueResolution = ({ issue }) => {
 IssueResolution.propTypes = {
     issue: propTypes.shape({
         id: propTypes.string,
-        shortId: propTypes.string,
         action: propTypes.string,
         alternate: propTypes.number,
-        systemsCount: propTypes.number
+        systems: propTypes.arrayOf(propTypes.string)
     }).isRequired
 };
 

--- a/packages/remediations/src/steps/review.js
+++ b/packages/remediations/src/steps/review.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
-import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
+import { Table, TableVariant, TableHeader, TableBody, sortable, expandable } from '@patternfly/react-table';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import {
     Button,
@@ -14,21 +14,34 @@ import {
 import {
     buildRows,
     getResolution,
+    onCollapse,
     EXISTING_PLAYBOOK,
     EXISTING_PLAYBOOK_SELECTED,
     SELECT_PLAYBOOK,
     SYSTEMS
 } from '../utils';
+import { useSelector } from 'react-redux';
 import './review.scss';
 
 const Review = (props) => {
-    const { data, issuesById } = props;
-    const { input } = useFieldApi(props);
     const formOptions = useFormApi();
-    const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
-
     const selectedPlaybook = formOptions.getState().values[EXISTING_PLAYBOOK];
     const existingPlaybookSelected = formOptions.getState().values[EXISTING_PLAYBOOK_SELECTED];
+    const systems = formOptions.getState().values[SYSTEMS];
+
+    const { data, issuesById } = {
+        ...props,
+        data: {
+            ...props.data,
+            issues: props.data.issues.filter(issue => systems[issue.id]?.length > 0)
+        }
+    };
+    const { input } = useFieldApi(props);
+    const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
+
+    const allSystemsNamed = useSelector(({ hostReducer: { hosts } }) => hosts?.map(host => (
+        { id: host.id, name: host.display_name })) || []
+    );
 
     const records = data.issues.map(issue => {
         const issueResolutions = getResolution(issue.id, formOptions.getState().values);
@@ -37,7 +50,7 @@ const Review = (props) => {
             action: issuesById[issue.id].description,
             resolution: description,
             needsReboot,
-            systemsCount: formOptions.getState().values[SYSTEMS]?.length || 0
+            systems: systems[issue.id].map(id => allSystemsNamed.find(system => system.id === id)?.name)
         };
     });
 
@@ -49,7 +62,7 @@ const Review = (props) => {
         );
     }, []);
 
-    const rows = buildRows(records, sortByState, false);
+    const [ rows, setRows ] = useState(buildRows(records, sortByState, false));
 
     return (
         <Stack hasGutter data-component-ouia-id="wizard-review">
@@ -103,11 +116,12 @@ const Review = (props) => {
                         transforms: [ sortable ]
                     }, {
                         title: 'Systems',
-                        transforms: [ sortable ]
+                        cellFormatters: [ expandable ]
                     }]
                 }
                 rows={ rows }
                 onSort={ (event, index, direction) => setSortByState({ index, direction }) }
+                onCollapse={(event, rowKey, isOpen) => onCollapse(event, rowKey, isOpen, rows, setRows)}
                 sortBy={ sortByState }
             >
                 <TableHeader noWrap />

--- a/packages/remediations/src/steps/review.js
+++ b/packages/remediations/src/steps/review.js
@@ -64,6 +64,10 @@ const Review = (props) => {
 
     const [ rows, setRows ] = useState(buildRows(records, sortByState, false));
 
+    useEffect(() => {
+        setRows(buildRows(records, sortByState, true));
+    }, [ sortByState ]);
+
     return (
         <Stack hasGutter data-component-ouia-id="wizard-review">
             <StackItem>

--- a/packages/remediations/src/steps/review.js
+++ b/packages/remediations/src/steps/review.js
@@ -65,7 +65,7 @@ const Review = (props) => {
     const [ rows, setRows ] = useState(buildRows(records, sortByState, false));
 
     useEffect(() => {
-        setRows(buildRows(records, sortByState, true));
+        setRows(buildRows(records, sortByState, false));
     }, [ sortByState ]);
 
     return (
@@ -120,6 +120,7 @@ const Review = (props) => {
                         transforms: [ sortable ]
                     }, {
                         title: 'Systems',
+                        transforms: [ sortable ],
                         cellFormatters: [ expandable ]
                     }]
                 }

--- a/packages/remediations/src/steps/reviewActions.js
+++ b/packages/remediations/src/steps/reviewActions.js
@@ -13,12 +13,11 @@ import {
 } from '@patternfly/react-core';
 import {
     buildRows,
+    onCollapse,
     pluralize,
-    sortRecords,
     EXISTING_PLAYBOOK,
     EXISTING_PLAYBOOK_SELECTED,
     ISSUES_MULTIPLE,
-    onCollapse,
     SYSTEMS
 } from '../utils';
 import './reviewActions.scss';

--- a/packages/remediations/src/steps/reviewActions.js
+++ b/packages/remediations/src/steps/reviewActions.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
@@ -14,6 +14,7 @@ import {
 import {
     buildRows,
     pluralize,
+    sortRecords,
     EXISTING_PLAYBOOK,
     EXISTING_PLAYBOOK_SELECTED,
     ISSUES_MULTIPLE,
@@ -36,10 +37,14 @@ const ReviewActions = (props) => {
         ? values[ISSUES_MULTIPLE].filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
         : values[ISSUES_MULTIPLE]).map(issue => ({
         ...issue,
-        systems: (values[SYSTEMS][issue.id] || []).map(id => allSystemsNamed.find(system => system.id === id).name)
+        systems: (values[SYSTEMS][issue.id] || []).map(id => allSystemsNamed.find(system => system.id === id)?.name)
     })).filter(record => record.systems.length > 0);
 
     const [ rows, setRows ] = useState(buildRows(multiples, sortByState, true));
+
+    useEffect(() => {
+        setRows(buildRows(multiples, sortByState, true));
+    }, [ sortByState ]);
 
     return (
         <Stack hasGutter data-component-ouia-id="wizard-review-actions">
@@ -85,6 +90,7 @@ const ReviewActions = (props) => {
                         transforms: [ sortable ]
                     }, {
                         title: 'Systems',
+                        transforms: [ sortable ],
                         cellFormatters: [ expandable ]
                     }]
                 }

--- a/packages/remediations/src/steps/reviewActions.js
+++ b/packages/remediations/src/steps/reviewActions.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
-import { Table, TableVariant, TableHeader, TableBody, sortable } from '@patternfly/react-table';
+import { Table, TableVariant, TableHeader, TableBody, sortable, expandable } from '@patternfly/react-table';
 import {
     Radio,
     Text,
@@ -15,22 +16,30 @@ import {
     pluralize,
     EXISTING_PLAYBOOK,
     EXISTING_PLAYBOOK_SELECTED,
-    ISSUES_MULTIPLE
+    ISSUES_MULTIPLE,
+    onCollapse,
+    SYSTEMS
 } from '../utils';
 import './reviewActions.scss';
 
 const ReviewActions = (props) => {
-    const { issues } = props;
-    const { input } = useFieldApi(props);
     const formOptions = useFormApi();
-    const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
-
     const values = formOptions.getState().values;
-    const records = values[EXISTING_PLAYBOOK_SELECTED]
-        ? values[ISSUES_MULTIPLE].filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
-        : values[ISSUES_MULTIPLE];
+    const issues = props.issues.filter(issue => Object.keys(values[SYSTEMS]).includes(issue.id));
+    const { input } = useFieldApi(props);
+    const [ sortByState, setSortByState ] = useState({ index: undefined, direction: undefined });
+    const allSystemsNamed = useSelector(({ hostReducer: { hosts } }) => hosts?.map(host => (
+        { id: host.id, name: host.display_name })) || []
+    );
 
-    const rows = buildRows(records, sortByState, true);
+    const multiples = (values[EXISTING_PLAYBOOK_SELECTED]
+        ? values[ISSUES_MULTIPLE].filter(issue => !values[EXISTING_PLAYBOOK].issues.some(i => i.id === issue.id))
+        : values[ISSUES_MULTIPLE]).map(issue => ({
+        ...issue,
+        systems: (values[SYSTEMS][issue.id] || []).map(id => allSystemsNamed.find(system => system.id === id).name)
+    })).filter(record => record.systems.length > 0);
+
+    const [ rows, setRows ] = useState(buildRows(multiples, sortByState, true));
 
     return (
         <Stack hasGutter data-component-ouia-id="wizard-review-actions">
@@ -38,29 +47,32 @@ const ReviewActions = (props) => {
                 <TextContent>
                     <Text>
                         You have selected <b>{`${issues.length} ${pluralize(issues.length, 'item')}`}</b> to remediate. <b>
-                            {rows.length} of {`${issues.length} ${pluralize(issues.length, 'item')}`}</b> allow for you to chose from multiple resolution steps.
+                            {multiples.length} of {`${issues.length} ${pluralize(issues.length, 'item')}`}</b>
+                        {multiples.length !== 1 ? ' allow' : ' allows'} for you to chose from multiple resolution steps.
                     </Text>
                 </TextContent>
             </StackItem>
             <StackItem>
                 <Radio
                     label={
-                        `Review and/or change the resolution steps for ${rows.length > 1 ? 'these' : 'this'} ${rows.length} ${pluralize(rows.length, 'action')}.`
+                        `Review and/or change the resolution steps for ${multiples.length !== 1 ? 'these' : 'this'}
+                         ${multiples.length} ${pluralize(multiples.length, 'action')}.`
                     }
                     id="change"
                     name="radio"
                     isChecked={input.value}
                     onChange={() => input.onChange(true)}
                 />
-                {issues.length - rows.length > 0 && <Text className="ins-c-remediations-choose-actions-description">
-                    {`The ${issues.length - rows.length} other selected ${pluralize(issues.length - rows.length, 'issue')} 
-                    ${issues.length - rows.length > 1 ? 'do' : 'does'} not have multiple resolution options.`}
+                {issues.length - multiples.length > 0 && <Text className="ins-c-remediations-choose-actions-description">
+                    {`The ${issues.length - multiples.length} other selected ${pluralize(issues.length - multiples.length, 'issue')} 
+                    ${issues.length - multiples.length !== 1 ? 'do' : 'does'} not have multiple resolution options.`}
                 </Text>}
             </StackItem>
             <Table
                 aria-label='Actions'
                 className='ins-c-remediation-summary-table'
                 variant={ TableVariant.compact }
+                onCollapse={(event, rowKey, isOpen) => onCollapse(event, rowKey, isOpen, rows, setRows)}
                 cells={ [
                     {
                         title: 'Action',
@@ -73,7 +85,7 @@ const ReviewActions = (props) => {
                         transforms: [ sortable ]
                     }, {
                         title: 'Systems',
-                        transforms: [ sortable ]
+                        cellFormatters: [ expandable ]
                     }]
                 }
                 rows={ rows }

--- a/packages/remediations/src/steps/reviewSystems.js
+++ b/packages/remediations/src/steps/reviewSystems.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/dist/esm/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/dist/esm/use-form-api';
@@ -9,13 +9,9 @@ import {
     Stack, StackItem
 } from '@patternfly/react-core';
 import {
-    dedupeArray,
     fetchSystemsInfo,
-    getPlaybookSystems,
     inventoryEntitiesReducer as entitiesReducer,
-    EXISTING_PLAYBOOK,
-    TOGGLE_BULK_SELECT,
-    EXISTING_PLAYBOOK_SELECTED
+    TOGGLE_BULK_SELECT
 } from '../utils';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
@@ -23,10 +19,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import isEqual from 'lodash/isEqual';
-import unionWith from 'lodash/unionWith';
 import './reviewSystems.scss';
 
-const ReviewSystems = ({ issues, systems, registry, ...props }) => {
+const ReviewSystems = ({ issues, systems, allSystems, registry, ...props }) => {
 
     let dispatch = useDispatch();
     const inventory = useRef(null);
@@ -34,35 +29,25 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
     const formOptions = useFormApi();
     const inventoryApi = useRef({});
 
-    const formValues = formOptions.getState().values;
-    const playbook = formValues[EXISTING_PLAYBOOK];
     const error = formOptions.getState().errors?.systems;
 
     const rowsLength = useSelector(({ entities }) => (entities?.rows || []).length);
     const selected = useSelector(({ entities }) => entities?.selected || []);
     const loaded = useSelector(({ entities }) => entities?.loaded);
-    const newSystemsNamed = useSelector(({ hostReducer: { hosts } }) => hosts?.map(host => (
+    const allSystemsNamed = useSelector(({ hostReducer: { hosts } }) => hosts?.map(host => (
         { id: host.id, display_name: host.display_name })) || []
     );
 
-    const allSystems = useRef([]);
-    const [ allSystemsNamed, setAllSystemsNamed ] = useState([]);
-
     useEffect(() => {
-        const playbookSystems = formValues?.[EXISTING_PLAYBOOK_SELECTED] ? getPlaybookSystems(playbook) : [];
-        setAllSystemsNamed(unionWith(playbookSystems, newSystemsNamed, isEqual));
-        allSystems.current = dedupeArray([
-            ...dedupeArray(issues.reduce((acc, curr) => [
+        const value = issues.reduce((acc, curr) => {
+            const tempSystems = [ ...systems, ...curr.systems ].filter(id => selected?.includes(id));
+            return ({
                 ...acc,
-                ...(curr.systems || [])
-            ], [ ...systems ])),
-            ...(playbookSystems.map(system => system.id))
-        ]);
-    }, [ playbook, issues, systems ]);
-
-    useEffect(() => {
-        if (!isEqual(input.value, selected)) {
-            input.onChange(selected);
+                ...(tempSystems.length > 0 ? { [curr.id]: tempSystems } : {})
+            });
+        }, {});
+        if (!isEqual(input.value, value)) {
+            input.onChange(value);
         }
     }, [ selected ]);
 
@@ -106,7 +91,7 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
                             ref={inventory}
                             getEntities={(_i, config) => fetchSystemsInfo(config, allSystemsNamed, inventoryApi.current)}
                             onLoad={({ mergeWithEntities, api, INVENTORY_ACTION_TYPES }) => {
-                                registry.register(mergeWithEntities(entitiesReducer(allSystems.current, INVENTORY_ACTION_TYPES)));
+                                registry.register(mergeWithEntities(entitiesReducer(allSystems, INVENTORY_ACTION_TYPES)));
                                 inventoryApi.current = api;
                             }}
                             bulkSelect={{
@@ -143,11 +128,12 @@ const ReviewSystems = ({ issues, systems, registry, ...props }) => {
 };
 
 ReviewSystems.propTypes = {
-    systems: propTypes.arrayOf(propTypes.string).isRequired,
     issues: propTypes.arrayOf(propTypes.shape({
         description: propTypes.string,
         id: propTypes.string
     })).isRequired,
+    systems: propTypes.arrayOf(propTypes.string).isRequired,
+    allSystems: propTypes.arrayOf(propTypes.string).isRequired,
     registry: propTypes.instanceOf(ReducerRegistry).isRequired
 };
 

--- a/packages/remediations/src/steps/reviewSystems.js
+++ b/packages/remediations/src/steps/reviewSystems.js
@@ -40,7 +40,7 @@ const ReviewSystems = ({ issues, systems, allSystems, registry, ...props }) => {
 
     useEffect(() => {
         const value = issues.reduce((acc, curr) => {
-            const tempSystems = [ ...systems, ...curr.systems ].filter(id => selected?.includes(id));
+            const tempSystems = [ ...systems, ...(curr.systems || []) ].filter(id => selected?.includes(id));
             return ({
                 ...acc,
                 ...(tempSystems.length > 0 ? { [curr.id]: tempSystems } : {})

--- a/packages/remediations/src/steps/selectPlaybook.js
+++ b/packages/remediations/src/steps/selectPlaybook.js
@@ -181,12 +181,12 @@ const SelectPlaybook = (props) => {
 };
 
 SelectPlaybook.propTypes = {
-    allSystems: propTypes.arrayOf(propTypes.string).isRequired,
     issues: propTypes.arrayOf(propTypes.shape({
         description: propTypes.string,
         id: propTypes.string
     })).isRequired,
-    systems: propTypes.arrayOf(propTypes.string).isRequired
+    systems: propTypes.arrayOf(propTypes.string).isRequired,
+    allSystems: propTypes.arrayOf(propTypes.string).isRequired
 };
 
 export default SelectPlaybook;

--- a/packages/remediations/src/steps/selectPlaybook.js
+++ b/packages/remediations/src/steps/selectPlaybook.js
@@ -34,7 +34,7 @@ import {
 import './selectPlaybook.scss';
 
 const SelectPlaybook = (props) => {
-    const { issues, allSystems } = props;
+    const { issues, systems, allSystems } = props;
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
     const values = formOptions.getState().values;
@@ -62,7 +62,7 @@ const SelectPlaybook = (props) => {
     useEffect(() => {
         if (differenceWith(resolutions, values[RESOLUTIONS], isEqual)?.length > 0) {
             formOptions.change(RESOLUTIONS, resolutions);
-            formOptions.change(ISSUES_MULTIPLE, getIssuesMultiple(issues, allSystems, resolutions));
+            formOptions.change(ISSUES_MULTIPLE, getIssuesMultiple(issues, systems, resolutions));
         }
     });
 
@@ -185,7 +185,8 @@ SelectPlaybook.propTypes = {
     issues: propTypes.arrayOf(propTypes.shape({
         description: propTypes.string,
         id: propTypes.string
-    })).isRequired
+    })).isRequired,
+    systems: propTypes.arrayOf(propTypes.string).isRequired
 };
 
 export default SelectPlaybook;

--- a/packages/remediations/src/tests/schema.test.js
+++ b/packages/remediations/src/tests/schema.test.js
@@ -4,7 +4,8 @@ import {
     EXISTING_PLAYBOOK,
     MANUAL_RESOLUTION,
     EXISTING_PLAYBOOK_SELECTED,
-    ISSUES_MULTIPLE
+    ISSUES_MULTIPLE,
+    SYSTEMS
 } from '../utils';
 import { remediationWizardTestData } from './testData';
 
@@ -20,7 +21,8 @@ describe('reviewActionsNextStep', () => {
                     id: 'anotherId',
                     resolution: { id: 'test2' }
                 }]
-            }
+            },
+            [SYSTEMS]: remediationWizardTestData.selectedSystems
         };
     });
 
@@ -33,7 +35,8 @@ describe('reviewActionsNextStep', () => {
         const value = reviewActionsNextStep({
             ...formValues,
             [MANUAL_RESOLUTION]: true,
-            [EXISTING_PLAYBOOK_SELECTED]: true
+            [EXISTING_PLAYBOOK_SELECTED]: true,
+            [SYSTEMS]: remediationWizardTestData.selectedSystems
         }, [{ id: 'testId' }]);
         expect(value).toEqual('testId');
     });
@@ -51,7 +54,8 @@ describe('issueResolutionNextStep', () => {
                     resolution: { id: 'test' }
                 }]
             },
-            [ISSUES_MULTIPLE]: []
+            [ISSUES_MULTIPLE]: [],
+            [SYSTEMS]: remediationWizardTestData.selectedSystems
         };
     });
 
@@ -73,7 +77,10 @@ describe('issueResolutionNextStep', () => {
 
 describe('schema', () => {
 
-    const formValues = remediationWizardTestData.formValues;
+    const formValues = {
+        ...remediationWizardTestData.formValues,
+        [SYSTEMS]: remediationWizardTestData.selectedSystems
+    };
 
     it('should render issues', () => {
         const schema = schemaBuilder(remediationWizardTestData.issues);

--- a/packages/remediations/src/tests/steps/review.test.js
+++ b/packages/remediations/src/tests/steps/review.test.js
@@ -88,7 +88,7 @@ describe('Review', () => {
         expect(wrapper.find('Form')).toHaveLength(1);
         expect(wrapper.find('table')).toHaveLength(3);
         expect(wrapper.find(BodyRow)).toHaveLength(6);
-        expect(wrapper.find('button')).toHaveLength(7);
+        expect(wrapper.find('button')).toHaveLength(8);
     });
 
     it('should change autoreboot correctly', async () => {
@@ -117,9 +117,8 @@ describe('Review', () => {
         });
         wrapper.update();
         expect(wrapper.find('td').at(2).props().children).toEqual('test_description');
-        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
-        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
-        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
+        wrapper.find('button[className="pf-c-table__button"]').first().simulate('click');
+        wrapper.find('button[className="pf-c-table__button"]').first().simulate('click');
         expect(wrapper.find('td').at(2).props().children).toEqual('description');
     });
 

--- a/packages/remediations/src/tests/steps/review.test.js
+++ b/packages/remediations/src/tests/steps/review.test.js
@@ -4,10 +4,13 @@ import FormRenderer from '@data-driven-forms/react-form-renderer/dist/esm/form-r
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/esm/form-template';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { AUTO_REBOOT, RESOLUTIONS } from '../../utils';
+import { AUTO_REBOOT, RESOLUTIONS, SYSTEMS } from '../../utils';
+import promiseMiddleware from 'redux-promise-middleware';
+import configureStore from 'redux-mock-store';
 import Review from '../../steps/review';
 import { BodyRow } from '@patternfly/react-table/dist/js/components/Table/base';
 import { remediationWizardTestData } from '../testData';
+import { Provider } from 'react-redux';
 
 const RendererWrapper = (props) => (
     <FormRenderer
@@ -31,7 +34,8 @@ const RendererWrapper = (props) => (
             }
         }}
         initialValues={{
-            [RESOLUTIONS]: remediationWizardTestData.resolutions
+            [RESOLUTIONS]: remediationWizardTestData.resolutions,
+            [SYSTEMS]: { ...remediationWizardTestData.selectedSystems, testId2: [ 'system2' ] }
         }}
         schema={{ fields: [] }}
         subscription={{ values: true }}
@@ -47,6 +51,14 @@ const createSchema = () => ({
         }
     ]
 });
+
+let mockStore = configureStore([ promiseMiddleware ]);
+
+const initialState = {
+    hostReducer: {
+        hosts: [{ id: 'system', display_name: 'system1' }, { id: 'system2', display_name: 'system2' }]
+    }
+};
 
 describe('Review', () => {
 
@@ -65,20 +77,28 @@ describe('Review', () => {
 
     it('should render correctly', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema({})} {...initialProps} />);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema({})} {...initialProps} />
+                </Provider>);
         });
         wrapper.update();
         expect(wrapper.find('Form')).toHaveLength(1);
-        expect(wrapper.find('table')).toHaveLength(1);
-        expect(wrapper.find(BodyRow)).toHaveLength(2);
-        expect(wrapper.find('button')).toHaveLength(6);
+        expect(wrapper.find('table')).toHaveLength(3);
+        expect(wrapper.find(BodyRow)).toHaveLength(6);
+        expect(wrapper.find('button')).toHaveLength(7);
     });
 
     it('should change autoreboot correctly', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema({})} {...initialProps} />);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema({})} {...initialProps} />
+                </Provider>);
         });
         wrapper.update();
         expect(wrapper.find('Button[variant="link"]').props().children).toEqual([ 'Turn ', 'off', ' autoreboot' ]);
@@ -88,20 +108,29 @@ describe('Review', () => {
 
     it('should sort records correctly', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema({})} {...initialProps} />);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema({})} {...initialProps} />
+                </Provider>);
         });
         wrapper.update();
-        expect(wrapper.find('td').first().props().children).toEqual('test_description');
-        wrapper.find('button[className="pf-c-table__button"]').first().simulate('click');
-        wrapper.update();
-        expect(wrapper.find('td').first().props().children).toEqual('description');
+        expect(wrapper.find('td').at(2).props().children).toEqual('test_description');
+        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
+        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
+        wrapper.find('button[className="pf-c-table__button"]').at(2).simulate('click');
+        expect(wrapper.find('td').at(2).props().children).toEqual('description');
     });
 
     it('should submit the form', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema({})} {...initialProps} onSubmit={onSubmit}/>);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema({})} {...initialProps} onSubmit={onSubmit}/>
+                </Provider>);
         });
         wrapper.update();
         wrapper.find('Form').simulate('submit');

--- a/packages/remediations/src/tests/steps/reviewActions.test.js
+++ b/packages/remediations/src/tests/steps/reviewActions.test.js
@@ -6,9 +6,12 @@ import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import ReviewActions from '../../steps/reviewActions';
 import { reviewActionsFields } from '../../RemediationWizard/schema';
-import { EXISTING_PLAYBOOK, EXISTING_PLAYBOOK_SELECTED, ISSUES_MULTIPLE, RESOLUTIONS } from '../../utils';
+import promiseMiddleware from 'redux-promise-middleware';
+import configureStore from 'redux-mock-store';
+import { EXISTING_PLAYBOOK, EXISTING_PLAYBOOK_SELECTED, ISSUES_MULTIPLE, RESOLUTIONS, SYSTEMS } from '../../utils';
 import { BodyRow } from '@patternfly/react-table/dist/js/components/Table/base';
 import { remediationWizardTestData } from '../testData';
+import { Provider } from 'react-redux';
 
 const RendererWrapper = (props) => (
     <FormRenderer
@@ -32,7 +35,8 @@ const RendererWrapper = (props) => (
                 needs_reboot: false
             },
             [RESOLUTIONS]: remediationWizardTestData.resolutions,
-            [ISSUES_MULTIPLE]: remediationWizardTestData.issuesMultiple
+            [ISSUES_MULTIPLE]: remediationWizardTestData.issuesMultiple,
+            [SYSTEMS]: remediationWizardTestData.selectedSystems
         }}
         schema={{ fields: [] }}
         {...props}
@@ -42,6 +46,14 @@ const RendererWrapper = (props) => (
 const createSchema = () => ({
     fields: reviewActionsFields
 });
+
+let mockStore = configureStore([ promiseMiddleware ]);
+
+const initialState = {
+    hostReducer: {
+        hosts: [{ id: 'test2', display_name: 'test2' }]
+    }
+};
 
 describe('ReviewActions', () => {
 
@@ -53,18 +65,26 @@ describe('ReviewActions', () => {
 
     it('should render correctly', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema()} />);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema()} />
+                </Provider>);
         });
         expect(wrapper.find('input[type="radio"]')).toHaveLength(2);
-        expect(wrapper.find('table')).toHaveLength(1);
-        expect(wrapper.find(BodyRow)).toHaveLength(1);
+        expect(wrapper.find('table')).toHaveLength(2);
+        expect(wrapper.find(BodyRow)).toHaveLength(3);
     });
 
     it('should sort table & submit review option', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema()} onSubmit={onSubmit}/>);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema()} onSubmit={onSubmit}/>
+                </Provider>);
         });
         wrapper.find('button[className="pf-c-table__button"]').last().simulate('click');
         wrapper.find('input[type="radio"]').first().simulate('change', {
@@ -76,8 +96,12 @@ describe('ReviewActions', () => {
 
     it('should submit accept option', async () => {
         let wrapper;
+        const store = mockStore(initialState);
         await act(async() => {
-            wrapper = mount(<RendererWrapper schema={createSchema()} onSubmit={onSubmit}/>);
+            wrapper = mount(
+                <Provider store={store}>
+                    <RendererWrapper schema={createSchema()} onSubmit={onSubmit}/>
+                </Provider>);
         });
         wrapper.find('input[type="radio"]').last().simulate('change', {
             target: { checked: true } });

--- a/packages/remediations/src/tests/steps/reviewSystems.test.js
+++ b/packages/remediations/src/tests/steps/reviewSystems.test.js
@@ -60,6 +60,7 @@ const schema = {
             systems: [{ id: 'test', display_name: 'test' }]
         }],
         systems: [ 'test2' ],
+        allSystems: [ 'test', 'test2' ],
         registry: new ReducerRegistry({}, [ promiseMiddleware ])
     }]
 };

--- a/packages/remediations/src/tests/steps/selectPlaybook.test.js
+++ b/packages/remediations/src/tests/steps/selectPlaybook.test.js
@@ -23,6 +23,7 @@ const RendererWrapper = (props) => (
             'select-playbook': {
                 component: SelectPlaybook,
                 issues: remediationWizardTestData.issues,
+                systems: remediationWizardTestData.systems,
                 allSystems: remediationWizardTestData.systems
             }
         }}

--- a/packages/remediations/src/tests/testData.js
+++ b/packages/remediations/src/tests/testData.js
@@ -42,13 +42,18 @@ export const remediationWizardTestData = {
 
     systems: [ 'system' ],
 
+    selectedSystems: {
+        testId: [ 'system' ],
+        testId2: [ 'system' ]
+    },
+
     issuesById: {
         testId: {
             id: 'testId',
             description: 'test_description'
         },
         testId2: {
-            id: 'testId',
+            id: 'testId2',
             description: 'description'
         }
     },

--- a/packages/remediations/src/tests/utils.test.js
+++ b/packages/remediations/src/tests/utils.test.js
@@ -14,7 +14,8 @@ import {
     fetchSystemsInfo,
     splitArray,
     getPlaybookSystems,
-    createNotification
+    createNotification,
+    SYSTEMS
 } from '../utils';
 import { remediationWizardTestData } from './testData';
 
@@ -90,7 +91,8 @@ describe('submitRemediation', () => {
         formValues = {
             ...remediationWizardTestData.formValues,
             [EXISTING_PLAYBOOK]: remediationWizardTestData.existingPlaybook,
-            [EXISTING_PLAYBOOK_SELECTED]: true
+            [EXISTING_PLAYBOOK_SELECTED]: true,
+            [SYSTEMS]: remediationWizardTestData.selectedSystems
         };
     });
 

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -44,7 +44,7 @@ export const pluralize = (count, str, fallback) => count !== 1 ? (fallback || st
 
 const sortRecords = (records, sortByState) => [ ...records ].sort(
     (a, b) => {
-        const key = Object.keys(a)[sortByState.index];
+        const key = Object.keys(a)[sortByState.index - 1];
         return (
             (a[key] > b[key] ? 1 :
                 a[key] < b[key] ? -1 : 0)
@@ -279,10 +279,10 @@ export const getIssuesMultiple = (issues = [], systems = [], resolutions = []) =
         const { description, needs_reboot: needsReboot  } = issueResolutions?.[0] || {};
         return {
             action: issues.find(i => i.id === issue.id).description,
-            systems: dedupeArray([ ...(issue.systems || []), systems ]),
-            id: issue.id,
             resolution: description,
             needsReboot,
+            systems: dedupeArray([ ...(issue.systems || []), systems ]),
+            id: issue.id,
             alternate: issueResolutions?.length - 1
         };
     }).filter(record => record.alternate > 0);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/VULN-1656 & https://issues.redhat.com/browse/RHCLOUD-13891

Fixed issues caused by forgetting which systems were assigned to which issues and applying all issues to all systems. Now issues are being applied just to corresponding systems reflecting previously set systems. Also added expandable table to `reviewActions` step and `review` step showing names of NEW (not previously selected systems in case of enhancing existing playbook) systems on which the remmediation will be applied to. Finally, fixed broken sorting in tables because of wrong indexes in sortByState and updated tests.

@katierik I will create a separate PR to use InventoryTable (allowing to display Tags and so on) in the expandable section with systems. This needs some more changes.

![reviewActions_final](https://user-images.githubusercontent.com/50696716/119277574-c846f180-bc20-11eb-912c-adfa3c370d89.png)
![review](https://user-images.githubusercontent.com/50696716/119277575-ca10b500-bc20-11eb-8f61-1fe5721617bb.png)

@karelhala 
