### PR TITLE
Lock dev-server to 4.3.1 due to esi tags fetching issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33536,7 +33536,7 @@
                 "util": "^0.12.4",
                 "webpack": "^5.55.1",
                 "webpack-cli": "^4.8.0",
-                "webpack-dev-server": "^4.3.0",
+                "webpack-dev-server": "4.3.1",
                 "write-file-webpack-plugin": "^4.5.1",
                 "yargs": "^17.2.1"
             },
@@ -34027,9 +34027,9 @@
             }
         },
         "packages/config/node_modules/webpack-dev-server": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.0.tgz",
-            "integrity": "sha512-kuqP9Xn4OzcKe7f0rJwd4p8xqiD+4b5Lzu8tJa8OttRL3E1Q8gI2KmUtouJTgDswjjvHOHlZDV8LTQfSY5qZSA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
+            "integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
             "dependencies": {
                 "ansi-html-community": "^0.0.8",
                 "bonjour": "^3.5.0",
@@ -39813,7 +39813,7 @@
                 "util": "^0.12.4",
                 "webpack": "^5.55.1",
                 "webpack-cli": "^4.8.0",
-                "webpack-dev-server": "^4.3.0",
+                "webpack-dev-server": "4.3.1",
                 "write-file-webpack-plugin": "^4.5.1",
                 "yargs": "^17.2.1"
             },
@@ -40148,9 +40148,9 @@
                     }
                 },
                 "webpack-dev-server": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.0.tgz",
-                    "integrity": "sha512-kuqP9Xn4OzcKe7f0rJwd4p8xqiD+4b5Lzu8tJa8OttRL3E1Q8gI2KmUtouJTgDswjjvHOHlZDV8LTQfSY5qZSA==",
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
+                    "integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
                     "requires": {
                         "ansi-html-community": "^0.0.8",
                         "bonjour": "^3.5.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -48,7 +48,7 @@
         "util": "^0.12.4",
         "webpack": "^5.55.1",
         "webpack-cli": "^4.8.0",
-        "webpack-dev-server": "^4.3.0",
+        "webpack-dev-server": "4.3.1",
         "write-file-webpack-plugin": "^4.5.1",
         "yargs": "^17.2.1"
     }


### PR DESCRIPTION
This is a hot fix. More investigation and proper solution has to be found.

The latest version (4.7.x) causes issues with the esi tags fetching. The express `res.headersSent` flag is set to `true` when fetching the HTML template. That removes the ability to replace the ESI tags in the HTML template with the chrome partials. Resulting in an incomplete HTML template being sent to the browser. There are a couple of solutions, but I don't have time to work on it now and we have to unblock some teams from working.