### PR TITLE
Change path in esm scss exports

### DIFF
--- a/plugins/transform-scss-plugin.js
+++ b/plugins/transform-scss-plugin.js
@@ -34,6 +34,50 @@ module.exports = function (babel) {
                 }
 
                 path.replaceWith(t.importDeclaration(path.node.specifiers, t.stringLiteral(cssSourcePath)));
+            },
+            /**
+                 * In RuleTable component there is the style file reexported
+                 * for esm, we need to change the source path
+                 */
+            ExportDeclaration: function(path, state) {
+                /**
+                 * skip default export
+                 */
+                if (!path.node.source) {
+                    return;
+                }
+
+                /**
+                 * skip files with no sass exports
+                 */
+                if (!sassExt.test(path.node.source.value)) {
+                    return;
+                }
+
+                /**
+                 * replace sass extenstion with css extension
+                 */
+                const sassFileName = path.node.source.value.replace(sassExt, '.css');
+                /**
+                 * replace sass export with css import
+                 */
+                let cssSourcePath;
+                if (state.opts.esm === true) {
+                    /**
+                     * Get root folder for ESM reference
+                     */
+                    let relative = nodePath.relative(this.filename.replace('/src/', '/esm/'), this.filename.replace('/src', '')).replace(/^..\//, '').split('/');
+                    relative.pop();
+                    relative = relative.join('/');
+                    cssSourcePath =  `${relative}/${sassFileName}`;
+                } else {
+                    cssSourcePath = `${sassFileName}`;
+                }
+
+                /**
+                     * Change the export to new path
+                     */
+                path.replaceWith(t.exportNamedDeclaration(path.node.declarations, path.node.specifiers, t.stringLiteral(cssSourcePath)));
             }
         }
     };


### PR DESCRIPTION
This changes the wrong export `'./index.scss'` to correct `export { default as style } from "../../RuleTable/./index.css";`

But I am not sure if this is what we want as it still throws a warning:

```
WARNING in ../rule-components/esm/RuleTable/RuleTable.js 40:0-63
export 'default' (reexported as 'style') was not found in '../../RuleTable/./index.css' (module has no exports)
```