### PR TITLE
Fix not working closing the menu with inside click

### DIFF
--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -79,9 +79,7 @@ const Group = ({
     const onToggleClick = ev => {
         ev.stopPropagation(); // Stop handleClickOutside from handling
         ev.persist();
-        if (!(isOpen && toggleRef.current.contains(ev.target))) {
-            setIsOpen(!isOpen);
-        }
+        setIsOpen(!isOpen);
     };
 
     const groupMenuItems = getGroupMenuItems(groups, onChange, calculateSelection(selected));


### PR DESCRIPTION
Fixed issue:

User can only close the menu by clicking outside of the component, the toggle inside the component doesn't work.

