### PR TITLE
Mark quickstarts packge as a singleton.

### DIFF
--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -8,6 +8,7 @@ const include = {
     '@patternfly/react-table': {},
     '@patternfly/react-tokens': {},
     '@patternfly/react-icons': {},
+    '@patternfly/quickstarts': { singleton: true },
     '@redhat-cloud-services/frontend-components': {},
     '@redhat-cloud-services/frontend-components-utilities': {},
     '@redhat-cloud-services/frontend-components-notifications': {},


### PR DESCRIPTION
Quickstart must be a singleton in order to properly use the chrome integrated API.

cc @arivepr 