### PR TITLE
Make meta.notifications consume a function

### DIFF
--- a/packages/notifications/doc/notifications.md
+++ b/packages/notifications/doc/notifications.md
@@ -264,4 +264,24 @@ notificationsMiddleware({
 
 If you happen to have an error response that matches more paths, the first match will be chosen (order is equal to the order of items in array).
 
+3. More notification object customization.
+You can pass a function as a value to `notifications`. The function will receive dispatched action's payload and it's expected to return a notification object.
 
+```javascript
+// some async action
+export const asyncAction = data => ({
+  type: 'FOO',
+  payload: asyncHandler(data) // this function must return promise
+  meta: {
+    notifications: {
+      rejected: (payload) => ({ // transform payload to a notification object
+          variant: 'danger',
+          title: 'Custom title',
+          dismissDelay: 8000,
+          dismissable: false,
+          description: payload.error
+      }),
+    }
+  }
+})
+```

--- a/packages/notifications/src/notificationsMiddleware/notificationsMiddleware.js
+++ b/packages/notifications/src/notificationsMiddleware/notificationsMiddleware.js
@@ -64,10 +64,22 @@ export const createNotificationsMiddleware = (options = {}) => {
         if (meta && meta.notifications) {
             const { notifications } = meta;
             if (matchPending(type) && notifications.pending) {
+                if (typeof notifications.pending === 'function') {
+                    notifications.pending = notifications.pending(action.payload);
+                }
+
                 dispatch(addNotification({ ...defaultNotificationOptions, ...notifications.pending }));
             } else if (matchFulfilled(type) && notifications.fulfilled) {
+                if (typeof notifications.fulfilled === 'function') {
+                    notifications.fulfilled = notifications.fulfilled(action.payload);
+                }
+
                 dispatch(addNotification({ ...defaultNotificationOptions, ...notifications.fulfilled }));
             } else if (matchRejected(type) && notifications.rejected) {
+                if (typeof notifications.rejected === 'function') {
+                    notifications.rejected = notifications.rejected(action.payload);
+                }
+
                 dispatch(addNotification({
                     ...defaultNotificationOptions,
                     ...notifications.rejected,

--- a/packages/notifications/src/notificationsMiddleware/notificationsMiddleware.test.js
+++ b/packages/notifications/src/notificationsMiddleware/notificationsMiddleware.test.js
@@ -222,6 +222,42 @@ describe('Notifications middleware', () => {
         });
     });
 
+    it('should dispatch error notification using a function', () => {
+        const expectedActions = [
+            expect.objectContaining({
+                type: 'FOO_PENDING'
+            }),
+            expect.objectContaining({
+                type: ADD_NOTIFICATION,
+                payload: expect.objectContaining({
+                    variant: 'danger',
+                    title: 'error',
+                    description: 'description'
+                })
+            }),
+            expect.objectContaining({
+                type: 'FOO_REJECTED',
+                payload: { title: 'error' }
+            })
+        ];
+
+        const action = {
+            ...requestMock(true, { title: 'error' }),
+            meta: {
+                notifications: {
+                    rejected: (payload) => ({
+                        variant: 'danger',
+                        title: payload.title,
+                        description: 'description'
+                    })
+                }
+            }
+        };
+        return initialProps.store.dispatch(action).catch(() => {
+            expect(initialProps.store.getActions()).toEqual(expectedActions);
+        });
+    });
+
     it('should dispatch error notification automatically', () => {
         const expectedActions = [
             expect.objectContaining({


### PR DESCRIPTION
Added a possibility to pass a function as a value to `meta.notifications`. 
The function receives dispatched action's payload and it's expected to return a notification object.

@Hyperkid123 