### PR TITLE
Toolbar mobile fix

### DIFF
--- a/packages/components/src/TableToolbar/TableToolbar.scss
+++ b/packages/components/src/TableToolbar/TableToolbar.scss
@@ -22,7 +22,7 @@
 }
 
 @media only screen and (max-width: 768px) {
-	.ins-c-table__toolbar {
-	    padding: var(--pf-global--spacer--md) var(--pf-global--spacer--md);
-	}
+    .ins-c-table__toolbar, .ins-c-table__toolbar-results {
+        padding: 0 0;
+    }
 }


### PR DESCRIPTION
Remove extra footer padding in mobile

https://issues.redhat.com/browse/RHCLOUD-13822

Old
![Screen Shot 2021-06-15 at 10 55 59 AM](https://user-images.githubusercontent.com/1287144/122075961-741ad180-cdc8-11eb-971c-4e8c85d54943.png)

New
![Screen Shot 2021-06-15 at 10 47 09 AM](https://user-images.githubusercontent.com/1287144/122075964-74b36800-cdc8-11eb-9f0a-63472c8441cb.png)
