### PR TITLE
Add ErrorBoundary page

### DIFF
--- a/packages/components/src/ErrorBoundary/ErrorBoundary.scss
+++ b/packages/components/src/ErrorBoundary/ErrorBoundary.scss
@@ -1,0 +1,11 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/_all.scss';
+
+.ins-error-boundary-stack {
+  font-family: 'monospace';
+  font-size: var(--pf-global--icon--FontSize--md);
+  text-align: left;
+  background-color: white;
+  border-style: solid;
+  border-color: var(--pf-global--BackgroundColor--dark-300);
+  padding: var(--pf-global--spacer--sm);
+}

--- a/packages/components/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/components/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import ErrorBoundaryPage from './ErrorBoundary';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('ErrorBoundary component', () => {
+  const Surprise = () => {
+    throw new Error('but a welcome one');
+  };
+
+  // The error boundary is noisy, silence for this test
+  let mockConsole: jest.SpyInstance;
+  beforeEach(() => {
+    mockConsole = jest.spyOn(console, 'error');
+    mockConsole.mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    mockConsole.mockRestore();
+  });
+
+  it('should render content when there is no error', () => {
+    render(
+      <ErrorBoundaryPage headerTitle={'My app'}>
+        <div>hello world</div>
+      </ErrorBoundaryPage>
+    );
+
+    expect(screen.getByText('hello world')).toBeVisible();
+  });
+
+  it('should render error if there is any error', () => {
+    render(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <Surprise />
+      </ErrorBoundaryPage>
+    );
+
+    expect(screen.getByText(/Something wrong happened/i)).toBeVisible();
+  });
+
+  it('should have details hidden', () => {
+    render(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <Surprise />
+      </ErrorBoundaryPage>
+    );
+
+    expect(screen.getByText(/but a welcome one/i)).not.toBeVisible();
+  });
+
+  it('should show details when clicking the show details button', () => {
+    render(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <Surprise />
+      </ErrorBoundaryPage>
+    );
+
+    userEvent.click(screen.getByText(/show details/i));
+    expect(screen.getByText(/but a welcome one/i)).toBeVisible();
+  });
+
+  it('should show content again after changing url', () => {
+    let fail = true;
+    const FailConditionally = () => {
+      if (fail) {
+        throw new Error('failing');
+      } else {
+        return <div>hello world</div>;
+      }
+    };
+
+    const { rerender } = render(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <FailConditionally />
+      </ErrorBoundaryPage>
+    );
+
+    expect(screen.getByText(/Something wrong happened/i)).toBeVisible();
+
+    // a re-render does not get out of the error state
+    rerender(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <FailConditionally />
+      </ErrorBoundaryPage>
+    );
+
+    expect(screen.getByText(/Something wrong happened/i)).toBeVisible();
+
+    fail = false;
+    // Simulates a state change in the history
+    history.pushState({ data: 2 }, 'unused');
+    rerender(
+      <ErrorBoundaryPage headerTitle="My app" errorTitle="Something wrong happened">
+        <FailConditionally />
+      </ErrorBoundaryPage>
+    );
+    expect(screen.getByText('hello world')).toBeVisible();
+  });
+});

--- a/packages/components/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/components/src/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import PageHeader, { PageHeaderTitle } from '../PageHeader';
+import ErrorState from '../ErrorState';
+import { ExpandableSection } from '@patternfly/react-core';
+import ErrorStack from './ErrorStack';
+import Section from '../Section';
+
+interface ErrorPageProps {
+  headerTitle: string;
+  errorTitle?: string;
+  errorDescription?: string;
+}
+
+interface ErrorPageState {
+  hasError: boolean;
+  error?: Error;
+  historyState: History['state'];
+}
+
+// As of time of writing, React only supports error boundaries in class components
+class ErrorBoundaryPage extends React.Component<ErrorPageProps, ErrorPageState> {
+  constructor(props: Readonly<ErrorPageProps>) {
+    super(props);
+    this.state = {
+      hasError: false,
+      historyState: history.state,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorPageState {
+    return { hasError: true, error, historyState: history.state };
+  }
+
+  render() {
+    if (this.state.historyState !== history.state) {
+      this.setState({
+        hasError: false,
+        historyState: history.state,
+      });
+    }
+
+    if (this.state.hasError) {
+      return (
+        <div>
+          <PageHeader>
+            <PageHeaderTitle title={this.props.headerTitle} />
+          </PageHeader>
+          <Section>
+            <ErrorState
+              errorTitle={this.props.errorTitle}
+              errorDescription={
+                <>
+                  <span>{this.props.errorDescription}</span>
+                  {this.state.error && (
+                    <ExpandableSection toggleText="Show details">
+                      <ErrorStack error={this.state.error} />
+                    </ExpandableSection>
+                  )}
+                </>
+              }
+            />
+          </Section>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundaryPage;

--- a/packages/components/src/ErrorBoundary/ErrorStack.tsx
+++ b/packages/components/src/ErrorBoundary/ErrorStack.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Text } from '@patternfly/react-core';
+
+interface ErrorStackProps {
+  error: Error;
+}
+
+const errorStackClass = 'ins-error-boundary-stack';
+
+const ErrorStack: React.FunctionComponent<ErrorStackProps> = ({ error }) => {
+  if (error.stack) {
+    return (
+      <Text className={errorStackClass}>
+        {error.stack.split('\n').map((line) => (
+          <div key={line}>{line}</div>
+        ))}
+      </Text>
+    );
+  }
+
+  if (error.name && error.message) {
+    return (
+      <>
+        <Text component="h6">{error.name}</Text>
+        <Text className={errorStackClass} component="blockquote">
+          {error.message}
+        </Text>
+      </>
+    );
+  }
+
+  return (
+    <Text className={errorStackClass} component="blockquote">
+      {error.toString()}
+    </Text>
+  );
+};
+
+export default ErrorStack;

--- a/packages/components/src/ErrorBoundary/index.ts
+++ b/packages/components/src/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ErrorBoundary';
+export { default as ErrorBoundary } from './ErrorBoundary';

--- a/packages/components/src/index.scss
+++ b/packages/components/src/index.scss
@@ -4,6 +4,7 @@
 @import './ConditionalFilter/conditional-filter.scss';
 @import './CullingInfo/CullingInformation.scss';
 @import './EmptyTable/EmptyTable.scss';
+@import './ErrorBoundary/ErrorBoundary.scss';
 @import './FilterChips/filter-chips.scss';
 @import './FilterHooks/tagFilterHook.scss';
 @import './Filters/filter-dropdown.scss';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -45,3 +45,4 @@ export * from './Maintenance';
 export * from './FilterHooks';
 export * from './AsyncComponent';
 export * from './Ouia';
+export * from './ErrorBoundary';


### PR DESCRIPTION
 - adds a catch-all errors with an error boundary
 - displays an error state and a collapsed stack trace of the error

![Peek 2022-05-16 14-15](https://user-images.githubusercontent.com/3845764/168675275-e3b376f4-ac74-4910-9ebe-980c3f3eafd5.gif)
