### PR TITLE
feat(SystemDetails): RHICOMPL-1449 NoPolicies, NoReports empty states

### DIFF
--- a/packages/inventory-compliance/src/Compliance/Compliance.js
+++ b/packages/inventory-compliance/src/Compliance/Compliance.js
@@ -1,9 +1,22 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import propTypes from 'prop-types';
 import SystemPolicyCards from '../SystemPolicyCards';
 import SystemRulesTable, { columns } from '../SystemRulesTable';
 import ComplianceEmptyState from '../ComplianceEmptyState';
 import { useQuery } from '@apollo/react-hooks';
+import { PlusCircleIcon, CloudSecurityIcon } from '@patternfly/react-icons';
+import {
+    Title,
+    TextContent,
+    Bullseye,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStatePrimary,
+    EmptyStateSecondaryActions,
+    EmptyStateIcon
+} from '@patternfly/react-core';
 import gql from 'graphql-tag';
 import { ApolloClient, HttpLink, InMemoryCache } from 'apollo-boost';
 import { Spinner } from '@redhat-cloud-services/frontend-components/Spinner';
@@ -18,6 +31,10 @@ query System($systemId: String!){
     system(id: $systemId) {
         id
         name
+        hasPolicy
+        policies {
+            id
+        }
         testResultProfiles {
             id
             name
@@ -50,34 +67,102 @@ query System($systemId: String!){
 }
 `;
 
+const NoPoliciesState = ({ system }) => (
+    system?.hasPolicy ? null : <Bullseye>
+        <EmptyState>
+            <EmptyStateIcon icon={PlusCircleIcon} />
+            <Title headingLevel="h1" size="lg">This system is not part of any SCAP policies defined within Compliance.</Title>
+            <EmptyStateBody>
+                To assess and monitor compliance against a SCAP policy for this system,
+                add it to an existing policy or create a new policy.
+            </EmptyStateBody>
+            <EmptyStatePrimary>
+                <Button
+                    ouiaId="CreateNewPolicyButton"
+                    variant="primary"
+                    component="a"
+                    href="/insights/compliance/scappolicies/new">
+                    Create a policy
+                </Button>
+            </EmptyStatePrimary>
+            <EmptyStateSecondaryActions>
+                <Button variant='link' component='a' href='/insights/compliance/scappolicies'>
+                    View compliance policies
+                </Button>
+            </EmptyStateSecondaryActions>
+        </EmptyState>
+    </Bullseye>
+);
+
+NoPoliciesState.propTypes = {
+    system: propTypes.shape({
+        hasPolicy: propTypes.bool
+    })
+};
+
+const NoReportsState = ({ system }) => (
+    system?.hasPolicy && !system.testResultProfiles?.length ? <Bullseye>
+        <EmptyState>
+            <EmptyStateIcon
+                icon={CloudSecurityIcon} title="Compliance" size="xl"
+                style={{ fontWeight: '500', color: 'var(--pf-global--primary-color--100)' }} />
+            <Title headingLevel="h1" size="lg">No results reported</Title>
+            <EmptyStateBody>
+                This system is part of { system.policies.length }
+                { system.policies.length > 1 ? ' policies' : ' policy' },
+                but has not returned any results.
+            </EmptyStateBody>
+            <EmptyStateBody>
+                Reports are returned when the system checks into Insights.
+                By default, systems check in every 24 hours.
+            </EmptyStateBody>
+        </EmptyState>
+    </Bullseye> : null
+);
+
+NoReportsState.propTypes = {
+    system: propTypes.shape({
+        hasPolicy: propTypes.bool,
+        testResultProfiles: propTypes.array,
+        policies: propTypes.array
+    })
+};
+
 const SystemQuery = ({ data: { system }, loading, hidePassed }) => (
     <React.Fragment>
         <SystemPolicyCards policies={ system?.testResultProfiles } loading={ loading } />
+        <NoPoliciesState system={ system } />
+        <NoReportsState system={ system } />
         <br/>
-        <SystemRulesTable
-            hidePassed={ hidePassed }
-            sortBy={{
-                index: 4,
-                direction: 'asc',
-                property: 'severity'
-            }}
-            system={ {
-                ...system,
-                supported: ((system?.testResultProfiles || []).filter((profile) => (profile.supported)).length > 0)
-            } }
-            columns={ columns }
-            profileRules={ system?.testResultProfiles.map(profile => ({
-                system,
-                profile,
-                rules: profile.rules
-            })) }
-            loading={ loading } />
+        { system?.testResultProfiles?.length ?
+            <SystemRulesTable
+                hidePassed={ hidePassed }
+                sortBy={{
+                    index: 4,
+                    direction: 'asc',
+                    property: 'severity'
+                }}
+                system={ {
+                    ...system,
+                    supported: ((system?.testResultProfiles || []).filter((profile) => (profile.supported)).length > 0)
+                } }
+                columns={ columns }
+                profileRules={ system?.testResultProfiles.map(profile => ({
+                    system,
+                    profile,
+                    rules: profile.rules
+                })) }
+                loading={ loading } /> : undefined }
     </React.Fragment>
 );
 
 SystemQuery.propTypes = {
     data: propTypes.shape({
         system: propTypes.shape({
+            hasPolicy: propTypes.bool,
+            policies: propTypes.shape({
+                id: propTypes.string
+            }),
             profiles: propTypes.array,
             testResultProfiles: propTypes.array
         })


### PR DESCRIPTION
Add the NoPoliciesState and NoReportsState empty state components to the
SystemDetails page.

Draft for refactoring and tests

No policy:

![image](https://user-images.githubusercontent.com/761923/122626152-c4b75680-d076-11eb-9f1d-2020ad67abad.png)

Yes policy, no reports:

![image](https://user-images.githubusercontent.com/761923/122626195-f7614f00-d076-11eb-93fe-91df809b9768.png)

Signed-off-by: Andrew Kofink <akofink@redhat.com>