### PR TITLE
Conditional filter Group fixes

### DIFF
--- a/packages/components/src/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.js
@@ -57,7 +57,7 @@ class ConditionalFilter extends Component {
     }
 
     render() {
-        const { items, value, onChange, placeholder, hideLabel, isDisabled, ...props } = this.props;
+        const { items, value, onChange, placeholder, hideLabel, isDisabled, containerRef, ...props } = this.props;
         const { isOpen, stateValue, isMobile } = this.state;
         const currentValue = onChange ? value : stateValue;
         const activeItem = items && items.length && (
@@ -160,6 +160,7 @@ class ConditionalFilter extends Component {
                                             }
                                                 }
                                                 { ...activeItem.filterValues }
+                                                containerRef={containerRef}
                                             />
                                         </SplitItem>
                                     }

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -29,7 +29,8 @@ const Group = ({
     groups = [],
     onChange,
     selected,
-    isFilterable
+    isFilterable,
+    containerRef
 }) => {
     const [ stateSelected, setStateSelected ] = useState({});
     const [ searchString, setSearchString ] = useState('');
@@ -158,7 +159,7 @@ const Group = ({
         }
     </MenuItem>));
 
-    return <Popper trigger={(
+    return <Popper appendTo={containerRef} trigger={(
         <MenuToggle
             ref={toggleRef}
             onClick={onToggleClick}
@@ -248,7 +249,8 @@ Group.propTypes = {
         })
     ),
     onChange: PropTypes.func.isRequired,
-    selectedTags: PropTypes.shape({})
+    selectedTags: PropTypes.shape({}),
+    containerRef: PropTypes.element
 };
 
 export default Group;

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -180,7 +180,7 @@ const Group = ({
     )} popper={(
         <Menu
             ref={menuRef}
-            className={classNames(className, { 'pf-m-expanded': isOpen })}
+            className={classNames('ins-c-menu__scrollable', className, { 'pf-m-expanded': isOpen })}
         >
             <MenuContent>
                 <MenuList>

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -199,10 +199,7 @@ const Group = ({
                             itemId="loader"
                             className="ins-c-menu__show--more"
                             {...showMoreOptions}
-                            onClick={(e) => {
-                                setIsOpen(false);
-                                onShowMore(e);
-                            }}
+                            onClick={(e) => onShowMore(e)}
                         >
                             {showMoreTitle}
                         </MenuItem>

--- a/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
+++ b/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
@@ -5,7 +5,7 @@ exports[`Group - component render should render correctly 1`] = `
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -31,7 +31,7 @@ exports[`Group - component render should render correctly placeholder 1`] = `
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -163,7 +163,7 @@ exports[`Group - component render should render correctly with items - isDisable
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -293,7 +293,7 @@ exports[`Group - component render should render correctly with items 1`] = `
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -423,7 +423,7 @@ exports[`Group - component render should render correctly with items and default
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -553,7 +553,7 @@ exports[`Group - component render should render correctly with items and selecte
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -683,7 +683,7 @@ exports[`Group - component render show more should render correctly with items a
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -819,7 +819,7 @@ exports[`Group - component render show more should render correctly with items a
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -952,7 +952,7 @@ exports[`Group - component render show more should render correctly with items a
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>
@@ -1083,7 +1083,7 @@ exports[`Group - component render show more should render correctly with items a
   isVisible={false}
   popper={
     <Menu
-      className=""
+      className="ins-c-menu__scrollable"
     >
       <MenuContent>
         <MenuList>

--- a/packages/components/src/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/ConditionalFilter/conditional-filter.scss
@@ -71,7 +71,7 @@
 
 .pf-c-menu {
     &.ins-c-menu__scrollable {
-        height: 416px;
+        max-height: 416px;
         overflow-y: auto;
     }
     .ins-c-menu__show--more {

--- a/packages/components/src/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/ConditionalFilter/conditional-filter.scss
@@ -71,7 +71,7 @@
 
 .pf-c-menu {
     .ins-c-menu__show--more {
-        &:hover { background: none; }
+        background: none;
         .pf-c-menu__item-text{ color: var(--pf-global--active-color--100); }
     }
 }

--- a/packages/components/src/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/ConditionalFilter/conditional-filter.scss
@@ -70,6 +70,10 @@
 }
 
 .pf-c-menu {
+    &.ins-c-menu__scrollable {
+        height: 416px;
+        overflow-y: auto;
+    }
     .ins-c-menu__show--more {
         background: none;
         .pf-c-menu__item-text{ color: var(--pf-global--active-color--100); }


### PR DESCRIPTION
Needed for: https://issues.redhat.com/browse/RHCLOUD-16306

- disabled highlighting a "Show more" button on focus (after click)
- allowed appending GroupFilter to containerRef if passed
- disabled closing the menu on "Show more" click
- added scrolling to the expanded state
- updated snapshots

Unwanted behavior in RBAC (before):
https://user-images.githubusercontent.com/50696716/135491839-1b007c6f-7257-4082-92a4-58f87c7352cf.mp4

Fixed experience:
https://user-images.githubusercontent.com/50696716/135491684-4d1bcff5-f656-4791-abf7-385406a868aa.mp4


