### PR TITLE
Fix docs deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/nodejs-16
 USER root
 WORKDIR /docs
-COPY . .
+COPY ./packages /docs/packages
+COPY ./tsconfig.json /docs/tsconfig.json
 WORKDIR /docs/packages/docs
 RUN npm i
-RUN npx next telemetry disable
 RUN npm run build
 
 EXPOSE 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -3884,7 +3884,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.1.tgz",
             "integrity": "sha512-SXC18cChut3F2zkVXwsb2no0fzTQ1z6swjK13XwFbF5QU/SFQM0orAItPypSdL3GvqYyzVJtz8UofzJhPEQtMw==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/mdx": "^2.0.0",
@@ -3912,8 +3911,7 @@
         "node_modules/@mdx-js/mdx/node_modules/estree-walker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-            "dev": true
+            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
         },
         "node_modules/@mdx-js/react": {
             "version": "2.1.1",
@@ -5250,7 +5248,6 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
             "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
-            "dev": true,
             "dependencies": {
                 "@types/estree": "*"
             }
@@ -5386,7 +5383,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-0.0.1.tgz",
             "integrity": "sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==",
-            "dev": true,
             "dependencies": {
                 "@types/estree": "*"
             }
@@ -7193,7 +7189,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.1.tgz",
             "integrity": "sha512-Aj3mbwVzj7Vve4I/v2JYOPFkCGM2YS7OqQTNSxmUR+LECRpokuPgAYghePgr6SALDo5bD5DlfbSaYjOzGJZOLQ==",
-            "dev": true,
             "bin": {
                 "astring": "bin/astring"
             }
@@ -8524,7 +8519,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8640,7 +8634,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
             "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8650,7 +8643,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8660,7 +8652,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
             "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -13686,7 +13677,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-2.0.0.tgz",
             "integrity": "sha512-kT9YVRvlt2ewPp9BazfIIgXMGsXOEpOm57bK8aa4F3eOEndMml2JAETjWaG3SZYHmC6axSNIzHGY718dYwIuVg==",
-            "dev": true,
             "dependencies": {
                 "@types/estree": "^0.0.46"
             },
@@ -13698,14 +13688,12 @@
         "node_modules/estree-util-attach-comments/node_modules/@types/estree": {
             "version": "0.0.46",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-            "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
-            "dev": true
+            "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
         },
         "node_modules/estree-util-build-jsx": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-2.0.0.tgz",
             "integrity": "sha512-d49hPGqBCJF/bF06g1Ywg7zjH1mrrUdPPrixBlKBxcX4WvMYlUUJ8BkrwlzWc8/fm6XqGgk5jilhgeZBDEGwOQ==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "estree-util-is-identifier-name": "^2.0.0",
@@ -13719,14 +13707,12 @@
         "node_modules/estree-util-build-jsx/node_modules/estree-walker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-            "dev": true
+            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
         },
         "node_modules/estree-util-is-identifier-name": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.0.tgz",
             "integrity": "sha512-aXXZFVMnBBDRP81vS4YtAYJ0hUkgEsXea7lNKWCOeaAquGb1Jm2rcONPB5fpzwgbNxulTvrWuKnp9UElUGAKeQ==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -13736,7 +13722,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.1.0.tgz",
             "integrity": "sha512-3lXJ4Us9j8TUif9cWcQy81t9p5OLasnDuuhrFiqb+XstmKC1d1LmrQWYsY49/9URcfHE64mPypDBaNK9NwWDPQ==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/unist": "^2.0.0"
