### PR TITLE
Allow functions as default exports from config

### DIFF
--- a/packages/config-utils/serve-federated.js
+++ b/packages/config-utils/serve-federated.js
@@ -15,7 +15,11 @@ function federate(argv, cwd) {
 
     try {
         fs.statSync(configPath);
-        const config = require(configPath);
+        let config = require(configPath);
+        if (typeof config === 'function') {
+            config = config(process.env);
+        }
+
         const outputPath = config.output.path;
 
         concurrently([


### PR DESCRIPTION
### Default export from config can be function

Some apps (like advisor) are expecting to receive env variables, this is achieved by exporting default function from webpack config. This PR adjusts federated build to such thing by checking if exported config is function and if so, call it with `process.env`.