### PR TITLE
Fix GroupFilter styling

### DIFF
--- a/packages/components/src/ConditionalFilter/conditional-filter.scss
+++ b/packages/components/src/ConditionalFilter/conditional-filter.scss
@@ -61,7 +61,6 @@
     }
 
     .pf-c-menu-toggle {
-        padding: 0;
         .pf-c-menu-toggle__text {
             flex: 1;
             input { border: none; }
@@ -73,6 +72,7 @@
     &.ins-c-menu__scrollable {
         max-height: 416px;
         overflow-y: auto;
+        min-width: initial;
     }
     .ins-c-menu__show--more {
         background: none;


### PR DESCRIPTION
This fixes styling issues in the Conditional filter Group variant

Images before:
![screenshot_2021-10-29_at_10 35 53](https://user-images.githubusercontent.com/50696716/139828798-582f0a24-253e-40bc-981a-3db2fffdcb44.png)

![screenshot_2021-10-29_at_10 36 02](https://user-images.githubusercontent.com/50696716/139828775-6ec73a20-92ee-43f7-bfdf-0d7ba8136852.png)

thanks for help @Hyperkid123 