### PR TITLE
Use tsc directly instead of npx tsc, this way we are not vulnerable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
                 "redux-mock-store": "^1.5.3",
                 "sass": "^1.34.0",
                 "ts-jest": "^26.5.6",
-                "typescript": "^4.5.4",
+                "typescript": "^4.5.5",
                 "whatwg-fetch": "^3.6.2"
             },
             "engines": {
@@ -30999,9 +30999,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -60032,9 +60032,9 @@
             }
         },
         "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
         },
         "ua-parser-js": {
             "version": "0.7.28"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "redux-mock-store": "^1.5.3",
         "sass": "^1.34.0",
         "ts-jest": "^26.5.6",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "whatwg-fetch": "^3.6.2"
     },
     "scripts": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,8 +14,8 @@
         "build:css": "node ../../scripts/build-styles.js",
         "build:packages": "node ../../scripts/build-packages.js --forceTypes",
         "start": "concurrently \"npm run build:esm -- --watch\" \"npm run build:js -- --watch\" \"npm run build:css -- --watch\" \"npm run build:packages\"",
-        "build:esm": "npx tsc --module es2015 --target es5",
-        "build:js": "npx tsc -p tsconfig.cjs.json",
+        "build:esm": "tsc --module es2015 --target es5",
+        "build:js": "tsc -p tsconfig.cjs.json",
         "transform:css": "node ../../scripts/transform-scss.js"
     },
     "repository": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -12,8 +12,8 @@
         "build:css": "node ../../scripts/build-styles.js",
         "build:packages": "node ../../scripts/build-packages.js --forceTypes",
         "start": "concurrently \"npm run build:esm -- --watch\" \"npm run build:js -- --watch\" \"npm run build:css -- --watch\"",
-        "build:esm": "npx tsc --module es2015 --target es5",
-        "build:js": "npx tsc -p tsconfig.cjs.json",
+        "build:esm": "tsc --module es2015 --target es5",
+        "build:js": "tsc -p tsconfig.cjs.json",
         "transform:css": "node ../../scripts/transform-scss.js"
     },
     "repository": {


### PR DESCRIPTION
## Run `tsc` instead of `npx tsc`

We don't have to use the `npx` fixture, npm will look in the folder tree to the parent package.json and will comply. The usage of `npx` is somewhat vulnerable to MiM attacks, this is more safe.