### PR TITLE
remove prettier/react from eslint config

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -24,8 +24,7 @@ module.exports = {
         'eslint:recommended',
         'prettier',
         'plugin:prettier/recommended',
-        'plugin:react/recommended',
-        'prettier/react'
+        'plugin:react/recommended'
     ],
     rules: {
         'no-unused-vars': [


### PR DESCRIPTION
As of version 8 of `prettier`, there is no need to list prettier sub-modules. Its all included out of the box: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

Fixes following issue:
```
$ eslint config src

Oops! Something went wrong! :(

ESLint: 7.27.0

Error: Cannot read config file: /home/martin/insights/insights-remediations-frontend/node_modules/eslint-config-prettier/react.js
Error: "prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
Referenced from: /home/martin/insights/insights-remediations-frontend/node_modules/@redhat-cloud-services/eslint-config-redhat-cloud-services/index.js
    at Object.<anonymous> (/home/martin/insights/insights-remediations-frontend/node_modules/eslint-config-prettier/react.js:1:69)
    at Module._compile (/home/martin/insights/insights-remediations-frontend/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
    at Module.load (node:internal/modules/cjs/loader:972:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:996:19)
    at module.exports (/home/martin/insights/insights-remediations-frontend/node_modules/import-fresh/index.js:32:59)
    at loadJSConfigFile (/home/martin/insights/insights-remediations-frontend/node_modules/@eslint/eslintrc/lib/config-array-factory.js:225:16)
    at loadConfigFile (/home/martin/insights/insights-remediations-frontend/node_modules/@eslint/eslintrc/lib/config-array-factory.js:309:20)
    at ConfigArrayFactory._loadConfigData (/home/martin/insights/insights-remediations-frontend/node_modules/@eslint/eslintrc/lib/config-array-factory.js:609:42)
error Command failed with exit code 2.

```