### PR TITLE
Add has all permissions check function

### DIFF
--- a/packages/utils/src/RBAC/RBAC.test.js
+++ b/packages/utils/src/RBAC/RBAC.test.js
@@ -1,4 +1,4 @@
-import { getRBAC, doesHavePermissions } from './RBAC';
+import { getRBAC, doesHavePermissions, hasAllPermissions } from './RBAC';
 
 describe('RBAC utilities', () => {
   describe('does have permissions', () => {
@@ -16,6 +16,31 @@ describe('RBAC utilities', () => {
     });
     it('return true for permission object', () => {
       expect(doesHavePermissions([{ permission: 'cost-management:rate:write' }, 'cost-management:cluster:write'], requiredPermissions)).toBe(true);
+    });
+  });
+  describe('has all permissions', () => {
+    const requiredPermissions = ['cost-management:rate:write', 'some-app:*:*'];
+    it('returns false permissions is null or undefined', () => {
+      expect(hasAllPermissions(null, requiredPermissions)).toBe(false);
+      expect(hasAllPermissions(undefined, requiredPermissions)).toBe(false);
+    });
+    it('returns false if permissions do not exist', () => {
+      expect(hasAllPermissions([], requiredPermissions)).toBe(false);
+      expect(hasAllPermissions(['cost-management:rate:read', 'cost-management:cluster:write'], requiredPermissions)).toBe(false);
+    });
+    it('returns true for all permissions', () => {
+      expect(hasAllPermissions(['cost-management:rate:write', 'some-app:*:*'], requiredPermissions)).toBe(true);
+    });
+    it('return true for permission object', () => {
+      expect(doesHavePermissions([{ permission: 'cost-management:rate:write' }, { permission: 'some-app:*:*' }], requiredPermissions)).toBe(true);
+    });
+    it('returns true for star permissions', () => {
+      expect(
+        hasAllPermissions(['cost-management:rate:*', 'cost-management:*:write', '*:*:*', '*:*:write', 'some-app:*:*'], requiredPermissions)
+      ).toBe(true);
+    });
+    it('returns false for missing permissions', () => {
+      expect(hasAllPermissions(['cost-management:*:read', 'some-app:*:*'], requiredPermissions)).toBe(false);
     });
   });
   describe('ger RBAC', () => {

--- a/packages/utils/src/RBAC/RBAC.ts
+++ b/packages/utils/src/RBAC/RBAC.ts
@@ -38,4 +38,26 @@ export function doesHavePermissions(userPermissions: (Access | string)[], permis
   });
 }
 
+export function hasAllPermissions(userPermissions: (Access | string)[], permissionList: string[]): boolean {
+  if (!userPermissions) {
+    return false;
+  }
+
+  return permissionList.every((permission) => {
+    return userPermissions.some((access) => {
+      const accessArray = (isAccessType(access) ? access?.permission : access)?.split(':') || [];
+      const permissionArray = permission.split(':');
+      const hasAccess = accessArray.slice(0).reduce((acc, curr, index, array) => {
+        if (acc === false) {
+          array.splice(index);
+          return acc;
+        }
+
+        return curr === '*' || curr === permissionArray?.[index];
+      }, true);
+      return hasAccess || accessArray.join(':') === permission;
+    });
+  });
+}
+
 export default getRBAC;

--- a/packages/utils/src/RBACHook/RBACHook.ts
+++ b/packages/utils/src/RBACHook/RBACHook.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
-import { getRBAC, doesHavePermissions, RBAC } from '../RBAC';
+import { getRBAC, doesHavePermissions, RBAC, hasAllPermissions } from '../RBAC';
 
 export interface UsePermissionsState extends RBAC {
   hasAccess: boolean;
   isLoading: boolean;
 }
 
-export function usePermissions(appName: string, permissionsList: string[], disableCache?: boolean): UsePermissionsState {
+export function usePermissions(appName: string, permissionsList: string[], disableCache?: boolean, checkAll?: boolean): UsePermissionsState {
   const [permissions, setPermissions] = useState<UsePermissionsState>({
     isLoading: true,
     hasAccess: false,
@@ -21,7 +21,7 @@ export function usePermissions(appName: string, permissionsList: string[], disab
         isLoading: false,
         isOrgAdmin,
         permissions: userPermissions,
-        hasAccess: doesHavePermissions(userPermissions, permissionsList),
+        hasAccess: checkAll ? hasAllPermissions(userPermissions, permissionsList) : doesHavePermissions(userPermissions, permissionsList),
       });
     })();
   }, [appName, disableCache]);


### PR DESCRIPTION
### Has all permissions

Some apps are requesting to check for every existing permission. This PR adds function `hasAllPermissions` which checks each given permission to be present on user's permission list. Also add star checks, so if user has for instance `some-app:resource:*` and app wants to check for `some-app:resource:read` return true since user has all actions for this resource on said app.