### PR TITLE
Update follow-redirects dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32708,7 +32708,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.7.5",
+            "version": "3.7.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -32721,9 +32721,6 @@
                 "@patternfly/patternfly": ">=4.102.2",
                 "@types/react": "^16.9.34",
                 "node-sass-package-importer": "^5.3.2"
-            },
-            "optionalDependencies": {
-                "@redhat-cloud-services/rbac-client": "^1.0.104"
             },
             "peerDependencies": {
                 "@patternfly/react-core": ">=4.18.5",
@@ -32738,6 +32735,11 @@
                 "react-redux": ">=5.0.7",
                 "react-router-dom": ">=4.2.2"
             }
+        },
+        "packages/components/node_modules/@redhat-cloud-services/types": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.1.tgz",
+            "integrity": "sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA=="
         },
         "packages/components/node_modules/@scalprum/react-core": {
             "version": "0.1.7",
@@ -32765,7 +32767,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.6.2",
+            "version": "4.6.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.11",
@@ -33860,7 +33862,7 @@
                 "@babel/preset-typescript": "^7.16.7",
                 "@mdx-js/loader": "^1.6.22",
                 "@next/mdx": "^11.0.1",
-                "codesandbox": "^2.2.1",
+                "codesandbox": "^2.2.3",
                 "concurrently": "^5.3.0",
                 "eslint-config-next": "^12.1.0",
                 "file-loader": "^6.2.0",
@@ -35480,7 +35482,7 @@
         },
         "packages/types": {
             "name": "@redhat-cloud-services/types",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@patternfly/quickstarts": "^1.4.1-rc.1",
@@ -35490,13 +35492,13 @@
         },
         "packages/utils": {
             "name": "@redhat-cloud-services/frontend-components-utilities",
-            "version": "3.2.10",
+            "version": "3.2.11",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/types": "0.0.1",
                 "@sentry/browser": "^5.4.0",
                 "awesome-debounce-promise": "^2.1.0",
-                "axios": "^0.21.4",
+                "axios": "^0.25.0",
                 "commander": ">=2.20.0",
                 "mkdirp": "^1.0.4",
                 "react-content-loader": ">=3.4.1"
@@ -35514,6 +35516,11 @@
                 "react-router-dom": ">=4.2.2"
             }
         },
+        "packages/utils/node_modules/@redhat-cloud-services/types": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.1.tgz",
+            "integrity": "sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA=="
+        },
         "packages/utils/node_modules/@types/react": {
             "version": "16.14.23",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.23.tgz",
@@ -35523,6 +35530,14 @@
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
                 "csstype": "^3.0.2"
+            }
+        },
+        "packages/utils/node_modules/axios": {
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "dependencies": {
+                "follow-redirects": "^1.14.7"
             }
         }
     },
@@ -38933,7 +38948,6 @@
             "requires": {
                 "@patternfly/patternfly": ">=4.102.2",
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.104",
                 "@redhat-cloud-services/types": "0.0.1",
                 "@scalprum/core": "^0.1.1",
                 "@scalprum/react-core": "^0.1.7",
@@ -38942,6 +38956,11 @@
                 "sanitize-html": "^2.3.2"
             },
             "dependencies": {
+                "@redhat-cloud-services/types": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.1.tgz",
+                    "integrity": "sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA=="
+                },
                 "@scalprum/react-core": {
                     "version": "0.1.7",
                     "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.1.7.tgz",
@@ -40193,12 +40212,17 @@
                 "@sentry/browser": "^5.4.0",
                 "@types/react": "^16.9.34",
                 "awesome-debounce-promise": "^2.1.0",
-                "axios": "^0.21.4",
+                "axios": "^0.25.0",
                 "commander": ">=2.20.0",
                 "mkdirp": "^1.0.4",
                 "react-content-loader": ">=3.4.1"
             },
             "dependencies": {
+                "@redhat-cloud-services/types": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.1.tgz",
+                    "integrity": "sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA=="
+                },
                 "@types/react": {
                     "version": "16.14.23",
                     "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.23.tgz",
@@ -40208,6 +40232,14 @@
                         "@types/prop-types": "*",
                         "@types/scheduler": "*",
                         "csstype": "^3.0.2"
+                    }
+                },
+                "axios": {
+                    "version": "0.25.0",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+                    "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+                    "requires": {
+                        "follow-redirects": "^1.14.7"
                     }
                 }
             }
@@ -45879,7 +45911,7 @@
                 "@patternfly/react-table": "^4.19.24",
                 "@redhat-cloud-services/frontend-components": "^3.0.10",
                 "classnames": "^2.3.1",
-                "codesandbox": "^2.2.1",
+                "codesandbox": "^2.2.3",
                 "concurrently": "^5.3.0",
                 "eslint-config-next": "^12.1.0",
                 "file-loader": "^6.2.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@mdx-js/loader": "^1.6.22",
     "@next/mdx": "^11.0.1",
-    "codesandbox": "^2.2.1",
+    "codesandbox": "^2.2.3",
     "concurrently": "^5.3.0",
     "eslint-config-next": "^12.1.0",
     "file-loader": "^6.2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
         "@sentry/browser": "^5.4.0",
         "@redhat-cloud-services/types": "0.0.1",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.21.4",
+        "axios": "^0.25.0",
         "commander": ">=2.20.0",
         "mkdirp": "^1.0.4",
         "react-content-loader": ">=3.4.1"


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-18052

Unable to fix the CVE for the docs package. That `follow-redirects` comes from the codesandbox dependency and there is no update with the CVE fixed just yet.