### PR TITLE
Check sortable duplicate using string

### DIFF
--- a/packages/inventory/src/components/table/helpers.js
+++ b/packages/inventory/src/components/table/helpers.js
@@ -63,13 +63,15 @@ export const onDeleteTag = (deleted, selectedTags, onApplyTags) => {
     return selectedTags;
 };
 
+const includesSortable = (transforms) => transforms?.reduce((acc, fn) => acc || fn.toString().includes('onSort:'), false);
+
 export const createColumns = (columns, hasItems, rows, isExpandable) => (
     columns?.map(({ props, transforms, cellFormatters, ...oneCell }) => ({
         ...oneCell,
         transforms: [
             ...transforms || [],
             ...props?.width ? [ cellWidth(props.width) ] : [],
-            ...hasItems || rows.length <= 0 || (props && props.isStatic) || transforms?.includes(sortable) ? [] : [ sortable ]
+            ...hasItems || rows.length <= 0 || (props && props.isStatic) || transforms?.includes(sortable) || includesSortable(transforms) ? [] : [ sortable ]
         ],
         cellFormatters: [
             ...cellFormatters || [],

--- a/packages/inventory/src/components/table/helpers.test.js
+++ b/packages/inventory/src/components/table/helpers.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import { buildCells, createRows, onDeleteFilter, onDeleteTag, createColumns } from './helpers';
+import { sortable } from '@patternfly/react-table';
 
 describe('buildCells', () => {
     it('should create cells without renderFunc', () => {
@@ -154,6 +155,28 @@ describe('createColumns', () => {
     it('should create columns with width', () => {
         const data = createColumns([{ data: 'something', props: { width: 10 } }], false, [ 'something' ]);
         expect(data[0].transforms.length).toBe(2);
+    });
+
+    describe('sortable', () => {
+        it('adds sortable by default', () => {
+            const data = createColumns([{ data: 'something' }], false, [ 'something' ]);
+
+            expect(data[0].transforms).toEqual([ sortable ]);
+        });
+
+        it('filter duplicate sortables', () => {
+            const data = createColumns([{ data: 'something', transforms: [ sortable ] }], false, [ 'something' ]);
+
+            expect(data[0].transforms).toEqual([ sortable ]);
+        });
+
+        it('filter duplicate sortables when different function', () => {
+            const thisAddsSorting = () => ({ element: { onSort: jest.fn() } });
+
+            const data = createColumns([{ data: 'something', transforms: [ thisAddsSorting ] }], false, [ 'something' ]);
+
+            expect(data[0].transforms).toEqual([ thisAddsSorting ]);
+        });
     });
 
     describe('non sortable', () => {


### PR DESCRIPTION
Some applications does not use `isStatic` to control `sortable`.

This PR adds an additional check for `sortable` duplicates. Checking function reference does not work in applications, because their sortables can be imported differently. Also, we cannot use `name` attribute of the function as it is missing often. So I made a fallback to check presence of `onSort:` string in the function.