### PR TITLE
fix: Accept html props

### DIFF
--- a/packages/components/src/Ansible/Ansible.tsx
+++ b/packages/components/src/Ansible/Ansible.tsx
@@ -4,12 +4,11 @@ import classNames from 'classnames';
 
 import './ansible.scss';
 
-export interface AnsibleProps {
+export interface AnsibleProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
   /**
    * Description that will generate MD docs file
    */
   unsupported?: boolean | number;
-  className?: string;
 }
 
 /**

--- a/packages/components/src/AsyncComponent/index.tsx
+++ b/packages/components/src/AsyncComponent/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 export type ExcludeModulesKeys = 'appName' | 'module' | 'scope';
 
-export interface AsyncComponentProps {
+export interface AsyncComponentProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
   /** Name of the app from which module will be loaded. */
   appName: string;
   /** Loaded module, it has to start with `./`. */
@@ -14,8 +14,6 @@ export interface AsyncComponentProps {
   scope?: string;
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: React.ReactNode;
-  /** Optional classname applied to wrapper component */
-  className: string;
   /** Optional wrapper component */
   component: keyof JSX.IntrinsicElements;
   /** Other props passed to the AsyncComponent */

--- a/packages/components/src/Battery/Battery.tsx
+++ b/packages/components/src/Battery/Battery.tsx
@@ -12,7 +12,7 @@ import './battery.scss';
  */
 export type BatterySeverity = 1 | 2 | 3 | 4 | 'info' | 'low' | 'warn' | 'medium' | 'error' | 'high' | 'critical';
 
-export interface BatteryProps {
+export interface BatteryProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
   severity: BatterySeverity;
   label: string;
   labelHidden?: boolean;

--- a/packages/components/src/Section/Section.tsx
+++ b/packages/components/src/Section/Section.tsx
@@ -3,9 +3,8 @@ import classNames from 'classnames';
 
 import './section.scss';
 
-export interface SectionProps {
+export interface SectionProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
   type?: string;
-  className?: string;
 }
 
 const Section: React.FunctionComponent<SectionProps> = ({ type, children, className, ...props }) => {


### PR DESCRIPTION
Unsure if this is the desired behavior. Only updated some components.

Before, with js, these component accepted any excess props and happily passed to an HTMLElement.
When migrating to typescript this got limited to only `className` and e.g. `style` is not forbidden. 

Updating the props types to extend from `React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>` to accept these props again.