### PR TITLE
Adding testing package with OuiaSelectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "packages/router",
                 "packages/rule-components",
                 "packages/translations",
+                "packages/testing",
                 "packages/utils"
             ],
             "dependencies": {
@@ -4985,6 +4986,10 @@
         },
         "node_modules/@redhat-cloud-services/rule-components": {
             "resolved": "packages/rule-components",
+            "link": true
+        },
+        "node_modules/@redhat-cloud-services/testing": {
+            "resolved": "packages/testing",
             "link": true
         },
         "node_modules/@redhat-cloud-services/vulnerabilities-client": {
@@ -36298,6 +36303,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "packages/testing": {
+            "name": "@redhat-cloud-services/testing",
+            "version": "3.7.0",
+            "license": "Apache-2.0",
+            "devDependencies": {}
+        },
         "packages/translations": {
             "name": "@redhat-cloud-services/frontend-components-translations",
             "version": "3.2.3",
@@ -41221,6 +41232,9 @@
                     "version": "0.7.0"
                 }
             }
+        },
+        "@redhat-cloud-services/testing": {
+            "version": "file:packages/testing"
         },
         "@redhat-cloud-services/vulnerabilities-client": {
             "version": "1.0.97",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4969,6 +4969,10 @@
             "resolved": "packages/router",
             "link": true
         },
+        "node_modules/@redhat-cloud-services/frontend-components-testing": {
+            "resolved": "packages/testing",
+            "link": true
+        },
         "node_modules/@redhat-cloud-services/frontend-components-translations": {
             "resolved": "packages/translations",
             "link": true
@@ -4986,10 +4990,6 @@
         },
         "node_modules/@redhat-cloud-services/rule-components": {
             "resolved": "packages/rule-components",
-            "link": true
-        },
-        "node_modules/@redhat-cloud-services/testing": {
-            "resolved": "packages/testing",
             "link": true
         },
         "node_modules/@redhat-cloud-services/vulnerabilities-client": {
@@ -36304,8 +36304,8 @@
             }
         },
         "packages/testing": {
-            "name": "@redhat-cloud-services/testing",
-            "version": "3.7.0",
+            "name": "@redhat-cloud-services/frontend-components-testing",
+            "version": "1.0.0",
             "license": "Apache-2.0",
             "devDependencies": {}
         },
@@ -41181,6 +41181,9 @@
                 "react-router-dom": "^5.0.0"
             }
         },
+        "@redhat-cloud-services/frontend-components-testing": {
+            "version": "file:packages/testing"
+        },
         "@redhat-cloud-services/frontend-components-translations": {
             "version": "file:packages/translations",
             "requires": {
@@ -41232,9 +41235,6 @@
                     "version": "0.7.0"
                 }
             }
