### PR TITLE
Add V2 of the inventoryTable

### DIFF
--- a/packages/demo/src/index.js
+++ b/packages/demo/src/index.js
@@ -1,46 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
-import { Provider, useDispatch } from 'react-redux';
-import NotificationPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
-import { notificationsReducer, notificationActions } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
-
-const App = () => {
-    const dispatch = useDispatch();
-    const handleClick = () => {
-        dispatch({ type: 'prd' });
-        dispatch(notificationActions.addNotification({
-            variant: 'success',
-            title: 'foo'
-        }));
-    };
-
-    return (
-        <button onClick={handleClick}>Click me</button>
-    );
-};
-
-const registry = new ReducerRegistry({}, [
-    notificationsMiddleware({
-        errorTitleKey: [ 'message' ],
-        errorDescriptionKey: [ 'errors', 'stack' ]
-    })
-]);
-
-registry.register({
-    notifications: notificationsReducer
-});
-
-const store = registry.getStore();
+import InventoryTable from '@redhat-cloud-services/frontend-components-inventory/components/table-v2';
 
 const MyCmp = () => {
     return (
-        <Provider store={store}>
-            <NotificationPortal />
-            <App />
-        </Provider>
+        <Router>
+            <InventoryTable />
+        </Router>
     );
 };
 

