### PR TITLE
Remove custom styles as they mess the PDF render

### DIFF
--- a/packages/pdf-generator/src/utils/styles.js
+++ b/packages/pdf-generator/src/utils/styles.js
@@ -33,13 +33,13 @@ export default (style = {}) => StyleSheet.create({
     ...style,
     page: {
         fontWeight: 500,
-        fontFamily: 'RedHatText',
+        // fontFamily: 'RedHatText',
         height: '100%',
         padding: '20 50',
         lineHeight: 1.5
     },
     displayFont: {
-        fontFamily: 'RedHatDisplay'
+        // fontFamily: 'RedHatDisplay'
     },
     headerContainer: {
         display: 'flex',


### PR DESCRIPTION
### Unable to load RH fonts

There's an error when using PDF renderer that it can't load fonts. I tried many things to fix it, but was not successfull. This PR removes custom fonts so we can continue generating PDFs and try to the fonts issue.