### PR TITLE
Remove redux and react-redux from dependency sharing

### DIFF
--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -14,11 +14,9 @@ const include = {
     '@redhat-cloud-services/frontend-components-notifications': {},
     axios: {},
     lodash: {},
-    redux: {},
     'redux-promise-middleware': {},
     react: { singleton: true },
     'react-dom': { singleton: true },
-    'react-redux': {},
     'react-router-dom': {}
 };
 


### PR DESCRIPTION
Recently with new major version of react-redux, we had issues with context access. This package does not have to be shared as it is very small and the benefit of the sharing is not that large to deal with additional bugs.