--- a/packages/inventory/src/components/table-v2/InventoryTable.js
+++ b/packages/inventory/src/components/table-v2/InventoryTable.js
@@ -188,8 +188,6 @@ const InventoryTable = ({
 
     const onSortChange = (orderBy, orderDirection) => refreshData({ orderBy, orderDirection: orderDirection.toUpperCase() });
 
-    console.log(enabledFilters);
-
     return (<React.Fragment>
         <TableToolbar
             state={state}

--- a/packages/inventory/src/components/table-v2/InventoryTable.js
+++ b/packages/inventory/src/components/table-v2/InventoryTable.js
@@ -1,0 +1,232 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useHistory, useLocation } from 'react-router-dom';
+
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { SkeletonTable } from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import { ErrorState } from '@redhat-cloud-services/frontend-components/ErrorState';
+
+import {
+    Table as PfTable,
+    TableBody,
+    TableHeader,
+    TableGridBreakpoint
+} from '@patternfly/react-table';
+
+import AccessDenied from '../../shared/AccessDenied';
+import { createColumns, createRows } from '../table/helpers';
+import NoSystemsTable from '../table/NoSystemsTable';
+import useColumns from './useColumns';
+import useCallbackReducer from './useCallbackReducer';
+import { getEntities as apiGetEntities } from './api';
+
+const initialStateReducer = {
+    orderBy: '',
+    orderDirection: '',
+    page: 0,
+    perPage: 50,
+    filters: {},
+    entities: [],
+    total: 0,
+    loadingCounter: 0,
+    isLoaded: true,
+    error: false,
+    selected: []
+};
+
+const reducer = (state, action) => {
+    switch (action.type) {
+        default:
+            return state;
+    }
+};
+
+const InventoryTable = ({
+    hasAccess,
+    isFullView,
+    errorState = <ErrorState />,
+    paginationProps = {},
+    tableProps = {},
+    columns,
+    noSystemsTable = <NoSystemsTable />,
+    onRowClick,
+    showTags,
+    disableDefaultColumns,
+    columnsCounter,
+    bulkSelect,
+    getEntities
+}) => {
+    const [ state, dispatch ] = useCallbackReducer(reducer, initialStateReducer);
+    const columnsRef = useColumns({ columns, showTags, disableDefaultColumns, columnsCounter });
+
+    const history = useHistory();
+    const location = useLocation();
+
+    const refreshData = async (options) => {
+        dispatch({ type: 'entitiesPending', options }, async (state) => {
+            try {
+                const results = await apiGetEntities(
+                    items,
+                    filters,
+                    perPage,
+                    page,
+                    orderBy,
+                    orderDirection,
+                    fields = { system_profile: [ 'operating_system' ] },
+                    tags, // ?
+                    filter, // ?
+                    showTags
+                );
+
+
+            } catch {
+                dispatch({ type: 'setError' });
+            }
+        });
+    };
+
+    useState(() => {
+
+    }, []);
+
+    const noAccess = hasAccess === false;
+
+    if (noAccess && isFullView) {
+        return <AccessDenied
+            title="This application requires Inventory permissions"
+            description={<div>
+            To view the content of this page, you must be granted a minimum of inventory permissions from your Organization Administrator.
+            </div>}
+        />;
+    }
+
+    if (state.error) {
+        return errorState;
+    }
+
+    const paginationConfig = {
+        itemCount: state.total,
+        page: state.page,
+        perPage: state.perPage,
+        onSetPage: () => null,
+        onPerPageSelect: () => null,
+        ...paginationProps
+    };
+
+    const paginationConfigBottom = {
+        ...paginationConfig,
+        dropDirection: 'up',
+        variant: 'bottom',
+        isCompact: false
+    };
+
+    const { hasCheckbox, expandable, actions, noDetail, ...tablePropsRest } = tableProps;
+
+    const cells = state.isLoaded && createColumns(columnsRef.current, false, state.entities, expandable);
+
+    const defaultRowClick = (_event, key) => {
+        history.push(`${location.pathname}${location.pathname.slice(-1) === '/' ? '' : '/'}${key}`);
+    };
+
+    const onItemSelect = () => null;
+
+    const onExpandClick = () => null;
+
+    const onSortChange = () => null;
+
+    return (<React.Fragment>
+        <PrimaryToolbar
+            pagination={state.isLoaded ? paginationConfig : <Skeleton size={SkeletonSize.lg} /> }
+            {...bulkSelect && {
+                bulkSelect: {
+                    ...bulkSelect,
+                    isDisabled: bulkSelect?.isDisabled || noAccess
+                }
+            }}
+        />
+        {!state.isLoaded && <SkeletonTable colSize={ columnsRef.current?.length || 3 } rowSize={ 15 } />}
+        {state.isLoaded && noAccess && <div className="ins-c-inventory__no-access">
+            <AccessDenied showReturnButton={false} />
+        </div>}
+        { state.isLoaded && !noAccess &&
+            <PfTable
+                aria-label="Host inventory"
+                cells={ cells }
+                rows={ createRows(
+                    state.entities,
+                    columnsRef.current,
+                    {
+                        actions,
+                        expandable,
+                        loaded: state.isLoaded,
+                        onRowClick: onRowClick || defaultRowClick,
+                        noDetail,
+                        sortBy: state.orderBy,
+                        noSystemsTable
+                    })
+                }
+                gridBreakPoint={
+                    columnsRef.current?.length > 5 ? TableGridBreakpoint.gridLg : TableGridBreakpoint.gridMd
+                }
+                className="ins-c-entity-table"
+                onSort={ (event, index, direction) => {
+                    onSortChange(
+                        event,
+                        cells[index - Boolean(hasCheckbox) - Boolean(expandable)]?.key,
+                        direction,
+                        index
+                    );
+                } }
+                sortBy={ {
+                    index: cells.findIndex(item => state.orderBy === item.key) + Boolean(hasCheckbox) + Boolean(expandable),
+                    direction: state.orderDirection
+                } }
+                { ...tablePropsRest }
+                { ...{
+                    ...hasCheckbox && state.entities.length !== 0 ? { onSelect: onItemSelect } : {},
+                    ...expandable ? { onCollapse: onExpandClick } : {},
+                    ...actions && state.entities.length > 0 && { actions }
+                } }
+            >
+                <TableHeader />
+                <TableBody />
+            </PfTable>
+        }
+        {state.isLoaded && <PrimaryToolbar pagination={paginationConfigBottom} />}
+    </React.Fragment>);
+};
+
+InventoryTable.propTypes = {
+    // autoRefresh: PropTypes.bool,
+    // onRefresh: PropTypes.func,
+    // children: PropTypes.node,
+    // inventoryRef: PropTypes.object,
+    // items: PropTypes.array,
+    // total: PropTypes.number,
+    // page: PropTypes.number,
+    // perPage: PropTypes.number,
+    // filters: PropTypes.any,
+    showTags: PropTypes.bool,
+    // sortBy: PropTypes.object,
+    customFilters: PropTypes.any,
+    hasAccess: PropTypes.bool,
+    isFullView: PropTypes.bool,
+    getEntities: PropTypes.func,
+    hideFilters: PropTypes.object,
+    paginationProps: PropTypes.object,
+    errorState: PropTypes.node,
+    tableProps: PropTypes.object,
+    columns: PropTypes.any,
+    noSystemsTable: PropTypes.node,
+    onRowClick: PropTypes.func,
+    disableDefaultColumns: PropTypes.oneOfType([ PropTypes.bool, PropTypes.arrayOf(PropTypes.string) ]),
+    columnsCounter: PropTypes.number,
+    bulkSelect: PropTypes.object
+    // isLoaded: PropTypes.bool,
+    // initialLoading: PropTypes.bool,
+    // ignoreRefresh: PropTypes.bool,
+    // showTagModal: PropTypes.bool
+};
+
+export default InventoryTable;

--- a/packages/inventory/src/components/table-v2/TableToolbar.js
+++ b/packages/inventory/src/components/table-v2/TableToolbar.js
@@ -1,0 +1,82 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+
+import generateFilters from './filters';
+
+const TableToolbar = ({
+    state,
+    paginationConfig,
+    actionsConfig,
+    dispatch,
+    enabledFilters,
+    bulkSelect,
+    rows,
+    selectAll,
+    children,
+    noAccess
+}) => {
+    const [ textFilters, setTextFilter ] = useState({});
+
+    const updateTextFilter = (key, value) => setTextFilter({ ...textFilters, [key]: value });
+
+    const bulkSelectConfig = useMemo(() => (
+        {
+            count: state.selected.length,
+            isDisabled: (state.total === 0 && state.selected.length === 0) || !state.isLoaded || noAccess,
+            checked: rows.every(({ selected }) => selected) || (rows.some(({ selected }) => selected) && null),
+            onSelect: () => rows.some(({ selected }) => selected) ? dispatch({ type: 'unselectPage' }) : dispatch({ type: 'selectPage' }),
+            items: [
+                {
+                    title: 'Select none (0)',
+                    onClick: () => dispatch({ type: 'selectNone' })
+                },
+                ...state.isLoaded && rows?.length > 0 ? [{
+                    title: `Select page (${ rows.length })`,
+                    onClick: () => dispatch({ type: 'selectPage' })
+                }] : [{}],
+                ...selectAll && state.isLoaded && rows?.length > 0 ? [{
+                    title: `Select all (${ state.total })`,
+                    onClick: () => selectAll((selected) => dispatch({ type: 'selectAll', payload: { selected } }))
+                }] : [{}]
+            ]
+        }
+    ), [ state.selected, state.total, state.isLoaded, noAccess, rows.length, Boolean(selectAll) ]);
+
+    return (
+        <PrimaryToolbar
+            pagination={state.isLoaded ? paginationConfig : <Skeleton size={SkeletonSize.lg} /> }
+            filterConfig={
+                generateFilters(
+                    enabledFilters,
+                    {},
+                    state.filters,
+                    (key, value) => dispatch({ type: 'setFilter', payload: { key, value } }),
+                    textFilters,
+                    updateTextFilter
+                )
+            }
+            {...actionsConfig && { actionsConfig }}
+            {...bulkSelect && {
+                bulkSelect: bulkSelectConfig
+            }}
+        >{children}</PrimaryToolbar>
+    );
+};
+
+TableToolbar.propTypes = {
+    state: PropTypes.object,
+    paginationConfig: PropTypes.object,
+    actionsConfig: PropTypes.object,
+    dispatch: PropTypes.func,
+    enabledFilters: PropTypes.object,
+    bulkSelect: PropTypes.bool,
+    rows: PropTypes.array,
+    selectAll: PropTypes.func,
+    children: PropTypes.node,
+    noAccess: PropTypes.bool
+};
+
+export default TableToolbar;

--- a/packages/inventory/src/components/table-v2/TableToolbar.js
+++ b/packages/inventory/src/components/table-v2/TableToolbar.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
 
-import generateFilters from './filters';
+import { generateFilters, generateChips } from './filters';
 
 const TableToolbar = ({
     state,
@@ -18,9 +18,12 @@ const TableToolbar = ({
     children,
     noAccess
 }) => {
-    const [ textFilters, setTextFilter ] = useState({});
+    const [ filters, setFilter ] = useState(state.filters);
 
-    const updateTextFilter = (key, value) => setTextFilter({ ...textFilters, [key]: value });
+    const updateTextFilter = (key, value) => {
+        setFilter({ ...filters, [key]: value });
+        // debounce dispatch({ type: 'setFilter', payload: { key, value } })
+    };
 
     const bulkSelectConfig = useMemo(() => (
         {
@@ -52,15 +55,17 @@ const TableToolbar = ({
                 generateFilters(
                     enabledFilters,
                     {},
-                    state.filters,
-                    (key, value) => dispatch({ type: 'setFilter', payload: { key, value } }),
-                    textFilters,
+                    filters,
                     updateTextFilter
                 )
             }
             {...actionsConfig && { actionsConfig }}
             {...bulkSelect && {
                 bulkSelect: bulkSelectConfig
+            }}
+            activeFiltersConfig={{
+                filters: generateChips(filters),
+                onDelete: console.log
             }}
         >{children}</PrimaryToolbar>
     );

--- a/packages/inventory/src/components/table-v2/api.js
+++ b/packages/inventory/src/components/table-v2/api.js
@@ -1,0 +1,90 @@
+/* eslint-disable camelcase */
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
+
+import { generateFilter, mergeArraysByKey } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import { constructTags, hosts, mapData, mapTags } from '../../api';
+
+export async function getEntities({
+    controller,
+    items,
+    filters,
+    perPage,
+    page,
+    orderBy,
+    orderDirection,
+    fields = { system_profile: [ 'operating_system' ] },
+    tags, // ?
+    filter, // ?
+    showTags
+}) {
+    let data;
+
+    if (items) {
+        data = await hosts.apiHostGetHostById(items, undefined, undefined, undefined, undefined, undefined, { cancelToken: controller && controller.token });
+
+        if (fields && Object.keys(fields).length) {
+            const result = await hosts.apiHostGetHostSystemProfileById(
+                items,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                {
+                    cancelToken: controller && controller.token,
+                    query: generateFilter(fields, 'fields')
+                }
+            );
+
+            data = {
+                ...data,
+                results: mergeArraysByKey([
+                    data?.results,
+                    result?.results || []
+                ], 'id')
+            };
+
+        }
+    } else {
+        data = await hosts.apiHostGetHostList(
+            undefined,
+            undefined,
+            filters.hostnameOrId,
+            undefined,
+            undefined,
+            perPage,
+            page,
+            orderBy,
+            orderDirection,
+            filters.staleFilter,
+            [
+                ...constructTags(filters.tagFilters),
+                ...tags || []
+            ],
+            filters.registeredWithFilter,
+            undefined,
+            undefined,
+            {
+                cancelToken: controller && controller.token,
+                query: {
+                    ...(filter && Object.keys(filter).length && generateFilter(filter)),
+                    ...(fields && Object.keys(fields).length && generateFilter(fields, 'fields'))
+                }
+            }
+        );
+    }
+
+    data = showTags ? await mapTags(data, { orderBy, orderDirection }) : data;
+
+    data = {
+        ...data,
+        filters,
+        results: data.results.map(result => mapData({
+            ...result,
+            display_name: result.display_name || result.fqdn || result.id
+        }))
+    };
+
+    return data;
+}

--- a/packages/inventory/src/components/table-v2/api.js
+++ b/packages/inventory/src/components/table-v2/api.js
@@ -59,7 +59,7 @@ export async function getEntities({
             orderDirection,
             filters.staleFilter,
             [
-                ...constructTags(filters.tagFilters),
+                ...constructTags(filters.tagFilters || []),
                 ...tags || []
             ],
             filters.registeredWithFilter,

--- a/packages/inventory/src/components/table-v2/filters.js
+++ b/packages/inventory/src/components/table-v2/filters.js
@@ -1,0 +1,53 @@
+import { registered, staleness } from '../../shared';
+
+const textFilter = (value, onChange) => ({
+    label: 'Name',
+    value: 'name-filter',
+    filterValues: {
+        placeholder: 'Filter by name',
+        value,
+        onChange: (_e, value) => onChange('name', value)
+    }
+});
+
+const stalenessFilter = (value, onChange) => ({
+    label: 'Status',
+    value: 'stale-status',
+    type: 'checkbox',
+    filterValues: {
+        value: value,
+        onChange: (_e, value) => onChange('stale', value),
+        items: staleness
+    }
+});
+
+const registeredWithFilter = (value, onChange) => ({
+    label: 'Source',
+    value: 'source-registered-with',
+    type: 'checkbox',
+    filterValues: {
+        value: value,
+        onChange: (_e, value) => onChange('registeredWith', value),
+        items: registered
+    }
+});
+
+const tagsFilter = (value, onChange) => ({
+    label: 'Source',
+    value: 'source-registered-with',
+    type: 'checkbox',
+    filterValues: {
+        value: value,
+        onChange: (_e, value) => onChange(value),
+        items: registered
+    }
+});
+
+const generateFilters = (enabledFilters, customFilters, filter, onChange, textFilters, updateTextFilter) => ({ items: [
+    ...(enabledFilters.name ? [ textFilter(textFilters.name, updateTextFilter) ] : []),
+    ...(enabledFilters.stale ? [ stalenessFilter(filter.stale, onChange) ] : []),
+    ...(enabledFilters.registeredWith ? [ registeredWithFilter(filter.registeredWith, onChange) ] : [])
+    //...(enabledFilters.tagsFilter ? [tagsFilter] : []),
+] });
+
+export default generateFilters;

--- a/packages/inventory/src/components/table-v2/helpers.js
+++ b/packages/inventory/src/components/table-v2/helpers.js
@@ -1,0 +1,6 @@
+export const getEnabledFilters = (hideFilters = {}) => ({
+    name: !(hideFilters.all && hideFilters.name !== false) && !hideFilters.name,
+    stale: !(hideFilters.all && hideFilters.stale !== false) && !hideFilters.stale,
+    registeredWith: !(hideFilters.all && hideFilters.registeredWith !== false) && !hideFilters.registeredWith,
+    tags: !(hideFilters.all && hideFilters.tags !== false) && !hideFilters.tags
+});

--- a/packages/inventory/src/components/table-v2/index.js
+++ b/packages/inventory/src/components/table-v2/index.js
@@ -1,0 +1,1 @@
+export { default } from './InventoryTable';

--- a/packages/inventory/src/components/table-v2/useCallbackReducer.js
+++ b/packages/inventory/src/components/table-v2/useCallbackReducer.js
@@ -1,0 +1,24 @@
+import { useReducer, useRef } from 'react';
+
+const useCallbackReducer = (reducer, initialState, initFn) => {
+    const stateRef = useRef(initialState);
+
+    const enhancedReducer = (...args) => {
+        const newState = reducer(...args);
+
+        stateRef.current = newState;
+
+        return newState;
+    };
+
+    const [ state, originalDispatch ] = useReducer(enhancedReducer, initialState, initFn);
+
+    const enhancedDispatch = async (args, callback) => {
+        originalDispatch(args);
+        callback && await callback(stateRef.current);
+    };
+
+    return [ state, enhancedDispatch ];
+};
+
+export default useCallbackReducer;

--- a/packages/inventory/src/components/table-v2/useCallbackReducer.js
+++ b/packages/inventory/src/components/table-v2/useCallbackReducer.js
@@ -1,4 +1,5 @@
 import { useReducer, useRef } from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 
 const useCallbackReducer = (reducer, initialState, initFn) => {
     const stateRef = useRef(initialState);
@@ -14,8 +15,12 @@ const useCallbackReducer = (reducer, initialState, initFn) => {
     const [ state, originalDispatch ] = useReducer(enhancedReducer, initialState, initFn);
 
     const enhancedDispatch = async (args, callback) => {
-        originalDispatch(args);
-        callback && await callback(stateRef.current);
+        if (callback) {
+            await originalDispatch(args);
+            await callback(cloneDeep(stateRef.current));
+        } else {
+            originalDispatch(args);
+        }
     };
 
     return [ state, enhancedDispatch ];

--- a/packages/inventory/src/components/table-v2/useColumns.js
+++ b/packages/inventory/src/components/table-v2/useColumns.js
@@ -1,0 +1,29 @@
+import { useMemo, useRef } from 'react';
+
+import { defaultColumns } from '../../redux/entities';
+
+const useColumns = ({ columns: columnsProp, showTags, disableDefaultColumns, columnsCounter }) => {
+    const columns = useRef([]);
+    useMemo(() => {
+        if (typeof columnsProp === 'function') {
+            columns.current = columnsProp(defaultColumns);
+        } else if (columnsProp) {
+            columns.current = columnsProp;
+        } else {
+            const disabledColumns = Array.isArray(disableDefaultColumns) ? disableDefaultColumns : [];
+            const defaultColumnsFiltered = defaultColumns.filter(({ key }) =>
+                (key === 'tags' && showTags) || (key !== 'tags' && !disabledColumns.includes(key))
+            );
+            columns.current = defaultColumnsFiltered;
+        }
+    }, [
+        showTags,
+        Array.isArray(disableDefaultColumns) ? disableDefaultColumns.join() : disableDefaultColumns,
+        Array.isArray(columnsProp) ? columnsProp.map(({ key }) => key).join() : typeof columnsProp === 'function' ? 'function' : columnsProp,
+        columnsCounter
+    ]);
+
+    return columns;
+};
+
+export default useColumns;

--- a/packages/inventory/src/components/table/InventoryTable.js
+++ b/packages/inventory/src/components/table/InventoryTable.js
@@ -11,6 +11,7 @@ import AccessDenied from '../../shared/AccessDenied';
 import { loadSystems } from '../../shared';
 import isEqual from 'lodash/isEqual';
 import { entitiesLoading } from '../../redux/actions';
+import InventoryTableV2 from '../table-v2';
 
 /**
  * A helper function to store props and to always return the latest state.
@@ -260,4 +261,10 @@ InventoryTable.propTypes = {
     showTagModal: PropTypes.bool
 };
 
-export default InventoryTable;
+const TablesWrapper = ({ v2, ...props }) => v2 ? <InventoryTableV2 {...props} /> : <InventoryTable {...props} />;
+
+TablesWrapper.propTypes = {
+    v2: PropTypes.bool
+};
+
+export default TablesWrapper;


### PR DESCRIPTION
This a draft proposal to introduce version 2 of the inventory table:

- no redux
- simplified data flow
- less props

todo:
- [x] data fetching
    - [x] missing functionality (pagination, sort)
    - [x] custom getEntities
- [ ] filters
  - [x] chips
  - [ ] remove chips
- [ ] custom filters
- [x] children
- [x] bulkSelect
- [ ] tags
- [ ] expanded support