@@ -15896,7 +15881,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-2.0.2.tgz",
             "integrity": "sha512-UQrZVeBj6A9od0lpFvqHKNSH9zvDrNoyWKbveu1a2oSCXEDUI+3bnd6BoiQLPnLrcXXn/jzJ6y9hmJTTlvf8lQ==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -16676,7 +16660,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
             "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -16686,7 +16669,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
             "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-            "dev": true,
             "dependencies": {
                 "is-alphabetical": "^2.0.0",
                 "is-decimal": "^2.0.0"
@@ -16845,7 +16827,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
             "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -16959,7 +16940,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
             "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -19347,7 +19327,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
             "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==",
-            "dev": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -19538,7 +19517,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
             "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -19752,7 +19730,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.0.tgz",
             "integrity": "sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==",
-            "dev": true,
             "dependencies": {
                 "mdast-util-mdx-expression": "^1.0.0",
                 "mdast-util-mdx-jsx": "^2.0.0",
@@ -19767,7 +19744,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.2.0.tgz",
             "integrity": "sha512-wb36oi09XxqO9RVqgfD+xo8a7xaNgS+01+k3v0GKW0X0bYbeBmUZz22Z/IJ8SuphVlG+DNgNo9VoEaUJ3PKfJQ==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -19784,7 +19760,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.0.1.tgz",
             "integrity": "sha512-oPC7/smPBf7vxnvIYH5y3fPo2lw1rdrswFfSb4i0GTAXRUQv7JUU/t/hbp07dgGdUFTSDOHm5DNamhNg/s2Hrg==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -19806,7 +19781,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.2.0.tgz",
             "integrity": "sha512-IPpX9GBzAIbIRCjbyeLDpMhACFb0wxTIujuR3YElB8LWbducUdMgRJuqs/Vg8xQ1bIAMm7lw8L+YNtua0xKXRw==",
-            "dev": true,
             "dependencies": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -19823,7 +19797,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
             "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
-            "dev": true,
             "dependencies": {
                 "@types/mdast": "^3.0.0",
                 "@types/unist": "^2.0.0",
@@ -20198,7 +20171,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
             "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -20223,7 +20195,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz",
             "integrity": "sha512-VfA369RdqUISF0qGgv2FfV7gGjHDfn9+Qfiv5hEwpyr1xscRj/CiVRkU7rywGFCO7JwJ5L0e7CJz60lY52+qOA==",
-            "dev": true,
             "dependencies": {
                 "@types/acorn": "^4.0.0",
                 "estree-util-is-identifier-name": "^2.0.0",
@@ -20244,7 +20215,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.0.tgz",
             "integrity": "sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==",
-            "dev": true,
             "dependencies": {
                 "micromark-util-types": "^1.0.0"
             },
@@ -20257,7 +20227,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.0.tgz",
             "integrity": "sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==",
-            "dev": true,
             "dependencies": {
                 "acorn": "^8.0.0",
                 "acorn-jsx": "^5.0.0",
@@ -20277,7 +20246,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.2.tgz",
             "integrity": "sha512-bIaxblNIM+CCaJvp3L/V+168l79iuNmxEiTU6i3vB0YuDW+rumV64BFMxvhfRDxaJxQE1zD5vTPdyLBbW4efGA==",
-            "dev": true,
             "dependencies": {
                 "micromark-core-commonmark": "^1.0.0",
                 "micromark-util-character": "^1.0.0",
@@ -20297,7 +20265,6 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -20350,7 +20317,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.6.tgz",
             "integrity": "sha512-WRQIc78FV7KrCfjsEf/sETopbYjElh3xAmNpLkd1ODPqxEngP42eVRGbiPEQWpRV27LzqW+XVTvQAMIIRLPnNA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -20568,7 +20534,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.6.tgz",
             "integrity": "sha512-+kUMe2kNGy4mljNVt+YmFfwomSIVqX3NI6ePrk6SIl/0GaR53a6eUIGmhV5DDUkbLPPNWgVFCS6ExOqb0WFgHQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -20592,8 +20557,7 @@
         "node_modules/micromark-util-events-to-acorn/node_modules/@types/estree": {
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "dev": true
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "node_modules/micromark-util-html-tag-name": {
             "version": "1.0.0",
@@ -22771,7 +22735,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
             "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
-            "dev": true,
             "dependencies": {
                 "@types/unist": "^2.0.0",
                 "character-entities": "^2.0.0",
@@ -22968,7 +22931,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
             "integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
-            "dev": true,
             "dependencies": {
                 "estree-walker": "^3.0.0",
                 "is-reference": "^3.0.0"
@@ -22977,14 +22939,12 @@
         "node_modules/periscopic/node_modules/estree-walker": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-            "dev": true
+            "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
         },
         "node_modules/periscopic/node_modules/is-reference": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
             "integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
-            "dev": true,
             "dependencies": {
                 "@types/estree": "*"
             }
@@ -27133,7 +27093,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.1.1.tgz",
             "integrity": "sha512-0wXdEITnFyjLquN3VvACNLzbGzWM5ujzTvfgOkONBZgSFJ7ezLLDaTWqf6H9eUgVITEP8asp6LJ0W/X090dXBg==",
-            "dev": true,
             "dependencies": {
                 "mdast-util-mdx": "^2.0.0",
                 "micromark-extension-mdxjs": "^1.0.0"
@@ -29466,7 +29425,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.2.tgz",
             "integrity": "sha512-MTxTVcEkorNtBbNpoFJPEh0kKdM6+QbMjLbaxmvaPMmayOXdr/AIVIIJX7FReUVweRBFJfZepK4A4AKgwuFpMQ==",
-            "dev": true,
             "dependencies": {
                 "character-entities-html4": "^2.0.0",
                 "character-entities-legacy": "^3.0.0"
@@ -29556,25 +29514,6 @@
             "license": "MIT",
             "dependencies": {
                 "inline-style-parser": "0.1.1"
-            }
-        },
-        "node_modules/styled-jsx": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
-            "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "peerDependencies": {
-                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
-            },
-            "peerDependenciesMeta": {
-                "@babel/core": {
-                    "optional": true
-                },
-                "babel-plugin-macros": {
-                    "optional": true
-                }
             }
         },
         "node_modules/stylehacks": {
@@ -31178,7 +31117,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.1.tgz",
             "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
-            "dev": true,
             "dependencies": {
                 "@types/unist": "^2.0.0"
             },
@@ -31191,7 +31129,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
             "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
-            "dev": true,
             "dependencies": {
                 "@types/unist": "^2.0.0",
                 "unist-util-visit": "^4.0.0"
@@ -33419,7 +33356,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.8.8",
+            "version": "3.8.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -33435,7 +33372,7 @@
             },
             "peerDependencies": {
                 "@patternfly/react-core": ">=4.18.5",
-                "@patternfly/react-icons": "4.53.16",
+                "@patternfly/react-icons": ">=4.53.16",
                 "@patternfly/react-table": ">=4.5.7",
                 "classnames": ">=2.2.5",
                 "lodash": ">=4.17.15",
@@ -33478,7 +33415,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.6.7",
+            "version": "4.6.11",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
@@ -34509,6 +34446,7 @@
         "packages/docs": {
             "version": "0.1.0",
             "dependencies": {
+                "@mdx-js/mdx": "^2.1.1",
                 "@mdx-js/react": "^2.1.1",
                 "@patternfly/react-core": "4.192.0",
                 "@patternfly/react-icons": "^4.53.16",
@@ -34528,6 +34466,7 @@
             "devDependencies": {
                 "@babel/preset-typescript": "^7.16.7",
                 "@mdx-js/loader": "^2.1.1",
+                "@next/env": "^12.1.5",
                 "@next/mdx": "^12.1.5",
                 "chokidar": "^3.5.3",
                 "codesandbox": "^2.2.3",
@@ -34541,6 +34480,7 @@
                 "raw-loader": "^4.0.2",
                 "react-docgen": "^5.3.1",
                 "remark-gfm": "^3.0.1",
+                "styled-jsx": "^5.0.2",
                 "typedoc": "^0.22.10",
                 "typescript": "^4.6.2",
                 "url-loader": "^4.1.1"
@@ -34647,6 +34587,25 @@
                 }
             }
         },
+        "packages/docs/node_modules/next/node_modules/styled-jsx": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
+            "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
         "packages/docs/node_modules/postcss": {
             "version": "8.4.5",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
@@ -34704,6 +34663,26 @@
             "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "packages/docs/node_modules/styled-jsx": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+            "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "babel-plugin-macros": {
+                    "optional": true
+                }
             }
         },
         "packages/docs/node_modules/typescript": {
@@ -38511,7 +38490,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-2.1.1.tgz",
             "integrity": "sha512-SXC18cChut3F2zkVXwsb2no0fzTQ1z6swjK13XwFbF5QU/SFQM0orAItPypSdL3GvqYyzVJtz8UofzJhPEQtMw==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/mdx": "^2.0.0",
@@ -38535,8 +38513,7 @@
                 "estree-walker": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-                    "dev": true
+                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
                 }
             }
         },
@@ -40800,7 +40777,6 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
             "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
-            "dev": true,
             "requires": {
                 "@types/estree": "*"
             }
@@ -40927,7 +40903,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-0.0.1.tgz",
             "integrity": "sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==",
-            "dev": true,
             "requires": {
                 "@types/estree": "*"
             }
@@ -42294,8 +42269,7 @@
         "astring": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.1.tgz",
-            "integrity": "sha512-Aj3mbwVzj7Vve4I/v2JYOPFkCGM2YS7OqQTNSxmUR+LECRpokuPgAYghePgr6SALDo5bD5DlfbSaYjOzGJZOLQ==",
-            "dev": true
+            "integrity": "sha512-Aj3mbwVzj7Vve4I/v2JYOPFkCGM2YS7OqQTNSxmUR+LECRpokuPgAYghePgr6SALDo5bD5DlfbSaYjOzGJZOLQ=="
         },
         "async": {
             "version": "2.6.4",
@@ -43223,8 +43197,7 @@
         "ccount": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-            "dev": true
+            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
         },
         "chalk": {
             "version": "4.1.2",
@@ -43307,20 +43280,17 @@
         "character-entities-html4": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-            "dev": true
+            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
         },
         "character-entities-legacy": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-            "dev": true
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
         },
         "character-reference-invalid": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-            "dev": true
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
         },
         "chardet": {
             "version": "0.7.0"
@@ -46152,7 +46122,9 @@
             "requires": {
                 "@babel/preset-typescript": "^7.16.7",
                 "@mdx-js/loader": "^2.1.1",
+                "@mdx-js/mdx": "^2.1.1",
                 "@mdx-js/react": "^2.1.1",
+                "@next/env": "^12.1.5",
                 "@next/mdx": "^12.1.5",
                 "@patternfly/react-core": "4.192.0",
                 "@patternfly/react-icons": "^4.53.16",
@@ -46180,6 +46152,7 @@
                 "react-router-dom": "^5.2.0",
                 "redux": "^4.0.5",
                 "remark-gfm": "^3.0.1",
+                "styled-jsx": "^5.0.2",
                 "typedoc": "^0.22.10",
                 "typescript": "^4.6.2",
                 "url-loader": "^4.1.1"
@@ -46239,6 +46212,14 @@
                         "caniuse-lite": "^1.0.30001283",
                         "postcss": "8.4.5",
                         "styled-jsx": "5.0.1"
+                    },
+                    "dependencies": {
+                        "styled-jsx": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
+                            "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
+                            "requires": {}
+                        }
                     }
                 },
                 "postcss": {
@@ -46283,6 +46264,13 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
                     "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+                },
+                "styled-jsx": {
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
+                    "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
+                    "dev": true,
+                    "requires": {}
                 },
                 "typescript": {
                     "version": "4.6.2",
@@ -47171,7 +47159,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-2.0.0.tgz",
             "integrity": "sha512-kT9YVRvlt2ewPp9BazfIIgXMGsXOEpOm57bK8aa4F3eOEndMml2JAETjWaG3SZYHmC6axSNIzHGY718dYwIuVg==",
-            "dev": true,
             "requires": {
                 "@types/estree": "^0.0.46"
             },
@@ -47179,8 +47166,7 @@
                 "@types/estree": {
                     "version": "0.0.46",
                     "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-                    "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
-                    "dev": true
+                    "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
                 }
             }
         },
@@ -47188,7 +47174,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-2.0.0.tgz",
             "integrity": "sha512-d49hPGqBCJF/bF06g1Ywg7zjH1mrrUdPPrixBlKBxcX4WvMYlUUJ8BkrwlzWc8/fm6XqGgk5jilhgeZBDEGwOQ==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "estree-util-is-identifier-name": "^2.0.0",
@@ -47198,22 +47183,19 @@
                 "estree-walker": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-                    "dev": true
+                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
                 }
             }
         },
         "estree-util-is-identifier-name": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.0.tgz",
