### PR TITLE
Implement expand on hover for Truncate

### DIFF
--- a/packages/components/src/Truncate/Truncate.js
+++ b/packages/components/src/Truncate/Truncate.js
@@ -10,7 +10,15 @@ const dangerousHtml = (html) =>
     ({ __html: sanitizeHtml(html) });
 
 const Truncate = ({
-    text = '', length = 150, expandText = 'Read more', collapseText = 'Collapse',  className, inline, spaceBetween
+    text = '',
+    length = 150,
+    expandText = 'Read more',
+    hideExpandText = false,
+    expandOnMouseOver = false,
+    collapseText = 'Collapse',
+    className,
+    inline,
+    spaceBetween
 }) => {
     const truncateClasses = classNames(
         'ins-c-truncate',
@@ -42,20 +50,26 @@ const Truncate = ({
         </Button>;
     const textWithOverflow = showText === false ? `${trimmedText}${textOverflow ? '...' : '' }` : text;
     const html = dangerousHtml(textWithOverflow);
+    const mouseOverHandler = expandOnMouseOver && {
+        onMouseEnter: () => setShowText(true),
+        onMouseLeave: () => setShowText(false)
+    };
 
     return inline ? <React.Fragment>
         <span
             className={ truncateClasses }
             widget-type='InsightsTruncateInline'
-            dangerouslySetInnerHTML={ html } />
-        { textOverflow && (showText === false ? expandButton : collapseButton) }
+            dangerouslySetInnerHTML={ html }
+            { ...mouseOverHandler }
+        />
+        { !hideExpandText && textOverflow && (showText === false ? expandButton : collapseButton) }
     </React.Fragment> : <Stack className={ truncateClasses }>
-        <StackItem>
+        <StackItem { ...mouseOverHandler }>
             <span
                 widget-type='InsightsTruncateBlock'
                 dangerouslySetInnerHTML={ html } />
         </StackItem>
-        { textOverflow && <StackItem className={spaceBetween && 'pf-u-mt-sm'}>
+        { !hideExpandText && textOverflow && <StackItem className={spaceBetween && 'pf-u-mt-sm'}>
             { showText === false ? expandButton : collapseButton }
         </StackItem>
         }
@@ -69,7 +83,9 @@ Truncate.propTypes = {
     expandText: propTypes.string,
     collapseText: propTypes.string,
     inline: propTypes.bool,
-    spaceBetween: propTypes.bool
+    spaceBetween: propTypes.bool,
+    hideExpandText: propTypes.bool,
+    expandOnMouseOver: propTypes.bool
 };
 
 export default Truncate;

--- a/packages/components/src/Truncate/Truncate.js
+++ b/packages/components/src/Truncate/Truncate.js
@@ -1,97 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
 import propTypes from 'prop-types';
-
 import classNames from 'classnames';
-
 import { Button, Stack, StackItem } from '@patternfly/react-core';
+import sanitizeHtml from 'sanitize-html';
 
 import './truncate.scss';
 
-import sanitizeHtml from 'sanitize-html';
+const dangerousHtml = (html) =>
+    ({ __html: sanitizeHtml(html) });
 
-class Truncate extends React.Component {
-
-    constructor(props) {
-        super(props);
-        this.state = {
-            showText: false
-        };
-        this.toggleText = this.toggleText.bind(this);
-    }
-
-    toggleText (event) {
+const Truncate = ({
+    text = '', length = 150, expandText = 'Read more', collapseText = 'Collapse',  className, inline, spaceBetween
+}) => {
+    const truncateClasses = classNames(
+        'ins-c-truncate',
+        className,
+        { [`is-inline`]: inline },
+        { [`is-block`]: !inline }
+    );
+    const trimmedText = text.substring(0, length);
+    const textOverflow = text.length > length;
+    const [ showText, setShowText ] = useState(false);
+    const toggleText = (event) => {
         event && event.preventDefault();
-        this.setState({
-            showText: !this.state.showText
-        });
-    }
+        setShowText(!showText);
+    };
 
-    dangerousHtml(text) {
-        return { __html: sanitizeHtml(text) };
-    }
+    const expandButton =
+        <Button
+            className='ins-c-expand-button'
+            variant='link'
+            onClick={ toggleText }>
+            { expandText }
+        </Button>;
+    const collapseButton =
+        <Button
+            className='ins-c-collapse-button'
+            variant='link'
+            onClick={ toggleText }>
+            { collapseText }
+        </Button>;
+    const textWithOverflow = showText === false ? `${trimmedText}${textOverflow ? '...' : '' }` : text;
+    const html = dangerousHtml(textWithOverflow);
 
-    render() {
-
-        const truncateClasses = classNames(
-            'ins-c-truncate',
-            this.props.className,
-            { [`is-inline`]: this.props.inline },
-            { [`is-block`]: !this.props.inline }
-        );
-
-        const trimmedText = this.props.text.substring(0, this.props.length);
-
-        const textOverflow = this.props.text.length > this.props.length;
-
-        const { showText } = this.state;
-
-        const expandButton =
-            <Button
-                className='ins-c-expand-button'
-                variant='link'
-                onClick={ this.toggleText }>
-                { this.props.expandText }
-            </Button>;
-
-        const collapseButton =
-            <Button
-                className='ins-c-collapse-button'
-                variant='link'
-                onClick={ this.toggleText }>
-                { this.props.collapseText }
-            </Button>;
-
-        if (this.props.inline) {
-            return (
-                <React.Fragment>
-                    <span
-                        className={ truncateClasses }
-                        widget-type='InsightsTruncateInline'
-                        dangerouslySetInnerHTML={ this.dangerousHtml(showText === false ? `${trimmedText}${textOverflow ? '...' : '' }`
-                            : this.props.text) } />
-                    { textOverflow && (showText === false ? expandButton : collapseButton) }
-                </React.Fragment>
-            );
-        } else {
-            return (
-                <Stack className={ truncateClasses }>
-                    <StackItem>
-                        <span
-                            widget-type='InsightsTruncateBlock'
-                            dangerouslySetInnerHTML={ this.dangerousHtml(showText === false ? `${trimmedText}${textOverflow ? '...' : '' }`
-                                : this.props.text) } />
-                    </StackItem>
-                    { textOverflow && <StackItem className={this.props.spaceBetween && 'pf-u-mt-sm'}>
-                        { showText === false ? expandButton : collapseButton }
-                    </StackItem>
-                    }
-                </Stack>
-            );
+    return inline ? <React.Fragment>
+        <span
+            className={ truncateClasses }
+            widget-type='InsightsTruncateInline'
+            dangerouslySetInnerHTML={ html } />
+        { textOverflow && (showText === false ? expandButton : collapseButton) }
+    </React.Fragment> : <Stack className={ truncateClasses }>
+        <StackItem>
+            <span
+                widget-type='InsightsTruncateBlock'
+                dangerouslySetInnerHTML={ html } />
+        </StackItem>
+        { textOverflow && <StackItem className={spaceBetween && 'pf-u-mt-sm'}>
+            { showText === false ? expandButton : collapseButton }
+        </StackItem>
         }
-    }
+    </Stack>;
 };
-
-export default Truncate;
 
 Truncate.propTypes = {
     className: propTypes.string,
@@ -103,9 +72,4 @@ Truncate.propTypes = {
     spaceBetween: propTypes.bool
 };
 
-Truncate.defaultProps = {
-    length: 150,
-    expandText: 'Read more',
-    collapseText: 'Collapse',
-    text: ''
-};
+export default Truncate;

--- a/packages/components/src/Truncate/Truncate.test.js
+++ b/packages/components/src/Truncate/Truncate.test.js
@@ -61,6 +61,20 @@ describe('Truncate component', () => {
                     const wrapper = shallow(<Truncate text={text} inline={isInline} length={1000} />);
                     expect(toJson(wrapper)).toMatchSnapshot();
                 });
+
+                it('hovering over toggles to collapse', () => {
+                    const wrapper = shallow(<Truncate length={50} inline={isInline} text={text} expandOnMouseOver hideExpandText />);
+                    const eventElement = isInline ? wrapper.find('.ins-c-truncate').first() : wrapper.find('.ins-c-truncate').first().children().first();
+
+                    expect(toJson(wrapper)).toMatchSnapshot();
+
+                    eventElement.simulate('mouseenter');
+                    expect(toJson(wrapper)).toMatchSnapshot();
+
+                    eventElement.simulate('mouseleave');
+                    expect(toJson(wrapper)).toMatchSnapshot();
+                });
+
             });
         });
     });

--- a/packages/components/src/Truncate/__snapshots__/Truncate.test.js.snap
+++ b/packages/components/src/Truncate/__snapshots__/Truncate.test.js.snap
@@ -174,6 +174,70 @@ et dolore magna aliqua. Ut enim ad minim veniam, q...",
 </Stack>
 `;
 
+exports[`Truncate component should render correctly block hovering over toggles to collapse 1`] = `
+<Stack
+  className="ins-c-truncate is-block"
+>
+  <StackItem
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing...",
+        }
+      }
+      widget-type="InsightsTruncateBlock"
+    />
+  </StackItem>
+</Stack>
+`;
+
+exports[`Truncate component should render correctly block hovering over toggles to collapse 2`] = `
+<Stack
+  className="ins-c-truncate is-block"
+>
+  <StackItem
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+laborum.",
+        }
+      }
+      widget-type="InsightsTruncateBlock"
+    />
+  </StackItem>
+</Stack>
+`;
+
+exports[`Truncate component should render correctly block hovering over toggles to collapse 3`] = `
+<Stack
+  className="ins-c-truncate is-block"
+>
+  <StackItem
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing...",
+        }
+      }
+      widget-type="InsightsTruncateBlock"
+    />
+  </StackItem>
+</Stack>
+`;
+
 exports[`Truncate component should render correctly block when text length is less than user specified length 1`] = `
 <Stack
   className="ins-c-truncate is-block"
