### PR TITLE
remove .gitignore symlinks

### DIFF
--- a/packages/charts/.gitignore
+++ b/packages/charts/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/inventory-compliance/.gitignore
+++ b/packages/inventory-compliance/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/inventory-general-info/.gitignore
+++ b/packages/inventory-general-info/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/inventory-insights/.gitignore
+++ b/packages/inventory-insights/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/inventory/.gitignore
+++ b/packages/inventory/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/notifications/.gitignore
+++ b/packages/notifications/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/pdf-generator/.gitignore
+++ b/packages/pdf-generator/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/remediations/.gitignore
+++ b/packages/remediations/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/rule-components/.gitignore
+++ b/packages/rule-components/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/translations/.gitignore
+++ b/packages/translations/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -1,1 +1,24 @@
-../../config/.gitignore
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+
+# Incremental ts info
+tsconfig.tsbuildinfo


### PR DESCRIPTION
The newest version of git ignores symlinks for `.gitignore`. We have to use real files :disappointed: 