### PR TITLE
Pass exactUrl attribute to proxy

### DIFF
--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -26,7 +26,8 @@ module.exports = ({
     reposDir,
     appUrl = [],
     proxyVerbose,
-    useCloud
+    useCloud,
+    exactUrl
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     if (betaEnv) {
@@ -177,7 +178,8 @@ module.exports = ({
                 reposDir,
                 appUrl,
                 publicPath,
-                proxyVerbose
+                proxyVerbose,
+                exactUrl
             })
         }
     };


### PR DESCRIPTION
When doing standalone conversion, exactUrl went missing


needed for https://github.com/RedHatInsights/landing-page-frontend/pull/303