### PR TITLE
Fix group filter when selected is empty

### DIFF
--- a/packages/components/src/ConditionalFilter/ConditionalFilter.js
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.js
@@ -57,7 +57,7 @@ class ConditionalFilter extends Component {
     }
 
     render() {
-        const { items, value, onChange, placeholder, hideLabel, isDisabled, ...props } = this.props;
+        const { items, value, onChange, placeholder, hideLabel, isDisabled, useMobileLayout, ...props } = this.props;
         const { isOpen, stateValue, isMobile } = this.state;
         const currentValue = onChange ? value : stateValue;
         const activeItem = items && items.length && (
@@ -68,11 +68,11 @@ class ConditionalFilter extends Component {
         const ActiveComponent = activeItem && (typeMapper[activeItem.type] || typeMapper.text);
         const capitalize = (string) => string[0].toUpperCase() + string.substring(1);
 
-        const shouldRenderNewLayout = this.props.useMobileLayout && isMobile;
+        const shouldRenderNewLayout = useMobileLayout && isMobile;
         const Wrapper = this.getWrapper();
         return (
             <Wrapper>
-                {this.props.useMobileLayout && isMobile && (
+                {useMobileLayout && isMobile && (
                     <ToolbarGroup className="ins-c-conditional-filter mobile">
                         {items.map((activeItem, key) => {
                             const ActiveComponent = activeItem && (typeMapper[activeItem.type] || typeMapper.text);
@@ -102,7 +102,7 @@ class ConditionalFilter extends Component {
                         {
                             !items || (items && items.length <= 0) ?
                                 <div className={classNames('ins-c-conditional-filter', {
-                                    desktop: this.props.useMobileLayout
+                                    desktop: useMobileLayout
                                 })}>
                                     <Text { ...props }
                                         value={ currentValue }
@@ -112,7 +112,7 @@ class ConditionalFilter extends Component {
                                     />
                                 </div> :
                                 <Split className={classNames('ins-c-conditional-filter', {
-                                    desktop: this.props.useMobileLayout
+                                    desktop: useMobileLayout
                                 })}>
                                     { items.length > 1 &&
                                 <SplitItem>

--- a/packages/components/src/ConditionalFilter/ConditionalFilter.test.js
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ConditionalFilter from './ConditionalFilter';
 import { shallow, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { act } from 'react-dom/test-utils';
 
 const config = [{
     id: 'some',
@@ -140,6 +141,114 @@ describe('ConditionalFilter', () => {
             wrappper.update();
             wrappper.find('ul.pf-c-dropdown__menu button.pf-c-dropdown__menu-item').at(2).simulate('click');
             expect(wrappper.instance().state.stateValue).toBe('checkbox-filter');
+        });
+
+        it('should select group - RHEL case', async () => {
+            const onChange = jest.fn();
+
+            const items = [
+                {
+                    type: 'group',
+                    label: 'Operating system',
+                    id: 'operatingsystem',
+                    filterValues: {
+                        selected: undefined,
+                        onChange,
+                        groups: [
+                            {
+                                label: 'RHEL 7',
+                                value: '7',
+                                groupSelectable: true,
+                                items: [
+                                    {
+                                        label: 'RHEL 7.1',
+                                        value: '1',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.2',
+                                        value: '2',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.3',
+                                        value: '3',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.4',
+                                        value: '4',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.5',
+                                        value: '5',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.6',
+                                        value: '6',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.7',
+                                        value: '7',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.8',
+                                        value: '8',
+                                        type: 'checkbox'
+                                    },
+                                    {
+                                        label: 'RHEL 7.9',
+                                        value: '9',
+                                        type: 'checkbox'
+                                    }
+                                ],
+                                type: 'checkbox'
+                            }
+                        ]
+                    }
+                }
+
+            ];
+
+            const wrapper = mount(<ConditionalFilter {...initialProps} items={ items } />);
+
+            await act(async () => {
+                wrapper.find('button.pf-c-menu-toggle').simulate('click');
+            });
+            wrapper.update();
+
+            await act(async () => {
+                wrapper.find('button[role="menuitem"]').at(1).simulate('click');
+            });
+            wrapper.update();
+
+            expect(onChange).toHaveBeenCalledWith(
+                undefined,
+                { 7: { 2: true } },
+                {
+                    groupSelectable: true, id: undefined,
+                    items: [
+                        { label: 'RHEL 7.1', type: 'checkbox', value: '1' },
+                        { label: 'RHEL 7.2', type: 'checkbox', value: '2' },
+                        { label: 'RHEL 7.3', type: 'checkbox', value: '3' },
+                        { label: 'RHEL 7.4', type: 'checkbox', value: '4' },
+                        { label: 'RHEL 7.5', type: 'checkbox', value: '5' },
+                        { label: 'RHEL 7.6', type: 'checkbox', value: '6' },
+                        { label: 'RHEL 7.7', type: 'checkbox', value: '7' },
+                        { label: 'RHEL 7.8', type: 'checkbox', value: '8' },
+                        { label: 'RHEL 7.9', type: 'checkbox', value: '9' }
+                    ],
+                    label: 'RHEL 7',
+                    type: 'checkbox',
+                    value: '7' },
+                { label: 'RHEL 7.2', type: 'checkbox', value: '2' },
+                '7',
+                '2'
+            );
         });
     });
 });

--- a/packages/components/src/ConditionalFilter/GroupFilter.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -42,8 +42,6 @@ const Group = ({
         setStateSelected(selected);
     }, [ selected ]);
 
-    const calculateSelection = useCallback(calculateSelected, [ stateSelected ]);
-
     useEffect(() => {
         setSearchString(filterBy);
     }, [ filterBy ]);
@@ -82,8 +80,8 @@ const Group = ({
         setIsOpen(!isOpen);
     };
 
-    const groupMenuItems = getGroupMenuItems(groups, onChange, calculateSelection(selected));
-    const menuItems = getMenuItems(items, onChange, calculateSelection(selected));
+    const groupMenuItems = getGroupMenuItems(groups, onChange, calculateSelected(selected));
+    const menuItems = getMenuItems(items, onChange, calculateSelected(selected));
 
     // eslint-disable-next-line react/prop-types
     const renderItems = (items, type, groupKey = '') => items.map((item, key) => (<MenuItem

--- a/packages/components/src/ConditionalFilter/GroupFilter.test.js
+++ b/packages/components/src/ConditionalFilter/GroupFilter.test.js
@@ -5,6 +5,7 @@ import toJson from 'enzyme-to-json';
 import { act } from 'react-dom/test-utils';
 
 const config = {
+    onChange: jest.fn(),
     groups: [
         {
             label: 'First value',
@@ -64,7 +65,7 @@ const config = {
 describe('Group - component', () => {
     describe('render', () => {
         it('should render correctly', () => {
-            const wrapper = shallow(<Group />);
+            const wrapper = shallow(<Group onChange={jest.fn()} />);
             expect(toJson(wrapper)).toMatchSnapshot();
         });
 
@@ -125,9 +126,11 @@ describe('Group - component', () => {
     });
 
     describe('API', () => {
-        it('should open', () => {
+        it('should open', async () => {
             const wrapper = mount(<Group { ...config } />);
-            wrapper.find('button.pf-c-menu-toggle').simulate('click');
+            await act(async () => {
+                wrapper.find('button.pf-c-menu-toggle').simulate('click');
+            });
             wrapper.update();
             expect(wrapper.find('.pf-c-menu').length > 0).toBe(true);
         });

--- a/packages/components/src/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
+++ b/packages/components/src/ConditionalFilter/__snapshots__/ConditionalFilter.test.js.snap
@@ -102,7 +102,6 @@ exports[`ConditionalFilter render should render correctly 1`] = `
       isDisabled={false}
       onChange={[Function]}
       onSubmit={[Function]}
-      useMobileLayout={true}
       value=""
       widget-type="InsightsInput"
     />

--- a/packages/components/src/ConditionalFilter/groupFilterConstants.js
+++ b/packages/components/src/ConditionalFilter/groupFilterConstants.js
@@ -65,7 +65,7 @@ export const getGroupMenuItems = (groups, onChange, calculateSelected) => {
 };
 
 export const calculateSelected = (selectedTags) => (type, groupKey, itemKey) => {
-    const activeGroup = selectedTags[groupKey];
+    const activeGroup = selectedTags?.[groupKey];
     if (activeGroup) {
         if (type !== groupType.radio && (activeGroup[itemKey] instanceof Object ? activeGroup[itemKey].isSelected : Boolean(activeGroup[itemKey]))) {
             return {


### PR DESCRIPTION
When `selected` is undefined, the group filter cannot handle it, this add a conditional check.

Also some test cleanups.