### PR TITLE
fix(fedmod): properly share scalprum

### DIFF
--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -48,7 +48,7 @@ module.exports = ({
      * No application should be installing/interacting with scalprum directly.
      */
     if (dependencies['@redhat-cloud-services/frontend-components']) {
-        sharedDeps.push({ '@scalprum/react-core': { singleton: true } });
+        sharedDeps.push({ '@scalprum/react-core': { requiredVersion: '*', singleton: true } });
     }
 
     if (debug) {


### PR DESCRIPTION
Webpack requires that you pass a `requiredVersion` when using this syntax.

Fix for @jschuler.