### PR TITLE
Downgrade chalk to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35056,7 +35056,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.5.12",
+            "version": "4.6.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.9",
@@ -35065,7 +35065,7 @@
                 "babel-loader": "^8.2.2",
                 "browserify-zlib": "^0.2.0",
                 "buffer": "^6.0.3",
-                "chalk": "^5.0.0",
+                "chalk": "^4.0.0",
                 "clean-webpack-plugin": "^3.0.0",
                 "concurrently": "^6.3.0",
                 "css-loader": "^5.2.6",
@@ -35873,10 +35873,10 @@
             }
         },
         "packages/create-crc-app": {
-            "version": "0.0.1",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "chalk": "^5.0.0",
+                "chalk": "^4.0.0",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.2.0",
                 "inquirer": "^8.2.0",
@@ -41884,7 +41884,7 @@
                 "babel-loader": "^8.2.2",
                 "browserify-zlib": "^0.2.0",
                 "buffer": "^6.0.3",
-                "chalk": "^5.0.0",
+                "chalk": "^4.0.0",
                 "clean-webpack-plugin": "^3.0.0",
                 "concurrently": "^6.3.0",
                 "css-loader": "^5.2.6",
@@ -47350,7 +47350,7 @@
         "create-crc-app": {
             "version": "file:packages/create-crc-app",
             "requires": {
-                "chalk": "^5.0.0",
+                "chalk": "^4.0.0",
                 "fs-extra": "^10.0.0",
                 "glob": "^7.2.0",
                 "inquirer": "^8.2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,7 +29,7 @@
         "clean-webpack-plugin": "^3.0.0",
         "css-loader": "^5.2.6",
         "concurrently": "^6.3.0",
-        "chalk": "^5.0.0",
+        "chalk": "^4.0.0",
         "express": "^4.17.2",
         "git-revision-webpack-plugin": "^3.0.6",
         "glob": "^7.0.0",

--- a/packages/create-crc-app/package.json
+++ b/packages/create-crc-app/package.json
@@ -20,7 +20,7 @@
         "create-crc-app": "./bin/create-crc-app.js"
     },
     "dependencies": {
-        "chalk": "^5.0.0",
+        "chalk": "^4.0.0",
         "fs-extra": "^10.0.0",
         "glob": "^7.2.0",
         "inquirer": "^8.2.0",


### PR DESCRIPTION
v5 has only ESM build which makes it impossible to use in commonjs
enviroment without some hacking. Until we ESM in node packages we have
to stay on v4.