### PR TITLE
[WIP]Append PF vendor to the top of the head.

### DIFF
--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -29,7 +29,14 @@ module.exports = ({
     new MiniCssExtractPlugin({
         chunkFilename: 'css/[name].[contenthash].css',
         filename: 'css/[name].[contenthash].css',
-        ignoreOrder: true
+        ignoreOrder: true,
+        insert: function(linkTag) {
+            if (linkTag.href && linkTag.href.includes('pfVendor')) {
+                document.head.insertBefore(linkTag, document.head.firstElementChild);
+            } else {
+                document.head.appendChild(linkTag);
+            }
+        }
     }),
     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
We have CSS loading order issues in the ansible automation UI. The PF vendor gets loaded after the chrome which causes major graphical issues in chrome. By adding the `pfVendor` to the top of the head we give higher priority to the chrome CSS PF styles. Anything else will be still appended to the end of the head tag as it should be.

### Before
![screenshot-cloud redhat com-2021 06 14-16_24_11](https://user-images.githubusercontent.com/22619452/121908126-fa81d580-cd2c-11eb-8b94-530f9d83e78b.png)

### After
![screenshot-ci foo redhat com_1337-2021 06 14-16_24_53](https://user-images.githubusercontent.com/22619452/121908210-11282c80-cd2d-11eb-9e34-a544efe241b8.png)
