### PR TITLE
fix(proxy): don't use agent for routes

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -84,7 +84,6 @@ module.exports = ({
                     onProxyReq: cookieTransform,
                     ...(currTarget === 'PORTAL_BACKEND_MARKER' && { router }),
                     ...typeof redirect === 'object' ? redirect : {},
-                    ...(agent && { agent })
                 };
             })
         );

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -83,7 +83,7 @@ module.exports = ({
                     ws: true,
                     onProxyReq: cookieTransform,
                     ...(currTarget === 'PORTAL_BACKEND_MARKER' && { router }),
-                    ...typeof redirect === 'object' ? redirect : {},
+                    ...typeof redirect === 'object' ? redirect : {}
                 };
             })
         );


### PR DESCRIPTION
Using `agent` and `onProxyReq` crashes with this:
```sh
_http_outgoing.js:561
    throw new ERR_HTTP_HEADERS_SENT('set');
    ^
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ClientRequest.setHeader (_http_outgoing.js:561:11)
    at ProxyServer.cookieTransform (/home/akofink/dev/repos/compliance-frontend/node_modules/@redhat-cloud-services/frontend-components-config-utilities/cookieTransform.js:48:18)
    at ProxyServer.emit (/home/akofink/dev/repos/compliance-frontend/node_modules/eventemitter3/index.js:184:35)
    at ClientRequest.<anonymous> (/home/akofink/dev/repos/compliance-frontend/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js:133:16)
    at ClientRequest.emit (events.js:412:35)
    at tickOnSocket (_http_client.js:784:7)
    at onSocketNT (_http_client.js:823:5)
    at processTicksAndRejections (internal/process/task_queues.js:83:21) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```