### PR TITLE
Update expandable SystemsTables styling

### DIFF
--- a/packages/remediations/src/common/SystemsTable.js
+++ b/packages/remediations/src/common/SystemsTable.js
@@ -66,7 +66,7 @@ export const SystemsTableWithContext = (props) => {
     }, []);
 
     return registry?.store  ? <Provider store={registry.store}>
-        <div className="ins-c-remediations-table-expandable">
+        <div className="pf-u-pl-lg">
             <SystemsTable {...props} registry={registry} />
         </div>
     </Provider> : null;

--- a/packages/remediations/src/common/SystemsTable.js
+++ b/packages/remediations/src/common/SystemsTable.js
@@ -8,6 +8,7 @@ import {
     fetchSystemsInfo,
     inventoryEntitiesReducer as entitiesReducer
 } from '../utils';
+import './systemsTable.scss';
 
 const SystemsTable = ({ registry, allSystemsNamed, allSystems, hasCheckbox, disabledColumns, bulkSelect }) => {
 
@@ -65,7 +66,9 @@ export const SystemsTableWithContext = (props) => {
     }, []);
 
     return registry?.store  ? <Provider store={registry.store}>
-        <SystemsTable {...props} registry={registry} />
+        <div className="ins-c-remediations-table-expandable">
+            <SystemsTable {...props} registry={registry} />
+        </div>
     </Provider> : null;
 };
 

--- a/packages/remediations/src/common/systemsTable.scss
+++ b/packages/remediations/src/common/systemsTable.scss
@@ -1,24 +1,22 @@
-.ins-c-remediations-table-expandable {
-    .ins-c-entity-table.pf-c-table.pf-m-compact {
-        tr > *:first-child {
-            --pf-c-table--cell--PaddingLeft: var(--pf-global--spacer--lg);
-        }
-        tr > *:last-child {
-            --pf-c-table--cell--PaddingRight: var(--pf-global--spacer--lg);
-        }
-        .ins-composed-col * {
-            font-size: var(--pf-global--FontSize--sm);
-        }
-        .ins-c-inventory__list-tags {
-            vertical-align: bottom;
-            button {
-                padding: 0;
-                svg {
-                    width: 14px;
-                }
-                .ins-c-tag__text {
-                    font-size: var(--pf-global--FontSize--sm);
-                }
+.ins-c-entity-table.pf-c-table.pf-m-compact {
+    tr > *:first-child {
+        --pf-c-table--cell--PaddingLeft: var(--pf-global--spacer--lg);
+    }
+    tr > *:last-child {
+        --pf-c-table--cell--PaddingRight: var(--pf-global--spacer--lg);
+    }
+    .ins-composed-col * {
+        font-size: var(--pf-global--FontSize--sm);
+    }
+    .ins-c-inventory__list-tags {
+        vertical-align: bottom;
+        button {
+            padding: 0;
+            svg {
+                width: 14px;
+            }
+            .ins-c-tag__text {
+                font-size: var(--pf-global--FontSize--sm);
             }
         }
     }

--- a/packages/remediations/src/common/systemsTable.scss
+++ b/packages/remediations/src/common/systemsTable.scss
@@ -1,0 +1,25 @@
+.ins-c-remediations-table-expandable {
+    .ins-c-entity-table.pf-c-table.pf-m-compact {
+        tr > *:first-child {
+            --pf-c-table--cell--PaddingLeft: var(--pf-global--spacer--lg);
+        }
+        tr > *:last-child {
+            --pf-c-table--cell--PaddingRight: var(--pf-global--spacer--lg);
+        }
+        .ins-composed-col * {
+            font-size: var(--pf-global--FontSize--sm);
+        }
+        .ins-c-inventory__list-tags {
+            vertical-align: bottom;
+            button {
+                padding: 0;
+                svg {
+                    width: 14px;
+                }
+                .ins-c-tag__text {
+                    font-size: var(--pf-global--FontSize--sm);
+                }
+            }
+        }
+    }
+}

--- a/packages/remediations/src/utils/utils.js
+++ b/packages/remediations/src/utils/utils.js
@@ -81,6 +81,7 @@ export const buildRows = (records, sortByState, showAlternate, allSystemsNamed) 
     },
     ...(curr.systems?.length > 0 ? [{
         parent: index * 2,
+        fullWidth: true,
         cells: [
             {
                 title: (
@@ -92,7 +93,7 @@ export const buildRows = (records, sortByState, showAlternate, allSystemsNamed) 
                         />
                     </Router>
                 ),
-                props: { colSpan: 4, className: 'pf-m-no-padding' }
+                props: { colSpan: 5, className: 'pf-m-no-padding' }
             }
         ]
     }] : []) ], []);


### PR DESCRIPTION
UX changes from https://github.com/RedHatInsights/frontend-components/pull/1154

**Before:**
![before](https://user-images.githubusercontent.com/50696716/120556229-8118e780-c3fc-11eb-8987-b347362a2640.png)

**After:**
![after](https://user-images.githubusercontent.com/50696716/120556245-86763200-c3fc-11eb-837d-1585c1e64fbb.png)

@katierik is it correct this way?

@epwinchell stole a bit of your code from https://github.com/RedHatInsights/insights-remediations-frontend/pull/249 it probably needs to be added there separately