### PR TITLE
Add empty state for Insights not connected

### DIFF
--- a/packages/components/src/NotConnected/NotConnected.js
+++ b/packages/components/src/NotConnected/NotConnected.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { EmptyState, EmptyStateIcon, EmptyStateBody, Title, Button } from '@patternfly/react-core';
+import { DisconnectedIcon } from '@patternfly/react-icons';
+
+const NotConnected = ({ titleText, bodyText, buttonText }) => (
+    <EmptyState>
+        <EmptyStateIcon icon={DisconnectedIcon} />
+        <Title headingLevel="h5" size="lg">
+            {titleText}
+        </Title>
+        <EmptyStateBody>
+            {bodyText}
+        </EmptyStateBody>
+        <Button
+            variant="primary"
+            component="a"
+            href="http://access.redhat.com/products/cloud_management_services_for_rhel#getstarted"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="pf-u-mt-lg"
+        >
+            {buttonText}
+        </Button>
+    </EmptyState>
+);
+
+NotConnected.propTypes = {
+    titleText: propTypes.node,
+    bodyText: propTypes.node,
+    buttonText: propTypes.node
+};
+
+NotConnected.defaultProps = {
+    titleText: 'This system is not yet connected to Insights',
+    bodyText: 'Activate the Insights client for this system to get started.',
+    buttonText: 'Learn about the Insights client'
+};
+
+export default NotConnected;

--- a/packages/components/src/NotConnected/NotConnected.test.js
+++ b/packages/components/src/NotConnected/NotConnected.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import NotConnected from './NotConnected';
+
+describe('Not connected component', () => {
+    it('should render', () => {
+        const wrapper = mount(<NotConnected/>);
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+});

--- a/packages/components/src/NotConnected/__snapshots__/NotConnected.test.js.snap
+++ b/packages/components/src/NotConnected/__snapshots__/NotConnected.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Not connected component should render 1`] = `
+<NotConnected
+  bodyText="Activate the Insights client for this system to get started."
+  buttonText="Learn about the Insights client"
+  titleText="This system is not yet connected to Insights"
+>
+  <EmptyState>
+    <div
+      className="pf-c-empty-state"
+    >
+      <div
+        className="pf-c-empty-state__content"
+      >
+        <EmptyStateIcon
+          icon={[Function]}
+        >
+          <DisconnectedIcon
+            aria-hidden="true"
+            className="pf-c-empty-state__icon"
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden="true"
+              aria-labelledby={null}
+              className="pf-c-empty-state__icon"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M107.625758,511.919812 C107.647579,453.639819 120.473237,396.076275 145.195758,343.299812 L66.0757577,263.919812 C64.9757577,266.019812 63.7857577,268.019812 62.6857577,270.119812 C-38.2858609,455.136708 -13.6478565,683.418046 124.475758,842.629812 C134.640866,854.227038 149.304208,860.890207 164.725758,860.920803 C177.621501,860.999229 190.089847,856.300444 199.725758,847.729812 C222.045758,828.339812 224.235758,794.349812 204.725758,771.959812 C142.116482,699.791587 107.639971,607.46129 107.625758,511.919812 Z M298.965758,512.769812 C298.965758,507.959812 299.165758,503.349812 299.465758,498.849812 L223.695758,422.919812 C195.943021,511.49644 210.859555,607.936744 264.075758,683.989812 C272.417691,695.880397 286.040845,702.947712 300.565758,702.92092 C309.717884,702.984827 318.661486,700.187766 326.145758,694.919812 C346.244069,680.682503 351.030068,652.865563 336.845758,632.729812 C312.094475,597.618928 298.858215,555.687799 298.965758,512.729812 L298.965758,512.769812 Z M903.425758,837.839812 C1064.25516,648.181373 1062.68818,369.557312 899.735758,181.719812 C890.46515,170.983736 877.290268,164.395355 863.139154,163.418898 C848.98804,162.442441 835.033106,167.158807 824.375758,176.519812 C802.005758,195.919812 799.815758,229.919812 819.185758,252.309812 C945.123654,397.620078 948.572544,612.370403 827.365758,761.649812 L754.005758,688.159812 C755.244385,686.815558 756.37773,685.377981 757.395758,683.859812 C792.844775,633.759435 811.790626,573.852791 811.595758,512.479812 C811.595758,450.189812 792.735758,390.599812 756.695758,340.199812 C749.880846,330.567 739.510358,324.044705 727.876268,322.074416 C716.242178,320.104127 704.302408,322.848071 694.695758,329.699812 C674.625758,343.899812 670.135758,371.699812 684.215758,391.799812 C733.317078,460.966176 735.688504,552.965658 690.215758,624.569812 L615.045758,549.479812 C619.447596,537.503845 621.679174,524.839047 621.635758,512.079812 C621.657896,451.518897 572.616613,402.388105 512.055758,402.299812 C499.315423,402.259246 486.670236,404.494336 474.715758,408.899812 L82.6457577,15.6398121 C64.3651324,-2.58558468 34.7711544,-2.54081316 16.5457577,15.7398121 C-1.67963909,34.0204373 -1.63486757,63.6144153 16.6457577,81.8398121 L120.475758,185.919812 L196.535758,261.919812 L333.185758,398.799812 L408.845758,474.589812 L549.005758,614.969812 L941.455758,1008.21981 C959.733621,1026.4673 989.34327,1026.44268 1007.59076,1008.16481 C1025.83825,989.886948 1025.81362,960.2773 1007.53576,942.029812 L903.425758,837.839812 Z"
+              />
+            </svg>
+          </DisconnectedIcon>
+        </EmptyStateIcon>
+        <Title
+          headingLevel="h5"
+          size="lg"
+        >
+          <h5
+            className="pf-c-title pf-m-lg"
+          >
+            This system is not yet connected to Insights
+          </h5>
+        </Title>
+        <EmptyStateBody>
+          <div
+            className="pf-c-empty-state__body"
+          >
+            Activate the Insights client for this system to get started.
+          </div>
+        </EmptyStateBody>
+        <Button
+          className="pf-u-mt-lg"
+          component="a"
+          href="http://access.redhat.com/products/cloud_management_services_for_rhel#getstarted"
+          rel="noopener noreferrer"
+          target="_blank"
+          variant="primary"
+        >
+          <a
+            aria-disabled={false}
+            aria-label={null}
+            className="pf-c-button pf-m-primary pf-u-mt-lg"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={null}
+            href="http://access.redhat.com/products/cloud_management_services_for_rhel#getstarted"
+            rel="noopener noreferrer"
+            role={null}
+            target="_blank"
+            type={null}
+          >
+            Learn about the Insights client
+          </a>
+        </Button>
+      </div>
+    </div>
+  </EmptyState>
+</NotConnected>
+`;

--- a/packages/components/src/NotConnected/index.js
+++ b/packages/components/src/NotConnected/index.js
@@ -1,0 +1,2 @@
+export { default } from './NotConnected';
+export { default as NotConnected } from './NotConnected';


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/ESSNTL-12
Mockup: https://marvelapp.com/prototype/geh911a/screen/79982935

Add component to make `Not connected` empty state consistent. Default text can be overwritten with props to enable intl.

![notConnected](https://user-images.githubusercontent.com/8426204/122977353-9480f800-d395-11eb-9fae-42caf5687dfc.png)
