### PR TITLE
Allow passing custom bulk select to TagModal

### DIFF
--- a/packages/components/src/TagModal/TableWithFilter.js
+++ b/packages/components/src/TagModal/TableWithFilter.js
@@ -34,7 +34,8 @@ const TableWithFilter = ({
     systemName,
     columns,
     tableProps,
-    entityName
+    entityName,
+    bulkSelect
 }) => {
     const onRowSelect = ({ isSelected, rowId }) => {
         const currRow = rows?.[rowId];
@@ -66,7 +67,8 @@ const TableWithFilter = ({
                                 title: `Select page (${ rows.length })`,
                                 onClick: () => onSelect(unique([ ...rows, ...selected ]))
                             } : {}
-                        }]
+                        }],
+                        ...bulkSelect || {}
                     }
                 }}
                 {...filters && {
@@ -151,7 +153,8 @@ TableWithFilter.propTypes = {
     calculateChecked: PropTypes.func,
     unique: PropTypes.func,
     onSelect: PropTypes.func,
-    onUpdateData: PropTypes.func
+    onUpdateData: PropTypes.func,
+    bulkSelect: PropTypes.any
 };
 
 TableWithFilter.defaultProps = {

--- a/packages/components/src/TagModal/TagModal.js
+++ b/packages/components/src/TagModal/TagModal.js
@@ -30,7 +30,7 @@ class TagModal extends Component {
         this.setState({ activeTabKey: tabIndex });
     };
 
-    renderTable = (rows, columns, pagination, loaded, filters, selected, onSelect, onUpdateData) => (
+    renderTable = (rows, columns, pagination, loaded, filters, selected, onSelect, onUpdateData, bulkSelect) => (
         <TableWithFilter
             {...this.props}
             rows={rows}
@@ -45,6 +45,7 @@ class TagModal extends Component {
             onSelect={onSelect}
             onUpdateData={onUpdateData}
             selected={selected}
+            bulkSelect={bulkSelect}
         >
             {this.props.children}
         </TableWithFilter>
@@ -69,6 +70,7 @@ class TagModal extends Component {
             onUpdateData,
             selected,
             tableProps,
+            bulkSelect,
             ...props
         } = this.props;
 
@@ -123,7 +125,8 @@ class TagModal extends Component {
                                             filters?.[key],
                                             selected?.[key],
                                             onSelect?.[key],
-                                            onUpdateData?.[key]
+                                            onUpdateData?.[key],
+                                            bulkSelect?.[key]
                                         )
                                     }
                                 </Tab>
@@ -138,7 +141,8 @@ class TagModal extends Component {
                         filters,
                         selected,
                         onSelect,
-                        onUpdateData
+                        onUpdateData,
+                        bulkSelect
                     )}
             </Modal>
         );
@@ -160,6 +164,7 @@ TagModal.propTypes = {
     }),
     onSelect: PropTypes.oneOfType([ PropTypes.func, PropTypes.arrayOf(PropTypes.func) ]),
     onUpdateData: PropTypes.oneOfType([ PropTypes.func, PropTypes.arrayOf(PropTypes.func) ]),
+    bulkSelect: PropTypes.oneOfType([ PropTypes.any, PropTypes.arrayOf(PropTypes.any) ]),
     pagination: PropTypes.oneOfType([
         TableWithFilter.propTypes.pagination,
         PropTypes.arrayOf(TableWithFilter.propTypes.pagination)


### PR DESCRIPTION
### Custom bulk select

If there is tag modal visible and user clicks on select all on page, the checkbox used by PF fires event also for any bulk selects on page. This PR fixes such issue by allowing passing custom bulk select props to change the ID of bulk select and not to fire for multiple checkboxes.