### PR TITLE
Fix rule component scss import.

### DIFF
--- a/packages/rule-components/src/RuleTable/RuleTable.js
+++ b/packages/rule-components/src/RuleTable/RuleTable.js
@@ -11,7 +11,7 @@ import flatten from 'lodash/flatten';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import { calculateMeta, calculateActiveFilters, createRows } from './helpers';
-export { default as style } from './index.scss';
+import './index.scss';
 
 class RuleTable extends Component {
     state = {


### PR DESCRIPTION
closes #1206 

For some reason, the styles were re-exported as CSS a module even, though we do not use CSS modules anywhere. 