### PR TITLE
Use typedoc from node instead of cli

### DIFF
--- a/packages/docs/components/navigation/components-navigation.json
+++ b/packages/docs/components/navigation/components-navigation.json
@@ -85,13 +85,15 @@
 			{
 				"group": "CullingInfo",
 				"items": [
-					"CullingInformation"
+					"CullingInformation",
+					"utils"
 				]
 			},
 			{
 				"group": "Dark",
 				"items": [
-					"Dark"
+					"Dark",
+					"DarkContext"
 				]
 			},
 			{
@@ -124,6 +126,13 @@
 				"group": "FilterChips",
 				"items": [
 					"FilterChips"
+				]
+			},
+			{
+				"group": "FilterHooks",
+				"items": [
+					"constants",
+					"tagFilterHook"
 				]
 			},
 			{
@@ -222,6 +231,7 @@
 			{
 				"group": "Shield",
 				"items": [
+					"consts",
 					"Shield"
 				]
 			},
@@ -278,6 +288,7 @@
 				"group": "TreeTable",
 				"items": [
 					"decorator",
+					"helpers",
 					"rowWrapper"
 				]
 			},
@@ -308,6 +319,7 @@
 			{
 				"group": "useScreenSize",
 				"items": [
+					"breakpoints",
 					"getVariant",
 					"isSmallScreen",
 					"useScreenSize"
@@ -339,9 +351,33 @@
 		"packageName": "notifications",
 		"groups": [
 			{
+				"group": "actions",
+				"items": [
+					"action-types"
+				]
+			},
+			{
 				"group": "Notification",
 				"items": [
 					"Notification"
+				]
+			},
+			{
+				"group": "NotificationPortal",
+				"items": [
+					"NotificationPortal"
+				]
+			},
+			{
+				"group": "notificationsMiddleware",
+				"items": [
+					"notificationsMiddleware"
+				]
+			},
+			{
+				"group": "Portal",
+				"items": [
+					"Portal"
 				]
 			}
 		]
@@ -442,6 +478,17 @@
 		]
 	},
 	{
+		"packageName": "testing",
+		"groups": [
+			{
+				"group": "OuiaSelectors",
+				"items": [
+					"OuiaSelectors"
+				]
+			}
+		]
+	},
+	{
 		"packageName": "translations",
 		"groups": [
 			{
@@ -471,9 +518,27 @@
 				]
 			},
 			{
+				"group": "interceptors",
+				"items": [
+					"interceptors"
+				]
+			},
+			{
 				"group": "parseCvssScore",
 				"items": [
 					"parseCvssScore"
+				]
+			},
+			{
+				"group": "RBAC",
+				"items": [
+					"RBAC"
+				]
+			},
+			{
+				"group": "RBACHook",
+				"items": [
+					"RBACHook"
 				]
 			},
 			{

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,8 +12,7 @@
     "generate:components": "node generators/docgen.js",
     "generate:components:docs": "npm run generate:components && node generators/docs-generator.js && npm run generate:navigation",
     "generate:watch": "concurrently \"npm run generate:components -- --watch\" \"node generators/docs-generator.js --watch\" \"npm run generate:navigation -- --watch\"",
-    "serve": "node server.js",
-    "typedoc": "typedoc"
+    "serve": "node server.js"
   },
   "dependencies": {
     "@patternfly/react-core": "4.192.0",


### PR DESCRIPTION
### Changes
use `typedoc` module instead of spinning a new CLI process to run `typedoc` per each file.

This reduced docker memory consumption by a lot. With this method, it peeks at 2.4 BG. Before docker ate almost 9 GB. it should make it easier for people to run the docs locally.

Once the generators are done it uses about 200 MB of memory.