### PR TITLE
Add chrome's PDF generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32411,7 +32411,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -33087,7 +33087,7 @@
         },
         "packages/inventory": {
             "name": "@redhat-cloud-services/frontend-components-inventory",
-            "version": "3.2.11",
+            "version": "3.2.12",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
@@ -33168,7 +33168,7 @@
         },
         "packages/inventory-insights": {
             "name": "@redhat-cloud-services/frontend-components-inventory-insights",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": "^3.1.7",
@@ -33213,7 +33213,7 @@
         },
         "packages/pdf-generator": {
             "name": "@redhat-cloud-services/frontend-components-pdf-generator",
-            "version": "2.6.5",
+            "version": "2.6.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-charts": "^6.3.9",
@@ -34215,7 +34215,7 @@
         },
         "packages/utils": {
             "name": "@redhat-cloud-services/frontend-components-utilities",
-            "version": "3.2.3",
+            "version": "3.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@sentry/browser": "^5.4.0",

--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -38,7 +38,8 @@
         "@redhat-cloud-services/frontend-components": ">=3.0.0",
         "react": "16.12.0",
         "react-dom": "16.12.0",
-        "rgb-hex": "^3.0.0"
+        "rgb-hex": "^3.0.0",
+        "@scalprum/react-core": ">=0.1.1"
     },
     "devDependencies": {
         "rollup": "^2.46.0",

--- a/packages/pdf-generator/src/DownloadButton.js
+++ b/packages/pdf-generator/src/DownloadButton.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { PDFDownloadLink, PDFViewer, BlobProvider } from '@react-pdf/renderer';
 import { Button } from '@patternfly/react-core';
 import PDFDocument from './components/PDFDocument';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 
-class DownloadButton extends React.Component {
+class DownloadButtonWrapper extends React.Component {
 
     constructor(props) {
         super(props);
@@ -96,7 +97,7 @@ class DownloadButton extends React.Component {
     }
 }
 
-DownloadButton.propTypes = {
+DownloadButtonWrapper.propTypes = {
     ...PDFDocument.propTypes,
     fileName: PropTypes.string,
     isPreview: PropTypes.bool,
@@ -108,7 +109,7 @@ DownloadButton.propTypes = {
     onError: PropTypes.func
 };
 
-DownloadButton.defaultProps = {
+DownloadButtonWrapper.defaultProps = {
     ...PDFDocument.defaultProps,
     fileName: '',
     label: 'Download PDF',
@@ -118,5 +119,15 @@ DownloadButton.defaultProps = {
     onError: () => undefined,
     onLoading: () => undefined
 };
+
+const DownloadButton = (props) => (
+    <AsyncComponent
+        appName="chrome"
+        module="./DownloadButton"
+        {...props}
+    />
+);
+
+export { DownloadButtonWrapper };
 
 export default DownloadButton;

--- a/packages/pdf-generator/src/index.js
+++ b/packages/pdf-generator/src/index.js
@@ -1,4 +1,4 @@
-export { default as DownloadButton } from './DownloadButton';
+export { default as DownloadButton, DownloadButtonWrapper } from './DownloadButton';
 export { default as RHLogo } from './components/Logo';
 export { default as Section } from './components/Section';
 export { default as Column } from './components/Column';


### PR DESCRIPTION
### Expose default download button

As we are now using pdf generator trough chrome we have to expose this button as default export. And re-export the wrapper button for chrome to use it.