### PR TITLE
Update maintenance screen

### DIFF
--- a/packages/components/src/Maintenance/Maintenance.js
+++ b/packages/components/src/Maintenance/Maintenance.js
@@ -25,7 +25,7 @@ const Maintenance = ({ title, utcStartTime, utcEndTime, startTime, endTime, time
                     ? description
                     : <Stack>
                         <StackItem>We are currently undergoing scheduled maintenance and will be</StackItem>
-                        <StackItem>unavailable from {utcStartTime}-{utcEndTime} UTC ({startTime}-{endTime} {timeZone}).</StackItem>
+                        <StackItem>unavailable from {utcStartTime} to {utcEndTime} UTC ({startTime}-{endTime} {timeZone}).</StackItem>
                         <StackItem>For more information please visit <a href={redirectLink}>status.redhat.com</a>.</StackItem>
                     </Stack>
                 }

--- a/packages/components/src/Maintenance/__snapshots__/Maintenance.test.js.snap
+++ b/packages/components/src/Maintenance/__snapshots__/Maintenance.test.js.snap
@@ -21,7 +21,7 @@ exports[`Maintenance component should render with default props 1`] = `
       <StackItem>
         unavailable from 
         10am
-        -
+         to 
         12am
          UTC (
         6am
@@ -87,7 +87,7 @@ exports[`Maintenance component should render with times 1`] = `
       <StackItem>
         unavailable from 
         10am
-        -
+         to 
         12am
          UTC (
         12am


### PR DESCRIPTION
- Using `from 14:00 to 15:00` instead of `from 14:00 - 15:00`

as seen in the screenshots: 
https://docs.google.com/document/d/1VLs7vFczWUzyIpH6EUsTEpJugDsjeuh4a_azs6IJbC0/edit#heading=h.4mjp25jpkwpb

// cc: @katierik 