### PR TITLE
Add console routes to proxy config utils

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -25,15 +25,16 @@ module.exports = ({
     localChrome,
     appUrl = [],
     publicPath,
-    proxyVerbose
+    proxyVerbose,
+    useCloud = false
 }) => {
     const proxy = [];
     const registry = [];
     const majorEnv = env.split('-')[0];
     const minorEnv = majorEnv === 'prod' ? '' : `${majorEnv}.`;
     const target = env === 'prod-stable'
-        ? 'https://cloud.redhat.com/'
-        : `https://${minorEnv}cloud.redhat.com/`;
+        ? `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`
+        : `https://${minorEnv}${useCloud ? 'cloud' : 'console'}.redhat.com/`;
     if (!Array.isArray(appUrl)) {
         appUrl = [ appUrl ];
     }
@@ -150,7 +151,7 @@ module.exports = ({
                 return false;
             },
             target,
-            router: router(target)
+            router: router(target, useCloud)
         });
     }
 

--- a/packages/config-utils/standalone/helpers/router.js
+++ b/packages/config-utils/standalone/helpers/router.js
@@ -1,10 +1,10 @@
-function router(target) {
+function router(target, useCloud) {
     return (req) => {
         switch (req.hostname) {
-            case 'ci.foo.redhat.com':    return 'https://ci.cloud.redhat.com/';
-            case 'qa.foo.redhat.com':    return 'https://qa.cloud.redhat.com/';
-            case 'stage.foo.redhat.com': return 'https://cloud.stage.redhat.com/';
-            case 'prod.foo.redhat.com':  return 'https://cloud.redhat.com/';
+            case 'ci.foo.redhat.com':    return `https://ci.${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+            case 'qa.foo.redhat.com':    return `https://qa.${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+            case 'stage.foo.redhat.com': return `https://${useCloud ? 'cloud' : 'console'}.stage.redhat.com/`;
+            case 'prod.foo.redhat.com':  return `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`;
             default: return target;
         }
     };

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -55,6 +55,7 @@ const { config: webpackConfig, plugins } = config({
 |[routes](#routes)|`object`|An object with additional routes.|
 |[routesPath](#routespath)|`string`|A path to an object with additional routes.|
 |[customProxy](#custom-proxy-settings)|`object[]`|An array of custom provided proxy configurations.|
+|[useCloud](#use-cloud)|`boolean`|Toggle to use old fallback to cloud.redhat.com paths instead of console.redhat.com.|
 
 ### localChrome
 
@@ -140,6 +141,10 @@ const { config: webpackConfig, plugins } = config({
 ```
 
 This configuration will redirect all API requests to QA environment, so you can check CI UI with QA data.
+
+### Use cloud
+
+If you want to run in legace mode please pass `useCloud: true` in your config, this way paths which does not match your proxy config (API for instance) will be passed to `cloud.redhat.com` (respective to your env `ci|qa|stage`). Without this all fallback routes will be redirected to `console.redhat.com`.
 
 ## standalone
 A way to run cloud.redhat.com apps from `localhost` offline.

--- a/packages/pdf-generator/src/utils/fonts.js
+++ b/packages/pdf-generator/src/utils/fonts.js
@@ -1,5 +1,10 @@
 const fontBaseUrl = 'https://overpass-30e2.kxcdn.com/';
-const RHFontUrl = (window.location.hostname.includes('foo.redhat.com') || window.location.hostname.includes('cloud.redhat.com'))
+const RHFontUrl = (
+    window.location.hostname.includes('foo.redhat.com') ||
+    window.location.hostname.includes('cloud.redhat.com') ||
+    window.location.hostname.includes('console.redhat.com') ||
+    window.location.hostname.includes('stage.redhat.com')
+)
     ? `${window.location.origin}/apps/frontend-assets/fonts/RedHat/RedHatDisplay`
     : 'https://raw.githubusercontent.com/RedHatOfficial/RedHatFont/master/fonts/proportional/static/ttf/RedHatDisplay';
 


### PR DESCRIPTION
### New console routes

Since we will be migrating to console.redhat.com let's migrate our paths in proxy as well. We want to have as smooth transition as possible so I've added new config option to use cloud paths. This way apps which start to use the new config can pass this option untill console paths are available.