### PR TITLE
fix(proxy): fix building stage url

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -27,6 +27,7 @@ module.exports = ({
     publicPath,
     proxyVerbose,
     useCloud = false,
+    useStage = false,
     target = ''
 }) => {
     const proxy = [];
@@ -34,17 +35,19 @@ module.exports = ({
     const majorEnv = env.split('-')[0];
     if (target === '') {
         target += 'https://';
-        if (useCloud && majorEnv !== 'prod') {
+        if (!useStage && majorEnv !== 'prod') {
             target += majorEnv + '.';
         }
 
         target += useCloud ? 'cloud' : 'console';
-        if (!useCloud && majorEnv !== 'prod') {
+        if (useStage && majorEnv !== 'prod') {
             target += '.stage';
         }
 
         target += '.redhat.com/';
     }
+
+    console.log('Proxing to', target);
 
     if (!Array.isArray(appUrl)) {
         appUrl = [ appUrl ];

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -26,15 +26,26 @@ module.exports = ({
     appUrl = [],
     publicPath,
     proxyVerbose,
-    useCloud = false
+    useCloud = false,
+    target = ''
 }) => {
     const proxy = [];
     const registry = [];
     const majorEnv = env.split('-')[0];
-    const minorEnv = majorEnv === 'prod' ? '' : `${majorEnv}.`;
-    const target = env === 'prod-stable'
-        ? `https://${useCloud ? 'cloud' : 'console'}.redhat.com/`
-        : `https://${minorEnv}${useCloud ? 'cloud' : 'console'}.redhat.com/`;
+    if (target === '') {
+        target += 'https://';
+        if (useCloud && majorEnv !== 'prod') {
+            target += majorEnv + '.';
+        }
+
+        target += useCloud ? 'cloud' : 'console';
+        if (!useCloud && majorEnv !== 'prod') {
+            target += '.stage';
+        }
+
+        target += '.redhat.com/';
+    }
+
     if (!Array.isArray(appUrl)) {
         appUrl = [ appUrl ];
     }

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -27,7 +27,6 @@ module.exports = ({
     publicPath,
     proxyVerbose,
     useCloud = false,
-    useStage = false,
     target = ''
 }) => {
     const proxy = [];
@@ -35,12 +34,12 @@ module.exports = ({
     const majorEnv = env.split('-')[0];
     if (target === '') {
         target += 'https://';
-        if (!useStage && majorEnv !== 'prod') {
+        if (![ 'prod', 'stage' ].includes(majorEnv)) {
             target += majorEnv + '.';
         }
 
         target += useCloud ? 'cloud' : 'console';
-        if (useStage && majorEnv !== 'prod') {
+        if (majorEnv === 'stage') {
             target += '.stage';
         }
 
@@ -48,6 +47,12 @@ module.exports = ({
     }
 
     console.log('Proxing to', target);
+
+    if (env.startsWith('stage')) {
+        // stage-stable / stage-beta branches don't exist in build repos
+        // Currently stage pulls from QA
+        env = env.replace('stage', 'qa');
+    }
 
     if (!Array.isArray(appUrl)) {
         appUrl = [ appUrl ];

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -55,7 +55,9 @@ const { config: webpackConfig, plugins } = config({
 |[routes](#routes)|`object`|An object with additional routes.|
 |[routesPath](#routespath)|`string`|A path to an object with additional routes.|
 |[customProxy](#custom-proxy-settings)|`object[]`|An array of custom provided proxy configurations.|
+|[env](#env)|`string`|Environment to proxy against such as ci-beta.|
 |[useCloud](#use-cloud)|`boolean`|Toggle to use old fallback to cloud.redhat.com paths instead of console.redhat.com.|
+|[target](#target)|`string`|Override `env` and `useCloud` to use a custom URI.|
 
 ### localChrome
 
@@ -142,9 +144,15 @@ const { config: webpackConfig, plugins } = config({
 
 This configuration will redirect all API requests to QA environment, so you can check CI UI with QA data.
 
+### Env
+A hyphenated string in the form of (qa|ci|stage|prod)-(stable|beta). Used to determine the proxy target (such as ci.console.redhat.com or console.stage.redhat.com) and branch to checkout of build repos. If "stage" is specific qa is used as the branch.
+
 ### Use cloud
 
-If you want to run in legace mode please pass `useCloud: true` in your config, this way paths which does not match your proxy config (API for instance) will be passed to `cloud.redhat.com` (respective to your env `ci|qa|stage`). Without this all fallback routes will be redirected to `console.redhat.com`.
+If you want to run in legacy mode pass `useCloud: true` in your config, this way paths which does not match your proxy config (API for instance) will be passed to `cloud.redhat.com` (respective to your env `ci|qa|stage`). Without this all fallback routes will be redirected to `console.redhat.com`.
+
+### Target
+Override for the target `env` and `useCloud` build. Useful for cross-environment testing.
 
 ## standalone
 A way to run cloud.redhat.com apps from `localhost` offline.

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -26,7 +26,8 @@ module.exports = ({
     reposDir,
     appUrl = [],
     proxyVerbose,
-    useCloud
+    useCloud,
+    target
 } = {}) => {
     const filenameMask = `js/[name]${useFileHash ? '.[chunkhash]' : ''}.js`;
     if (betaEnv) {
@@ -190,7 +191,8 @@ module.exports = ({
                 reposDir,
                 appUrl,
                 publicPath,
-                proxyVerbose
+                proxyVerbose,
+                target
             })
         }
     };


### PR DESCRIPTION
Only care about `majorEnv === 'prod'` if `useCloud: false` in order to map to https://console.redhat.com or https://console.stage.redhat.com .

Allow custom `target` to override for urls like https://cloud.stage.redhat.com/