### PR TITLE
fix(standalone): fix cookie inject regex

### DIFF
--- a/packages/config-utils/cookieTransform.js
+++ b/packages/config-utils/cookieTransform.js
@@ -13,7 +13,7 @@ const defaultEntitlements = {
 
 function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlements, user, internal, identity: customIdentity }) {
     const cookie = req.headers.cookie;
-    const match = cookie && cookie.match(/cs_jwt=([^;]+);/);
+    const match = cookie && cookie.match(/cs_jwt=([^;]+)/);
     if (match) {
         const cs_jwt = match[1];
         const { payload } = jws.decode(cs_jwt);

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -100,12 +100,13 @@ module.exports = ({
         // Create network for services.
         execSync(`docker network inspect ${NET} >/dev/null 2>&1 || docker network create ${NET}`);
 
-        // Clone repos
+        // Clone repos and resolve functions
         // If we manage the repos it's okay to overwrite the contents
         const overwrite = reposDir === defaultReposDir;
-        // Need to use for loop for `await`
-        for (const [ projName, proj ] of Object.entries(standaloneConfig)) {
-            const { services, path, assets, onProxyReq, keycloakUri, register, target, ...rest } = proj;
+
+        // Resolve config functions for cross-service references
+        for (const [ _projName, proj ] of Object.entries(standaloneConfig)) {
+            const { services, path, assets, register } = proj;
             if (typeof register === 'function') {
                 registry.push(register);
             }
@@ -129,8 +130,11 @@ module.exports = ({
             if (typeof services === 'function') {
                 proj.services = services({ env, port, assets });
             }
+        }
 
-            // Start standalone services.
+        // Start standalone services.
+        for (const [ projName, proj ] of Object.entries(standaloneConfig)) {
+            const { services, path, assets, onProxyReq, keycloakUri, register, target, ...rest } = proj;
             const serviceNames = [];
             for (let [ subServiceName, subService ] of Object.entries(proj.services || {})) {
                 const name = [ projName, subServiceName ].join('_');
@@ -140,10 +144,7 @@ module.exports = ({
                 console.log('Container', name, 'listening', port ? 'on' : '', port || '');
             }
 
-            process.on('SIGINT', () => {
-                serviceNames.forEach(stopService);
-                process.exit();
-            });
+            process.on('SIGINT', () => serviceNames.forEach(stopService));
 
             if (target) {
                 proxy.push({
@@ -155,6 +156,8 @@ module.exports = ({
                 });
             }
         }
+
+        process.on('SIGINT', () => process.exit());
     }
 
     if (useProxy) {

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -141,7 +141,6 @@ module.exports = ({
             }
 
             process.on('SIGINT', () => {
-                console.log();
                 serviceNames.forEach(stopService);
                 process.exit();
             });
@@ -167,7 +166,10 @@ module.exports = ({
             context: url => {
                 const shouldProxy = !appUrl.find(u => typeof u === 'string' ? url.startsWith(u) : u.test(url));
                 if (shouldProxy) {
-                    console.log('proxy', url);
+                    if (proxyVerbose) {
+                        console.log('proxy', url);
+                    }
+
                     return true;
                 }
 

--- a/packages/config-utils/standalone/services/rbac.js
+++ b/packages/config-utils/standalone/services/rbac.js
@@ -31,6 +31,7 @@ const services = ({ port, env, assets }) => ({
     },
     // Last since this depends on redis + postgres
     rbac: {
+        startMessage: 'Booting worker',
         dependsOn: [
             `rbac_redis`,
             `rbac_postgres`


### PR DESCRIPTION
The `cs_jwt` cookie now appears at the end of the string so the regex needed tweaking.

New standalone apps might want access to other standalone apps to wait on them, so I've allowed that by resolving the config before starting the services.