-            "integrity": "sha512-aXXZFVMnBBDRP81vS4YtAYJ0hUkgEsXea7lNKWCOeaAquGb1Jm2rcONPB5fpzwgbNxulTvrWuKnp9UElUGAKeQ==",
-            "dev": true
+            "integrity": "sha512-aXXZFVMnBBDRP81vS4YtAYJ0hUkgEsXea7lNKWCOeaAquGb1Jm2rcONPB5fpzwgbNxulTvrWuKnp9UElUGAKeQ=="
         },
         "estree-util-visit": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-1.1.0.tgz",
             "integrity": "sha512-3lXJ4Us9j8TUif9cWcQy81t9p5OLasnDuuhrFiqb+XstmKC1d1LmrQWYsY49/9URcfHE64mPypDBaNK9NwWDPQ==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/unist": "^2.0.0"
@@ -48694,7 +48676,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-2.0.2.tgz",
             "integrity": "sha512-UQrZVeBj6A9od0lpFvqHKNSH9zvDrNoyWKbveu1a2oSCXEDUI+3bnd6BoiQLPnLrcXXn/jzJ6y9hmJTTlvf8lQ==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -49241,14 +49222,12 @@
         "is-alphabetical": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-            "dev": true
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
         },
         "is-alphanumerical": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
             "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-            "dev": true,
             "requires": {
                 "is-alphabetical": "^2.0.0",
                 "is-decimal": "^2.0.0"
@@ -49334,8 +49313,7 @@
         "is-decimal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-            "dev": true
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
         },
         "is-descriptor": {
             "version": "1.0.2",
@@ -49391,8 +49369,7 @@
         "is-hexadecimal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-            "dev": true
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
         },
         "is-in-browser": {
             "version": "1.1.3",
@@ -51090,8 +51067,7 @@
         "longest-streak": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.0.1.tgz",
-            "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==",
-            "dev": true
+            "integrity": "sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg=="
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -51216,8 +51192,7 @@
         "markdown-extensions": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
-            "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
-            "dev": true
+            "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q=="
         },
         "markdown-it": {
             "version": "12.3.2",
@@ -51375,7 +51350,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-2.0.0.tgz",
             "integrity": "sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==",
-            "dev": true,
             "requires": {
                 "mdast-util-mdx-expression": "^1.0.0",
                 "mdast-util-mdx-jsx": "^2.0.0",
@@ -51386,7 +51360,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-1.2.0.tgz",
             "integrity": "sha512-wb36oi09XxqO9RVqgfD+xo8a7xaNgS+01+k3v0GKW0X0bYbeBmUZz22Z/IJ8SuphVlG+DNgNo9VoEaUJ3PKfJQ==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -51399,7 +51372,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-2.0.1.tgz",
             "integrity": "sha512-oPC7/smPBf7vxnvIYH5y3fPo2lw1rdrswFfSb4i0GTAXRUQv7JUU/t/hbp07dgGdUFTSDOHm5DNamhNg/s2Hrg==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -51417,7 +51389,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-1.2.0.tgz",
             "integrity": "sha512-IPpX9GBzAIbIRCjbyeLDpMhACFb0wxTIujuR3YElB8LWbducUdMgRJuqs/Vg8xQ1bIAMm7lw8L+YNtua0xKXRw==",
-            "dev": true,
             "requires": {
                 "@types/estree-jsx": "^0.0.1",
                 "@types/hast": "^2.0.0",
@@ -51430,7 +51401,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.3.0.tgz",
             "integrity": "sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==",
-            "dev": true,
             "requires": {
                 "@types/mdast": "^3.0.0",
                 "@types/unist": "^2.0.0",
@@ -51710,7 +51680,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
             "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
-            "dev": true,
             "requires": {
                 "micromark-factory-mdx-expression": "^1.0.0",
                 "micromark-factory-space": "^1.0.0",
@@ -51725,7 +51694,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz",
             "integrity": "sha512-VfA369RdqUISF0qGgv2FfV7gGjHDfn9+Qfiv5hEwpyr1xscRj/CiVRkU7rywGFCO7JwJ5L0e7CJz60lY52+qOA==",
-            "dev": true,
             "requires": {
                 "@types/acorn": "^4.0.0",
                 "estree-util-is-identifier-name": "^2.0.0",
@@ -51742,7 +51710,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-1.0.0.tgz",
             "integrity": "sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==",
-            "dev": true,
             "requires": {
                 "micromark-util-types": "^1.0.0"
             }
@@ -51751,7 +51718,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-1.0.0.tgz",
             "integrity": "sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==",
-            "dev": true,
             "requires": {
                 "acorn": "^8.0.0",
                 "acorn-jsx": "^5.0.0",
@@ -51766,8 +51732,7 @@
                 "acorn": {
                     "version": "8.7.0",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-                    "dev": true
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
                 }
             }
         },
@@ -51775,7 +51740,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-1.0.2.tgz",
             "integrity": "sha512-bIaxblNIM+CCaJvp3L/V+168l79iuNmxEiTU6i3vB0YuDW+rumV64BFMxvhfRDxaJxQE1zD5vTPdyLBbW4efGA==",
-            "dev": true,
             "requires": {
                 "micromark-core-commonmark": "^1.0.0",
                 "micromark-util-character": "^1.0.0",
@@ -51812,7 +51776,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-1.0.6.tgz",
             "integrity": "sha512-WRQIc78FV7KrCfjsEf/sETopbYjElh3xAmNpLkd1ODPqxEngP42eVRGbiPEQWpRV27LzqW+XVTvQAMIIRLPnNA==",
-            "dev": true,
             "requires": {
                 "micromark-factory-space": "^1.0.0",
                 "micromark-util-character": "^1.0.0",
@@ -51920,7 +51883,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.6.tgz",
             "integrity": "sha512-+kUMe2kNGy4mljNVt+YmFfwomSIVqX3NI6ePrk6SIl/0GaR53a6eUIGmhV5DDUkbLPPNWgVFCS6ExOqb0WFgHQ==",
-            "dev": true,
             "requires": {
                 "@types/acorn": "^4.0.0",
                 "@types/estree": "^0.0.51",
@@ -51934,8 +51896,7 @@
                 "@types/estree": {
                     "version": "0.0.51",
                     "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-                    "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-                    "dev": true
+                    "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
                 }
             }
         },
@@ -53393,7 +53354,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
             "integrity": "sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==",
-            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "character-entities": "^2.0.0",
@@ -53535,7 +53495,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
             "integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
-            "dev": true,
             "requires": {
                 "estree-walker": "^3.0.0",
                 "is-reference": "^3.0.0"
@@ -53544,14 +53503,12 @@
                 "estree-walker": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.1.tgz",
-                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==",
-                    "dev": true
+                    "integrity": "sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g=="
                 },
                 "is-reference": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
                     "integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
-                    "dev": true,
                     "requires": {
                         "@types/estree": "*"
                     }
@@ -56523,7 +56480,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-2.1.1.tgz",
             "integrity": "sha512-0wXdEITnFyjLquN3VvACNLzbGzWM5ujzTvfgOkONBZgSFJ7ezLLDaTWqf6H9eUgVITEP8asp6LJ0W/X090dXBg==",
-            "dev": true,
             "requires": {
                 "mdast-util-mdx": "^2.0.0",
                 "micromark-extension-mdxjs": "^1.0.0"
@@ -58188,7 +58144,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.2.tgz",
             "integrity": "sha512-MTxTVcEkorNtBbNpoFJPEh0kKdM6+QbMjLbaxmvaPMmayOXdr/AIVIIJX7FReUVweRBFJfZepK4A4AKgwuFpMQ==",
-            "dev": true,
             "requires": {
                 "character-entities-html4": "^2.0.0",
                 "character-entities-legacy": "^3.0.0"
@@ -58239,12 +58194,6 @@
             "requires": {
                 "inline-style-parser": "0.1.1"
             }
-        },
-        "styled-jsx": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.1.tgz",
-            "integrity": "sha512-+PIZ/6Uk40mphiQJJI1202b+/dYeTVd9ZnMPR80pgiWbjIwvN2zIp4r9et0BgqBuShh48I0gttPlAXA7WVvBxw==",
-            "requires": {}
         },
         "stylehacks": {
             "version": "4.0.3",
@@ -59341,7 +59290,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-1.1.1.tgz",
             "integrity": "sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==",
-            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0"
             }
@@ -59350,7 +59298,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.1.tgz",
             "integrity": "sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==",
-            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-visit": "^4.0.0"

--- a/packages/docs/.babelrc
+++ b/packages/docs/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": []
-}

--- a/packages/docs/components/navigation/components-navigation.json
+++ b/packages/docs/components/navigation/components-navigation.json
@@ -189,7 +189,6 @@
 			{
 				"group": "InsightsLabel",
 				"items": [
-					"CriticalIcon",
 					"InsightsLabel"
 				]
 			},

--- a/packages/docs/generators/generate-functions-md.js
+++ b/packages/docs/generators/generate-functions-md.js
@@ -48,7 +48,9 @@ function createParams(item) {
   let content = '';
   if (item.params) {
     item.params.forEach((param) => {
-      content = `${content}\n|${getParamName(param)}|${getParamType(param)}|${getParamDefaultValue(param)}|${getParamDescription(param)}`;
+      content = `${content}\n|${getParamName(param)}|${getParamType(param)
+        .replace(/\{/gm, '&#123;')
+        .replace(/\}/gm, '&#125;')}|${getParamDefaultValue(param).replace(/\{/gm, '&#123;').replace(/\}/gm, '&#125;')}|${getParamDescription(param)}`;
     });
   }
 

--- a/packages/docs/generators/generate-react-md.js
+++ b/packages/docs/generators/generate-react-md.js
@@ -237,7 +237,9 @@ ${Object.entries(API.props)
     ([name, value]) => `|${name}${value.required ? `&#42;` : ''}|${getPropType(value, file, { name, ...value })
       .replace(/@@spacerPlaceholder/gm, '"default-prop-spacer"')
       .replace(/\{/gm, '&#123;')
-      .replace(/\}/gm, '&#125;')}|${generateDefaultValue(value)}|${generatePropDescription(value)}|
+      .replace(/\}/gm, '&#125;')}|${generateDefaultValue(value).replace(/\{/gm, '&#123;').replace(/\}/gm, '&#125;')}|${generatePropDescription(value)
+      .replace(/\{/gm, '&#123;')
+      .replace(/\}/gm, '&#125;')}|
 `
   )
   .join('')}`

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.1.1",
+    "@mdx-js/mdx": "^2.1.1",
     "@patternfly/react-core": "4.192.0",
     "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-table": "^4.19.24",
@@ -35,6 +36,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@mdx-js/loader": "^2.1.1",
     "@next/mdx": "^12.1.5",
+    "@next/env": "^12.1.5",
     "chokidar": "^3.5.3",
     "codesandbox": "^2.2.3",
     "concurrently": "^5.3.0",
@@ -47,6 +49,7 @@
     "raw-loader": "^4.0.2",
     "react-docgen": "^5.3.1",
     "remark-gfm": "^3.0.1",
+    "styled-jsx": "^5.0.2",
     "typedoc": "^0.22.10",
     "typescript": "^4.6.2",
     "url-loader": "^4.1.1"

--- a/packages/docs/pages/csc/environments.mdx
+++ b/packages/docs/pages/csc/environments.mdx
@@ -6,17 +6,17 @@ These are the urls for each branch:
 
 ### Beta
 
-* ci-beta -> <https://ci.console.redhat.com/beta>
-* qa-beta -> <https://qa.console.redhat.com/beta>
-* stage-beta -> <https://console.stage.redhat.com/beta>
-* prod-beta -> <https://console.redhat.com/beta>
+* ci-beta -> `https://ci.console.redhat.com/beta`
+* qa-beta -> `https://qa.console.redhat.com/beta`
+* stage-beta -> `https://console.stage.redhat.com/beta`
+* prod-beta -> `https://console.redhat.com/beta`
 
 ### Stable
 
-* ci-stable -> <https://ci.console.redhat.com>
-* qa-stable -> <https://qa.console.redhat.com>
-* stage -> <https://console.stage.redhat.com>
-* prod-stable -> <https://console.redhat.com>
+* ci-stable -> `https://ci.console.redhat.com`
+* qa-stable -> `https://qa.console.redhat.com`
+* stage -> `https://console.stage.redhat.com`
+* prod-stable -> `https://console.redhat.com`
 
 These branches sync:
 

--- a/packages/docs/pages/csc/index.mdx
+++ b/packages/docs/pages/csc/index.mdx
@@ -66,4 +66,4 @@ index 67237cc..4485daa 100644
 
 ```
 
-Now go to `/insights/dashboard`. You may not see your navigation change at this point! Try clearing your local storage in your browser. To do this in Firefox, hit Shift-F9 and click "Local Storage", then right click on <https://ci.foo.redhat.com:1337> and delete all. Refresh the page and you should then see your changes. You'll notice too that SimpleHTTPServer logged another request.
+Now go to `/insights/dashboard`. You may not see your navigation change at this point! Try clearing your local storage in your browser. To do this in Firefox, hit Shift-F9 and click "Local Storage", then right click on `https://ci.foo.redhat.com:1337` and delete all. Refresh the page and you should then see your changes. You'll notice too that SimpleHTTPServer logged another request.

--- a/packages/docs/pages/deployment-process/index.mdx
+++ b/packages/docs/pages/deployment-process/index.mdx
@@ -24,7 +24,7 @@ If you have already been through the UI onboarding step, please pick up here. Ot
 3. **Generate the new key** (in the source repo)
     * ssh-keygen -t rsa -b 4096
       Save the key without a passphrase
-    * Save the key as deploy\_key in {source-repo}/.travis/deploy\_key
+    * Save the key as deploy\_key in &#123;source-repo&#125;/.travis/deploy\_key
       i. You should get a deploy\_key and deploy\_key.pub
 
 4. **Add the new deploy key to the build repo** (build repo)
@@ -35,7 +35,7 @@ If you have already been through the UI onboarding step, please pick up here. Ot
       i. [Installation](https://github.com/travis-ci/travis.rb#installation) ** **
     * [Add a personal access token](https://github.com/settings/tokens) in github if you don&#39;t have one already
     * Login to Travis CLI with the --com flag with your github token
-      i. travis login --com --github-token {token}
+      i. travis login --com --github-token &#123;token&#125;
     * Verify that you are inside of your development repo and then encrypt the key with Travis CLI
       i. travis encrypt-file .travis/deploy\_key --com
     * You may be prompted to add an openssl command, **do not add the openssl command to the .travis file.**
@@ -47,11 +47,9 @@ If you have already been through the UI onboarding step, please pick up here. Ot
     * Commit your deploy\_key.enc file _**(DO NOT COMMIT THE PRIVATE KEY)**_
     * Open a PR against master branch
 8. **Verify that the Travis env variables have been added**
-    * [https://app.travis-ci.com/github/RedHatInsights/{source-repo}/settings](https://app.travis-ci.com/github/RedHatInsights/%7Bsource-repo%7D/settings)
+    * [https://app.travis-ci.com/github/RedHatInsights/&#123;source-repo&#125;/settings](https://app.travis-ci.com/github/RedHatInsights/%7Bsource-repo%7D/settings)
     * The hash for the key and iv should match the hash you see in the logs after you run the encryption in Step 7
 9. **Confirm** the build completed successfully on Travis-CI and verify that the files were pushed to your build repo.
-
-<!-- Describe the travis -> build repo -> jenkins -> akamai process -->
 
 ## Deploying
 


### PR DESCRIPTION
The upgrade to next ^12 and MDX ^2 had additional braking changes.

- missing peer dependencies
- new reserved characters for the MDX format
- no need for custom babelrc 