### PR TITLE
fix(proxy): split standalone proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5584,6 +5584,11 @@
                 "react-router-dom": "^5.2.0"
             }
         },
+        "node_modules/@schibstedpl/circuit-breaker-js": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@schibstedpl/circuit-breaker-js/-/circuit-breaker-js-0.0.2.tgz",
+            "integrity": "sha512-82fEbDRVsEAO/XlaFsGb5GKoAMvlfOd/hiNxyPWMvd1ZYJxxHs8hAu4i5Jrlcgpf1sUhhgV53oJSHNwyThsVFQ=="
+        },
         "node_modules/@sentry/browser": {
             "version": "5.30.0",
             "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
@@ -8020,7 +8025,6 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
             "dependencies": {
                 "safer-buffer": "~2.1.0"
             }
@@ -8056,7 +8060,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -8164,8 +8167,7 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
@@ -8258,7 +8260,6 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -8266,8 +8267,7 @@
         "node_modules/aws4": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-            "dev": true
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "node_modules/axios": {
             "version": "0.21.1",
@@ -8825,7 +8825,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
@@ -9776,6 +9775,11 @@
                 "url": "https://opencollective.com/browserslist"
             }
         },
+        "node_modules/capitalize": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
+            "integrity": "sha1-3IAsWAruEBkpAg0soUtMqKCuRL4="
+        },
         "node_modules/capture-exit": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -9800,8 +9804,7 @@
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "node_modules/catharsis": {
             "version": "0.9.0",
@@ -10370,7 +10373,6 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true,
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -11256,7 +11258,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -13212,7 +13213,6 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             },
@@ -13642,7 +13642,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -14029,7 +14028,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
             "dependencies": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -15275,8 +15273,7 @@
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "node_modules/extend-shallow": {
             "version": "2.0.1",
@@ -15342,7 +15339,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true,
             "engines": [
                 "node >=0.6.0"
             ]
@@ -15979,7 +15975,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -16689,7 +16684,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
             "dependencies": {
                 "assert-plus": "^1.0.0"
             }
@@ -17005,6 +16999,153 @@
                 "node": ">=8"
             }
         },
