### PR TITLE
Remove lock files in build and clean step to allow linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,8 +122,8 @@
         "whatwg-fetch": "^3.6.2"
     },
     "scripts": {
-        "clean": "lerna clean -y && rm -rf node_modules",
-        "postinstall": "npm run build",
+        "clean": "lerna clean -y && lerna exec rm -- -f package-lock.json && rm -rf node_modules",
+        "postinstall": "npm run build && lerna exec rm -- -f package-lock.json",
         "start": "lerna run --parallel start --ignore=docs",
         "build": "lerna run build --stream --no-private --ignore=@redhat-cloud-services/frontend-components-config*",
         "generate-translations": "npm run build && node packages/utils/src/mergeMessages.js",


### PR DESCRIPTION
### Incorrect linking

Since we are using npm@v7 and its workspaces the linking of a package is somewhat not correct. Based on this reply https://github.com/npm/cli/issues/2036#issuecomment-716762752 it looks like the problem is that we store lock files in each folder. This PR adds a new command to clean and after install to remove such files.