### PR TITLE
Add useScreenSize hook

### DIFF
--- a/packages/components/doc/useScreenSize.md
+++ b/packages/components/doc/useScreenSize.md
@@ -1,0 +1,51 @@
+- [useScreenSize](#usescreensize)
+  - [Usage](#usage)
+  - [Breakpoints](#breakpoints)
+  - [Variants](#variants)
+  - [isSmallScreen](#issmallscreen)
+
+# useScreenSize
+
+`useScreenSize` is a React hook that listens to windows resizing and returns a PatternFly variant of the current size. This hook is helping when different React structures has to be shown accordingly to the window size. For example, when you want to show a dropdown instead of a button set.
+
+## Usage
+
+```jsx
+import useScreenSize from '@redhat-cloud-services/frontend-components/useScreenSize';
+
+const DummyComponent = () => {
+    const currentVariant = useScreenSize();
+
+    return <div>Current PF4 variant is: {currentVariant}</div>;
+};
+```
+
+## Breakpoints
+
+`breakpoints` object is a map of `{ [variant]: size (as number) }`.
+
+## Variants
+
+Current variants can be found as keys of `breakpoints` object.
+
+```jsx
+['xs', 'sm', 'md', 'lg', '2xl']
+```
+
+## isSmallScreen
+
+`isSmallScreen` is a simple helper that returns `true` if the current variant is a small screen.
+
+```jsx
+import { useScreenSize, isSmallScreen } from '@redhat-cloud-services/frontend-components/useScreenSize';
+
+const DummyComponent = () => {
+    const currentVariant = useScreenSize();
+
+    if(isSmallScreen(currentVariant)) {
+        return <div>Mobile content</div>;
+    }
+
+    return <div>Desktop content</div>;
+};
+```

--- a/packages/components/src/useScreenSize/breakpoints.js
+++ b/packages/components/src/useScreenSize/breakpoints.js
@@ -1,0 +1,17 @@
+import xsBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_xs';
+import smBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_sm';
+import mdBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_md';
+import lgBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_lg';
+import xlBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_xl';
+import xxlBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_2xl';
+
+const breakPoints = {
+    xs: parseInt(xsBreakpoint.value.replace('px', '')),
+    sm: parseInt(smBreakpoint.value.replace('px', '')),
+    md: parseInt(mdBreakpoint.value.replace('px', '')),
+    lg: parseInt(lgBreakpoint.value.replace('px', '')),
+    xl: parseInt(xlBreakpoint.value.replace('px', '')),
+    '2xl': parseInt(xxlBreakpoint.value.replace('px', ''))
+};
+
+export default breakPoints;

--- a/packages/components/src/useScreenSize/breakpoints.js
+++ b/packages/components/src/useScreenSize/breakpoints.js
@@ -1,9 +1,9 @@
-import xsBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_xs';
-import smBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_sm';
-import mdBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_md';
-import lgBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_lg';
-import xlBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_xl';
-import xxlBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_2xl';
+import xsBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_xs';
+import smBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_sm';
+import mdBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_md';
+import lgBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
+import xlBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_xl';
+import xxlBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_2xl';
 
 const breakPoints = {
     xs: parseInt(xsBreakpoint.value.replace('px', '')),

--- a/packages/components/src/useScreenSize/getVariant.js
+++ b/packages/components/src/useScreenSize/getVariant.js
@@ -5,13 +5,13 @@ const getVariant = () => {
 
     let result;
 
-    Object.entries(breakpoints).some(([ variant, size ]) => {
-        if (width > size) {
-            result = variant;
-        } else {
-            return true;
+    for (const [ variant, size ] of Object.entries(breakpoints)) {
+        if (size >= width) {
+            break;
         }
-    });
+
+        result = variant;
+    }
 
     return result;
 };

--- a/packages/components/src/useScreenSize/getVariant.js
+++ b/packages/components/src/useScreenSize/getVariant.js
@@ -1,0 +1,19 @@
+import breakpoints from './breakpoints';
+
+const getVariant = () => {
+    const width = window.innerWidth;
+
+    let result;
+
+    Object.entries(breakpoints).some(([ variant, size ]) => {
+        if (width > size) {
+            result = variant;
+        } else {
+            return true;
+        }
+    });
+
+    return result;
+};
+
+export default getVariant;

--- a/packages/components/src/useScreenSize/index.js
+++ b/packages/components/src/useScreenSize/index.js
@@ -1,0 +1,5 @@
+export { default } from './useScreenSize';
+export { default as useScreenSize } from './useScreenSize';
+export { default as getVariant } from './getVariant';
+export { default as isSmallScreen } from './isSmallScreen';
+export { default as breakpoints } from './breakpoints';

--- a/packages/components/src/useScreenSize/isSmallScreen.js
+++ b/packages/components/src/useScreenSize/isSmallScreen.js
@@ -1,0 +1,7 @@
+import breakpoints from './breakpoints';
+
+const variants = Object.keys(breakpoints);
+
+const isSmallScreen = screenSize => variants.indexOf(screenSize) <= variants.indexOf('sm');
+
+export default isSmallScreen;

--- a/packages/components/src/useScreenSize/isSmallScreen.js
+++ b/packages/components/src/useScreenSize/isSmallScreen.js
@@ -1,7 +1,5 @@
 import breakpoints from './breakpoints';
 
-const variants = Object.keys(breakpoints);
-
-const isSmallScreen = screenSize => variants.indexOf(screenSize) <= variants.indexOf('sm');
+const isSmallScreen = screenSize => breakpoints?.[screenSize] <= breakpoints.sm;
 
 export default isSmallScreen;

--- a/packages/components/src/useScreenSize/useScreenSize.js
+++ b/packages/components/src/useScreenSize/useScreenSize.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
+
+import getVariant from './getVariant';
+
+const useScreen = () => {
+    const [ variant, setVariant ] = useState(() => getVariant());
+    const prev = useRef(variant);
+
+    useEffect(() => {
+        function handleResize() {
+            const newVariant = getVariant();
+            if (newVariant !== prev.current) {
+                prev.current = newVariant;
+                setVariant(newVariant);
+            }
+        }
+
+        window.addEventListener('resize', handleResize);
+
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return variant;
+};
+
+export default useScreen;

--- a/packages/components/src/useScreenSize/useScreenSize.test.js
+++ b/packages/components/src/useScreenSize/useScreenSize.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+
+import useScreen from './useScreenSize';
+import breakpoints from './breakpoints';
+import isSmallScreen from './isSmallScreen';
+
+describe('useScreen', () => {
+    it('isSmallScreen', () => {
+        expect(isSmallScreen('2xl')).toEqual(false);
+        expect(isSmallScreen('lg')).toEqual(false);
+        expect(isSmallScreen('md')).toEqual(false);
+        expect(isSmallScreen('sm')).toEqual(true);
+        expect(isSmallScreen('xs')).toEqual(true);
+    });
+
+    it('renders only on size change', async () => {
+        const tmpSize = global.innerWidth;
+
+        const renderSpy = jest.fn();
+
+        let wrapper;
+
+        const changeSize = async (size) => {
+            await act(async () => {
+                global.innerWidth = size;
+                global.dispatchEvent(new Event('resize'));
+            });
+            wrapper.update();
+        };
+
+        const Dummy = () => {
+            const screenSize = useScreen();
+
+            renderSpy(screenSize);
+
+            return null;
+        };
+
+        global.innerWidth = 540;
+
+        const variants = Object.keys(breakpoints);
+
+        await act(async () => {
+            wrapper = mount(<Dummy />);
+        });
+        wrapper.update();
+
+        expect(renderSpy).toHaveBeenCalledWith(variants[0]);
+        renderSpy.mockClear();
+
+        await changeSize(541);
+        expect(renderSpy).not.toHaveBeenCalled();
+
+        await changeSize(768);
+        expect(renderSpy).toHaveBeenCalledWith(variants[1]);
+        renderSpy.mockClear();
+
+        await changeSize(992);
+        expect(renderSpy).toHaveBeenCalledWith(variants[2]);
+        renderSpy.mockClear();
+
+        await changeSize(993);
+        expect(renderSpy).toHaveBeenCalledWith(variants[3]);
+        renderSpy.mockClear();
+
+        await changeSize(1200);
+        expect(renderSpy).not.toHaveBeenCalled();
+
+        await changeSize(1201);
+        expect(renderSpy).toHaveBeenCalledWith(variants[4]);
+        renderSpy.mockClear();
+
+        await changeSize(1201);
+        expect(renderSpy).not.toHaveBeenCalled();
+
+        await changeSize(992);
+        expect(renderSpy).toHaveBeenCalledWith(variants[2]);
+        renderSpy.mockClear();
+
+        global.innerWidth = tmpSize;
+
+        await act(async () => {
+            wrapper.unmount();
+        });
+        wrapper.update();
+    });
+});


### PR DESCRIPTION
- [useScreenSize](#usescreensize)
  - [Usage](#usage)
  - [Breakpoints](#breakpoints)
  - [Variants](#variants)
  - [isSmallScreen](#issmallscreen)

# useScreenSize

`useScreenSize` is a React hook that listens to windows resizing and returns a PatternFly variant of the current size. This hook is helping when different React structures has to be shown accordingly to the window size. For example, when you want to show a dropdown instead of a button set.

## Usage

```jsx
import useScreenSize from '@redhat-cloud-services/frontend-components/useScreenSize';

const DummyComponent = () => {
    const currentVariant = useScreenSize();

    return <div>Current PF4 variant is: {currentVariant}</div>;
};
```

## Breakpoints

`breakpoints` object is a map of `{ [variant]: size (as number) }`.

## Variants

Current variants can be found as keys of `breakpoints` object.

```jsx
['xs', 'sm', 'md', 'lg', '2xl']
```

## isSmallScreen

`isSmallScreen` is a simple helper that returns `true` if the current variant is a small screen.

```jsx
import { useScreenSize, isSmallScreen } from '@redhat-cloud-services/frontend-components/useScreenSize';

const DummyComponent = () => {
    const currentVariant = useScreenSize();

    if(isSmallScreen(currentVariant)) {
        return <div>Mobile content</div>;
    }

    return <div>Desktop content</div>;
};
```