### PR TITLE
Bounce PROD requests when not using Red Hat VPN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32816,7 +32816,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.6.5",
+            "version": "4.6.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
@@ -32864,8 +32864,49 @@
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
             "version": "1.5.17",
             "license": "Apache-2.0",
+            "dependencies": {
+                "node-fetch": "2.6.7"
+            },
             "peerDependencies": {
                 "webpack": "^5.0.0"
+            }
+        },
+        "packages/config-utils/node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/config-utils/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "packages/config-utils/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "packages/config-utils/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "packages/config/node_modules/ansi-regex": {
@@ -39602,7 +39643,38 @@
         },
         "@redhat-cloud-services/frontend-components-config-utilities": {
             "version": "file:packages/config-utils",
-            "requires": {}
+            "requires": {
+                "node-fetch": "2.6.7"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.7",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+                    "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+                    "requires": {
+                        "whatwg-url": "^5.0.0"
+                    }
+                },
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
+            }
         },
         "@redhat-cloud-services/frontend-components-demo": {
             "version": "file:packages/demo",

--- a/packages/config-utils/package.json
+++ b/packages/config-utils/package.json
@@ -18,5 +18,8 @@
     "homepage": "https://github.com/RedHatInsights/frontend-components#readme",
     "peerDependencies": {
         "webpack": "^5.0.0"
+    },
+    "dependencies": {
+        "node-fetch": "2.6.7"
     }
 }

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -53,8 +53,8 @@ module.exports = ({
 
   let agent;
 
-  if (env.startsWith('prod') || env.startsWith('stage')) {
-    // PROD and stage are deployed with Akamai which requires a corporate proxy
+  if (env.startsWith('stage')) {
+    // stage is deployed with Akamai which requires a corporate proxy
     agent = new HttpsProxyAgent(proxyURL);
   }
 

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -36,8 +36,8 @@ module.exports = ({
   registry = [],
   isChrome = false,
   onBeforeSetupMiddleware = () => {},
-  bounceProd = true,
-  useAgent,
+  bounceProd = false,
+  useAgent = true,
 }) => {
   const proxy = [];
   const majorEnv = env.split('-')[0];
@@ -58,13 +58,14 @@ module.exports = ({
   let agent;
 
   const isProd = env.startsWith('prod');
+  const isStage = env.startsWith('stage');
 
-  if (env.startsWith('stage') || useAgent) {
+  if (isStage || (isProd && useAgent)) {
     // stage is deployed with Akamai which requires a corporate proxy
     agent = new HttpsProxyAgent(proxyURL);
   }
 
-  if (env.startsWith('stage')) {
+  if (isStage) {
     // stage-stable / stage-beta branches don't exist in build repos
     // Currently stage pulls from QA
     env = env.replace('stage', 'qa');

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -36,6 +36,8 @@ module.exports = ({
   registry = [],
   isChrome = false,
   onBeforeSetupMiddleware = () => {},
+  bounceProd = true,
+  useAgent,
 }) => {
   const proxy = [];
   const majorEnv = env.split('-')[0];
@@ -57,7 +59,7 @@ module.exports = ({
 
   const isProd = env.startsWith('prod');
 
-  if (env.startsWith('stage')) {
+  if (env.startsWith('stage') || useAgent) {
     // stage is deployed with Akamai which requires a corporate proxy
     agent = new HttpsProxyAgent(proxyURL);
   }
@@ -202,7 +204,7 @@ module.exports = ({
          * Use node-fetch to proxy all non-GET requests (this avoids all origin/host akamai policy)
          * This enables using PROD proxy without VPN and agent
          */
-        if (isProd && req.method !== 'GET') {
+        if (isProd && bounceProd && !useAgent && req.method !== 'GET') {
           const result = await fetch((target + req.url).replace(/\/\//g, '/'), {
             method: req.method,
             body: JSON.stringify(req.body),

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -7,22 +7,35 @@
     - [Removed features with webpack 5](#removed-features-with-webpack-5)
   - [useProxy](#useproxy)
     - [Attributes](#attributes)
-      - [useChromeTemplate](#useChromeTemplate)
+      - [useChromeTemplate](#usechrometemplate)
       - [localChrome](#localchrome)
-      - [registry](#registry)
+      - [keycloakUri](#keycloakuri)
+      - [Registry](#registry)
       - [Custom routes](#custom-routes)
         - [routes](#routes)
         - [routesPath](#routespath)
-    - [Custom proxy settings](#custom-proxy-settings)
+      - [Custom proxy settings](#custom-proxy-settings)
+      - [Env](#env)
+      - [Use cloud](#use-cloud)
+      - [Target](#target)
+      - [useAgent](#useagent)
+      - [bounceProd](#bounceprod)
   - [standalone](#standalone)
     - [Usage](#usage)
       - [Simple](#simple)
       - [Advanced](#advanced)
-        - [Using provided services](#Using-provided-services)
-        - [Writing services](#Writing-services)
-        - [Customizing default services](#Customizing-default-services)
-  - [fec node scripts](#fec-node-scripts)
-  - [include PF css modules in your bundle](#include-PF-css-modules-in-your-bundle)
+        - [Using provided services](#using-provided-services)
+        - [Writing services](#writing-services)
+        - [Customizing default services](#customizing-default-services)
+- [fec node scripts](#fec-node-scripts)
+  - [Usage](#usage-1)
+  - [Patch etc hosts](#patch-etc-hosts)
+  - [Static](#static)
+    - [Inventory example](#inventory-example)
+    - [In inventory UI repository changes](#in-inventory-ui-repository-changes)
+    - [Compliance frontend setup](#compliance-frontend-setup)
+    - [Run servers](#run-servers)
+- [include PF css modules in your bundle](#include-pf-css-modules-in-your-bundle)
 
 ## Webpack 5
 
@@ -65,6 +78,8 @@ const { config: webpackConfig, plugins } = config({
 |[env](#env)|`string`|Environment to proxy against such as ci-beta.|
 |[useCloud](#use-cloud)|`boolean`|Toggle to use old fallback to cloud.redhat.com paths instead of console.redhat.com.|
 |[target](#target)|`string`|Override `env` and `useCloud` to use a custom URI.|
+|[useAgent](#useAgent)|`boolean`|Enforce using the agent to proxy requests via `proxyUrl`.|
+|[bounceProd](#bounceProd)|`boolean` = `true`|Bounce all non-GET requests via server requests.|
 
 
 #### useChromeTemplate
@@ -206,6 +221,18 @@ If you want to run in legacy mode pass `useCloud: true` in your config, this way
 
 #### Target
 Override for the target `env` and `useCloud` build. Useful for cross-environment testing.
+
+#### useAgent
+
+`boolean`
+
+Enforces using the agent to proxy requests via `proxyUrl`. Setting this to `true` will enforce using agent for PROD environemnt too (use when you are using Red Hat VPN and you do not want to bounce PROD requests). STAGE is using the agent automatically and it cannot be turned off.
+
+#### bounceProd
+
+`boolean` = `true`
+
+Bounce all non-GET PROD requests via server. This option removes all headers except `cookie` and `body` so Akamai won't have issues with different origins/hosts. This behavior allows to access PROD environment without using Red Hat VPN.
 
 ## standalone
 A way to run cloud.redhat.com apps from `localhost` offline.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -20,6 +20,7 @@
       - [Target](#target)
       - [useAgent](#useagent)
       - [bounceProd](#bounceprod)
+        - [Running PROD proxy without VPN](#running-prod-proxy-without-vpn)
   - [standalone](#standalone)
     - [Usage](#usage)
       - [Simple](#simple)
@@ -78,8 +79,8 @@ const { config: webpackConfig, plugins } = config({
 |[env](#env)|`string`|Environment to proxy against such as ci-beta.|
 |[useCloud](#use-cloud)|`boolean`|Toggle to use old fallback to cloud.redhat.com paths instead of console.redhat.com.|
 |[target](#target)|`string`|Override `env` and `useCloud` to use a custom URI.|
-|[useAgent](#useAgent)|`boolean`|Enforce using the agent to proxy requests via `proxyUrl`.|
-|[bounceProd](#bounceProd)|`boolean` = `true`|Bounce all non-GET requests via server requests.|
+|[useAgent](#useAgent)|`boolean` = `true`|Enforce using the agent to proxy requests via `proxyUrl`.|
+|[bounceProd](#bounceProd)|`boolean` = `false`|Bounce all non-GET requests via server requests.|
 
 
 #### useChromeTemplate
@@ -224,15 +225,30 @@ Override for the target `env` and `useCloud` build. Useful for cross-environment
 
 #### useAgent
 
-`boolean`
+`boolean` = `true`
 
 Enforces using the agent to proxy requests via `proxyUrl`. Setting this to `true` will enforce using agent for PROD environemnt too (use when you are using Red Hat VPN and you do not want to bounce PROD requests). STAGE is using the agent automatically and it cannot be turned off.
 
 #### bounceProd
 
-`boolean` = `true`
+`boolean` = `false`
 
 Bounce all non-GET PROD requests via server. This option removes all headers except `cookie` and `body` so Akamai won't have issues with different origins/hosts. This behavior allows to access PROD environment without using Red Hat VPN.
+
+##### Running PROD proxy without VPN
+
+Set following attributes in your dev webpack proxy:
+
+```jsx
+const config = {
+  ...options,
+  env: 'prod-stable', // or 'prod-beta'
+  useAgent: false,
+  bounceProd: true
+}
+```
+
+Now, you can access PROD env without being connected to Red Hat VPN.
 
 ## standalone
 A way to run cloud.redhat.com apps from `localhost` offline.

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -36,6 +36,8 @@ module.exports = ({
   client = {},
   bundlePfModules = false,
   useChromeTemplate = false,
+  bounceProd,
+  useAgent,
 } = {}) => {
   const filenameMask = `js/[name]${useFileHash ? `.${Date.now()}.[fullhash]` : ''}.js`;
   if (betaEnv) {
@@ -197,6 +199,8 @@ module.exports = ({
             copyTemplate(chromePath);
           }
         },
+        bounceProd,
+        useAgent,
       }),
     },
   };


### PR DESCRIPTION
- [x] todo: `npm install node-fetch@2`

All non-GET PROD requests are bounced on server to target, so Akamai won't be messed up because of different headers

@Hyperkid123 releasing as a minor version because it adds a new behavior