@@ -389,6 +453,58 @@ et dolore magna aliqua. Ut enim ad minim veniam, q...",
   >
     Custom expand
   </Button>
+</Fragment>
+`;
+
+exports[`Truncate component should render correctly inline hovering over toggles to collapse 1`] = `
+<Fragment>
+  <span
+    className="ins-c-truncate is-inline"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing...",
+      }
+    }
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    widget-type="InsightsTruncateInline"
+  />
+</Fragment>
+`;
+
+exports[`Truncate component should render correctly inline hovering over toggles to collapse 2`] = `
+<Fragment>
+  <span
+    className="ins-c-truncate is-inline"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+laborum.",
+      }
+    }
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    widget-type="InsightsTruncateInline"
+  />
+</Fragment>
+`;
+
+exports[`Truncate component should render correctly inline hovering over toggles to collapse 3`] = `
+<Fragment>
+  <span
+    className="ins-c-truncate is-inline"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Lorem ipsum dolor sit amet, consectetur adipiscing...",
+      }
+    }
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    widget-type="InsightsTruncateInline"
+  />
 </Fragment>
 `;
 


### PR DESCRIPTION
We are removing `react-truncate` from compliance in favour of `Truncate`[0] 
This PR would allow us to also replace cases where we toggle the text on hover and previously (partly) used `react-truncate`, but had the hover implemented ourselves.

Here an example of what it looks like:

https://user-images.githubusercontent.com/7757/132039282-f6da281d-31d4-4e87-8f83-3758a1b34231.mp4

It also refactors the Truncate component to a function component.

[0] https://github.com/RedHatInsights/compliance-frontend/pull/1352