### PR TITLE
Add option to load chrome HTML template via proxy.

### DIFF
--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -32,7 +32,8 @@ module.exports = ({
     target = '',
     keycloakUri = '',
     registry = [],
-    isChrome = false
+    isChrome = false,
+    onBeforeSetupMiddleware = () => {}
 }) => {
     const proxy = [];
     const majorEnv = env.split('-')[0];
@@ -251,6 +252,8 @@ module.exports = ({
                         overwrite: true
                     });
                 }
+
+                onBeforeSetupMiddleware({ chromePath });
 
                 if (chromePath) {
                     registerChrome({

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -7,6 +7,7 @@
     - [Removed features with webpack 5](#removed-features-with-webpack-5)
   - [useProxy](#useproxy)
     - [Attributes](#attributes)
+      - [useChromeTemplate](#useChromeTemplate)
       - [localChrome](#localchrome)
       - [registry](#registry)
       - [Custom routes](#custom-routes)
@@ -54,6 +55,7 @@ const { config: webpackConfig, plugins } = config({
 |---------|----|-----------|
 |[useProxy](#useproxy)|`boolean`|Enables webpack proxy.|
 |[proxyURL](#proxyURL)|`string`|URL to proxy Akamai environment requests to.|
+|[useChromeTemplate](#useChromeTemplate)|`boolean`|Load chrome HTMl template.|
 |[localChrome](#localChrome)|`string`|Path to your local chrome build folder.|
 |[keycloakUri](#keycloakUri)|`string`|Uri to inject into proxied chrome assets.|
 |[registry](#registry)|`(({ app, server, compiler, standaloneConfig }) => void)[]`|Express middleware to register.|
@@ -63,6 +65,24 @@ const { config: webpackConfig, plugins } = config({
 |[env](#env)|`string`|Environment to proxy against such as ci-beta.|
 |[useCloud](#use-cloud)|`boolean`|Toggle to use old fallback to cloud.redhat.com paths instead of console.redhat.com.|
 |[target](#target)|`string`|Override `env` and `useCloud` to use a custom URI.|
+
+
+#### useChromeTemplate
+
+**This option will become the default. App-specific templates are deprecated**
+
+To load chrome HTML template instead of using the APP-specific template add `useChromeTemplate` flag to your config.
+
+```js
+const config = require('@redhat-cloud-services/frontend-components-config');
+
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  useProxy: true,
+  useChromeTemplate: true
+  ...
+});
+```
 
 #### localChrome
 

--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -15,7 +15,8 @@ module.exports = ({
     insights,
     modules,
     generateSourceMaps,
-    plugins
+    plugins,
+    useChromeTemplate = false
 } = {}) => [
     ...(generateSourceMaps
         ? [
@@ -31,20 +32,30 @@ module.exports = ({
         filename: 'css/[name].[contenthash].css',
         ignoreOrder: true
     }),
-    new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
-    new HtmlWebpackPlugin({
-        title: 'My App',
-        filename: 'index.html',
-        template: `${rootFolder || ''}/src/index.html`,
-        inject: false,
-        ...htmlPlugin || {}
+    new CleanWebpackPlugin({
+        cleanStaleWebpackAssets: false,
+        cleanOnceBeforeBuildPatterns: useChromeTemplate ? [
+            '**/*',
+            '!index.html'
+        ] : [
+            '**/*'
+        ]
     }),
-    new HtmlReplaceWebpackPlugin([
-        {
-            pattern: '@@env',
-            replacement: appDeployment || ''
-        },
-        ...replacePlugin || []
+    ...(useChromeTemplate ? [] : [
+        new HtmlWebpackPlugin({
+            title: 'My App',
+            filename: 'index.html',
+            template: `${rootFolder || ''}/src/index.html`,
+            inject: false,
+            ...htmlPlugin || {}
+        }),
+        new HtmlReplaceWebpackPlugin([
+            {
+                pattern: '@@env',
+                replacement: appDeployment || ''
+            },
+            ...replacePlugin || []
+        ])
     ]),
     new ProvidePlugin({
         process: 'process/browser.js',


### PR DESCRIPTION
The HTML webpack will be copied to webpack output folder instead of using the generated template. 

Why copy instead of using a proxy? The same reason why we have difficulties loading the ESI tags. The headers for the template are already sent to the client which makes it impossible to mutate the actual response.