### PR TITLE
Add useChrome hook to return chrome global context.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5571,9 +5571,9 @@
             "integrity": "sha512-iTXWltn+7x3uGghQ1gR4upZzu2ltILaTMA4zY54yUP/DqR9x5NpSlSZnjnVoyqZ1ftL2PjU7pPokt3fVv6phqQ=="
         },
         "node_modules/@scalprum/react-core": {
-            "version": "0.0.16",
-            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.0.16.tgz",
-            "integrity": "sha512-VNsh3oBBvMjzm8ByTXiHkJCYwNgRbY9Apz2zVU+1rzZPtRRbjvvnRZTop5vcRa6CRMyttNNtSQ3R2n0EZlNBGg==",
+            "version": "0.1.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.1.0-beta.1.tgz",
+            "integrity": "sha512-iu1KOjS4sfz7LREYJD/cPWXZTZwIPpDHylIT7+pmB3gcYHiKi2VBDByqdAVYwxT4zIHSm1ODWYzKecZ5jeTLHg==",
             "dependencies": {
                 "@scalprum/core": "^0.0.11",
                 "lodash": "^4.17.0"
@@ -35553,12 +35553,12 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.2.4",
+            "version": "3.2.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
                 "@scalprum/core": "^0.0.11",
-                "@scalprum/react-core": "^0.0.16",
+                "@scalprum/react-core": "0.1.0-beta.1",
                 "sanitize-html": "^2.3.2"
             },
             "devDependencies": {
@@ -35582,7 +35582,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.1.10",
+            "version": "4.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.1.2",
@@ -35616,7 +35616,8 @@
             }
         },
         "packages/config-utils": {
-            "version": "1.1.2",
+            "name": "@redhat-cloud-services/frontend-components-config-utilities",
+            "version": "1.2.0",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "webpack": "^5.0.0"
@@ -35731,7 +35732,7 @@
         },
         "packages/inventory": {
             "name": "@redhat-cloud-services/frontend-components-inventory",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
@@ -35856,7 +35857,7 @@
         },
         "packages/pdf-generator": {
             "name": "@redhat-cloud-services/frontend-components-pdf-generator",
-            "version": "2.6.2",
+            "version": "2.6.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-charts": "^6.3.9",
@@ -36190,7 +36191,7 @@
         },
         "packages/remediations": {
             "name": "@redhat-cloud-services/frontend-components-remediations",
-            "version": "3.2.3",
+            "version": "3.2.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@data-driven-forms/pf4-component-mapper": "^2.23.3",
@@ -40547,7 +40548,7 @@
                 "@patternfly/patternfly": ">=4.102.2",
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
                 "@scalprum/core": "^0.0.11",
-                "@scalprum/react-core": "^0.0.16",
+                "@scalprum/react-core": "0.1.0-beta.1",
                 "@types/react": "^16.9.34",
                 "node-sass-package-importer": "^5.3.2",
                 "sanitize-html": "^2.3.2"
@@ -41162,9 +41163,9 @@
             "integrity": "sha512-iTXWltn+7x3uGghQ1gR4upZzu2ltILaTMA4zY54yUP/DqR9x5NpSlSZnjnVoyqZ1ftL2PjU7pPokt3fVv6phqQ=="
         },
         "@scalprum/react-core": {
-            "version": "0.0.16",
-            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.0.16.tgz",
-            "integrity": "sha512-VNsh3oBBvMjzm8ByTXiHkJCYwNgRbY9Apz2zVU+1rzZPtRRbjvvnRZTop5vcRa6CRMyttNNtSQ3R2n0EZlNBGg==",
+            "version": "0.1.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.1.0-beta.1.tgz",
+            "integrity": "sha512-iu1KOjS4sfz7LREYJD/cPWXZTZwIPpDHylIT7+pmB3gcYHiKi2VBDByqdAVYwxT4zIHSm1ODWYzKecZ5jeTLHg==",
             "requires": {
                 "@scalprum/core": "^0.0.11",
                 "lodash": "^4.17.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "sanitize-html": "^2.3.2",
         "@scalprum/core": "^0.0.11",
-        "@scalprum/react-core": "^0.0.16"
+        "@scalprum/react-core": "0.1.0-beta.1"
     },
     "devDependencies": {
         "@patternfly/patternfly": ">=4.102.2",

--- a/packages/components/src/useChrome/index.js
+++ b/packages/components/src/useChrome/index.js
@@ -1,0 +1,2 @@
+export { default } from './useChrome';
+export { default as useChrome } from './useChrome';

--- a/packages/components/src/useChrome/useChrome.js
+++ b/packages/components/src/useChrome/useChrome.js
@@ -1,0 +1,17 @@
+import { useScalprum } from '@scalprum/react-core';
+
+const useChrome = (selector) => {
+    const state = useScalprum();
+    let chrome = state.api?.chrome || {};
+    chrome = {
+        ...chrome,
+        initialized: state.initialized
+    };
+    if (typeof selector === 'function') {
+        return selector(chrome);
+    }
+
+    return chrome;
+};
+
+export default useChrome;

--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -42,6 +42,15 @@ module.exports = ({
         }
     }));
 
+    /**
+     * Add scalprum and force it as singletong.
+     * It is required to share the context via `useChrome`.
+     * No application should be installing/interacting with scalprum directly.
+     */
+    if (dependencies['@redhat-cloud-services/frontend-components']) {
+        sharedDeps.push({ '@scalprum/react-core': { singleton: true } });
+    }
+
     if (debug) {
         console.log('Using package at path: ', resolve(root, './package.json'));
         console.log('Using appName: ', appName);


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-14898

Enables sharing a global context via `useChrome` hook. Eventually will replace the current chrome API available on window.