+        "node_modules/good-guy-http": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/good-guy-http/-/good-guy-http-1.14.0.tgz",
+            "integrity": "sha512-QkxYpypxMBVU+YRgbSckOoIi17a3/1JO1PXERHff1NpFdLrFNoAzn6CQ3xuYJ6veQtVMcVoLzxT8Zp0M6p0Jhg==",
+            "dependencies": {
+                "@schibstedpl/circuit-breaker-js": "0.0.2",
+                "capitalize": "^1.0.0",
+                "clone": "2.1.1",
+                "request": "2.87.0",
+                "underscore": "1.12.1"
+            },
+            "engines": {
+                "node": ">=5"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dependencies": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/clone": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+            "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "node_modules/good-guy-http/node_modules/form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/har-validator": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "deprecated": "this library is no longer supported",
+            "dependencies": {
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "node_modules/good-guy-http/node_modules/oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "node_modules/good-guy-http/node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/request": {
+            "version": "2.87.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/tough-cookie": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "dependencies": {
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/good-guy-http/node_modules/underscore": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+        },
+        "node_modules/good-guy-http/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
         "node_modules/got": {
             "version": "6.7.1",
             "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -17126,7 +17267,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -17779,7 +17919,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -18958,8 +19097,7 @@
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "node_modules/is-upper-case": {
             "version": "1.1.2",
@@ -19055,8 +19193,7 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.0.0",
@@ -21192,8 +21329,7 @@
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "node_modules/jsdoc": {
             "version": "3.6.7",
@@ -21324,8 +21460,7 @@
         "node_modules/json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -21420,7 +21555,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -23857,6 +23991,27 @@
                 "npm": ">=3.0.0"
             }
         },
+        "node_modules/nodesi": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/nodesi/-/nodesi-1.17.0.tgz",
+            "integrity": "sha512-xDdTZbmzfiDlizkPWP21hKr22ISyZdD7v+mXWohnacubhGzvyO5WQfuxuO202rIXt+sL4aJccrzQjR6dwLwT4g==",
+            "dependencies": {
+                "clone": "1.0.3",
+                "good-guy-http": "1.14.0",
+                "he": "1.2.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/nodesi/node_modules/clone": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+            "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
         "node_modules/nopt": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
@@ -25150,8 +25305,7 @@
         "node_modules/performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "node_modules/picomatch": {
             "version": "2.3.0",
@@ -30896,7 +31050,6 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dev": true,
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -32835,7 +32988,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -32846,8 +32998,7 @@
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -33736,7 +33887,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
             "engines": [
                 "node >=0.6.0"
             ],
@@ -35553,7 +35703,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.3.0",
+            "version": "3.3.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -35582,10 +35732,10 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.2.0",
+            "version": "4.2.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@redhat-cloud-services/frontend-components-config-utilities": "^1.3.0",
+                "@redhat-cloud-services/frontend-components-config-utilities": "1.3.1",
                 "assert": "^2.0.0",
                 "babel-loader": "^8.2.2",
                 "browserify-zlib": "^0.2.0",
@@ -35617,8 +35767,11 @@
         },
         "packages/config-utils": {
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "Apache-2.0",
+            "dependencies": {
+                "nodesi": "^1.17.0"
+            },
             "peerDependencies": {
                 "webpack": "^5.0.0"
             }
@@ -35732,7 +35885,7 @@
         },
         "packages/inventory": {
             "name": "@redhat-cloud-services/frontend-components-inventory",
-            "version": "3.2.4",
+            "version": "3.2.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
@@ -40566,7 +40719,7 @@
         "@redhat-cloud-services/frontend-components-config": {
             "version": "file:packages/config",
             "requires": {
-                "@redhat-cloud-services/frontend-components-config-utilities": "^1.3.0",
+                "@redhat-cloud-services/frontend-components-config-utilities": "1.3.1",
                 "assert": "^2.0.0",
                 "babel-loader": "^8.2.2",
                 "browserify-zlib": "^0.2.0",
@@ -40626,7 +40779,9 @@
         },
         "@redhat-cloud-services/frontend-components-config-utilities": {
             "version": "file:packages/config-utils",
-            "requires": {}
+            "requires": {
+                "nodesi": "^1.17.0"
+            }
         },
         "@redhat-cloud-services/frontend-components-demo": {
             "version": "file:packages/demo",
@@ -41170,6 +41325,11 @@
                 "@scalprum/core": "^0.0.11",
                 "lodash": "^4.17.0"
             }
+        },
+        "@schibstedpl/circuit-breaker-js": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@schibstedpl/circuit-breaker-js/-/circuit-breaker-js-0.0.2.tgz",
+            "integrity": "sha512-82fEbDRVsEAO/XlaFsGb5GKoAMvlfOd/hiNxyPWMvd1ZYJxxHs8hAu4i5Jrlcgpf1sUhhgV53oJSHNwyThsVFQ=="
         },
         "@sentry/browser": {
             "version": "5.30.0",
@@ -43261,7 +43421,6 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -43298,8 +43457,7 @@
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -43375,8 +43533,7 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "at-least-node": {
             "version": "1.0.0",
@@ -43438,14 +43595,12 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-            "dev": true
+            "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "axios": {
             "version": "0.21.1",
@@ -43891,7 +44046,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -44663,6 +44817,11 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
             "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
         },
+        "capitalize": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
+            "integrity": "sha1-3IAsWAruEBkpAg0soUtMqKCuRL4="
+        },
         "capture-exit": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -44681,8 +44840,7 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "catharsis": {
             "version": "0.9.0",
@@ -45120,8 +45278,7 @@
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "coa": {
             "version": "2.0.2",
@@ -45894,7 +46051,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -47491,7 +47647,6 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -47814,8 +47969,7 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
             "version": "1.0.0",
@@ -48154,7 +48308,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -49110,8 +49263,7 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extend-shallow": {
             "version": "2.0.1",
@@ -49166,8 +49318,7 @@
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -49670,8 +49821,7 @@
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
             "version": "3.0.1",
@@ -50243,7 +50393,6 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -50494,6 +50643,125 @@
                 }
             }
         },
+        "good-guy-http": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/good-guy-http/-/good-guy-http-1.14.0.tgz",
+            "integrity": "sha512-QkxYpypxMBVU+YRgbSckOoIi17a3/1JO1PXERHff1NpFdLrFNoAzn6CQ3xuYJ6veQtVMcVoLzxT8Zp0M6p0Jhg==",
+            "requires": {
+                "@schibstedpl/circuit-breaker-js": "0.0.2",
+                "capitalize": "^1.0.0",
+                "clone": "2.1.1",
+                "request": "2.87.0",
+                "underscore": "1.12.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "requires": {
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
+                "request": {
+                    "version": "2.87.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+                    "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.4",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+                    "requires": {
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "underscore": {
+                    "version": "1.12.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+                    "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+                }
+            }
+        },
         "got": {
             "version": "6.7.1",
             "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -50591,8 +50859,7 @@
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
             "version": "5.1.5",
@@ -51123,7 +51390,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -51980,8 +52246,7 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-upper-case": {
             "version": "1.1.2",
@@ -52057,8 +52322,7 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "istanbul-lib-coverage": {
             "version": "3.0.0",
@@ -53679,8 +53943,7 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "jsdoc": {
             "version": "3.6.7",
@@ -53783,8 +54046,7 @@
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -53859,7 +54121,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -55881,6 +56142,23 @@
                 "node-sass-magic-importer": "^5.3.2"
             }
         },
+        "nodesi": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/nodesi/-/nodesi-1.17.0.tgz",
+            "integrity": "sha512-xDdTZbmzfiDlizkPWP21hKr22ISyZdD7v+mXWohnacubhGzvyO5WQfuxuO202rIXt+sL4aJccrzQjR6dwLwT4g==",
+            "requires": {
+                "clone": "1.0.3",
+                "good-guy-http": "1.14.0",
+                "he": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+                }
+            }
+        },
         "nopt": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
@@ -56895,8 +57173,7 @@
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
             "version": "2.3.0",
@@ -61437,7 +61714,6 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -62952,7 +63228,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -62960,8 +63235,7 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "type-check": {
             "version": "0.4.0",
@@ -63642,7 +63916,6 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",

--- a/packages/config-utils/package.json
+++ b/packages/config-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-config-utilities",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Utilities for shared config used in RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {
@@ -16,6 +16,9 @@
         "url": "https://github.com/RedHatInsights/frontend-components/issues"
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components#readme",
+    "dependencies": {
+        "nodesi": "^1.17.0"
+    },
     "peerDependencies": {
         "webpack": "^5.0.0"
     }

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -1,55 +1,176 @@
 /* eslint-disable no-console */
 // Webpack proxy and express config for `useProxy: true` or `standalone: true`
-const { execSync } = require('child_process');
-const path = require('path');
+const standaloneProxy = require('./standalone/proxy');
+const { readFileSync } = require('fs');
+const { sync } = require('glob');
+const ESI = require('nodesi');
 const cookieTransform = require('./cookieTransform');
-const router = require('./standalone/helpers/router');
-const { getConfig, isGitUrl, getExposedPort, resolvePath } = require('./standalone/helpers/index');
-const { checkoutRepo } = require('./standalone/helpers/checkout');
-const { startService, stopService } = require('./standalone/startService');
-const { NET } = require('./standalone/helpers');
-const defaultServices = require('./standalone/services/default');
-const { registerChrome } = require('./standalone/services/default/chrome');
+const transformUrl = require('./router');
 
-const defaultReposDir = path.join(__dirname, 'repos');
+module.exports = (options) => {
+    const {
+        betaEnv = 'ci',
+        customProxy = [],
+        routes,
+        routesPath,
+        standalone,
+        port = 1337,
+        localChrome,
+        appUrl = [],
+        publicPath,
+        proxyVerbose,
+        rootFolder,
+        useCloud = false,
+        https = true,
+        exactUrl,
+        disableFallback
+    } = options;
 
-module.exports = ({
-    env = 'ci-beta',
-    customProxy = [],
-    routes,
-    routesPath,
-    useProxy,
-    standalone,
-    port,
-    reposDir = defaultReposDir,
-    localChrome,
-    appUrl = [],
-    publicPath,
-    proxyVerbose,
-    useCloud = false
-}) => {
-    const proxy = [];
-    const registry = [];
-    const majorEnv = env.split('-')[0];
-    const minorEnv = majorEnv === 'prod' ? '' : `${majorEnv}.`;
-    const target = env === 'prod-stable'
-        ? `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`
-        : `https://${minorEnv}${useCloud ? 'cloud' : 'console'}.redhat.com/`;
-    if (!Array.isArray(appUrl)) {
-        appUrl = [ appUrl ];
+    if (standalone) {
+        return standaloneProxy(options);
     }
 
-    appUrl.push(publicPath);
+    let appUrls = appUrl;
+    if (appUrls && !Array.isArray(appUrls)) {
+        appUrls = [ appUrls ];
+    }
+
+    let comparator = (path, url) => path.includes(url);
+    if (exactUrl) {
+        comparator = (path, url) => path === url;
+    }
+
+    // disable self signed CERT checks for esi
+    if (appUrl) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+    }
+
+    const target = betaEnv === 'prod' ? `https://${useCloud ? 'cloud' : 'console'}.redhat.com/` : `https://${betaEnv}.${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+
+    let proxyRoutes = routes;
 
     if (routesPath) {
-        routes = require(routesPath);
+        proxyRoutes = require(routesPath);
     }
 
-    if (routes) {
-        routes = routes.routes || routes;
-        console.log('Making proxy from SPANDX routes');
-        proxy.push(
-            ...Object.entries(routes || {}).map(([ route, redirect ]) => {
+    if (proxyRoutes) {
+        proxyRoutes = proxyRoutes.routes || proxyRoutes;
+    }
+
+    const esi = appUrl && new ESI({
+        allowedHosts: [ /^https:\/\/.*cloud.redhat.com$/ ],
+        baseUrl: `${https ? 'https' : 'http'}://${betaEnv}.foo.redhat.com:${port}`,
+        cache: false,
+        onError: (src, error) => {
+            console.error(
+                `An error occurred while resolving an ESI tag`
+            );
+            console.error(error);
+        }
+    });
+
+    proxyVerbose && proxyRoutes && console.log(`Using proxy routes: ${JSON.stringify(proxyRoutes, null, 2)}`);
+
+    const isNotCustomContext = (path) => {
+        if (Object.keys(proxyRoutes || {}).some((route) => path.includes(route))) {
+            return false;
+        }
+
+        return customProxy.length > 0 ? customProxy.reduce((acc, curr) => acc && !curr.context(path), true) : true;
+    };
+
+    const isChrome = (path) => localChrome && path.includes(process.env.BETA ? '/beta/apps/chrome/' : '/apps/chrome/');
+    const pathInCustomUrl = (path) => appUrls && appUrls.some((customPath) => comparator(path, customPath));
+    const removeHashQuery = (path) => path.replace(/(\?|#).*/, '');
+
+    if (appUrls && proxyVerbose) {
+        console.log('\n\nServing HTML on: ', appUrls.join(', '));
+        console.log('Exact URL: ', exactUrl ? 'true' : 'false', '\n\n');
+    }
+
+    const router = transformUrl(target, useCloud);
+
+    return {
+        contentBase: `${rootFolder || ''}/dist`,
+        index: `${rootFolder || ''}/dist/index.html`,
+        host: `${betaEnv}.foo.redhat.com`,
+        port,
+        https,
+        inline: true,
+        disableHostCheck: true,
+        historyApiFallback: true,
+        writeToDisk: true,
+        publicPath,
+        proxy: [
+            {
+                context: (path) => isNotCustomContext(path) && !pathInCustomUrl(removeHashQuery(path)) && !isChrome(path),
+                target,
+                secure: false,
+                changeOrigin: true,
+                autoRewrite: true,
+                router
+            },
+            ...(appUrl ? [{
+                context: path => pathInCustomUrl(removeHashQuery(path)),
+                target,
+                secure: false,
+                changeOrigin: true,
+                autoRewrite: true,
+                selfHandleResponse: true,
+                // serve index.html from local and replace ESI tags for chrome
+                onProxyReq: async (_proxyReq, req, res) => {
+                    const fileName = removeHashQuery(req.url.split('/').pop()) || 'index.html';
+                    let localPath = sync(`${rootFolder}/dist/${fileName}`);
+
+                    if (!localPath[0] && !disableFallback) {
+                        proxyVerbose && console.log(`page ${fileName} not found, fallback to index.html`);
+                        localPath = sync(`${rootFolder}/dist/index.html`);
+                    }
+
+                    proxyVerbose && console.log('serving locally', req.url, '>', fileName, '--->', localPath[0], '\n\n');
+
+                    if (localPath[0]) {
+                        const localFile = readFileSync(localPath[0]);
+                        const newData = await esi.process(localFile.toString());
+                        res.end(newData);
+                    }
+                }
+            }] : []),
+            ...(localChrome ? [{
+                context: (path) => isChrome(path),
+                target,
+                secure: false,
+                changeOrigin: true,
+                autoRewrite: true,
+                ws: true,
+                // When running chrome locally, we have to redirect all requests and serve files locally
+                selfHandleResponse: true,
+                onProxyReq: (_proxyReq, req, res) => {
+                    let newPath = req.url;
+                    const fileType = req.url.match(/\.([a-z]|\d)+$/);
+
+                    newPath = newPath.replace(process.env.BETA ? '/beta/apps/chrome/' : '/apps/chrome/', ''); //remove chrome URL
+
+                    let localPath = sync(`${localChrome}${newPath}`); // try to find it locally
+
+                    // if the file does not exist locally and it is a JS/CSS, let's try to remove hash
+                    if (localPath.length === 0 && fileType && (fileType[0] === '.js' || fileType[0] === '.css')) {
+                        newPath = newPath
+                        .replace(/\.([a-z]|\d)+\.[a-z]+$/, '**') //removeHash and add wilcard
+                        .concat(fileType[0]); // add file extension back
+
+                        localPath = sync(`${localChrome}${newPath}`);
+                    }
+
+                    proxyVerbose && console.log('serving locally', req.url, '--->', newPath, '------>', localPath[0], '\n\n');
+
+                    // if there is a local file with the same name, it's served
+                    if (localPath[0]) {
+                        res.sendFile(localPath[0]);
+                    }
+                }
+            }] : []),
+            ...proxyRoutes ? Object.entries(proxyRoutes).map(([ route, redirect ]) => {
                 const currTarget = redirect.host || redirect;
                 delete redirect.host;
                 return {
@@ -59,154 +180,15 @@ module.exports = ({
                     changeOrigin: true,
                     autoRewrite: true,
                     ws: true,
-                    onProxyReq: cookieTransform,
-                    ...(currTarget === 'PORTAL_BACKEND_MARKER' && { router }),
+                    onProxyReq: (...args) => {
+                        cookieTransform(...args);
+                    },
+                    ...(currTarget === 'PORTAL_BACKEND_MARKER' &&  { router }),
                     ...typeof redirect === 'object' ? redirect : {}
                 };
-            })
-        );
-    }
-
-    if (customProxy) {
-        proxy.push(...customProxy);
-    }
-
-    let standaloneConfig;
-    if (standalone) {
-        standaloneConfig = getConfig(standalone, localChrome, env, port);
-        // Create network for services.
-        execSync(`docker network inspect ${NET} >/dev/null 2>&1 || docker network create ${NET}`);
-
-        // Clone repos
-        // If we manage the repos it's okay to overwrite the contents
-        const overwrite = reposDir === defaultReposDir;
-        // Need to use for loop for `await`
-        for (const [ projName, proj ] of Object.entries(standaloneConfig)) {
-            const { services, path, assets, onProxyReq, keycloakUri, register, target, ...rest } = proj;
-            if (typeof register === 'function') {
-                registry.push(register);
-            }
-
-            if (isGitUrl(path)) {
-                // Add typical branch if not included
-                if (!path.includes('#')) {
-                    proj.path = `${path}#${env}`;
-                }
-
-                proj.path = checkoutRepo({ repo: proj.path, reposDir, overwrite });
-            }
-
-            Object.keys(assets || []).forEach(key => {
-                if (isGitUrl(assets[key])) {
-                    assets[key] = checkoutRepo({ repo: assets[key], reposDir, overwrite });
-                }
-            });
-
-            // Resolve functions that depend on env, port, or assets
-            if (typeof services === 'function') {
-                proj.services = services({ env, port, assets });
-            }
-
-            // Start standalone services.
-            const serviceNames = [];
-            for (let [ subServiceName, subService ] of Object.entries(proj.services || {})) {
-                const name = [ projName, subServiceName ].join('_');
-                startService(standaloneConfig, name, subService);
-                serviceNames.push(name);
-                const port = getExposedPort(subService.args);
-                console.log('Container', name, 'listening', port ? 'on' : '', port || '');
-            }
-
-            process.on('SIGINT', () => {
-                console.log();
-                serviceNames.forEach(stopService);
-                process.exit();
-            });
-
-            if (target) {
-                proxy.push({
-                    secure: false,
-                    changeOrigin: true,
-                    onProxyReq: cookieTransform,
-                    target,
-                    ...rest
-                });
-            }
-        }
-    }
-
-    if (useProxy) {
-        // Catch-all
-        proxy.push({
-            secure: false,
-            changeOrigin: true,
-            autoRewrite: true,
-            context: url => {
-                const shouldProxy = !appUrl.find(u => url.startsWith(u));
-                if (shouldProxy) {
-                    console.log('proxy', url);
-                    return true;
-                }
-
-                return false;
-            },
-            target,
-            router: router(target, useCloud)
-        });
-    }
-
-    return {
-        ...(proxy.length > 0 && { proxy }),
-        onListening(server) {
-            if (useProxy || standaloneConfig) {
-                const host = useProxy ? `${majorEnv}.foo.redhat.com` : 'localhost';
-                const origin = `http${server.options.https ? 's' : ''}://${host}:${server.options.port}`;
-                console.log('App should run on:');
-
-                console.log('\u001b[34m'); // Use same webpack-dev-server blue
-                if (appUrl.length > 0) {
-                    appUrl.forEach(url => console.log(`  - ${origin}${url}`));
-                } else {
-                    console.log(`  - ${origin}`);
-                }
-
-                console.log('\u001b[0m');
-            }
-        },
-        before(app, server, compiler) {
-            app.enable('strict routing'); // trailing slashes are mean
-            let chromePath = localChrome;
-            if (standaloneConfig) {
-                chromePath = resolvePath(reposDir, standaloneConfig.chrome.path);
-            } else if (!localChrome && useProxy) {
-                if (typeof defaultServices.chrome === 'function') {
-                    defaultServices.chrome = defaultServices.chrome({});
-                }
-
-                chromePath = checkoutRepo({
-                    repo: `${defaultServices.chrome.path}#${env}`,
-                    reposDir,
-                    overwrite: true
-                });
-            }
-
-            if (chromePath) {
-                registerChrome({
-                    app,
-                    chromePath,
-                    keycloakUri: (standaloneConfig && standaloneConfig.chrome) ? standaloneConfig.chrome.keycloakUri : null,
-                    https: Boolean(server.options.https),
-                    proxyVerbose
-                });
-            }
-
-            registry.forEach(cb => cb({
-                app,
-                server,
-                compiler,
-                config: standaloneConfig
-            }));
-        }
+            }) : [],
+            ...customProxy
+        ]
     };
 };
 

--- a/packages/config-utils/router.js
+++ b/packages/config-utils/router.js
@@ -1,0 +1,14 @@
+
+function router(target, useCloud) {
+    return (req) => {
+        switch (req.hostname) {
+            case 'ci.foo.redhat.com':    return `https://ci.${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+            case 'qa.foo.redhat.com':    return `https://qa.${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+            case 'stage.foo.redhat.com': return `https://${useCloud ? 'cloud' : 'console'}.stage.redhat.com/`;
+            case 'prod.foo.redhat.com':  return `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+            default: return target;
+        }
+    };
+}
+
+module.exports = router;

--- a/packages/config-utils/standalone/proxy.js
+++ b/packages/config-utils/standalone/proxy.js
@@ -1,0 +1,206 @@
+/* eslint-disable no-console */
+// Webpack proxy and express config for `standalone: true`
+const { execSync } = require('child_process');
+const path = require('path');
+const cookieTransform = require('../cookieTransform');
+const router = require('./helpers/router');
+const { getConfig, isGitUrl, getExposedPort, resolvePath } = require('./helpers/index');
+const { checkoutRepo } = require('./helpers/checkout');
+const { startService, stopService } = require('./startService');
+const { NET } = require('./helpers');
+const defaultServices = require('./services/default');
+const { registerChrome } = require('./services/default/chrome');
+
+const defaultReposDir = path.join(__dirname, 'repos');
+
+module.exports = ({
+    env = 'ci-beta',
+    customProxy = [],
+    routes,
+    routesPath,
+    standalone,
+    port,
+    reposDir = defaultReposDir,
+    localChrome,
+    appUrl = [],
+    publicPath,
+    proxyVerbose,
+    useCloud = false
+}) => {
+
+    const proxy = [];
+    const registry = [];
+    const majorEnv = env.split('-')[0];
+    const minorEnv = majorEnv === 'prod' ? '' : `${majorEnv}.`;
+    const target = env === 'prod-stable'
+        ? `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`
+        : `https://${minorEnv}${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+    if (!Array.isArray(appUrl)) {
+        appUrl = [ appUrl ];
+    }
+
+    appUrl.push(publicPath);
+
+    if (routesPath) {
+        routes = require(routesPath);
+    }
+
+    if (routes) {
+        routes = routes.routes || routes;
+        console.log('Making proxy from SPANDX routes');
+        proxy.push(
+            ...Object.entries(routes || {}).map(([ route, redirect ]) => {
+                const currTarget = redirect.host || redirect;
+                delete redirect.host;
+                return {
+                    context: (path) => path.includes(route),
+                    target: currTarget === 'PORTAL_BACKEND_MARKER' ? target : currTarget,
+                    secure: false,
+                    changeOrigin: true,
+                    autoRewrite: true,
+                    ws: true,
+                    onProxyReq: cookieTransform,
+                    ...(currTarget === 'PORTAL_BACKEND_MARKER' && { router }),
+                    ...typeof redirect === 'object' ? redirect : {}
+                };
+            })
+        );
+    }
+
+    if (customProxy) {
+        proxy.push(...customProxy);
+    }
+
+    let standaloneConfig;
+    if (standalone) {
+        standaloneConfig = getConfig(standalone, localChrome, env, port);
+        // Create network for services.
+        execSync(`docker network inspect ${NET} >/dev/null 2>&1 || docker network create ${NET}`);
+
+        // Clone repos
+        // If we manage the repos it's okay to overwrite the contents
+        const overwrite = reposDir === defaultReposDir;
+        // Need to use for loop for `await`
+        for (const [ projName, proj ] of Object.entries(standaloneConfig)) {
+            const { services, path, assets, onProxyReq, keycloakUri, register, target, ...rest } = proj;
+            if (typeof register === 'function') {
+                registry.push(register);
+            }
+
+            if (isGitUrl(path)) {
+                // Add typical branch if not included
+                if (!path.includes('#')) {
+                    proj.path = `${path}#${env}`;
+                }
+
+                proj.path = checkoutRepo({ repo: proj.path, reposDir, overwrite });
+            }
+
+            Object.keys(assets || []).forEach(key => {
+                if (isGitUrl(assets[key])) {
+                    assets[key] = checkoutRepo({ repo: assets[key], reposDir, overwrite });
+                }
+            });
+
+            // Resolve functions that depend on env, port, or assets
+            if (typeof services === 'function') {
+                proj.services = services({ env, port, assets });
+            }
+
+            // Start standalone services.
+            const serviceNames = [];
+            for (let [ subServiceName, subService ] of Object.entries(proj.services || {})) {
+                const name = [ projName, subServiceName ].join('_');
+                startService(standaloneConfig, name, subService);
+                serviceNames.push(name);
+                const port = getExposedPort(subService.args);
+                console.log('Container', name, 'listening', port ? 'on' : '', port || '');
+            }
+
+            process.on('SIGINT', () => {
+                console.log();
+                serviceNames.forEach(stopService);
+                process.exit();
+            });
+
+            if (target) {
+                proxy.push({
+                    secure: false,
+                    changeOrigin: true,
+                    onProxyReq: cookieTransform,
+                    target,
+                    ...rest
+                });
+            }
+        }
+    }
+
+    return {
+        host: '0.0.0.0', // This shares on local network. Needed for docker.host.internal
+        // https://github.com/bripkens/connect-history-api-fallback
+        historyApiFallback: {
+            // We should really implement the same logic as cloud-services-config
+            // and only redirect (/beta)?/bundle/app-name to /index.html
+            //
+            // Until then let known api calls fall through instead of returning /index.html
+            // for easier `fetch` debugging
+            rewrites: [
+                { from: /^\/api/, to: '/404.html' },
+                { from: /^(\/beta)?\/config/, to: '/404.html' }
+            ],
+            verbose: Boolean(proxyVerbose)
+        },
+        ...(proxy.length > 0 && { proxy }),
+        onListening(server) {
+            if (standaloneConfig) {
+                const host = 'localhost';
+                const origin = `http${server.options.https ? 's' : ''}://${host}:${server.options.port}`;
+                console.log('App should run on:');
+
+                console.log('\u001b[34m'); // Use same webpack-dev-server blue
+                if (appUrl.length > 0) {
+                    appUrl.forEach(url => console.log(`  - ${origin}${url}`));
+                } else {
+                    console.log(`  - ${origin}`);
+                }
+
+                console.log('\u001b[0m');
+            }
+        },
+        before(app, server, compiler) {
+            app.enable('strict routing'); // trailing slashes are mean
+            let chromePath = localChrome;
+            if (standaloneConfig) {
+                chromePath = resolvePath(reposDir, standaloneConfig.chrome.path);
+            } else if (!localChrome) {
+                if (typeof defaultServices.chrome === 'function') {
+                    defaultServices.chrome = defaultServices.chrome({});
+                }
+
+                chromePath = checkoutRepo({
+                    repo: `${defaultServices.chrome.path}#${env}`,
+                    reposDir,
+                    overwrite: true
+                });
+            }
+
+            if (chromePath) {
+                registerChrome({
+                    app,
+                    chromePath,
+                    keycloakUri: (standaloneConfig && standaloneConfig.chrome) ? standaloneConfig.chrome.keycloakUri : null,
+                    https: Boolean(server.options.https),
+                    proxyVerbose
+                });
+            }
+
+            registry.forEach(cb => cb({
+                app,
+                server,
+                compiler,
+                config: standaloneConfig
+            }));
+        }
+    };
+};
+

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,7 +17,7 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#readme",
     "dependencies": {
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.3.0",
+        "@redhat-cloud-services/frontend-components-config-utilities": "1.3.1",
         "assert": "^2.0.0",
         "babel-loader": "^8.2.2",
         "browserify-zlib": "^0.2.0",

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -160,22 +160,8 @@ module.exports = ({
             contentBase: `${rootFolder || ''}/dist`,
             port: devServerPort,
             https: https || Boolean(useProxy),
-            host: '0.0.0.0', // This shares on local network. Needed for docker.host.internal
             hot: false, // Use livereload instead of HMR which is spotty with federated modules
             disableHostCheck: true,
-            // https://github.com/bripkens/connect-history-api-fallback
-            historyApiFallback: {
-                // We should really implement the same logic as cloud-services-config
-                // and only redirect (/beta)?/bundle/app-name to /index.html
-                //
-                // Until then let known api calls fall through instead of returning /index.html
-                // for easier `fetch` debugging
-                rewrites: [
-                    { from: /^\/api/, to: '/404.html' },
-                    { from: /^(\/beta)?\/config/, to: '/404.html' }
-                ],
-                verbose: Boolean(proxyVerbose)
-            },
             writeToDisk: true,
             ...proxy({
                 useCloud,
@@ -185,6 +171,7 @@ module.exports = ({
                 routes,
                 routesPath,
                 useProxy,
+                rootFolder,
                 standalone,
                 port: devServerPort,
                 reposDir,

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -71,22 +71,36 @@ describe('should create dummy config with no options', () => {
 
     test('devServer', () => {
         expect(devServer).toEqual({
-            before: expect.any(Function),
-            onListening: expect.any(Function),
             contentBase: '/dist',
-            https: false,
-            host: '0.0.0.0',
             port: 8002,
+            https: true,
             hot: false,
             disableHostCheck: true,
-            historyApiFallback: {
-                rewrites: [
-                    { from: /^\/api/, to: '/404.html' },
-                    { from: /^(\/beta)?\/config/, to: '/404.html' }
-                ],
-                verbose: false
-            },
-            writeToDisk: true
+            writeToDisk: true,
+            index: '/dist/index.html',
+            host: 'ci.foo.redhat.com',
+            inline: true,
+            historyApiFallback: true,
+            publicPath: undefined,
+            proxy: [
+                {
+                    context: expect.any(Function),
+                    target: 'https://ci.console.redhat.com/',
+                    secure: false,
+                    changeOrigin: true,
+                    autoRewrite: true,
+                    router: expect.any(Function)
+                },
+                {
+                    context: expect.any(Function),
+                    target: 'https://ci.console.redhat.com/',
+                    secure: false,
+                    changeOrigin: true,
+                    autoRewrite: true,
+                    selfHandleResponse: true,
+                    onProxyReq: expect.any(Function)
+                }
+            ]
         });
     });
 });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14981

The common proxy config required migration to applications that were using the proxy (cost) without the config.

I've split the two configurations to fix the issue. We can make a reader later about what we can merge and what we can't. For now the standalone has its win proxy config.