### PR TITLE
Add HTTPSProxyAgent to prod envs.

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -51,12 +51,16 @@ module.exports = ({
     }
 
     let agent;
+
+    if (env.startsWith('prod') || env.startsWith('stage')) {
+        // PROD and stage are deployed with Akamai which requires a corporate proxy
+        agent = new HttpsProxyAgent(proxyURL);
+    }
+
     if (env.startsWith('stage')) {
         // stage-stable / stage-beta branches don't exist in build repos
         // Currently stage pulls from QA
         env = env.replace('stage', 'qa');
-        // QA and stage are deployed with Akamai which requires a corporate proxy
-        agent = new HttpsProxyAgent(proxyURL);
     }
 
     if (!Array.isArray(appUrl)) {


### PR DESCRIPTION
Some non-GET requests are having auth issues due to different origin header in production as well when using the proxy. We have to re-write it.