### PR TITLE
fix(docker): Use volume for docs node_volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   docs:
-    build: 
+    build:
       context: ./
       dockerfile: Dockerfile.dev
     command: sh -c "npm i && npm run generate:components && npm run watch"
@@ -9,4 +9,4 @@ services:
       - '3000:3000'
     volumes:
       - .:/docs
-  
+      - /docs/packages/docs/node_modules


### PR DESCRIPTION
On macOS there appears to be an issue when not using node_modules in a volume and `npm install` would randomly stall and if it succeeded the build process would fail/leak and not render properly and eventually kill the task/container and/or make it unresponsive.

Adding a volume for the docs' node_modules fixes these issues and the build seems to work properly.