### PR TITLE
RuleFeedback: correct prop name in comment

### DIFF
--- a/packages/rule-components/src/ReportDetails/RuleFeedback.js
+++ b/packages/rule-components/src/ReportDetails/RuleFeedback.js
@@ -8,7 +8,7 @@ import { OutlinedThumbsDownIcon } from '@patternfly/react-icons';
 
 export const feedback = { negative: -1, neutral: 0, positive: 1 };
 // ruleId - is id of current rule
-// onFeedbackSent(ruleId, vote) is a callback which is called when feedback is changed
+// onFeedbackChanged(ruleId, vote) is a callback which is called when feedback is changed
 // where ruleId is id of the rule, vote is either -1, 0 or 1
 class RuleFeedback extends React.Component {
     state = { feedbackSaved: false }


### PR DESCRIPTION
Tiny followup to #401.  I don't really know what's going on here, just noticed the disrepancy :smile:  cc @karelhala 

BTW, #544 mentions preferring `feedback` consts rather than -1, 0, 1, maybe you want to update the doc comment accordingly.
