### PR TITLE
Fix webpack dev server container loading

### DIFF
--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -45,35 +45,6 @@ module.exports = ({
     return {
         mode: mode || (isProd ? 'production' : 'development'),
         devtool: false,
-        optimization: {
-            splitChunks: {
-                chunks: 'all',
-                maxInitialRequests: Infinity,
-                minSize: 0,
-                cacheGroups: {
-                    reactVendor: {
-                        test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
-                        name: 'reactVendor',
-                        priority: 10
-                    },
-                    pfVendor: {
-                        test: /[\\/]node_modules[\\/](@patternfly)[\\/]/,
-                        name: 'pfVendor',
-                        priority: 10
-                    },
-                    rhcsVendor: {
-                        test: /[\\/]node_modules[\\/](@redhat-cloud-services)[\\/]/,
-                        name: 'rhcsVendor',
-                        priority: 10
-                    },
-                    vendor: {
-                        test: /[\\/]node_modules[\\/]/,
-                        name: 'vendor',
-                        priority: 9
-                    }
-                }
-            }
-        },
         entry: {
             App: appEntry
         },

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -27,35 +27,7 @@ describe('should create dummy config with no options', () => {
     });
 
     test('optimization', () => {
-        expect(optimization).toEqual({
-            splitChunks: {
-                chunks: 'all',
-                maxInitialRequests: Infinity,
-                minSize: 0,
-                cacheGroups: {
-                    reactVendor: {
-                        test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
-                        name: 'reactVendor',
-                        priority: 10
-                    },
-                    pfVendor: {
-                        test: /[\\/]node_modules[\\/](@patternfly)[\\/]/,
-                        name: 'pfVendor',
-                        priority: 10
-                    },
-                    rhcsVendor: {
-                        test: /[\\/]node_modules[\\/](@redhat-cloud-services)[\\/]/,
-                        name: 'rhcsVendor',
-                        priority: 10
-                    },
-                    vendor: {
-                        test: /[\\/]node_modules[\\/]/,
-                        name: 'vendor',
-                        priority: 9
-                    }
-                }
-            }
-        });
+        expect(optimization).toEqual(undefined);
     });
 
     test('entry', () => {

--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -36,6 +36,7 @@ module.exports = ({
         title: 'My App',
         filename: 'index.html',
         template: `${rootFolder || ''}/src/index.html`,
+        inject: false,
         ...htmlPlugin || {}
     }),
     new HtmlReplaceWebpackPlugin([


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-17016

### Changes
- fix issues with remote container initialization in local development
- stop injecting JS into the HTML template

### Remote container init issue

The optimization configuration entry was causing issues in local development environment. It was unable to initialize the self-referencing remote container. The specific configuration that was causing the issue is the [`splitchunks all`](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks) setting. We can remove the split chunks config as module federations add additional splitting behavior.