### PR TITLE
Fix PDF generator charts incorrectly sorting items by y-value

### DIFF
--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -77,14 +77,21 @@ const calcRoundPerc = (data) => {
 
 class Chart extends React.Component {
     getChartData = (currChart) => {
-        const { data, chartType, colorSchema, ...props } = this.props;
-        const newData = calcRoundPerc(data);
+        let { data } = this.props;
+        const { chartType, colorSchema, ...props } = this.props;
+
+        if (chartType !== 'bar') {
+            let roundPercData = calcRoundPerc(data);
+            // fix sorting caused by rounding function, revert to the initial order
+            data = data.map(({ x, y, ...rest }) => ({ x, y: roundPercData.find(item => item.x === x).y, ...rest }));
+        }
+
         const Chart = currChart.component;
         const el = document.createElement('div');
         document.body.appendChild(el);
         el.style.display = 'none';
         ReactDOM.render(
-            <Chart data={newData.sort((a, b) => a.y < b.y ? 1 : -1) } {...currChart.chartProps} { ...props } />,
+            <Chart data={data} {...currChart.chartProps} { ...props } />,
             el
         );
 


### PR DESCRIPTION
To resolve [VULN-1816](https://issues.redhat.com/browse/VULN-1816) and [VULN-1833](https://issues.redhat.com/browse/VULN-1833).

[`2fea6db3`](https://github.com/RedHatInsights/frontend-components/commit/2fea6db3f3feae2d24f0e365b85a8d59d19e5a4d) introduced a regression where the data would be sorted by descending y-value when passed to PDF chart. This caused some problems in Vulnerability.

### Notice the colors and percentages in the chart and table
![wrong1](https://user-images.githubusercontent.com/8426204/126347661-7c30b837-088f-4fe3-893d-45a74823d20c.png)

### Critical and important columns are incorrent (`critical` should have height 1 and `important` height 5) because they are ordered by y-value descending; ignore the y-axis labels being slightly off, that's a separate issue
![wrong2](https://user-images.githubusercontent.com/8426204/126347669-6b184759-84b0-4db5-b265-1e2cc26dd705.png)

`data` variable holds array of `{x,y}` pairs. `calcRoundPerc()` is used to normalize y-values the values into percentages (so their sum is 100). The sorting by y-value (I assume) was introduced to fix unsystematic order of the array returned from `calcRoundPerc()`. I fixed the problem by reverting the sort after `calcRoundPerc()` so the y-values get normalized but x-values stay on the same index they were passed into the component.

```js
[{x: 'Apples', y: 3}, {x: 'Oranges', y: 7}] ===> [{x: 'Apples', y: 30}, {x: 'Oranges', y: 70}]
// y-values were normalized to percentages, but apples are still on index 0 and oranges on index 1 within the array
```

### This fixed the problems
![correct1](https://user-images.githubusercontent.com/8426204/126349776-7a7dbfe6-f1bc-4a7e-b84f-8f118b44013f.png)
![correct2](https://user-images.githubusercontent.com/8426204/126349780-c51f4a3c-8b34-4470-8c1c-0e0a0fdfd0a9.png)