-        },
-        "@redhat-cloud-services/testing": {
-            "version": "file:packages/testing"
         },
         "@redhat-cloud-services/vulnerabilities-client": {
             "version": "1.0.97",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "packages/router",
         "packages/rule-components",
         "packages/translations",
+        "packages/testing",
         "packages/utils"
     ],
     "files": [

--- a/packages/testing/.gitignore
+++ b/packages/testing/.gitignore
@@ -1,0 +1,25 @@
+# ignore everything in root that will be the destination of build output
+/*
+
+# white list allowed files
+!src
+!src/
+!src/*
+!doc
+!doc/
+!doc/*
+!config
+!config/
+!config/*
+!.npmignore
+!.gitignore
+!babel.config.js
+!LICENSE
+!package.json
+!README.md
+!tsconfig.json
+!pre-publish.js
+!tsconfig.*
+
+# Incremental ts info
+tsconfig.tsbuildinfo

--- a/packages/testing/.npmignore
+++ b/packages/testing/.npmignore
@@ -1,0 +1,10 @@
+!components
+!index.js
+!index.css
+src/
+.babelrc
+babel.config.js
+doc/
+config/
+tsconfig.json
+pre-publish.js

--- a/packages/testing/.npmignore
+++ b/packages/testing/.npmignore
@@ -6,5 +6,5 @@ src/
 babel.config.js
 doc/
 config/
-tsconfig.json
+tsconfig.*
 pre-publish.js

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,22 @@
+# RedHat Cloud Services frontend components - testing
+
+[![npm version](https://badge.fury.io/js/%40redhat-cloud-services%2Ffrontend-components-testing.svg)](https://badge.fury.io/js/%40redhat-cloud-services%2Ffrontend-components-testing)
+
+
+This package exports utilities to use in tests.
+
+## Installation
+With NPM
+```bash
+npm i -S @redhat-cloud-services/frontend-components-testing
+```
+
+With yarn
+```bash
+yarn add @redhat-cloud-services/frontend-components-testing
+```
+
+## Documentation Links
+
+* Usage
+    * [Testing](doc/testing.md)

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -8,12 +8,12 @@ This package exports utilities to use in tests.
 ## Installation
 With NPM
 ```bash
-npm i -S @redhat-cloud-services/frontend-components-testing
+npm i --save-dev @redhat-cloud-services/frontend-components-testing
 ```
 
 With yarn
 ```bash
-yarn add @redhat-cloud-services/frontend-components-testing
+yarn add --dev @redhat-cloud-services/frontend-components-testing
 ```
 
 ## Documentation Links

--- a/packages/testing/babel.config.js
+++ b/packages/testing/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: '../../babel.config.js'
+};

--- a/packages/testing/doc/testing.md
+++ b/packages/testing/doc/testing.md
@@ -1,0 +1,38 @@
+# Ouia Selectors
+
+Ouia selectors provide utilities for fetching Ouia components by the `component-type` and `component-id`.
+It Allows to chain calls to search for components within a component.
+The inputs and results of these calls are compatible with the [Testing Library](https://testing-library.com/).
+
+The API is modeled after the [Testing Library](https://testing-library.com/).
+You will find the following alternatives `getByOuia`, `getAllByOuia`, `queryByOuia` and `queryAllByOuia` and they will
+behave as you would expect in the [testing Library](https://testing-library.com/).
+The only missing selectors are `findByOuia` and `findAllByOuia`. [PRs are welcome!](https://github.com/RedHatInsights/frontend-components/compare).
+
+Below are some examples, but more can be found on the [tests](../src/OuiaSelectors/OuiaSelectors.test.tsx).
+
+## Standalone example
+
+```typescript
+expect(
+    ouiaSelectors.getByOuia('PF4/Select')
+).toBeVisible();
+```
+
+## Using events from `@testing-library`
+
+```typescript
+userEvent.click(
+    ouiaSelectors.getByOuia('PF4/Button', 'action')
+);
+```
+
+## Mixing with calls of the `@testing-library`
+```typescript
+expect(
+  getByLabelText(
+      ouiaSelectors.getByOuia('Notifications/Integrations/Table'), 
+      /Enabled/i
+  )
+).toBeDisabled();
+```

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@redhat-cloud-services/testing",
-    "version": "3.7.0",
+    "name": "@redhat-cloud-services/frontend-components-testing",
+    "version": "1.0.0",
     "description": "Testing utilities for RedHat Cloud Services project.",
     "main": "index.js",
     "module": "esm/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,8 +12,8 @@
     "scripts": {
         "build": "npm run build:js && npm run build:esm && npm run build:packages",
         "build:packages": "node ../../scripts/build-packages.js --forceTypes",
-        "build:esm": "npx tsc --module es2015 --target es5",
-        "build:js": "npx tsc -p tsconfig.cjs.json"
+        "build:esm": "tsc --module es2015 --target es5",
+        "build:js": "tsc -p tsconfig.cjs.json"
     },
     "repository": {
         "type": "git",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "@redhat-cloud-services/testing",
+    "version": "3.7.0",
+    "description": "Testing utilities for RedHat Cloud Services project.",
+    "main": "index.js",
+    "module": "esm/index.js",
+    "types": "index.d.ts",
+    "sideEffects": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "npm run build:js && npm run build:esm && npm run build:css && npm run build:packages && npm run transform:css",
+        "build:packages": "node ../../scripts/build-packages.js --forceTypes",
+        "build:esm": "npx tsc --module es2015 --target es5",
+        "build:js": "npx tsc -p tsconfig.cjs.json"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/RedHatInsights/frontend-components.git"
+    },
+    "author": "",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/RedHatInsights/frontend-components/issues"
+    },
+    "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/testing#readme",
+    "peerDependencies": {
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+    }
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,11 +24,5 @@
     "bugs": {
         "url": "https://github.com/RedHatInsights/frontend-components/issues"
     },
-    "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/testing#readme",
-    "peerDependencies": {
-    },
-    "dependencies": {
-    },
-    "devDependencies": {
-    }
+    "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/testing#readme"
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -10,7 +10,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "npm run build:js && npm run build:esm && npm run build:css && npm run build:packages && npm run transform:css",
+        "build": "npm run build:js && npm run build:esm && npm run build:packages",
         "build:packages": "node ../../scripts/build-packages.js --forceTypes",
         "build:esm": "npx tsc --module es2015 --target es5",
         "build:js": "npx tsc -p tsconfig.cjs.json"

--- a/packages/testing/src/OuiaSelectors/OuiaSelectors.test.tsx
+++ b/packages/testing/src/OuiaSelectors/OuiaSelectors.test.tsx
@@ -1,0 +1,380 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { ouiaSelectors, ouiaSelectorsFor } from './OuiaSelectors';
+
+describe('OuiaSelectors', () => {
+  describe('getByOuia', () => {
+    it('Throws if nothing is found', () => {
+      render(<></>);
+      expect(() => ouiaSelectors.getByOuia('foobar')).toThrowError();
+    });
+
+    it('Throws error when more than one match found', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+          </div>
+        </div>
+      );
+      expect(() => ouiaSelectors.getByOuia('foobar')).toThrowError();
+    });
+
+    it('Returns found element by component type', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="foobar" id="me" />
+          <div data-ouia-component-type="foobar-2" />
+          <div data-ouia-component-type="foobar-3" />
+        </div>
+      );
+      expect(ouiaSelectors.getByOuia('foobar')).toHaveAttribute('id', 'me');
+    });
+
+    it('Throws error when more than one match found when using the component-id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+          </div>
+        </div>
+      );
+      expect(() => ouiaSelectors.getByOuia('foobar', 'baz')).toThrowError();
+    });
+
+    it('Returns found element by component type and component id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="beef" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(ouiaSelectors.getByOuia('foobar', 'baz')).toHaveAttribute('id', 'me');
+    });
+
+    it('Allows chaining calls', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="beef" />
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      const result = ouiaSelectors.getByOuia('my-component', 'c1').getByOuia('foobar');
+      const result2 = ouiaSelectors.getByOuia('my-component', 'c2').getAllByOuia('foobar');
+
+      expect(result).toHaveAttribute('id', 'me');
+      expect(result2).toHaveLength(2);
+    });
+  });
+
+  describe('queryByOuia', () => {
+    it('Returns null nothing is found', () => {
+      render(<></>);
+      expect(ouiaSelectors.queryByOuia('foobar')).toBeNull();
+    });
+
+    it('Throws error when more than one match found', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+          </div>
+        </div>
+      );
+      expect(() => ouiaSelectors.queryByOuia('foobar')).toThrowError();
+    });
+
+    it('Returns found element by component type', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="foobar" id="me" />
+          <div data-ouia-component-type="foobar-2" />
+          <div data-ouia-component-type="foobar-3" />
+        </div>
+      );
+      expect(ouiaSelectors.queryByOuia('foobar')).toHaveAttribute('id', 'me');
+    });
+
+    it('Throws error when more than one match found when using the component-id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+          </div>
+        </div>
+      );
+      expect(() => ouiaSelectors.queryByOuia('foobar', 'baz')).toThrowError();
+    });
+
+    it('Returns found element by component type and component id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="beef" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(ouiaSelectors.queryByOuia('foobar', 'baz')).toHaveAttribute('id', 'me');
+    });
+  });
+
+  describe('getAllByOuia', () => {
+    it('Throws if nothing is found', () => {
+      render(<></>);
+      expect(() => ouiaSelectors.getAllByOuia('foobar')).toThrowError();
+    });
+
+    it('Return multiple matches', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+          </div>
+        </div>
+      );
+      expect(ouiaSelectors.getAllByOuia('foobar')).toHaveLength(2);
+    });
+
+    it('Returns only element found by type', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="foobar" id="me" />
+          <div data-ouia-component-type="foobar-2" />
+          <div data-ouia-component-type="foobar-3" />
+        </div>
+      );
+      const result = ouiaSelectors.getAllByOuia('foobar');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveAttribute('id', 'me');
+    });
+
+    it('Return multiple elements with the same id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+          </div>
+        </div>
+      );
+
+      const result = ouiaSelectors.getAllByOuia('foobar', 'baz');
+      expect(result).toHaveLength(2);
+    });
+
+    it('Returns found element by component type and component id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+
+      const results = ouiaSelectors.getAllByOuia('foobar', 'baz');
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  describe('queryAllByOuia', () => {
+    it('Returns 0-length array nothing is found', () => {
+      render(<></>);
+      expect(ouiaSelectors.queryAllByOuia('foobar')).toHaveLength(0);
+    });
+
+    it('Return multiple matches', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+          </div>
+        </div>
+      );
+      expect(ouiaSelectors.queryAllByOuia('foobar')).toHaveLength(2);
+    });
+
+    it('Returns only element found by type', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="foobar" id="me" />
+          <div data-ouia-component-type="foobar-2" />
+          <div data-ouia-component-type="foobar-3" />
+        </div>
+      );
+      const result = ouiaSelectors.queryAllByOuia('foobar');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveAttribute('id', 'me');
+    });
+
+    it('Return multiple elements with the same id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" />
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+          </div>
+        </div>
+      );
+
+      const result = ouiaSelectors.queryAllByOuia('foobar', 'baz');
+      expect(result).toHaveLength(2);
+    });
+
+    it('Returns found element by component type and component id', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+
+      const results = ouiaSelectors.queryAllByOuia('foobar', 'baz');
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  describe('ouiaSelectorsFor', () => {
+    it('Uses the passed element as the base', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2" id="my-element">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="31415" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ouiaSelectorsFor(document.getElementById('my-element')!).getByOuia('foobar')
+      ).toHaveAttribute('id', '31415');
+    });
+
+    it('Has getAllByOuia', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2" id="my-element">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="31415" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ouiaSelectorsFor(document.getElementById('my-element')!).getAllByOuia('foobar')
+      ).toHaveLength(1);
+    });
+
+    it('Has queryByOuia', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2" id="my-element">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="31415" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ouiaSelectorsFor(document.getElementById('my-element')!).queryByOuia('foobar')
+      ).toHaveAttribute('id', '31415');
+    });
+
+    it('Has queryAllByOuia', () => {
+      render(
+        <div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c1">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="me" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="my-component" data-ouia-component-id="c2" id="my-element">
+            <div data-ouia-component-type="foobar" data-ouia-component-id="baz" id="31415" />
+            <div data-ouia-component-type="foobar-2" data-ouia-component-id="baz" />
+          </div>
+          <div data-ouia-component-type="foobar" />
+        </div>
+      );
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ouiaSelectorsFor(document.getElementById('my-element')!).queryAllByOuia('foobar4')
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/packages/testing/src/OuiaSelectors/OuiaSelectors.ts
+++ b/packages/testing/src/OuiaSelectors/OuiaSelectors.ts
@@ -1,0 +1,86 @@
+type OuiaFunction<R> = (componentType: string, componentId?: string) => R;
+type OuiaSelectableElement = HTMLElement & OuiaSelectors;
+
+// interface was modelled after testing-library queries: https://testing-library.com/docs/dom-testing-library/api-queries
+interface OuiaSelectors {
+  getByOuia: OuiaFunction<OuiaSelectableElement>;
+  getAllByOuia: OuiaFunction<Array<OuiaSelectableElement>>;
+  queryByOuia: OuiaFunction<OuiaSelectableElement | null>;
+  queryAllByOuia: OuiaFunction<Array<OuiaSelectableElement>>;
+}
+
+type OuiaSearchOptions = {
+  throwIfNone: boolean;
+  throwIfMultiple: boolean;
+};
+
+const _ouiaSearchFunction = (
+  base: HTMLElement,
+  componentType: string,
+  componentId: string | undefined,
+  options: OuiaSearchOptions
+): Array<OuiaSelectableElement> => {
+  let selector = `[data-ouia-component-type="${componentType}"]`;
+  if (componentId) {
+    selector += `[data-ouia-component-id="${componentId}"]`;
+  }
+
+  const result = base.querySelectorAll<HTMLElement>(selector);
+
+  if (options.throwIfMultiple && result.length > 1) {
+    throw new Error(`There are more than one element with the type: ${componentType} and the id ${componentId}`);
+  } else if (options.throwIfNone && result.length === 0) {
+    throw new Error(`There is not any element with the type: ${componentType} and the id ${componentId}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  return Array.from(result).map((r) => ouiaSelectorsFor(r));
+};
+
+const _queryAllByOuia = (base: HTMLElement, componentType: string, componentId?: string): Array<OuiaSelectableElement> => {
+  return _ouiaSearchFunction(base, componentType, componentId, {
+    throwIfNone: false,
+    throwIfMultiple: false,
+  });
+};
+
+const _queryByOuia = (base: HTMLElement, componentType: string, componentId?: string): OuiaSelectableElement | null => {
+  const elements = _ouiaSearchFunction(base, componentType, componentId, {
+    throwIfNone: false,
+    throwIfMultiple: true,
+  });
+
+  return elements.length > 0 ? elements[0] : null;
+};
+
+const _getAllByOuia = (base: HTMLElement, componentType: string, componentId?: string): Array<OuiaSelectableElement> => {
+  return _ouiaSearchFunction(base, componentType, componentId, {
+    throwIfNone: true,
+    throwIfMultiple: false,
+  });
+};
+
+const _getByOuia = (base: HTMLElement, componentType: string, componentId?: string): OuiaSelectableElement => {
+  const elements = _ouiaSearchFunction(base, componentType, componentId, {
+    throwIfNone: true,
+    throwIfMultiple: true,
+  });
+
+  return elements[0];
+};
+
+export const ouiaSelectors: Readonly<OuiaSelectors> = {
+  getByOuia: (componentType: string, componentId?: string) => _getByOuia(document.body, componentType, componentId),
+  getAllByOuia: (componentType: string, componentId?: string) => _getAllByOuia(document.body, componentType, componentId),
+  queryByOuia: (componentType: string, componentId?: string) => _queryByOuia(document.body, componentType, componentId),
+  queryAllByOuia: (componentType: string, componentId?: string) => _queryAllByOuia(document.body, componentType, componentId),
+};
+
+export const ouiaSelectorsFor = (base: HTMLElement): Readonly<OuiaSelectableElement> => {
+  return Object.assign(base, {
+    getByOuia: (componentType: string, componentId?: string) => _getByOuia(base, componentType, componentId),
+    getAllByOuia: (componentType: string, componentId?: string) => _getAllByOuia(base, componentType, componentId),
+    queryByOuia: (componentType: string, componentId?: string) => _queryByOuia(base, componentType, componentId),
+    queryAllByOuia: (componentType: string, componentId?: string) => _queryAllByOuia(base, componentType, componentId),
+  });
+};

--- a/packages/testing/src/OuiaSelectors/index.ts
+++ b/packages/testing/src/OuiaSelectors/index.ts
@@ -1,0 +1,1 @@
+export * from './OuiaSelectors';

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,1 @@
+export * from './OuiaSelectors';

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./",
+      "module": "commonjs"
+    }
+  }
+  

--- a/packages/testing/tsconfig.cjs.json
+++ b/packages/testing/tsconfig.cjs.json
@@ -1,8 +1,7 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-      "outDir": "./",
-      "module": "commonjs"
-    }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./",
+    "module": "commonjs"
   }
-  
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+      "rootDir": "./src",
+      "outDir": "./esm",
+      "declarationDir": "./",
+      "allowJs": true
+  },
+  "include": [
+      "./src/**/*"
+  ],
+}


### PR DESCRIPTION
I'm sharing this utility that I found useful while testing. 

I didn't see any package (ideally, one package used as dev) where this could live, so I'm creating a new one. I didn't go all the way to configure it propertly, but it's something I could do if this is something that could live here.

This adds a selector utility to get Ouia DOM elements. I'm mixing it with the `react-testing-library` when I want to scope my queries to a subset of the DOM.

It can be used standalone (without the `@testing-library`) as follows:

```ts
expect(ouiaSelectors.getByOuia('PF4/Select')).toBeVisible();
```

with the `userEvent` (from the `@testing-library`)

```ts
userEvent.click(ouiaSelectors.getByOuia('PF4/Button', 'action'));
```

or mixing it up with other queries (from the `@testing-library`)

```ts
expect(
  getByLabelText(ouiaSelectors.getByOuia('Notifications/Integrations/Table'), /Enabled/i)
).toBeDisabled();
```

If this is something of interest, I could invest more time to configure it properly in this repository.