### PR TITLE
RHICOMPL-1829: update link to supported SSGs in compliance

### DIFF
--- a/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
+++ b/packages/inventory-compliance/src/PresentationalComponents/UnsupportedSSGVersion.js
@@ -3,9 +3,8 @@ import propTypes from 'prop-types';
 import { Popover, Alert } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-export const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/' +
-    'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/' +
-    'con-compl-assess-overview_compl-assess-overview#con-compl-assess-supported-configurations_compl-assess-overview';
+export const supportedConfigsLink = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2021/' +
+    'html/assessing_and_monitoring_security_policy_compliance_of_rhel_systems/index';
 
 const UnsupportedSSGVersion = ({ ssgVersion, style }) => {
     const bodyContent = 'This system was using an incompatible version of the SSG at the time this report was generated.' +


### PR DESCRIPTION
Updating the URL from 2020 to the 2021 version