### PR TITLE
Fix middleware listener array conversion.

### DIFF
--- a/packages/utils/src/MiddlewareListener/MiddlewareListener.js
+++ b/packages/utils/src/MiddlewareListener/MiddlewareListener.js
@@ -26,7 +26,7 @@ export class MiddlewareListener {
   callOnAction(action, data) {
     let stopBubble = false;
     const preventBubble = () => (stopBubble = true);
-    const listeners = [...this.listeners];
+    const listeners = Array.from(this.listeners);
     for (let i = 0; i < listeners.length; i++) {
       listeners[i].on === action && listeners[i].hasOwnProperty('callback') && listeners[i].callback({ data, preventBubble });
     }


### PR DESCRIPTION
For some reason, the array spread has stopped working and borked our `chrome.on` events.

Using `Array.from` should fix the issue