### PR TITLE
Add glob search fo PF node_modules styles.

### DIFF
--- a/packages/config-utils/search-ignored-styles.js
+++ b/packages/config-utils/search-ignored-styles.js
@@ -1,0 +1,17 @@
+const path = require('path');
+const glob = require('glob');
+
+/**
+ * Function that searches for all patternfly styles in node_modules and outputs an webpack alias object to ignore found modules.
+ * @param {string} root absolute directory path to root folder containig package.json
+ * @returns {Object}
+ */
+const searchIgnoredStyles = (root) => {
+    const modulesPath = path.join(root, 'node_modules/@patternfly/react-styles');
+    return glob.sync(`${modulesPath}/**/*.css`).reduce((acc, curr) => ({
+        ...acc,
+        [curr]: false
+    }), {});
+};
+
+module.exports = searchIgnoredStyles;


### PR DESCRIPTION
### Changes
export new functions that return webpack alias object to ignore module bundling from PF/react-styles package.