### PR TITLE
Mark router as private package to prevent its publish.

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -6,6 +6,7 @@
     "module": "esm/index.js",
     "types": "index.d.ts",
     "sideEffects": false,
+    "private": true,
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
The build is failing after the TS merge because of the router package. It has not been released yet so the release plugin dies.

More info: https://app.travis-ci.com/github/RedHatInsights/frontend-components/builds/244383483

The router package is not meant to be released yet so it has to be disabled.