### PR TITLE
Advisor components: fix the issue with rendering of view affected button

### DIFF
--- a/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
+++ b/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
@@ -13,12 +13,12 @@ interface ViewAffectedLinkProps {
 const ViewAffectedLink: React.FC<ViewAffectedLinkProps> = ({ messages, product, rule, linkComponent: Link }) => (
   <React.Fragment>
     {product === AdvisorProduct.ocp
-      ? (rule as RuleContentOcp).impacted_clusters_count > 0 ?? (
+      ? (rule as RuleContentOcp).impacted_clusters_count > 0 && (
           <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedClusters}
           </Link>
         )
-      : (rule as RuleContentRhel).impacted_systems_count > 0 ?? (
+      : (rule as RuleContentRhel).impacted_systems_count > 0 && (
           <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedSystems}
           </Link>


### PR DESCRIPTION
Replaces nullish coalescing operator with the AND operator (&&) and fixes the issue when rule content had impacted_clusters_count or impacted_systems_count defined, however, the button "View affected {clusters|systems}" was rendered.

Improves #1493