### PR TITLE
Wrap inventory components with inventory clasName

### DIFF
--- a/packages/components/src/Inventory/AppInfo.js
+++ b/packages/components/src/Inventory/AppInfo.js
@@ -5,29 +5,35 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 const BaseAppInfo = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./AppInfo"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./AppInfo"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseAppInfo.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -40,6 +46,10 @@ const AppInfo = React.forwardRef((props, ref) => <BaseAppInfo innerRef={ref} {..
 AppInfo.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 AppInfo.defaultProps = {
@@ -48,6 +58,7 @@ AppInfo.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default AppInfo;

--- a/packages/components/src/Inventory/DetailWrapper.js
+++ b/packages/components/src/Inventory/DetailWrapper.js
@@ -5,29 +5,35 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 const BaseDetailWrapper = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./DetailWrapper"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./DetailWrapper"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseDetailWrapper.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -40,6 +46,10 @@ const DetailWrapper = React.forwardRef((props, ref) => <BaseDetailWrapper innerR
 DetailWrapper.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 DetailWrapper.defaultProps = {
@@ -48,6 +58,7 @@ DetailWrapper.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default DetailWrapper;

--- a/packages/components/src/Inventory/InventoryDetail.js
+++ b/packages/components/src/Inventory/InventoryDetail.js
@@ -5,29 +5,35 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 const BaseInventoryDetail = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./InventoryDetail"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./InventoryDetail"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseInventoryDetail.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -40,6 +46,10 @@ const InventoryDetail = React.forwardRef((props, ref) => <BaseInventoryDetail in
 InventoryDetail.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 InventoryDetail.defaultProps = {
@@ -48,6 +58,7 @@ InventoryDetail.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default InventoryDetail;

--- a/packages/components/src/Inventory/InventoryDetailHead.js
+++ b/packages/components/src/Inventory/InventoryDetailHead.js
@@ -5,29 +5,35 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 const BaseInventoryDetailHead = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./InventoryDetailHead"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./InventoryDetailHead"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseInventoryDetailHead.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -40,6 +46,10 @@ const InventoryDetailHead = React.forwardRef((props, ref) => <BaseInventoryDetai
 InventoryDetailHead.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 InventoryDetailHead.defaultProps = {
@@ -48,6 +58,7 @@ InventoryDetailHead.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default InventoryDetailHead;

--- a/packages/components/src/Inventory/InventoryTable.js
+++ b/packages/components/src/Inventory/InventoryTable.js
@@ -5,29 +5,35 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 const BaseInvTable = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./InventoryTable"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./InventoryTable"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseInvTable.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -40,6 +46,10 @@ const InvTable = React.forwardRef((props, ref) => <BaseInvTable innerRef={ref} {
 InvTable.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 InvTable.defaultProps = {
@@ -48,6 +58,7 @@ InvTable.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default InvTable;

--- a/packages/components/src/Inventory/TagWithDialog.js
+++ b/packages/components/src/Inventory/TagWithDialog.js
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { useStore } from 'react-redux';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import InventoryLoadError from './InventoryLoadError';
+import classNames from 'classnames';
 
 /**
  * Inventory sub component.
@@ -14,25 +15,30 @@ import InventoryLoadError from './InventoryLoadError';
 const BaseTagWithDialog = (props) => {
   const history = useHistory();
   const store = useStore();
+  const Cmp = props.component;
   return (
-    <Suspense fallback={props.fallback}>
-      <ScalprumComponent
-        history={history}
-        store={store}
-        appName="inventory"
-        module="./TagWithDialog"
-        scope="inventory"
-        ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
-        ref={props.innerRef}
-        {...props}
-      />
-    </Suspense>
+    <Cmp className={classNames(props.className, 'inventory')}>
+      <Suspense fallback={props.fallback}>
+        <ScalprumComponent
+          history={history}
+          store={store}
+          appName="inventory"
+          module="./TagWithDialog"
+          scope="inventory"
+          ErrorComponent={<InventoryLoadError component="InventoryDetailHead" history={history} store={store} {...props} />}
+          ref={props.innerRef}
+          {...props}
+        />
+      </Suspense>
+    </Cmp>
   );
 };
 
 BaseTagWithDialog.propTypes = {
   fallback: PropTypes.node,
   innerRef: PropTypes.object,
+  component: PropTypes.string,
+  className: PropTypes.string,
 };
 
 /**
@@ -45,6 +51,10 @@ const TagWithDialog = React.forwardRef((props, ref) => <BaseTagWithDialog innerR
 TagWithDialog.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional wrapper component */
+  component: PropTypes.string,
+  /** Optional classname applied to wrapper component */
+  className: PropTypes.string,
 };
 
 TagWithDialog.defaultProps = {
@@ -53,6 +63,7 @@ TagWithDialog.defaultProps = {
       <Spinner size="xl" />
     </Bullseye>
   ),
+  component: 'section',
 };
 
 export default TagWithDialog;


### PR DESCRIPTION
## Inventory styles not applied

Since we are using directly ScalprumComponent the wrapper which adds styling of inventory is not used. This PR fixes it by wrapping the inventory fed module in Cmp component as well. We might want to use `AsyncComponent` in future, but I didn't wanted to mess that much with it.