### PR TITLE
Fix DateFormat import in PDF generator

### DIFF
--- a/packages/pdf-generator/src/components/PDFDocument.js
+++ b/packages/pdf-generator/src/components/PDFDocument.js
@@ -8,7 +8,7 @@ import {
 } from '@react-pdf/renderer';
 import RHLogo from './Logo';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
-import { DateFormat } from '@redhat-cloud-services/frontend-components';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { customTitle } from '../utils/text';
 import styles from '../utils/styles';
 


### PR DESCRIPTION
Without this I was getting
`Cannot find module '@redhat-cloud-services/frontend-components/components/cjs/DateFormat.js' from 'node_modules/@redhat-cloud-services/frontend-components-pdf-generator/dist/esm/index.js'`