### PR TITLE
fix(groupFilter): add dummy value to not crash PF select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35696,7 +35696,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.1.13",
+            "version": "3.2.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -35725,7 +35725,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.1.8",
+            "version": "4.1.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.0.0",
@@ -35840,7 +35840,7 @@
         },
         "packages/inventory": {
             "name": "@redhat-cloud-services/frontend-components-inventory",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
@@ -36299,7 +36299,7 @@
         },
         "packages/remediations": {
             "name": "@redhat-cloud-services/frontend-components-remediations",
-            "version": "3.2.0",
+            "version": "3.2.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@data-driven-forms/pf4-component-mapper": "^2.23.3",

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -320,7 +320,13 @@ class Group extends Component {
                             .filter(Boolean);
 
                             return (
-                                <div key={groupId || groupValue || groupKey}>
+                                /**
+                                 * DO NOT DELET THE EMPTY VALUE ON THE DIV ELEMENT
+                                 * If we delete it, it breaks the select filtering
+                                 * Here is the code that creates the runtime crash:
+                                 * https://github.com/patternfly/patternfly-react/blob/master/packages/react-core/src/components/Select/Select.tsx#L615
+                                 */
+                                <div key={groupId || groupValue || groupKey} value="">
                                     {
                                         groupSelectable && <SelectOption
                                             onClick={ (event) => {

--- a/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
+++ b/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
@@ -314,6 +314,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -369,6 +370,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -442,6 +444,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -517,6 +520,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -657,6 +661,7 @@ exports[`Group - component render should render correctly with items - isDisable
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -712,6 +717,7 @@ exports[`Group - component render should render correctly with items - isDisable
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -785,6 +791,7 @@ exports[`Group - component render should render correctly with items - isDisable
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -860,6 +867,7 @@ exports[`Group - component render should render correctly with items - isDisable
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -1000,6 +1008,7 @@ exports[`Group - component render should render correctly with items 1`] = `
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1055,6 +1064,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1128,6 +1138,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1203,6 +1214,7 @@ exports[`Group - component render should render correctly with items 1`] = `
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -1343,6 +1355,7 @@ exports[`Group - component render should render correctly with items and default
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1398,6 +1411,7 @@ exports[`Group - component render should render correctly with items and default
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1471,6 +1485,7 @@ exports[`Group - component render should render correctly with items and default
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1546,6 +1561,7 @@ exports[`Group - component render should render correctly with items and default
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -1686,6 +1702,7 @@ exports[`Group - component render should render correctly with items and selecte
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1741,6 +1758,7 @@ exports[`Group - component render should render correctly with items and selecte
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1814,6 +1832,7 @@ exports[`Group - component render should render correctly with items and selecte
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -1889,6 +1908,7 @@ exports[`Group - component render should render correctly with items and selecte
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -2029,6 +2049,7 @@ exports[`Group - component render show more should render correctly with items a
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2084,6 +2105,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2157,6 +2179,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2232,6 +2255,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -2387,6 +2411,7 @@ exports[`Group - component render show more should render correctly with items a
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2442,6 +2467,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2515,6 +2541,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2590,6 +2617,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -2740,6 +2768,7 @@ exports[`Group - component render show more should render correctly with items a
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2795,6 +2824,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2868,6 +2898,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -2943,6 +2974,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""
@@ -3093,6 +3125,7 @@ exports[`Group - component render show more should render correctly with items a
     >
       <div
         key="0"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -3148,6 +3181,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="second"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -3221,6 +3255,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="third"
+        value=""
       >
         <SelectGroup
           className="pf-u-pl-sm"
@@ -3296,6 +3331,7 @@ exports[`Group - component render show more should render correctly with items a
       </div>
       <div
         key="3"
+        value=""
       >
         <SelectOption
           className=""


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14319

The PF select calss `children[x].props.value.toString()` but is not checking if the value prop exists which casues runtime errors for custom select children. This is a workaround that will fix the component until PF adjusts its filtering.