### PR TITLE
Transform CSS import path for ESM modules build by TS.

### DIFF
--- a/scripts/transform-scss.js
+++ b/scripts/transform-scss.js
@@ -8,6 +8,15 @@ async function transformFiles() {
   const files = glob.sync(esmRoot).filter((path) => !path.includes('/src/'));
   const cmds = files.map((file) => {
     let content = fs.readFileSync(file, { encoding: 'utf-8' });
+    const isEsm = file.includes('/esm/');
+    if (isEsm) {
+      /**
+       * For ESM module, tranform the CSS asset paht co CJS variant.
+       * Referencing CSS in esm directories causes webpack to tree shake the assets leading to missing CSS rules in build output.
+       */
+      const prefix = file.split('/esm/').pop().split('/').shift();
+      content = content.replaceAll(/(?<=^import )'\.\/(?=.*\.scss)/gm, `'../${prefix}/`);
+    }
     content = content.replace(/\.scss(?=('))/, '.css');
     content = content.replace(/\.scss(?=("\)))/, '.css');
     return fs.writeFile(file, content, 'utf-8', function (err) {


### PR DESCRIPTION
In sources, updates to the latest build of frontend components, CSS imported through ESM modules were missing. Webpack was applying tree shaking on these modules. Pre-TS this issue did not exist because the ESM modules were referencing CSS assets from the CJS variant. The transformation was removed and assets duplicated to the ESM directory to reduce the build complexity.

Seems like we have to move back to the previous solution in order to not tree shake important assets. Another option would be removing the `sideEffects: false` flag we have in our modules. But that can cause bundle sizes to increase.

### ESM build diff
```diff
        }
    return t;
};
import React from 'react';
import classNames from 'classnames';
- import './section.css';
+ import '../Section/section.css';
var Section = function (_a) {
    var _b;
    var type = _a.type, children = _a.children, className = _a.className, props = __rest(_a, ["type", "children", "className"]);
    var sectionClasses = classNames(className, (_b = {}, _b["ins-l-".concat(type)] = type !== undefined, _b));
    return (React.createElement("section", __assign({}, props, { className: sectionClasses }),

```

NOTE: this fix will only take effect after a new version of a package is built and released