### PR TITLE
Add router to proxy config

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -3,6 +3,7 @@ const { readFileSync } = require('fs');
 const { sync } = require('glob');
 const ESI = require('nodesi');
 const cookieTransform = require('./cookieTransform');
+const transformUrl = require('./router');
 
 function createInsightsProxy({
     betaEnv,
@@ -77,6 +78,8 @@ function createInsightsProxy({
         console.log('Exact URL: ', exactUrl ? 'true' : 'false', '\n\n');
     }
 
+    const router = transformUrl(target);
+
     return {
         contentBase: `${rootFolder || ''}/dist`,
         index: `${rootFolder || ''}/dist/index.html`,
@@ -94,7 +97,8 @@ function createInsightsProxy({
                 target,
                 secure: false,
                 changeOrigin: true,
-                autoRewrite: true
+                autoRewrite: true,
+                router
             },
             ...(appUrl ? [{
                 context: path => pathInCustomUrl(removeHashQuery(path)),
@@ -169,6 +173,7 @@ function createInsightsProxy({
                     onProxyReq: (...args) => {
                         cookieTransform(...args);
                     },
+                    ...(currTarget === 'PORTAL_BACKEND_MARKER' &&  { router }),
                     ...typeof redirect === 'object' ? redirect : {}
                 };
             }) : [],

--- a/packages/config-utils/router.js
+++ b/packages/config-utils/router.js
@@ -1,0 +1,13 @@
+function router(target) {
+    return (req) => {
+        switch (req.hostname) {
+            case 'ci.foo.redhat.com':    return 'https://ci.cloud.redhat.com/';
+            case 'qa.foo.redhat.com':    return 'https://qa.cloud.redhat.com/';
+            case 'stage.foo.redhat.com': return 'https://cloud.stage.redhat.com/';
+            case 'prod.foo.redhat.com':  return 'https://cloud.redhat.com/';
+            default: return target;
+        }
+    };
+}
+
+module.exports = router;

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -12,7 +12,7 @@
       - [routesPath](#routespath)
     - [Custom proxy settings](#custom-proxy-settings)
     - [Chrome 1 environments / application entry url](#chrome-1-environments--application-entry-url)
-      - [Prod environment example](#prod-environment-example)
+      - [Different environments](#different-environments)
       - [Multiple HTML entrypoints](#multiple-html-entrypoints)
       - [Exact URL](#exact-url)
     - [cookieTransform](#cookietransform)
@@ -57,8 +57,6 @@ NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.
 *Path to config can be different*
 
 Then you will find your application running on `https://ci.foo.redhat.com:1337/beta/...`. This works only with **Chrome 2** ready applications.
-
-You can change the environment by setting `betaEnv`, but unless the targeted environment is using Chrome 2.0, it won't work correctly.
 
 ### localChrome
 
@@ -171,22 +169,42 @@ This settings will redirect all requests to `appUrl` to your local `index.html` 
 
 By default, all subroutes are (`/beta/settings/sources/new`) will be redirected to `index.html`, you can disable this behavior by setting `disableFallback: true`.
 
-#### Prod environment example
+#### Different environments
+
+The proxy config automatically routes requests to the correct target.
 
 ```jsx
-const { config: webpackConfig, plugins } = config({
-  rootFolder: resolve(__dirname, '../'),
-  debug: true,
-  useFileHash: false,
-  deployment: process.env.BETA ? 'beta/apps' : 'apps',
-  useProxy: true,
-  betaEnv: 'prod',
-  appUrl: process.env.BETA ? '/beta/settings/sources' : '/settings/sources'
-});
+case 'ci.foo.redhat.com':    return 'https://ci.cloud.redhat.com/';
+case 'qa.foo.redhat.com':    return 'https://qa.cloud.redhat.com/';
+case 'stage.foo.redhat.com': return 'https://cloud.stage.redhat.com/';
+case 'prod.foo.redhat.com':  return 'https://cloud.redhat.com/';
 ```
 
-Then go to `https://prod.foo.redhat.com:1337/` and you should be able to login and use your local UI build within production environment.
+This `router` function is also available as a seperate module:
 
+```jsx
+const router = require('@redhat-cloud-services/frontend-components-config-utilities/router');
+
+...
+
+{
+  ...
+  customProxy: [
+    {
+      context: (path) => path.includes('/api/'),
+      target: defaultTarget,
+      // high-order function returning the router function (req) => ....
+      // defaultTarget can be empty, it is just a fallback
+      router: router(defaultTarget),
+      secure: false,
+      changeOrigin: true,
+      autoRewrite: true,
+      ws: true,
+    },
+  ],
+}
+
+```
 #### Multiple HTML entrypoints
 
 If your application has multiple HTML entrypoints, you can set an array of values in `appUrl`:


### PR DESCRIPTION
#### Different environments

The proxy config automatically routes requests to the correct target.

```jsx
case 'ci.foo.redhat.com':    return 'https://ci.cloud.redhat.com/';
case 'qa.foo.redhat.com':    return 'https://qa.cloud.redhat.com/';
case 'stage.foo.redhat.com': return 'https://cloud.stage.redhat.com/';
case 'prod.foo.redhat.com':  return 'https://cloud.redhat.com/';
```

This `router` function is also available as a seperate module:

```jsx
const router = require('@redhat-cloud-services/frontend-components-config-utilities/router');
...
{
  ...
  customProxy: [
    {
      context: (path) => path.includes('/api/'),
      target: defaultTarget,
      // high-order function returning the router function (req) => ....
      // defaultTarget can be empty, it is just a fallback
      router: router(defaultTarget),
      secure: false,
      changeOrigin: true,
      autoRewrite: true,
      ws: true,
    },
  ],
}
```