### PR TITLE
Add treeView groupType to Conditional Filter

### DIFF
--- a/packages/components/src/ConditionalFilter/GroupFilter.test.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Group from './GroupFilter';
 import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { act } from 'react-dom/test-utils';
 
 const config = {
     onChange: jest.fn(),
@@ -58,8 +57,60 @@ const config = {
                     label: 'Second value'
                 }
             ]
+        },
+        {
+            label: 'TreeView',
+            type: 'treeView',
+            items: [
+                {
+                    label: 'First level',
+                    value: 'firstLevel',
+                    hasCheck: false,
+                    type: 'treeView',
+                    children: [
+                        {
+                            label: 'Second level',
+                            value: 'secondLevel',
+                            children: [
+                                {
+                                    label: 'Item 1',
+                                    value: 'item1'
+                                },
+                                {
+                                    label: 'Item 2',
+                                    value: 'item2'
+                                }
+                            ]
+                        }
+                    ],
+                    defaultExpanded: true
+                }
+            ]
         }
-    ]
+    ],
+    items: [{
+        label: 'First level',
+        value: 'firstLevel2',
+        hasCheck: false,
+        type: 'treeView',
+        children: [
+            {
+                label: 'Second level',
+                value: 'secondLevel2',
+                children: [
+                    {
+                        label: 'Item 1',
+                        value: 'item12'
+                    },
+                    {
+                        label: 'Item 2',
+                        value: 'item22'
+                    }
+                ]
+            }
+        ],
+        defaultExpanded: true
+    }]
 };
 
 describe('Group - component', () => {

--- a/packages/components/src/ConditionalFilter/GroupFilter.test.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Group from './GroupFilter';
 import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { act } from 'react-dom/test-utils';
 
 const config = {
     onChange: jest.fn(),

--- a/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
+++ b/packages/components/src/ConditionalFilter/__snapshots__/GroupFilter.test.js.snap
@@ -38,6 +38,69 @@ exports[`Group - component render should render correctly placeholder 1`] = `
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -141,6 +204,71 @@ exports[`Group - component render should render correctly placeholder 1`] = `
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <span
               hidden={true}
@@ -172,6 +300,69 @@ exports[`Group - component render should render correctly with items - isDisable
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -275,6 +466,71 @@ exports[`Group - component render should render correctly with items - isDisable
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <span
               hidden={true}
@@ -304,6 +560,69 @@ exports[`Group - component render should render correctly with items 1`] = `
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -407,6 +726,71 @@ exports[`Group - component render should render correctly with items 1`] = `
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <span
               hidden={true}
@@ -436,6 +820,69 @@ exports[`Group - component render should render correctly with items and default
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -540,6 +987,71 @@ exports[`Group - component render should render correctly with items and default
                 Second value
               </MenuItem>
             </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <span
               hidden={true}
               value=""
@@ -568,6 +1080,69 @@ exports[`Group - component render should render correctly with items and selecte
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -672,6 +1247,71 @@ exports[`Group - component render should render correctly with items and selecte
                 Second value
               </MenuItem>
             </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <span
               hidden={true}
               value=""
@@ -700,6 +1340,69 @@ exports[`Group - component render show more should render correctly with items a
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -803,6 +1506,71 @@ exports[`Group - component render show more should render correctly with items a
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <MenuItem
               className="ins-c-menu__show--more"
@@ -838,6 +1606,69 @@ exports[`Group - component render show more should render correctly with items a
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -941,6 +1772,71 @@ exports[`Group - component render show more should render correctly with items a
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <MenuItem
               className="ins-c-menu__show--more"
@@ -973,6 +1869,69 @@ exports[`Group - component render show more should render correctly with items a
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -1076,6 +2035,71 @@ exports[`Group - component render show more should render correctly with items a
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <MenuItem
               className="ins-c-menu__show--more"
@@ -1106,6 +2130,69 @@ exports[`Group - component render show more should render correctly with items a
       >
         <MenuContent>
           <MenuList>
+            <MenuGroup>
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item12",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item12",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item22",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item22",
+                                },
+                              ],
+                              "id": "secondLevel2",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel2",
+                          "key": "firstLevel2",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel2",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
+            </MenuGroup>
             <MenuGroup
               label="First value"
             >
@@ -1209,6 +2296,71 @@ exports[`Group - component render show more should render correctly with items a
               >
                 Second value
               </MenuItem>
+            </MenuGroup>
+            <MenuGroup
+              label="TreeView"
+            >
+              <div
+                className="ins-c-tree-view"
+              >
+                <MenuItem
+                  itemId={0}
+                >
+                  <TreeView
+                    data={
+                      Array [
+                        Object {
+                          "checkProps": Object {
+                            "checked": false,
+                          },
+                          "children": Array [
+                            Object {
+                              "checkProps": Object {
+                                "checked": false,
+                              },
+                              "children": Array [
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item1",
+                                  "label": "Item 1",
+                                  "name": "Item 1",
+                                  "value": "item1",
+                                },
+                                Object {
+                                  "checkProps": Object {
+                                    "checked": false,
+                                  },
+                                  "id": "item2",
+                                  "label": "Item 2",
+                                  "name": "Item 2",
+                                  "value": "item2",
+                                },
+                              ],
+                              "id": "secondLevel",
+                              "label": "Second level",
+                              "name": "Second level",
+                              "value": "secondLevel",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "hasCheck": false,
+                          "id": "firstLevel",
+                          "key": "firstLevel",
+                          "label": "First level",
+                          "name": "First level",
+                          "onClick": [Function],
+                          "type": "treeView",
+                          "value": "firstLevel",
+                        },
+                      ]
+                    }
+                    hasChecks={true}
+                    onCheck={[Function]}
+                  />
+                </MenuItem>
+              </div>
             </MenuGroup>
             <MenuItem
               className="ins-c-menu__show--more"

--- a/packages/components/src/ConditionalFilter/group-filter.scss
+++ b/packages/components/src/ConditionalFilter/group-filter.scss
@@ -1,0 +1,23 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/_all.scss';
+
+.ins-c-tree-view {
+    .pf-c-tree-view {
+        padding: 0;
+    }
+
+    .pf-c-menu__list-item {
+        background: none;
+
+        .pf-c-menu__item {
+            padding: 0;
+
+            .pf-c-tree-view__content {
+                background: none;
+            }
+            
+            .pf-c-tree-view__node {
+                background: none;
+            }
+        }
+    }
+}

--- a/packages/components/src/ConditionalFilter/groupFilterConstants.js
+++ b/packages/components/src/ConditionalFilter/groupFilterConstants.js
@@ -130,7 +130,7 @@ export const calculateSelected = (selectedTags) => (type, groupKey, value, check
     return itemKeys.reduce((acc, curr) => ({
         ...acc,
         [groupKey]: {
-            ...acc[groupKey],
+            ...acc?.[groupKey],
             [curr]: true
         }
     }), selectedTags);

--- a/packages/components/src/ConditionalFilter/groupFilterConstants.js
+++ b/packages/components/src/ConditionalFilter/groupFilterConstants.js
@@ -1,4 +1,4 @@
-import groupType from './groupType';
+import groupTypes from './groupType';
 
 export const isChecked = (groupValue, itemValue, id, tagValue, stateSelected, propSelected) => {
     const selected = {
@@ -30,10 +30,16 @@ export const getMenuItems = (items, onChange, calculateSelected, groupType, grou
         ...item,
         key: item.id || item.value || index,
         value: String(item.value || item.id || index),
-        onClick: (event) => {
+        onClick: (event, treeViewItem, checked) => {
             const params = [
                 event,
-                calculateSelected(groupType || item.type, groupValue, item.value),
+                calculateSelected(
+                    groupType || item.type,
+                    groupValue,
+                    (groupType || item.type) === groupTypes.treeView
+                        ? treeViewItem
+                        : item.value,
+                    checked),
                 {
                     value: groupValue,
                     label: groupLabel || item.label,
@@ -54,42 +60,113 @@ export const getMenuItems = (items, onChange, calculateSelected, groupType, grou
     return result.filter(({ noFilter }) => !noFilter);
 };
 
+export const convertTreeItem = (item) => {
+    item.id = item.id || item.value;
+    item.name = item.label || item.name;
+    item.value = item.id;
+    item.label = item.name;
+
+    return item.children ? {
+        ...item,
+        children: item.children.map(child => convertTreeItem(child))
+    } : item;
+};
+
 export const getGroupMenuItems = (groups, onChange, calculateSelected) => {
-    const result = groups.map(({ value, label, id, type, items, ...group }) => ({
-        label,
-        value,
-        type,
-        items: getMenuItems(items, onChange, calculateSelected, type, value, label, id, group)
-    }));
+    const result = groups.map(({ value, label, id, type, items, ...group }) => {
+        const converted = type === groupTypes.treeView ? items.map(item => convertTreeItem(item)) : items;
+        return ({
+            label,
+            value,
+            type,
+            items: getMenuItems(converted, onChange, calculateSelected, type, value, label, id, group)
+        });
+    });
     return result.filter(({ noFilter, items = [] }) => !noFilter || items.length > 0);
 };
 
-export const calculateSelected = (selectedTags) => (type, groupKey, itemKey) => {
+export const calculateSelected = (selectedTags) => (type, groupKey, value, checked) => {
     const activeGroup = selectedTags?.[groupKey];
-    if (activeGroup) {
-        if (type !== groupType.radio && (activeGroup[itemKey] instanceof Object ? activeGroup[itemKey].isSelected : Boolean(activeGroup[itemKey]))) {
-            return {
-                ...selectedTags,
-                [groupKey]: {
-                    ...(activeGroup || {}),
-                    [itemKey]: false
-                }
-            };
+
+    let children = (type === groupTypes.treeView) && [ value ].reduce(function iter(r, a) {
+        if (Array.isArray(a.children)) {
+            return a.children.reduce(iter, r);
         }
 
-        return {
-            ...selectedTags,
-            [groupKey]: {
-                ...(type !== groupType.radio ? activeGroup || {} : {}),
-                [itemKey]: true
+        r.push(a);
+        return r;
+    }, []);
+
+    const itemKeys = (type === groupTypes.treeView) ?
+        (
+            children.map((item) => item.id)
+        ) : [ value ];
+
+    if (activeGroup) {
+        let result = selectedTags;
+        itemKeys.map((itemKey) => {
+            const activeGroup = result[groupKey];
+            if (type !== groupTypes.radio && (activeGroup[itemKey] instanceof Object ? activeGroup[itemKey].isSelected : Boolean(activeGroup[itemKey]))) {
+                result = {
+                    ...result,
+                    [groupKey]: {
+                        ...(activeGroup || {}),
+                        [itemKey]: (type === groupTypes.treeView) && checked
+                    }
+                };
+            } else {
+                result = {
+                    ...result,
+                    [groupKey]: {
+                        ...(type !== groupTypes.radio ? activeGroup || {} : {}),
+                        [itemKey]: true
+                    }
+                };
             }
+        });
+        return result;
+    }
+
+    return itemKeys.reduce((acc, curr) => ({
+        ...acc,
+        [groupKey]: {
+            ...acc[groupKey],
+            [curr]: true
+        }
+    }), selectedTags);
+};
+
+const areAllChildrenChecked = (dataItem, groupKey, stateSelected, selected) =>
+    dataItem.children
+        ? dataItem.children.every(child => areAllChildrenChecked(child, groupKey, stateSelected, selected))
+        : isChecked(groupKey, dataItem.id, undefined, undefined, stateSelected, selected);
+
+const areSomeChildrenChecked = (dataItem, groupKey, stateSelected, selected) =>
+    dataItem.children
+        ? dataItem.children.some(child => areSomeChildrenChecked(child, groupKey, stateSelected, selected))
+        : isChecked(groupKey, dataItem.id, undefined, undefined, stateSelected, selected);
+
+export const mapTree = (item, groupKey, stateSelected, selected) => {
+    const hasCheck = areAllChildrenChecked(item, groupKey, stateSelected, selected);
+    item.checkProps = { checked: false } ;
+
+    if (hasCheck) {
+        item.checkProps.checked = true;
+    } else {
+        const hasPartialCheck = areSomeChildrenChecked(item, groupKey, stateSelected, selected);
+        if (hasPartialCheck) {
+            item.checkProps = { checked: null };
+        }
+    }
+
+    if (item.children) {
+        return {
+            ...item,
+            children: item.children.map(child => mapTree(child, groupKey, stateSelected, selected))
         };
     }
 
-    return {
-        ...selectedTags,
-        [groupKey]: {
-            [itemKey]: true
-        }
-    };
+    return item;
 };
+
+export const onTreeCheck = (e, treeViewItem, tree) => tree[0].onClick(e, treeViewItem, e?.target?.checked);

--- a/packages/components/src/ConditionalFilter/groupFilterConstants.test.js
+++ b/packages/components/src/ConditionalFilter/groupFilterConstants.test.js
@@ -1,0 +1,95 @@
+import { calculateSelected, mapTree, onTreeCheck } from './groupFilterConstants';
+
+describe('onTreeCheck', () => {
+    const onClick = jest.fn();
+
+    const tree = [{
+        onClick
+    }];
+
+    it('should call onClick function', () => {
+        onTreeCheck(undefined, undefined, tree);
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('mapTree', () => {
+    const tree = {
+        name: 'First level',
+        id: 'firstLevel',
+        type: 'treeView',
+        children: [
+            {
+                name: 'Second level',
+                id: 'secondLevel',
+                children: [
+                    {
+                        name: 'Item 1',
+                        id: 'item1'
+                    },
+                    {
+                        name: 'Item 2',
+                        id: 'item2'
+                    }
+                ]
+            }
+        ],
+        defaultExpanded: true
+    };
+
+    it('should add partial check properly', () => {
+        const result = mapTree(tree, '', { '': { item1: true } }, { '': { item1: true } });
+        expect(result.children[0].children[0].checkProps.checked).toEqual(true);
+        expect(result.children[0].checkProps.checked).toEqual(null);
+        expect(result.checkProps.checked).toEqual(null);
+    });
+
+    it('should add no check properly', () => {
+        const result = mapTree(tree, '', { '': {} }, { '': {} });
+        expect(result.children[0].children[0].checkProps.checked).toEqual(false);
+        expect(result.children[0].checkProps.checked).toEqual(false);
+        expect(result.checkProps.checked).toEqual(false);
+    });
+
+    it('should add all checked properly', () => {
+        const result = mapTree(tree, '', { '': { item1: true, item2: true } }, { '': { item1: true, item2: true } });
+        expect(result.children[0].children[0].checkProps.checked).toEqual(true);
+        expect(result.children[0].checkProps.checked).toEqual(true);
+        expect(result.checkProps.checked).toEqual(true);
+    });
+});
+
+describe('calculateSelected - treeView', () => {
+    const tree = {
+        name: 'Second level',
+        id: 'secondLevel',
+        children: [
+            {
+                name: 'Item 1',
+                id: 'item1'
+            },
+            {
+                name: 'Item 2',
+                id: 'item2'
+            }
+        ]
+    };
+
+    it('should calculate selected properly, checked = true', () => {
+        const result = calculateSelected({ '': { item1: true } })('treeView', '', tree, true);
+        const expectedResult = { '': { item1: true, item2: true } };
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should calculate selected properly, checked = false', () => {
+        const result = calculateSelected({ '': { item1: true, item2: true } })('treeView', '', tree, false);
+        const expectedResult = { '': { item1: false, item2: false } };
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should calculate selected with no activeGroup', () => {
+        const result = calculateSelected({})('treeView', '', tree, false);
+        const expectedResult = { '': { item1: true, item2: true } };
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/packages/components/src/ConditionalFilter/groupType.js
+++ b/packages/components/src/ConditionalFilter/groupType.js
@@ -1,4 +1,5 @@
 const groupType = {
+    treeView: 'treeView',
     checkbox: 'checkbox',
     radio: 'radio',
     button: 'button',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-16354

- added a treeView groupType to ConditionalFilter
- updated and enhanced tests

To comply with both PatternFly and ConditionalFilter API conventions:
- `name` attribute can be used instead of `label`
- `id` attribute can be used instead of `value`

![screen](https://user-images.githubusercontent.com/50696716/138852485-61a42c24-d7ed-462e-867a-6705172c73d8.png)

**Example group data:**
```
groups: [
              {
                label: 'Group 1',
                type: 'treeView',
                items: [
                  {
                    name: 'Group 1',
                    id: 'groupOverall',
                    hasCheck: false,
                    children: [
                      {
                        name: 'Group section',
                        id: 'groupSection',
                        children: [
                          {
                            name: 'Group Item1',
                            id: 'groupItem1',
                          },
                          {
                            name: 'Group Item2',
                            id: 'groupItem2',
                          },
                        ],
                      },
                    ],
                    defaultExpanded: true,
                  },
                ],
              }
]
```
@karelhala 