### PR TITLE
fix(inventory): use default new tab browser handlers.

### DIFF
--- a/packages/inventory/src/components/table/TitleColumn.js
+++ b/packages/inventory/src/components/table/TitleColumn.js
@@ -13,12 +13,14 @@ const onRowClick = (event, key, { loaded, onRowClick: rowClick, noDetail }) => {
     if (loaded && !noDetail) {
         const isMetaKey = (event.ctrlKey || event.metaKey || event.which === 2);
         if (isMetaKey) {
-            const url = new URL(`./${key}`, location.href);
-            window.open(url.href);
+            return;
         } else if (rowClick) {
             rowClick(event, key, isMetaKey);
         }
     }
+
+    event.preventDefault();
+    event.stopPropagation();
 };
 
 /**
@@ -39,8 +41,6 @@ const TitleColumn = (data, id, item, props) => (
                     widget="col"
                     href={ `${location.pathname}${location.pathname.substr(-1) === '/' ? '' : '/'}${id}` }
                     onClick={ event => {
-                        event.preventDefault();
-                        event.stopPropagation();
                         onRowClick(event, id, props);
                     }}
                 >

--- a/packages/inventory/src/components/table/TitleColumn.test.js
+++ b/packages/inventory/src/components/table/TitleColumn.test.js
@@ -58,19 +58,5 @@ describe('TitleColumn', () => {
             wrapper.find('a').first().simulate('click');
             expect(onClick).not.toHaveBeenCalled();
         });
-
-        it('should NOT call onClick and call global open', () => {
-            const onClick = jest.fn();
-            const Cmp = () => TitleColumn(
-                'something',
-                'some-id',
-                { os_release: 'os_release' },
-                { onRowClick: onClick, loaded: true }
-            );
-            const wrapper = mount(<Cmp />);
-            wrapper.find('a').first().simulate('click', { ctrlKey: true });
-            expect(onClick).not.toHaveBeenCalled();
-            expect(open).toHaveBeenCalled();
-        });
     });
 });


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14034

the default prevention caused the browser to open a tab with a different URL. There is also no point in manually calling the `window.open`. The `ctrl+click` is a default method of opening new tabs/windows. This will now use the same behavior as if you would use `middleBTN` or `leftClick + open in a new tab`. Also, the middle mouse button event is never caught due to the fact that it does not trigger `onClick` event (only `onMouseDown`).