### PR TITLE
Update async component

### DIFF
--- a/packages/components/src/AsyncComponent/index.js
+++ b/packages/components/src/AsyncComponent/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { ScalprumComponent } from '@scalprum/react-core';
 import { Bullseye, Spinner } from '@patternfly/react-core';
@@ -12,17 +12,15 @@ const BaseAsyncComponent = ({
     ...props
 }) => {
     return (
-        <Suspense fallback={fallback}>
-            <ScalprumComponent
-                appName={appName}
-                module={module}
-                scope={scope || appName}
-                ErrorComponent={fallback}
-                ref={innerRef}
-                fallback={fallback}
-                {...props}
-            />
-        </Suspense>
+        <ScalprumComponent
+            appName={appName}
+            module={module}
+            scope={scope || appName}
+            ErrorComponent={fallback}
+            ref={innerRef}
+            fallback={fallback}
+            {...props}
+        />
     );
 };
 

--- a/packages/components/src/AsyncComponent/index.js
+++ b/packages/components/src/AsyncComponent/index.js
@@ -19,6 +19,7 @@ const BaseAsyncComponent = ({
                 scope={scope || appName}
                 ErrorComponent={fallback}
                 ref={innerRef}
+                fallback={fallback}
                 {...props}
             />
         </Suspense>


### PR DESCRIPTION
This PR adds two changes:

- Pass fallback component to scalprum component, it caused issues in the inventory frontend (See [here](https://github.com/RedHatInsights/insights-inventory-frontend/issues/1337))
- Removes the suspense component as suspense is already used [here](https://github.com/scalprum/scaffloding/blob/2f891051b0058fcf7666cf5d4ea38884a325eadd/packages/react-core/src/scalprum-component.tsx#L74) 

**After**

![Kapture 2021-08-04 at 13 08 53](https://user-images.githubusercontent.com/32869456/128171010-ba8dccc3-82b4-4339-bfd4-78528e641e22.gif)
