### PR TITLE
Fix standalone entitlements 404, add error handling

### DIFF
--- a/packages/config-utils/standalone/services/default/entitlements.js
+++ b/packages/config-utils/standalone/services/default/entitlements.js
@@ -20,6 +20,7 @@ module.exports = ({ env }) => ({
     },
     register({ app, config }) {
       app.get('/api/entitlements/v1/services', (_req, res) => {
+        try {
           const configPath = path.join(config.entitlements.assets['entitlements-config'], '/configs/stage/bundles.yml');
           // Use { json: true } in case of duplicate keys
           const outerYaml = yaml.load(fs.readFileSync(configPath, 'utf8'), { json: true });
@@ -31,6 +32,9 @@ module.exports = ({ env }) => ({
               return acc;
           }, {});
           res.json(entitlements);
+        } catch (error) {
+          res.status(500).json({ error });
+        }
       });
     }
 });

--- a/packages/config-utils/standalone/services/default/entitlements.js
+++ b/packages/config-utils/standalone/services/default/entitlements.js
@@ -20,9 +20,10 @@ module.exports = ({ env }) => ({
     },
     register({ app, config }) {
       app.get('/api/entitlements/v1/services', (_req, res) => {
-          const configPath = path.join(config.entitlements.assets['entitlements-config'], '/configs/bundles.yml');
+          const configPath = path.join(config.entitlements.assets['entitlements-config'], '/configs/stage/bundles.yml');
           // Use { json: true } in case of duplicate keys
-          const serviceSKUs = yaml.load(fs.readFileSync(configPath, 'utf8'), { json: true });
+          const outerYaml = yaml.load(fs.readFileSync(configPath, 'utf8'), { json: true });
+          const serviceSKUs = yaml.load(outerYaml.objects[0].data['bundles.yml'], { json: true });
           const services = serviceSKUs.map(serviceSKU => serviceSKU.name);
           // Grant access to all services
           const entitlements = services.reduce((acc, cur) => {

--- a/packages/config-utils/standalone/services/default/entitlements.js
+++ b/packages/config-utils/standalone/services/default/entitlements.js
@@ -19,22 +19,25 @@ module.exports = ({ env }) => ({
         'entitlements-config': `https://github.com/redhatinsights/entitlements-config#${getEntitlementsBranch(env)}`
     },
     register({ app, config }) {
-      app.get('/api/entitlements/v1/services', (_req, res) => {
-        try {
-          const configPath = path.join(config.entitlements.assets['entitlements-config'], '/configs/stage/bundles.yml');
-          // Use { json: true } in case of duplicate keys
-          const outerYaml = yaml.load(fs.readFileSync(configPath, 'utf8'), { json: true });
-          const serviceSKUs = yaml.load(outerYaml.objects[0].data['bundles.yml'], { json: true });
-          const services = serviceSKUs.map(serviceSKU => serviceSKU.name);
-          // Grant access to all services
-          const entitlements = services.reduce((acc, cur) => {
-              acc[cur] = { is_entitled: true, is_trial: false };
-              return acc;
-          }, {});
-          res.json(entitlements);
-        } catch (error) {
-          res.status(500).json({ error });
-        }
-      });
-    }
+        app.get('/api/entitlements/v1/services', (_req, res) => {
+            try {
+                const configPath = path.join(config.entitlements.assets['entitlements-config'], '/configs/stage/bundles.yml');
+
+                // Use { json: true } in case of duplicate keys
+                const outerYaml = yaml.load(fs.readFileSync(configPath, 'utf8'), { json: true });
+                const serviceSKUs = yaml.load(outerYaml.objects[0].data['bundles.yml'], { json: true });
+
+                const services = serviceSKUs.map(serviceSKU => serviceSKU.name);
+                // Grant access to all services
+                const entitlements = services.reduce((acc, cur) => {
+                    acc[cur] = { is_entitled: true, is_trial: false };
+                    return acc;
+                }, {});
+
+                res.json(entitlements);
+            } catch (error) {
+                res.status(500).json({ error });
+            }
+        });
+    },
 });


### PR DESCRIPTION
`config/bundles.yml` was removed in RedHatInsights/entitlements-config#51 ,
leading to a 404 on the `/api/entitlements/v1/services` local endpoint (caused by `fs.readFileSync` throwing),
when running in standalone mode.

Changing to use `configs/stage/bundles.yml` (`prod` also being an option),
except the original yaml data is hidden as a yaml string field inside `objects[0].data['bundles.yml']` in that file.

Also, if the handler throws, webpack acts as if the endpoint didn't exist, returning a 404, making debugging harder,
so this makes the error more explicit by returning a 500 with an actuall error json.

(And fixing indent to use 4 spaces consistently, I hope that's right here :).)
