### PR TITLE
Wrap async comp

### DIFF
--- a/packages/components/src/AsyncComponent/index.js
+++ b/packages/components/src/AsyncComponent/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ScalprumComponent } from '@scalprum/react-core';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import classNames from 'classnames';
 
 const BaseAsyncComponent = ({
     appName,
@@ -10,10 +11,11 @@ const BaseAsyncComponent = ({
     fallback,
     innerRef,
     className,
+    component: Cmp,
     ...props
 }) => {
     return (
-        <section className={`${className || ''} ${appName}`}>
+        <Cmp className={classNames(className, appName)}>
             <ScalprumComponent
                 className={className}
                 appName={appName}
@@ -24,7 +26,7 @@ const BaseAsyncComponent = ({
                 fallback={fallback}
                 {...props}
             />
-        </section>
+        </Cmp>
     );
 };
 
@@ -46,7 +48,9 @@ AsynComponent.propTypes = {
     /** Loaded module, it has to start with `./`. */
     module: PropTypes.string.isRequired,
     /** Optional scope, if not passed appName is used. */
-    scope: PropTypes.string
+    scope: PropTypes.string,
+    /** Optional wrapper component */
+    component: PropTypes.string
 };
 
 AsynComponent.defaultProps = {
@@ -54,7 +58,8 @@ AsynComponent.defaultProps = {
         <Bullseye>
             <Spinner size="xl" />
         </Bullseye>
-    )
+    ),
+    component: 'section'
 };
 
 BaseAsyncComponent.propTypes = {

--- a/packages/components/src/AsyncComponent/index.js
+++ b/packages/components/src/AsyncComponent/index.js
@@ -9,18 +9,22 @@ const BaseAsyncComponent = ({
     module,
     fallback,
     innerRef,
+    className,
     ...props
 }) => {
     return (
-        <ScalprumComponent
-            appName={appName}
-            module={module}
-            scope={scope || appName}
-            ErrorComponent={fallback}
-            ref={innerRef}
-            fallback={fallback}
-            {...props}
-        />
+        <section className={`${className || ''} ${appName}`}>
+            <ScalprumComponent
+                className={className}
+                appName={appName}
+                module={module}
+                scope={scope || appName}
+                ErrorComponent={fallback}
+                ref={innerRef}
+                fallback={fallback}
+                {...props}
+            />
+        </section>
     );
 };
 


### PR DESCRIPTION
### Missing styles on fed modules

When importing fed module the app wouldn't apply module's styles because of scoping. This PR fixes such issue, by adding container as a wrapper around async component and applying classname same as is the name of the application.

There are potentional bugs with visuals where the content might not span over the entire content. Should this error arise we can investigate if the app is not doing anything strange with the styling or we can apply the class to first rendered element.