### PR TITLE
Add ReportDetails component to the advisor-components library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Monorepo of Red Hat Cloud services Components for applications in a React.js env
   * [inventory-insights](https://github.com/RedHatInsights/frontend-components/tree/master/packages/inventory-insights#readme) - directly imported component to show insights data
 * [sources](https://github.com/RedHatInsights/sources-ui/) - Sources Wizard component was moved to Sources UI repository (it's also stored here in `sources_backup` branch)
 * [testing](https://github.com/RedHatInsights/frontend-components/tree/master/packages/testing) - Testing utilities.
+* [advisor-components](https://github.com/RedHatInsights/frontend-components/tree/master/packages/advisor-components#readme) - a library of Advisor components (rule content, report details, charts, etc.).
 ## Contributing to documentation
 
 To contribute to docs and run the docs developemnt environment, please follow these [guides](https://github.com/RedHatInsights/frontend-components/tree/master/packages/docs/pages/contributing).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6961,6 +6961,8 @@
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -6975,7 +6977,9 @@
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -17285,6 +17289,7 @@
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -19657,6 +19662,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "invert-kv": "^1.0.0"
             },
@@ -20692,6 +20698,7 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "mimic-fn": "^1.0.0"
             },
@@ -20704,6 +20711,7 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
             "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -23100,6 +23108,7 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "execa": "^0.7.0",
                 "lcid": "^1.0.0",
@@ -23114,6 +23123,7 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "lru-cache": "^4.0.1",
                 "shebang-command": "^1.2.0",
@@ -23125,6 +23135,7 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^5.0.1",
                 "get-stream": "^3.0.0",
@@ -23143,6 +23154,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -23152,6 +23164,7 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -23161,6 +23174,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -23171,6 +23185,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "path-key": "^2.0.0"
             },
@@ -23183,6 +23198,7 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
             "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -23192,6 +23208,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "shebang-regex": "^1.0.0"
             },
@@ -23204,6 +23221,7 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -23213,6 +23231,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -23224,7 +23243,8 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/os-name": {
             "version": "3.1.0",
@@ -29238,6 +29258,7 @@
             "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
             "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "yargs": "^10.0.3"
             },
@@ -29250,6 +29271,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
             "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -29259,6 +29281,7 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
             "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -29268,6 +29291,7 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^2.1.1",
                 "strip-ansi": "^4.0.0",
@@ -29279,6 +29303,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "locate-path": "^2.0.0"
             },
@@ -29290,13 +29315,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
             "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/showdown/node_modules/is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -29306,6 +29333,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -29319,6 +29347,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-try": "^1.0.0"
             },
@@ -29331,6 +29360,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "p-limit": "^1.1.0"
             },
@@ -29343,6 +29373,7 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
             "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -29352,6 +29383,7 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -29360,13 +29392,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/showdown/node_modules/string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -29380,6 +29414,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^3.0.0"
             },
@@ -29392,6 +29427,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -29405,6 +29441,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -29414,6 +29451,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -29426,6 +29464,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -29440,6 +29479,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -29451,13 +29491,15 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
             "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/showdown/node_modules/yargs": {
             "version": "10.1.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
             "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cliui": "^4.0.0",
                 "decamelize": "^1.1.1",
@@ -29478,6 +29520,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
             "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "camelcase": "^4.1.0"
             }
@@ -39812,8 +39855,7 @@
             "requires": {
                 "@patternfly/react-catalog-view-extension": "4.12.15",
                 "dompurify": "^2.2.6",
-                "history": "^5.0.0",
-                "showdown": "1.8.6"
+                "history": "^5.0.0"
             },
             "dependencies": {
                 "@patternfly/react-catalog-view-extension": {
@@ -42686,14 +42728,13 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "requires": {
-                "ajv": "^8.0.0"
-            },
+            "requires": {},
             "dependencies": {
                 "ajv": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "optional": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -42704,7 +42745,9 @@
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "optional": true,
+                    "peer": true
                 }
             }
         },
@@ -50256,7 +50299,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
             "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "ip": {
             "version": "1.1.5",
@@ -51878,6 +51922,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
+            "peer": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
@@ -52634,6 +52679,7 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
+            "peer": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
             },
@@ -52642,7 +52688,8 @@
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
                     "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -54209,6 +54256,7 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "execa": "^0.7.0",
                 "lcid": "^1.0.0",
@@ -54220,6 +54268,7 @@
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "lru-cache": "^4.0.1",
                         "shebang-command": "^1.2.0",
@@ -54231,6 +54280,7 @@
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "cross-spawn": "^5.0.1",
                         "get-stream": "^3.0.0",
@@ -54245,19 +54295,22 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                     "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "lru-cache": {
                     "version": "4.1.5",
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
                     "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "pseudomap": "^1.0.2",
                         "yallist": "^2.1.2"
@@ -54268,6 +54321,7 @@
                     "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
                     "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "path-key": "^2.0.0"
                     }
@@ -54276,13 +54330,15 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
                     "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "shebang-command": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "shebang-regex": "^1.0.0"
                     }
@@ -54291,13 +54347,15 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
                     "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "which": {
                     "version": "1.3.1",
                     "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "isexe": "^2.0.0"
                     }
@@ -54306,7 +54364,8 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
                     "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -58589,6 +58648,7 @@
             "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
             "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
             "dev": true,
+            "peer": true,
             "requires": {
                 "yargs": "^10.0.3"
             },
@@ -58597,19 +58657,22 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
                     "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "cliui": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "string-width": "^2.1.1",
                         "strip-ansi": "^4.0.0",
@@ -58621,6 +58684,7 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -58629,19 +58693,22 @@
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
                     "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "locate-path": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "p-locate": "^2.0.0",
                         "path-exists": "^3.0.0"
@@ -58652,6 +58719,7 @@
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "p-try": "^1.0.0"
                     }
@@ -58661,6 +58729,7 @@
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "p-limit": "^1.1.0"
                     }
@@ -58669,25 +58738,29 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
                     "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "require-main-filename": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
                     "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "string-width": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
                         "strip-ansi": "^4.0.0"
@@ -58698,6 +58771,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -58707,6 +58781,7 @@
                     "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
                     "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "string-width": "^1.0.1",
                         "strip-ansi": "^3.0.1"
@@ -58716,13 +58791,15 @@
                             "version": "2.1.1",
                             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                            "dev": true
+                            "dev": true,
+                            "peer": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                             "dev": true,
+                            "peer": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -58732,6 +58809,7 @@
                             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "dev": true,
+                            "peer": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -58743,6 +58821,7 @@
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "dev": true,
+                            "peer": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -58753,13 +58832,15 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
                     "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 },
                 "yargs": {
                     "version": "10.1.2",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
                     "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "cliui": "^4.0.0",
                         "decamelize": "^1.1.1",
@@ -58780,6 +58861,7 @@
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
                     "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "camelcase": "^4.1.0"
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5557,6 +5557,12 @@
                 "@types/ms": "*"
             }
         },
+        "node_modules/@types/dot": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@types/dot/-/dot-1.1.5.tgz",
+            "integrity": "sha512-fguu7IaFdubwG18Y6GbjVM9yItNeQezVCvsXn/QFPe/+Vsbjpz+Rddi3Fg/YX11+xqeaB0sPSfP3ebLI4NNGGw==",
+            "dev": true
+        },
         "node_modules/@types/enzyme": {
             "version": "3.10.10",
             "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
@@ -5825,6 +5831,12 @@
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
             }
+        },
+        "node_modules/@types/marked": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.3.tgz",
+            "integrity": "sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==",
+            "dev": true
         },
         "node_modules/@types/mdast": {
             "version": "3.0.3",
@@ -34195,7 +34207,9 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
+                "dot": "^1.1.3",
                 "lodash": "^4.17.21",
+                "marked": "^4.0.16",
                 "react-markdown": "^8.0.1",
                 "rehype-raw": "^6.1.1",
                 "rehype-sanitize": "^5.0.1"
@@ -34203,6 +34217,8 @@
             "devDependencies": {
                 "@cypress/react": "^5.12.4",
                 "@cypress/webpack-dev-server": "^1.8.4",
+                "@types/dot": "^1.1.5",
+                "@types/marked": "^4.0.3",
                 "css-loader": "^6.7.1",
                 "cypress": "^9.6.0",
                 "eslint-plugin-cypress": "^2.12.1",
@@ -34254,6 +34270,17 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
+            }
+        },
+        "packages/advisor-components/node_modules/marked": {
+            "version": "4.0.16",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+            "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "packages/advisor-components/node_modules/nanoid": {
@@ -40084,10 +40111,14 @@
                 "@cypress/react": "^5.12.4",
                 "@cypress/webpack-dev-server": "^1.8.4",
                 "@redhat-cloud-services/frontend-components": ">=3.0.0",
+                "@types/dot": "^1.1.5",
+                "@types/marked": "^4.0.3",
                 "css-loader": "^6.7.1",
                 "cypress": "^9.6.0",
+                "dot": "^1.1.3",
                 "eslint-plugin-cypress": "^2.12.1",
                 "lodash": "^4.17.21",
+                "marked": "^4.0.16",
                 "react-markdown": "^8.0.1",
                 "rehype-raw": "^6.1.1",
                 "rehype-sanitize": "^5.0.1",
@@ -40117,6 +40148,11 @@
                     "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
                     "dev": true,
                     "requires": {}
+                },
+                "marked": {
+                    "version": "4.0.16",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+                    "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA=="
                 },
                 "nanoid": {
                     "version": "3.3.3",
@@ -41621,6 +41657,12 @@
                 "@types/ms": "*"
             }
         },
+        "@types/dot": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@types/dot/-/dot-1.1.5.tgz",
+            "integrity": "sha512-fguu7IaFdubwG18Y6GbjVM9yItNeQezVCvsXn/QFPe/+Vsbjpz+Rddi3Fg/YX11+xqeaB0sPSfP3ebLI4NNGGw==",
+            "dev": true
+        },
         "@types/enzyme": {
             "version": "3.10.10",
             "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.10.tgz",
@@ -41861,6 +41903,12 @@
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*"
             }
+        },
+        "@types/marked": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.3.tgz",
+            "integrity": "sha512-HnMWQkLJEf/PnxZIfbm0yGJRRZYYMhb++O9M36UCTA9z53uPvVoSlAwJr3XOpDEryb7Hwl1qAx/MV6YIW1RXxg==",
+            "dev": true
         },
         "@types/mdast": {
             "version": "3.0.3",

--- a/packages/advisor-components/README.md
+++ b/packages/advisor-components/README.md
@@ -32,3 +32,4 @@ npx cypress open-ct
 
 * Components
   * [RuleDetails](doc/ruleDetails.md)
+  * [ReportDetails](doc/reportDetails.md)

--- a/packages/advisor-components/cypress/fixtures/report.json
+++ b/packages/advisor-components/cypress/fixtures/report.json
@@ -1,0 +1,39 @@
+{
+  "rule": {
+    "rule_id": "foobar_deprecated_something|FOOBAR_DEPRECATED_SOMETHING",
+    "node_id": "12345678",
+    "summary": "New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n",
+    "reason": "This system is running Red Hat Enterprise Linux with the following SAP\napplication{{?Object.keys(pydata.inst).length>=2}}s{{?}} but the `/etc/hosts`\nis not configured correctly, which results in some functions of SAP system failure.\n\n1. SAP applications running on this host.\n    {{~pydata.inst: e}}\n    * {{=e}}{{~}}\n1. Issues in the `/etc/hosts`:\n  {{?pydata.no_hn}}* The hostname of this host **{{=pydata.hostname}}** is not found.\n  {{?}}{{?pydata.line_127}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address **127.0.0.1**\n    ~~~\n    {{~pydata.line_127: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_hn}}* The FQDN is not in the second column or hostname is not followed\n    ~~~\n    {{~pydata.line_hn: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_ip}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address that does not belong to this host\n    ~~~\n    {{~pydata.line_ip: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.before_local}}* The following {{?Object.keys(pydata.before_local).length>=2}}lines are{{??}}line is{{?}} before the line of **127.0.0.1** or the line of **{{=pydata.hostname}}**\n    ~~~\n    {{~pydata.before_local: e}}{{=e}}\n    {{~}}\n    ~~~{{?}}\n  {{?pydata.long_before_local}}\n  **Note:** There are more than 10 lines in the `/etc/hosts` impacted and only the first 10 are displayed here. Please check the full list of them manually in the `/etc/hosts`.\n  {{?}}\n \nThis host is running **kernel-{{=pydata.kernel}}** and {{?Object.keys(pydata.ipv6_dev_routes).length>1}}`IPv6` routes are added for IPv6 addresses, associated with the interfaces.{{??}}`IPv6` route is added for IPv6 address, associated with the interface.{{?}} Due to a known bug in the `kernel`, when `ip6_route_dev_notify` function receives a **NULL** pointer from `snmp6_alloc_dev` while unregistering the network device, kernel panic occurs. The `snmp6_alloc_dev` returns **NULL** when CPU allocation fails.\n\nThe following IPv6 enabled {{?Object.keys(pydata.ipv6_dev_routes).length>1}}interfaces are{{??}}interface is{{?}} present on this host:\n<table>\n  <tr>\n    <th>Interface</th>\n    <th>IPv6 Address</th>\n  </tr>\n{{ for (var key in pydata.ipv6_dev_routes) { }}\n<tr>\n    <td>{{=key}} </td>\n    <td>{{=pydata.ipv6_dev_routes[key]}} </td>\n</tr>\n{{ } }}\n</table>\n",
+    "more_info": "* For more information regarding the dedicated Ansible Engine channel, please refer to [Ansible deprecated in the Extras channel](https://access.redhat.com/articles/3359651). \n* For how to use the dedicated Ansible Engine channel, please refer to [How do I Download and Install Red Hat Ansible Engine?](https://access.redhat.com/articles/3174981).\n",
+    "resolution_set": [
+      {
+        "system_type": 105,
+        "resolution": "Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n",
+        "resolution_risk": {
+          "name": "Update Package",
+          "risk": 1
+        },
+        "has_playbook": true
+      }
+    ],
+    "total_risk": 2
+  },
+  "details": {
+    "type": "rule",
+    "package": "ansible-1.8.42-5.elre",
+    "kernel": "3.9.0-862.2.3.el1.x86_64",
+    "error_key": "FOOBAR_DEPRECATED_SOMETHING",
+    "rhsm_rset": null,
+    "ipv6_dev_routes": {
+      "eth0": "fe81::c547:c849:ee14:2bdc"
+    },
+    "fqdn": "iqe-patch-rhel-75-7c99fe69-eaca-2144-a7db-69c9c792ae",
+    "inst": ["D00", "D01", "D02"],
+    "rhel": "7.1",
+    "no_hn": true,
+    "hostname": "iqe-patch-rhel-42-7c22fe69-eaca-4242-a7db-69c913c792ae",
+    "subs": ["Applications"],
+    "mis_repos": ["rhel-sap-for-rhel-42-server-rpms"]
+  },
+  "resolution": "Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n \n {{?pydata.subs&&pydata.subs.indexOf('Solutions') != -1}}\nWhen running SAP HANA on RHEL it must be ensured that only OS packages provided\nfor the specific RHEL minor release are installed. For supportability it is\ntherefore required that only either the EUS or E4S repos are active on the\nsystem.\n{{?}}\nThe following {{?pydata.mis_repos.length>1}}repositories{{??}}repository{{?}} should be enabled on this host:\n{{~pydata.mis_repos: e}}* {{=e}}\n{{~}}\nRed Hat recommends that you perform the following steps to enable {{?pydata.mis_repos.length>1}}these repos{{??}}this repo{{?}}:\n1. Find the serial number for current subscription:\n  ~~~\n  # subscription-manager list --consumed\n  ~~~\n1. Remove the system from the current subscription:\n  ~~~\n  # subscription-manager remove --serial='SERIAL NUMBER'\n  ~~~\n1. Find the pool ID for the **RHEL for SAP** subscription:\n  ~~~\n  # subscription-manager list --available\n  ~~~\n1. Subscribe to **RHEL for SAP** using the pool ID:\n  ~~~\n  # subscription-manager attach --pool='XXXX'\n  ~~~\n1. Enable the recommended yum repositories:\n  ~~~\n  # subscription-manager repos{{~pydata.mis_repos: e}} --enable={{=e}}{{~}}\n  ~~~\n1. Review the yum repolist and ensure that **RHEL for SAP** is enabled:\n  ~~~\n  # yum repolist\n  ~~~\n"
+}

--- a/packages/advisor-components/doc/reportDetails.md
+++ b/packages/advisor-components/doc/reportDetails.md
@@ -1,0 +1,59 @@
+# Report Details
+
+The component renders the rule evaluation results on a given cluster or system. It takes Markdown templates and polyfills them with report data with the help of [TemplateProcessor](../src/TemplateProcessor/TemplateProcessor.tsx).
+
+## Usage
+
+Import ReportDetails from this package.
+
+```JSX
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ReportDetails } from '@redhat-cloud-services/frontend-components-advisor-components';
+
+...
+
+const Component = () => (
+  <ReportDetails
+    report={{
+        rule: ruleContent,
+        details: systemDetails,
+        resolution: resolutionTemplate
+    }}
+    kbaDetail={{
+        publishedTitle: "foo bar article",
+        view_uri: "https://foo.bar/docs/123"
+    }}
+    kbaLoading={false}
+  />
+);
+
+```
+
+## Properties
+
+The component TS interface is described in [ReportDetails.tsx](../src/ReportDetails//ReportDetails.tsx).
+
+```ts
+interface Report {
+  rule: RuleContentRhel | RuleContentOcp;
+  details: Record<string, string | number>;
+  resolution: string;
+}
+
+interface ReportDetailsProps {
+  report: Report;
+  kbaDetail: {
+    publishedTitle: string;
+    view_uri: string;
+  };
+  kbaLoading: boolean; // if true, renders skeleton instead of kba link
+}
+```
+
+* `report`: a JS object that contains:
+    * `rule`: a content of the rule.
+    * `details`: cluster or system details that are required by the template.
+    * `resolution`: resolution steps required to render the "Steps to resolve" section.
+* `kbaDetail`: title and URL that points to the corresponding knowledgebase article.
+* `kbaLoading`: use this boolean parameter if you want to render a skeleton while fetching the kbaDetail in a separate request (e.g., in RHEL Advisor).

--- a/packages/advisor-components/doc/ruleDetails.md
+++ b/packages/advisor-components/doc/ruleDetails.md
@@ -25,8 +25,9 @@ const Component = () => (
     resolutionRisk={2}
     resolutionRiskDesc={resolutionRiskLowDescription}
     linkComponent={Link}
-    knowledgebaseUrl={`https://access.redhat.com/node/${rule.node_id}`} />
-    showViewAffected
+    knowledgebaseUrl={`https://access.redhat.com/node/${rule.node_id}`} 
+    showViewAffected 
+  />
 );
 
 ```

--- a/packages/advisor-components/package.json
+++ b/packages/advisor-components/package.json
@@ -29,13 +29,15 @@
         "@patternfly/react-core": ">=4.162.16",
         "@patternfly/react-icons": ">=4.3.5",
         "prop-types": ">=15.6.2",
-        "react": ">=16.14.0 || >=17.0.0",
-        "react-dom": ">=16.14.0 || >=17.0.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0",
         "react-router-dom": "^5.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/frontend-components": ">=3.0.0",
+        "dot": "^1.1.3",
         "lodash": "^4.17.21",
+        "marked": "^4.0.16",
         "react-markdown": "^8.0.1",
         "rehype-raw": "^6.1.1",
         "rehype-sanitize": "^5.0.1"
@@ -43,6 +45,8 @@
     "devDependencies": {
         "@cypress/react": "^5.12.4",
         "@cypress/webpack-dev-server": "^1.8.4",
+        "@types/dot": "^1.1.5",
+        "@types/marked": "^4.0.3",
         "css-loader": "^6.7.1",
         "cypress": "^9.6.0",
         "eslint-plugin-cypress": "^2.12.1",

--- a/packages/advisor-components/package.json
+++ b/packages/advisor-components/package.json
@@ -29,8 +29,8 @@
         "@patternfly/react-core": ">=4.162.16",
         "@patternfly/react-icons": ">=4.3.5",
         "prop-types": ">=15.6.2",
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
+        "react": ">=16.14.0 || >=17.0.0",
+        "react-dom": ">=16.14.0 || >=17.0.0",
         "react-router-dom": "^5.0.0"
     },
     "dependencies": {

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.scss
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.scss
@@ -1,0 +1,102 @@
+@import '~@redhat-cloud-services/frontend-components-utilities/styles/_mixins';
+
+.ins-c-inventory-insights__report-details__override {
+  .ins-c-rules-card {
+    .pf-c-card__header .pf-l-split__item:first-of-type {
+      white-space: nowrap;
+      @include rem('margin-right', 5px);
+    }
+    .ins-l-icon-group__with-major {
+      display: inline;
+    }
+    .space-between {
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+
+  .ins-c-rules-card .pf-c-card__header div {
+    font-weight: 600;
+  }
+
+  .ins-c-rules-card + .ins-c-rules-card {
+    margin-top: var(--pf-global--spacer--xl);
+  }
+
+  .ins-c-rules-card a[disabled] {
+    cursor: not-allowed;
+    color: var(--pf-global--disabled-color--200);
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .ins-c-inventory-advisor__card {
+    .ins-m-card__flat {
+      box-shadow: none;
+      border: 0px;
+    }
+
+    .pf-c-card__body svg {
+      @include rem('margin-right', 5px);
+    }
+
+    pre {
+      display: block;
+      @include rem('padding', 9.5px);
+      @include rem('margin-top', 5px);
+      color: #333;
+      word-break: break-all;
+      word-wrap: break-word;
+      background-color: #f5f5f5;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      code {
+        white-space: pre-wrap;
+      }
+    }
+
+    ol {
+      @include rem('margin-top', 10px);
+      @include rem('margin-left', 15px);
+    }
+
+    p + pre,
+    ul + pre {
+      @include rem('margin-bottom', 20px);
+    }
+
+    .pf-c-list {
+      @include rem('margin', 5px 0);
+      list-style: disc;
+      padding-left: var(--pf-global--spacer--lg);
+    }
+
+    table {
+      width: 100%;
+      tr {
+        border-bottom: 1px solid #ededed;
+
+        :first-child::after {
+          border-left: 0 !important;
+        }
+      }
+      th,
+      td {
+        @include rem('padding', 8px);
+      }
+
+      // Inline style overwrite
+      td {
+        background: white !important;
+      }
+      th {
+        text-align: left !important;
+      }
+    }
+  }
+
+  .ins-c-report-details-icon {
+    margin-right: var(--pf-global--spacer--sm);
+  }
+}

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.scss
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.scss
@@ -2,24 +2,17 @@
 
 .ins-c-report-details {
   &__cards-stack {
-    a[disabled] {
-      cursor: not-allowed;
-      color: var(--pf-global--disabled-color--200);
-      &:hover {
-        text-decoration: none;
-      }
-    }
-
     pre {
       display: block;
-      @include rem('padding', 9.5px);
-      @include rem('margin-top', 5px);
-      color: #333;
+      color: var(--pf-global--Color--100);
       word-break: break-all;
       word-wrap: break-word;
-      background-color: #f5f5f5;
-      border: 1px solid #ccc;
+      background-color: var(--pf-global--BackgroundColor--light-200);
+      border: 1px solid var(--pf-global--BorderColor--100);
       border-radius: 4px;
+      @include rem('padding', 10px);
+      @include rem('margin', (10px, 0));
+
       code {
         white-space: pre-wrap;
       }
@@ -30,9 +23,9 @@
       @include rem('margin-left', 15px);
     }
 
-    p + pre,
-    ul + pre {
-      @include rem('margin-bottom', 20px);
+    pre + p,
+    pre + ul {
+      @include rem('margin-top', 10px);
     }
 
     .pf-c-list {
@@ -41,24 +34,15 @@
 
     table {
       width: 100%;
-      tr {
-        border-bottom: 1px solid #ededed;
+      @include rem('margin-top', 10px);
 
-        :first-child::after {
-          border-left: 0 !important;
-        }
+      tr {
+        border-bottom: 1px solid var(--pf-global--BorderColor--300);
       }
+
       th,
       td {
         @include rem('padding', 8px);
-      }
-
-      // Inline style overwrite
-      td {
-        background: white !important;
-      }
-      th {
-        text-align: left !important;
       }
     }
   }

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.scss
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.scss
@@ -1,44 +1,13 @@
 @import '~@redhat-cloud-services/frontend-components-utilities/styles/_mixins';
 
-.ins-c-inventory-insights__report-details__override {
-  .ins-c-rules-card {
-    .pf-c-card__header .pf-l-split__item:first-of-type {
-      white-space: nowrap;
-      @include rem('margin-right', 5px);
-    }
-    .ins-l-icon-group__with-major {
-      display: inline;
-    }
-    .space-between {
-      display: flex;
-      justify-content: space-between;
-    }
-  }
-
-  .ins-c-rules-card .pf-c-card__header div {
-    font-weight: 600;
-  }
-
-  .ins-c-rules-card + .ins-c-rules-card {
-    margin-top: var(--pf-global--spacer--xl);
-  }
-
-  .ins-c-rules-card a[disabled] {
-    cursor: not-allowed;
-    color: var(--pf-global--disabled-color--200);
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  .ins-c-inventory-advisor__card {
-    .ins-m-card__flat {
-      box-shadow: none;
-      border: 0px;
-    }
-
-    .pf-c-card__body svg {
-      @include rem('margin-right', 5px);
+.ins-c-report-details {
+  &__cards-stack {
+    a[disabled] {
+      cursor: not-allowed;
+      color: var(--pf-global--disabled-color--200);
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     pre {
@@ -68,8 +37,6 @@
 
     .pf-c-list {
       @include rem('margin', 5px 0);
-      list-style: disc;
-      padding-left: var(--pf-global--spacer--lg);
     }
 
     table {
@@ -96,7 +63,7 @@
     }
   }
 
-  .ins-c-report-details-icon {
+  &__icon {
     margin-right: var(--pf-global--spacer--sm);
   }
 }

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
@@ -7,29 +7,11 @@ it('render report details', () => {
     <ReportDetails
       report={{
         rule: {
-          rule_id: 'ansible_deprecated_repo|ANSIBLE_DEPRECATED_REPO',
-          created_at: '2020-04-27T14:37:24.298648Z',
-          updated_at: '2022-05-24T05:45:39.928009Z',
-          description: 'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled',
-          active: true,
-          category: {
-            id: 1,
-            name: 'Availability',
-          },
-          impact: {
-            name: 'Compatibility Error',
-            impact: 2,
-          },
-          likelihood: 2,
-          node_id: '3359651',
-          tags: 'ansible sbr_services',
-          reboot_required: false,
-          publish_date: '2018-04-16T10:03:16Z',
+          rule_id: 'foobar_deprecated_something|FOOBAR_DEPRECATED_SOMETHING',
+          node_id: '12345678',
           summary: 'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n',
-          generic:
-            'Since the release of Ansible Engine 2.4, Red Hat will no longer provide future errata from the Extras repo but from a dedicated Ansible repo instead. New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n',
           reason:
-            'This host has `{{=pydata.package}}` installed and the dedicated Ansible repo `rhel-7-server-ansible-2-rpms` is not enabled. Since the release of Ansible Engine 2.4, Red Hat will no longer provide future errata from the Extras repo but from a dedicated Ansible repo instead. On this host, the new versions of `ansible` package will not be available.\n',
+            'This system is running Red Hat Enterprise Linux with the following SAP\napplication{{?Object.keys(pydata.inst).length>=2}}s{{?}} but the `/etc/hosts`\nis not configured correctly, which results in some functions of SAP system failure.\n\n1. SAP applications running on this host.\n    {{~pydata.inst: e}}\n    * {{=e}}{{~}}\n1. Issues in the `/etc/hosts`:\n  {{?pydata.no_hn}}* The hostname of this host **{{=pydata.hostname}}** is not found.\n  {{?}}{{?pydata.line_127}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address **127.0.0.1**\n    ~~~\n    {{~pydata.line_127: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_hn}}* The FQDN is not in the second column or hostname is not followed\n    ~~~\n    {{~pydata.line_hn: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_ip}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address that does not belong to this host\n    ~~~\n    {{~pydata.line_ip: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.before_local}}* The following {{?Object.keys(pydata.before_local).length>=2}}lines are{{??}}line is{{?}} before the line of **127.0.0.1** or the line of **{{=pydata.hostname}}**\n    ~~~\n    {{~pydata.before_local: e}}{{=e}}\n    {{~}}\n    ~~~{{?}}\n  {{?pydata.long_before_local}}\n  **Note:** There are more than 10 lines in the `/etc/hosts` impacted and only the first 10 are displayed here. Please check the full list of them manually in the `/etc/hosts`.\n  {{?}}\n \nThis host is running **kernel-{{=pydata.kernel}}** and {{?Object.keys(pydata.ipv6_dev_routes).length>1}}`IPv6` routes are added for IPv6 addresses, associated with the interfaces.{{??}}`IPv6` route is added for IPv6 address, associated with the interface.{{?}} Due to a known bug in the `kernel`, when `ip6_route_dev_notify` function receives a **NULL** pointer from `snmp6_alloc_dev` while unregistering the network device, kernel panic occurs. The `snmp6_alloc_dev` returns **NULL** when CPU allocation fails.\n\nThe following IPv6 enabled {{?Object.keys(pydata.ipv6_dev_routes).length>1}}interfaces are{{??}}interface is{{?}} present on this host:\n<table>\n  <tr>\n    <th>Interface</th>\n    <th>IPv6 Address</th>\n  </tr>\n{{ for (var key in pydata.ipv6_dev_routes) { }}\n<tr>\n    <td>{{=key}} </td>\n    <td>{{=pydata.ipv6_dev_routes[key]}} </td>\n</tr>\n{{ } }}\n</table>\n',
           more_info:
             '* For more information regarding the dedicated Ansible Engine channel, please refer to [Ansible deprecated in the Extras channel](https://access.redhat.com/articles/3359651). \n* For how to use the dedicated Ansible Engine channel, please refer to [How do I Download and Install Red Hat Ansible Engine?](https://access.redhat.com/articles/3174981).\n',
           resolution_set: [
@@ -48,13 +30,25 @@ it('render report details', () => {
         },
         details: {
           type: 'rule',
-          package: 'ansible-2.8.18-1.el7ae',
-          error_key: 'ANSIBLE_DEPRECATED_REPO',
+          package: 'ansible-1.8.42-5.elre',
+          kernel: '3.9.0-862.2.3.el1.x86_64',
+          error_key: 'FOOBAR_DEPRECATED_SOMETHING',
+          rhsm_rset: null,
+          ipv6_dev_routes: {
+            eth0: 'fe81::c547:c849:ee14:2bdc',
+          },
+          fqdn: 'iqe-patch-rhel-75-7c99fe69-eaca-2144-a7db-69c9c792ae',
+          inst: ['D00', 'D01', 'D02'],
+          rhel: '7.1',
+          no_hn: true,
+          hostname: 'iqe-patch-rhel-42-7c22fe69-eaca-4242-a7db-69c913c792ae',
+          subs: ['Applications'],
+          mis_repos: ['rhel-sap-for-rhel-42-server-rpms'],
         },
         resolution:
-          'Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n',
+          "Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n \n {{?pydata.subs&&pydata.subs.indexOf('Solutions') != -1}}\nWhen running SAP HANA on RHEL it must be ensured that only OS packages provided\nfor the specific RHEL minor release are installed. For supportability it is\ntherefore required that only either the EUS or E4S repos are active on the\nsystem.\n{{?}}\nThe following {{?pydata.mis_repos.length>1}}repositories{{??}}repository{{?}} should be enabled on this host:\n{{~pydata.mis_repos: e}}* {{=e}}\n{{~}}\nRed Hat recommends that you perform the following steps to enable {{?pydata.mis_repos.length>1}}these repos{{??}}this repo{{?}}:\n1. Find the serial number for current subscription:\n  ~~~\n  # subscription-manager list --consumed\n  ~~~\n1. Remove the system from the current subscription:\n  ~~~\n  # subscription-manager remove --serial='SERIAL NUMBER'\n  ~~~\n1. Find the pool ID for the **RHEL for SAP** subscription:\n  ~~~\n  # subscription-manager list --available\n  ~~~\n1. Subscribe to **RHEL for SAP** using the pool ID:\n  ~~~\n  # subscription-manager attach --pool='XXXX'\n  ~~~\n1. Enable the recommended yum repositories:\n  ~~~\n  # subscription-manager repos{{~pydata.mis_repos: e}} --enable={{=e}}{{~}}\n  ~~~\n1. Review the yum repolist and ensure that **RHEL for SAP** is enabled:\n  ~~~\n  # yum repolist\n  ~~~\n",
       }}
-      kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/1186753' }}
+      kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/12345678', publishedTitle: 'Lorem ipsum article' }}
       kbaLoading={false}
     />
   );

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
@@ -1,55 +1,75 @@
 import React from 'react';
 import { mount } from '@cypress/react';
-import { ReportDetails } from '..';
 
-it('render report details', () => {
-  mount(
-    <ReportDetails
-      report={{
-        rule: {
-          rule_id: 'foobar_deprecated_something|FOOBAR_DEPRECATED_SOMETHING',
-          node_id: '12345678',
-          summary: 'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n',
-          reason:
-            'This system is running Red Hat Enterprise Linux with the following SAP\napplication{{?Object.keys(pydata.inst).length>=2}}s{{?}} but the `/etc/hosts`\nis not configured correctly, which results in some functions of SAP system failure.\n\n1. SAP applications running on this host.\n    {{~pydata.inst: e}}\n    * {{=e}}{{~}}\n1. Issues in the `/etc/hosts`:\n  {{?pydata.no_hn}}* The hostname of this host **{{=pydata.hostname}}** is not found.\n  {{?}}{{?pydata.line_127}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address **127.0.0.1**\n    ~~~\n    {{~pydata.line_127: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_hn}}* The FQDN is not in the second column or hostname is not followed\n    ~~~\n    {{~pydata.line_hn: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.line_ip}}* The hostname of this host **{{=pydata.hostname}}** is associated with the IP address that does not belong to this host\n    ~~~\n    {{~pydata.line_ip: e}}{{=e}}\n    {{~}}\n    ~~~\n  {{?}}{{?pydata.before_local}}* The following {{?Object.keys(pydata.before_local).length>=2}}lines are{{??}}line is{{?}} before the line of **127.0.0.1** or the line of **{{=pydata.hostname}}**\n    ~~~\n    {{~pydata.before_local: e}}{{=e}}\n    {{~}}\n    ~~~{{?}}\n  {{?pydata.long_before_local}}\n  **Note:** There are more than 10 lines in the `/etc/hosts` impacted and only the first 10 are displayed here. Please check the full list of them manually in the `/etc/hosts`.\n  {{?}}\n \nThis host is running **kernel-{{=pydata.kernel}}** and {{?Object.keys(pydata.ipv6_dev_routes).length>1}}`IPv6` routes are added for IPv6 addresses, associated with the interfaces.{{??}}`IPv6` route is added for IPv6 address, associated with the interface.{{?}} Due to a known bug in the `kernel`, when `ip6_route_dev_notify` function receives a **NULL** pointer from `snmp6_alloc_dev` while unregistering the network device, kernel panic occurs. The `snmp6_alloc_dev` returns **NULL** when CPU allocation fails.\n\nThe following IPv6 enabled {{?Object.keys(pydata.ipv6_dev_routes).length>1}}interfaces are{{??}}interface is{{?}} present on this host:\n<table>\n  <tr>\n    <th>Interface</th>\n    <th>IPv6 Address</th>\n  </tr>\n{{ for (var key in pydata.ipv6_dev_routes) { }}\n<tr>\n    <td>{{=key}} </td>\n    <td>{{=pydata.ipv6_dev_routes[key]}} </td>\n</tr>\n{{ } }}\n</table>\n',
-          more_info:
-            '* For more information regarding the dedicated Ansible Engine channel, please refer to [Ansible deprecated in the Extras channel](https://access.redhat.com/articles/3359651). \n* For how to use the dedicated Ansible Engine channel, please refer to [How do I Download and Install Red Hat Ansible Engine?](https://access.redhat.com/articles/3174981).\n',
-          resolution_set: [
-            {
-              system_type: 105,
-              resolution:
-                'Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n',
-              resolution_risk: {
-                name: 'Update Package',
-                risk: 1,
-              },
-              has_playbook: true,
-            },
-          ],
-          total_risk: 2,
-        },
-        details: {
-          type: 'rule',
-          package: 'ansible-1.8.42-5.elre',
-          kernel: '3.9.0-862.2.3.el1.x86_64',
-          error_key: 'FOOBAR_DEPRECATED_SOMETHING',
-          rhsm_rset: null,
-          ipv6_dev_routes: {
-            eth0: 'fe81::c547:c849:ee14:2bdc',
-          },
-          fqdn: 'iqe-patch-rhel-75-7c99fe69-eaca-2144-a7db-69c9c792ae',
-          inst: ['D00', 'D01', 'D02'],
-          rhel: '7.1',
-          no_hn: true,
-          hostname: 'iqe-patch-rhel-42-7c22fe69-eaca-4242-a7db-69c913c792ae',
-          subs: ['Applications'],
-          mis_repos: ['rhel-sap-for-rhel-42-server-rpms'],
-        },
-        resolution:
-          "Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n \n {{?pydata.subs&&pydata.subs.indexOf('Solutions') != -1}}\nWhen running SAP HANA on RHEL it must be ensured that only OS packages provided\nfor the specific RHEL minor release are installed. For supportability it is\ntherefore required that only either the EUS or E4S repos are active on the\nsystem.\n{{?}}\nThe following {{?pydata.mis_repos.length>1}}repositories{{??}}repository{{?}} should be enabled on this host:\n{{~pydata.mis_repos: e}}* {{=e}}\n{{~}}\nRed Hat recommends that you perform the following steps to enable {{?pydata.mis_repos.length>1}}these repos{{??}}this repo{{?}}:\n1. Find the serial number for current subscription:\n  ~~~\n  # subscription-manager list --consumed\n  ~~~\n1. Remove the system from the current subscription:\n  ~~~\n  # subscription-manager remove --serial='SERIAL NUMBER'\n  ~~~\n1. Find the pool ID for the **RHEL for SAP** subscription:\n  ~~~\n  # subscription-manager list --available\n  ~~~\n1. Subscribe to **RHEL for SAP** using the pool ID:\n  ~~~\n  # subscription-manager attach --pool='XXXX'\n  ~~~\n1. Enable the recommended yum repositories:\n  ~~~\n  # subscription-manager repos{{~pydata.mis_repos: e}} --enable={{=e}}{{~}}\n  ~~~\n1. Review the yum repolist and ensure that **RHEL for SAP** is enabled:\n  ~~~\n  # yum repolist\n  ~~~\n",
-      }}
-      kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/12345678', publishedTitle: 'Lorem ipsum article' }}
-      kbaLoading={false}
-    />
-  );
+import { ReportDetails } from '..';
+import report from '../../cypress/fixtures/report.json';
+
+const ROOT = '.ins-c-report-details';
+const HEADERS = ['Detected issues', 'Steps to resolve', 'Related Knowledgebase article', 'Additional info'];
+
+describe('report details: kba loaded', () => {
+  beforeEach(() => {
+    mount(
+      <ReportDetails
+        report={report}
+        kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/12345678', publishedTitle: 'Lorem ipsum article' }}
+        kbaLoading={false}
+      />
+    );
+  });
+
+  it('renders component', () => {
+    cy.get(ROOT);
+  });
+
+  it('renders four headers', () => {
+    cy.get('.pf-c-card__header').should('have.length', 4);
+    HEADERS.forEach((h) => cy.get('.pf-c-card__header').contains(h).should('have.length', 1));
+  });
+
+  it('each header has an icon', () => {
+    cy.get('.pf-c-card__header > .ins-c-report-details__icon').should('have.length', 4);
+  });
+
+  it('links have an icon', () => {
+    cy.get('a > [class="fas fa-external-link-alt"]').should('have.length', 3);
+  });
+
+  it('renders lists with ol, ul, and li tags', () => {
+    cy.get('ol ul > li').should('have.length', 3);
+  });
+
+  it('renders code blocks with pre and code tags', () => {
+    cy.get('pre code').should('have.length', 7);
+  });
+
+  it('renders table correctly', () => {
+    cy.get('table > tbody').within(() => {
+      cy.get('tr').should('have.length', 2);
+      cy.get('tr > td').eq(0).should('contain', 'eth0');
+      cy.get('tr > td').eq(1).should('contain', 'fe81::c547:c849:ee14:2bdc');
+      cy.get('tr > th').should('have.length', 2);
+      cy.get('tr > th').eq(0).should('contain', 'Interface');
+      cy.get('tr > th').eq(1).should('contain', 'IPv6 Address');
+    });
+  });
+
+  it('renders three dividers', () => {
+    cy.get('hr[class=pf-c-divider]').should('have.length', 3);
+  });
+
+  it('renders a loaded kba link', () => {
+    cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`).find('.pf-c-skeleton').should('have.length', 0);
+    cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`).contains('Lorem ipsum article');
+  });
+});
+
+describe('report details: kba loading', () => {
+  beforeEach(() => {
+    mount(<ReportDetails report={report} kbaDetail={undefined} kbaLoading={true} />);
+  });
+
+  it('renders skeleton instead of a kba link', () => {
+    cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`).find('.pf-c-skeleton').should('have.length', 1);
+  });
 });

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
@@ -22,13 +22,13 @@ describe('report details: kba loaded', () => {
     cy.get(ROOT);
   });
 
-  it('renders four headers', () => {
-    cy.get('.pf-c-card__header').should('have.length', 4);
+  it('renders correct number of headers', () => {
+    cy.get('.pf-c-card__header').should('have.length', HEADERS.length);
     HEADERS.forEach((h) => cy.get('.pf-c-card__header').contains(h).should('have.length', 1));
   });
 
   it('each header has an icon', () => {
-    cy.get('.pf-c-card__header > .ins-c-report-details__icon').should('have.length', 4);
+    cy.get('.pf-c-card__header > .ins-c-report-details__icon').should('have.length', HEADERS.length);
   });
 
   it('links have an icon', () => {

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
@@ -7,15 +7,15 @@ import report from '../../cypress/fixtures/report.json';
 const ROOT = '.ins-c-report-details';
 const HEADERS = ['Detected issues', 'Steps to resolve', 'Related Knowledgebase article', 'Additional info'];
 
+const props = {
+  report,
+  kbaDetail: { view_uri: 'https://access.redhat.com/solutions/12345678', publishedTitle: 'Lorem ipsum article' },
+  kbaLoading: false,
+};
+
 describe('report details: kba loaded', () => {
   beforeEach(() => {
-    mount(
-      <ReportDetails
-        report={report}
-        kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/12345678', publishedTitle: 'Lorem ipsum article' }}
-        kbaLoading={false}
-      />
-    );
+    mount(<ReportDetails {...props} />);
   });
 
   it('renders component', () => {
@@ -32,41 +32,49 @@ describe('report details: kba loaded', () => {
   });
 
   it('links have an icon', () => {
+    // TODO: do not hardcode the value
     cy.get('a > [class="fas fa-external-link-alt"]').should('have.length', 3);
   });
 
   it('renders lists with ol, ul, and li tags', () => {
+    // TODO: do not hardcode the value
     cy.get('ol ul > li').should('have.length', 3);
   });
 
   it('renders code blocks with pre and code tags', () => {
+    // TODO: do not hardcode the value
     cy.get('pre code').should('have.length', 7);
   });
 
   it('renders table correctly', () => {
+    const ths = report.rule.reason.match(/(?<=<th>)\S*\D*(?=<\/th>)/g);
     cy.get('table > tbody').within(() => {
       cy.get('tr').should('have.length', 2);
+      // TODO: extract td data from the test data isntead of hardcoding it
       cy.get('tr > td').eq(0).should('contain', 'eth0');
       cy.get('tr > td').eq(1).should('contain', 'fe81::c547:c849:ee14:2bdc');
-      cy.get('tr > th').should('have.length', 2);
-      cy.get('tr > th').eq(0).should('contain', 'Interface');
-      cy.get('tr > th').eq(1).should('contain', 'IPv6 Address');
+      cy.get('tr > th').should('have.length', ths.length);
+      cy.get('tr > th').each(($th, index) => cy.wrap($th).should('contain', ths[index]));
     });
   });
 
   it('renders three dividers', () => {
+    // TODO: make the assertion number dependant on input test data
     cy.get('hr[class=pf-c-divider]').should('have.length', 3);
   });
 
   it('renders a loaded kba link', () => {
     cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`).find('.pf-c-skeleton').should('have.length', 0);
-    cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`).contains('Lorem ipsum article');
+    cy.get(`${ROOT} .ins-c-report-details__kba .pf-c-card__body`)
+      .contains(props.kbaDetail.publishedTitle)
+      .invoke('attr', 'href')
+      .should('eq', props.kbaDetail.view_uri);
   });
 });
 
 describe('report details: kba loading', () => {
   beforeEach(() => {
-    mount(<ReportDetails report={report} kbaDetail={undefined} kbaLoading={true} />);
+    mount(<ReportDetails {...{ ...props, kbaLoading: true }} />);
   });
 
   it('renders skeleton instead of a kba link', () => {

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.spec.ct.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import { ReportDetails } from '..';
+
+it('render report details', () => {
+  mount(
+    <ReportDetails
+      report={{
+        rule: {
+          rule_id: 'ansible_deprecated_repo|ANSIBLE_DEPRECATED_REPO',
+          created_at: '2020-04-27T14:37:24.298648Z',
+          updated_at: '2022-05-24T05:45:39.928009Z',
+          description: 'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled',
+          active: true,
+          category: {
+            id: 1,
+            name: 'Availability',
+          },
+          impact: {
+            name: 'Compatibility Error',
+            impact: 2,
+          },
+          likelihood: 2,
+          node_id: '3359651',
+          tags: 'ansible sbr_services',
+          reboot_required: false,
+          publish_date: '2018-04-16T10:03:16Z',
+          summary: 'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n',
+          generic:
+            'Since the release of Ansible Engine 2.4, Red Hat will no longer provide future errata from the Extras repo but from a dedicated Ansible repo instead. New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled.\n',
+          reason:
+            'This host has `{{=pydata.package}}` installed and the dedicated Ansible repo `rhel-7-server-ansible-2-rpms` is not enabled. Since the release of Ansible Engine 2.4, Red Hat will no longer provide future errata from the Extras repo but from a dedicated Ansible repo instead. On this host, the new versions of `ansible` package will not be available.\n',
+          more_info:
+            '* For more information regarding the dedicated Ansible Engine channel, please refer to [Ansible deprecated in the Extras channel](https://access.redhat.com/articles/3359651). \n* For how to use the dedicated Ansible Engine channel, please refer to [How do I Download and Install Red Hat Ansible Engine?](https://access.redhat.com/articles/3174981).\n',
+          resolution_set: [
+            {
+              system_type: 105,
+              resolution:
+                'Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n',
+              resolution_risk: {
+                name: 'Update Package',
+                risk: 1,
+              },
+              has_playbook: true,
+            },
+          ],
+          total_risk: 2,
+        },
+        details: {
+          type: 'rule',
+          package: 'ansible-2.8.18-1.el7ae',
+          error_key: 'ANSIBLE_DEPRECATED_REPO',
+        },
+        resolution:
+          'Red Hat recommends that you enable the dedicated Ansible repo and update `ansible` package to the latest version.\n  ~~~\n  # subscription-manager repos --enable rhel-7-server-ansible-2-rpms\n  # yum update ansible\n  ~~~\n',
+      }}
+      kbaDetail={{ view_uri: 'https://access.redhat.com/solutions/1186753' }}
+      kbaLoading={false}
+    />
+  );
+});

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -68,7 +68,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
             <React.Fragment>
               <Divider />
               <StackItem>
-                <Card isCompact isPlain>
+                <Card className="ins-c-report-details__kba" isCompact isPlain>
                   <CardHeader>
                     <LightbulbIcon className="ins-c-report-details__icon" />
                     <strong>Related Knowledgebase article</strong>

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -1,8 +1,8 @@
 import './ReportDetails.scss';
 
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Card, CardBody, CardHeader, Divider, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, Card, CardBody, CardHeader, Divider, Stack, StackItem } from '@patternfly/react-core';
 import { BullseyeIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
 
@@ -27,10 +27,17 @@ interface ReportDetailsProps {
 
 const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoading }) => {
   const { rule, details, resolution } = report;
+  const [error, setError] = useState<Error | null>(null);
 
   return (
     <Card className="ins-c-inventory-insights__report-details__override" style={{ boxShadow: 'none' }}>
       <CardBody>
+        {error && (
+          <React.Fragment>
+            <Alert variant="danger" title="Sorry, there was an error rendering the content correctly." isInline />
+            <br />
+          </React.Fragment>
+        )}
         <Stack className="ins-c-inventory-advisor__card ins-c-rules-card" widget-type="InsightsRulesCard" hasGutter>
           <StackItem>
             <Card className="ins-m-card__flat" isCompact>
@@ -38,7 +45,9 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <BullseyeIcon className="ins-c-report-details-icon" />
                 <strong>Detected issues</strong>
               </CardHeader>
-              <CardBody>{rule.reason && <TemplateProcessor template={rule.reason} definitions={details} />}</CardBody>
+              <CardBody>
+                {rule.reason && <TemplateProcessor template={rule.reason} definitions={details} onError={(e: Error) => setError(e)} />}
+              </CardBody>
             </Card>
           </StackItem>
           <Divider />
@@ -48,7 +57,9 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <ThumbsUpIcon className="ins-c-report-details-icon" />
                 <strong>Steps to resolve</strong>
               </CardHeader>
-              <CardBody>{resolution && <TemplateProcessor template={resolution} definitions={details} />}</CardBody>
+              <CardBody>
+                {resolution && <TemplateProcessor template={resolution} definitions={details} onError={(e: Error) => setError(e)} />}
+              </CardBody>
             </Card>
           </StackItem>
           {(rule as RuleContentRhel).node_id && (
@@ -83,7 +94,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                     <InfoCircleIcon className="ins-c-report-details-icon" />
                     <strong>Additional info</strong>
                   </CardHeader>
-                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} />}</CardBody>
+                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} onError={(e: Error) => setError(e)} />}</CardBody>
                 </Card>
               </StackItem>
             </React.Fragment>

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -3,11 +3,12 @@ import './ReportDetails.scss';
 import React from 'react';
 
 import { Card, CardBody, CardHeader, Divider, Stack, StackItem } from '@patternfly/react-core';
-import { BullseyeIcon, ExternalLinkAltIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
+import { BullseyeIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
 import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
 
 import { RuleContentOcp, RuleContentRhel } from '../types';
 import { TemplateProcessor } from '../TemplateProcessor';
+import { ExternalLink } from '../common';
 
 interface Report {
   rule: RuleContentRhel | RuleContentOcp;
@@ -63,9 +64,10 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                     {kbaLoading ? (
                       <Skeleton size={SkeletonSize.sm} />
                     ) : (
-                      <a rel="noopener noreferrer" target="_blank" href={`${kbaDetail.view_uri}`}>
-                        {kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`} <ExternalLinkAltIcon />
-                      </a>
+                      <ExternalLink
+                        href={`${kbaDetail.view_uri}`}
+                        content={kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`}
+                      />
                     )}
                   </CardBody>
                 </Card>

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -1,13 +1,13 @@
 import './ReportDetails.scss';
 
 import React from 'react';
-import doT from 'dot';
-import { marked } from 'marked';
+
 import { Card, CardBody, CardHeader, Divider, Stack, StackItem } from '@patternfly/react-core';
 import { BullseyeIcon, ExternalLinkAltIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
 
 import { RuleContentOcp, RuleContentRhel } from '../types';
-import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+import { TemplateProcessor } from '../TemplateProcessor';
 
 interface Report {
   rule: RuleContentRhel | RuleContentOcp;
@@ -27,42 +27,6 @@ interface ReportDetailsProps {
 const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoading }) => {
   const { rule, details, resolution } = report;
 
-  const templateProcessor = (template: string, definitions: Record<string, string | number>) => {
-    const DOT_SETTINGS = {
-      ...doT.templateSettings,
-      varname: 'pydata',
-      strip: false,
-    };
-    const externalLinkIcon = '';
-
-    try {
-      const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
-      const compiledMd = marked(compiledDot);
-
-      return (
-        <div
-          dangerouslySetInnerHTML={{
-            __html: compiledMd
-              .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
-              .replace(/<a>/gim, `<a> rel="noopener noreferrer" target="_blank"`)
-              .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`),
-          }}
-        />
-      );
-    } catch (error) {
-      console.warn(error, definitions, template); // eslint-disable-line no-console
-      return (
-        <React.Fragment>
-          {' '}
-          Ouch. We were unable to correctly render this text, instead please enjoy the raw data.
-          <pre>
-            <code>{template}</code>
-          </pre>
-        </React.Fragment>
-      );
-    }
-  };
-
   return (
     <Card className="ins-c-inventory-insights__report-details__override" style={{ boxShadow: 'none' }}>
       <CardBody>
@@ -73,7 +37,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <BullseyeIcon className="ins-c-report-details-icon" />
                 <strong>Detected issues</strong>
               </CardHeader>
-              <CardBody>{rule.reason && templateProcessor(rule.reason, details)}</CardBody>
+              <CardBody>{rule.reason && <TemplateProcessor template={rule.reason} definitions={details} />}</CardBody>
             </Card>
           </StackItem>
           <Divider />
@@ -83,7 +47,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <ThumbsUpIcon className="ins-c-report-details-icon" />
                 <strong>Steps to resolve</strong>
               </CardHeader>
-              <CardBody>{resolution && templateProcessor(resolution, details)}</CardBody>
+              <CardBody>{resolution && <TemplateProcessor template={resolution} definitions={details} />}</CardBody>
             </Card>
           </StackItem>
           {(rule as RuleContentRhel).node_id && (
@@ -117,7 +81,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                     <InfoCircleIcon className="ins-c-report-details-icon" />
                     <strong>Additional info</strong>
                   </CardHeader>
-                  <CardBody>{templateProcessor(rule.more_info, details)}</CardBody>
+                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} />}</CardBody>
                 </Card>
               </StackItem>
             </React.Fragment>

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -30,7 +30,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
   const [error, setError] = useState<Error | null>(null);
 
   return (
-    <Card className="ins-c-inventory-insights__report-details__override" style={{ boxShadow: 'none' }}>
+    <Card className="ins-c-report-details" style={{ boxShadow: 'none' }}>
       <CardBody>
         {error && (
           <React.Fragment>
@@ -38,11 +38,11 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
             <br />
           </React.Fragment>
         )}
-        <Stack className="ins-c-inventory-advisor__card ins-c-rules-card" widget-type="InsightsRulesCard" hasGutter>
+        <Stack className="ins-c-report-details__cards-stack" widget-type="InsightsRulesCard" hasGutter>
           <StackItem>
-            <Card className="ins-m-card__flat" isCompact>
+            <Card isCompact isPlain>
               <CardHeader>
-                <BullseyeIcon className="ins-c-report-details-icon" />
+                <BullseyeIcon className="ins-c-report-details__icon" />
                 <strong>Detected issues</strong>
               </CardHeader>
               <CardBody>
@@ -52,9 +52,9 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
           </StackItem>
           <Divider />
           <StackItem>
-            <Card className="ins-m-card__flat" isCompact>
+            <Card isCompact isPlain>
               <CardHeader>
-                <ThumbsUpIcon className="ins-c-report-details-icon" />
+                <ThumbsUpIcon className="ins-c-report-details__icon" />
                 <strong>Steps to resolve</strong>
               </CardHeader>
               <CardBody>
@@ -66,19 +66,22 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
             <React.Fragment>
               <Divider />
               <StackItem>
-                <Card className="ins-m-card__flat" isCompact>
+                <Card isCompact isPlain>
                   <CardHeader>
-                    <LightbulbIcon className="ins-c-report-details-icon" />
+                    <LightbulbIcon className="ins-c-report-details__icon" />
                     <strong>Related Knowledgebase article</strong>
                   </CardHeader>
                   <CardBody>
                     {kbaLoading ? (
                       <Skeleton size={SkeletonSize.sm} />
                     ) : (
-                      <ExternalLink
-                        href={`${kbaDetail.view_uri}`}
-                        content={kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`}
-                      />
+                      <React.Fragment>
+                        <ExternalLink
+                          href={`${kbaDetail.view_uri}`}
+                          content={kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`}
+                        />
+                        .
+                      </React.Fragment>
                     )}
                   </CardBody>
                 </Card>
@@ -89,9 +92,9 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
             <React.Fragment>
               <Divider />
               <StackItem>
-                <Card className="ins-m-card__flat" isCompact>
+                <Card isCompact isPlain>
                   <CardHeader>
-                    <InfoCircleIcon className="ins-c-report-details-icon" />
+                    <InfoCircleIcon className="ins-c-report-details__icon" />
                     <strong>Additional info</strong>
                   </CardHeader>
                   <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} onError={(e: Error) => setError(e)} />}</CardBody>

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -1,0 +1,131 @@
+import './ReportDetails.scss';
+
+import React from 'react';
+import doT from 'dot';
+import { marked } from 'marked';
+import { Card, CardBody, CardHeader, Divider, Stack, StackItem } from '@patternfly/react-core';
+import { BullseyeIcon, ExternalLinkAltIcon, InfoCircleIcon, LightbulbIcon, ThumbsUpIcon } from '@patternfly/react-icons';
+
+import { RuleContentOcp, RuleContentRhel } from '../types';
+import { Skeleton, SkeletonSize } from '@redhat-cloud-services/frontend-components/Skeleton';
+
+interface Report {
+  rule: RuleContentRhel | RuleContentOcp;
+  details: Record<string, string | number>;
+  resolution: string;
+}
+
+interface ReportDetailsProps {
+  report: Report;
+  kbaDetail: {
+    publishedTitle: string;
+    view_uri: string;
+  };
+  kbaLoading: boolean;
+}
+
+const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoading }) => {
+  const { rule, details, resolution } = report;
+
+  const templateProcessor = (template: string, definitions: Record<string, string | number>) => {
+    const DOT_SETTINGS = {
+      ...doT.templateSettings,
+      varname: 'pydata',
+      strip: false,
+    };
+    const externalLinkIcon = '';
+
+    try {
+      const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
+      const compiledMd = marked(compiledDot);
+
+      return (
+        <div
+          dangerouslySetInnerHTML={{
+            __html: compiledMd
+              .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
+              .replace(/<a>/gim, `<a> rel="noopener noreferrer" target="_blank"`)
+              .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`),
+          }}
+        />
+      );
+    } catch (error) {
+      console.warn(error, definitions, template); // eslint-disable-line no-console
+      return (
+        <React.Fragment>
+          {' '}
+          Ouch. We were unable to correctly render this text, instead please enjoy the raw data.
+          <pre>
+            <code>{template}</code>
+          </pre>
+        </React.Fragment>
+      );
+    }
+  };
+
+  return (
+    <Card className="ins-c-inventory-insights__report-details__override" style={{ boxShadow: 'none' }}>
+      <CardBody>
+        <Stack className="ins-c-inventory-advisor__card ins-c-rules-card" widget-type="InsightsRulesCard" hasGutter>
+          <StackItem>
+            <Card className="ins-m-card__flat" isCompact>
+              <CardHeader>
+                <BullseyeIcon className="ins-c-report-details-icon" />
+                <strong>Detected issues</strong>
+              </CardHeader>
+              <CardBody>{rule.reason && templateProcessor(rule.reason, details)}</CardBody>
+            </Card>
+          </StackItem>
+          <Divider />
+          <StackItem>
+            <Card className="ins-m-card__flat" isCompact>
+              <CardHeader>
+                <ThumbsUpIcon className="ins-c-report-details-icon" />
+                <strong>Steps to resolve</strong>
+              </CardHeader>
+              <CardBody>{resolution && templateProcessor(resolution, details)}</CardBody>
+            </Card>
+          </StackItem>
+          {(rule as RuleContentRhel).node_id && (
+            <React.Fragment>
+              <Divider />
+              <StackItem>
+                <Card className="ins-m-card__flat" isCompact>
+                  <CardHeader>
+                    <LightbulbIcon className="ins-c-report-details-icon" />
+                    <strong>Related Knowledgebase article</strong>
+                  </CardHeader>
+                  <CardBody>
+                    {kbaLoading ? (
+                      <Skeleton size={SkeletonSize.sm} />
+                    ) : (
+                      <a rel="noopener noreferrer" target="_blank" href={`${kbaDetail.view_uri}`}>
+                        {kbaDetail.publishedTitle ? kbaDetail.publishedTitle : `Knowledgebase article`} <ExternalLinkAltIcon />
+                      </a>
+                    )}
+                  </CardBody>
+                </Card>
+              </StackItem>
+            </React.Fragment>
+          )}
+          {rule.more_info && (
+            <React.Fragment>
+              <Divider />
+              <StackItem>
+                <Card className="ins-m-card__flat" isCompact>
+                  <CardHeader>
+                    <InfoCircleIcon className="ins-c-report-details-icon" />
+                    <strong>Additional info</strong>
+                  </CardHeader>
+                  <CardBody>{templateProcessor(rule.more_info, details)}</CardBody>
+                </Card>
+              </StackItem>
+            </React.Fragment>
+          )}
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default ReportDetails;

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -22,7 +22,7 @@ interface ReportDetailsProps {
     publishedTitle: string;
     view_uri: string;
   };
-  kbaLoading: boolean;
+  kbaLoading: boolean; // if true, renders skeleton instead of kba link
 }
 
 const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoading }) => {

--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -29,6 +29,12 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
   const { rule, details, resolution } = report;
   const [error, setError] = useState<Error | null>(null);
 
+  const handleError = (e: Error) => {
+    if (error === null) {
+      setError(e);
+    }
+  };
+
   return (
     <Card className="ins-c-report-details" style={{ boxShadow: 'none' }}>
       <CardBody>
@@ -45,9 +51,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <BullseyeIcon className="ins-c-report-details__icon" />
                 <strong>Detected issues</strong>
               </CardHeader>
-              <CardBody>
-                {rule.reason && <TemplateProcessor template={rule.reason} definitions={details} onError={(e: Error) => setError(e)} />}
-              </CardBody>
+              <CardBody>{rule.reason && <TemplateProcessor template={rule.reason} definitions={details} onError={handleError} />}</CardBody>
             </Card>
           </StackItem>
           <Divider />
@@ -57,9 +61,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                 <ThumbsUpIcon className="ins-c-report-details__icon" />
                 <strong>Steps to resolve</strong>
               </CardHeader>
-              <CardBody>
-                {resolution && <TemplateProcessor template={resolution} definitions={details} onError={(e: Error) => setError(e)} />}
-              </CardBody>
+              <CardBody>{resolution && <TemplateProcessor template={resolution} definitions={details} onError={handleError} />}</CardBody>
             </Card>
           </StackItem>
           {(rule as RuleContentRhel).node_id && (
@@ -97,7 +99,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
                     <InfoCircleIcon className="ins-c-report-details__icon" />
                     <strong>Additional info</strong>
                   </CardHeader>
-                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} onError={(e: Error) => setError(e)} />}</CardBody>
+                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} onError={handleError} />}</CardBody>
                 </Card>
               </StackItem>
             </React.Fragment>

--- a/packages/advisor-components/src/ReportDetails/index.ts
+++ b/packages/advisor-components/src/ReportDetails/index.ts
@@ -1,0 +1,2 @@
+export * from './ReportDetails';
+export { default as ReportDetails } from './ReportDetails';

--- a/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
+++ b/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import doT from 'dot';
+import { marked } from 'marked';
+
+interface TemplateProcessorProps {
+  template: string;
+  definitions: Record<string, string | number>;
+}
+
+const TemplateProcessor: React.FC<TemplateProcessorProps> = ({ template, definitions }) => {
+  const DOT_SETTINGS = {
+    ...doT.templateSettings,
+    varname: 'pydata',
+    strip: false,
+  };
+  const externalLinkIcon = '';
+
+  try {
+    const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
+    const compiledMd = marked(compiledDot);
+
+    return (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: compiledMd
+            .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
+            .replace(/<a>/gim, `<a> rel="noopener noreferrer" target="_blank"`)
+            .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`),
+        }}
+      />
+    );
+  } catch (error) {
+    console.warn(error, definitions, template); // eslint-disable-line no-console
+    return (
+      <React.Fragment>
+        {' '}
+        Ouch. We were unable to correctly render this text, instead please enjoy the raw data.
+        <pre>
+          <code>{template}</code>
+        </pre>
+      </React.Fragment>
+    );
+  }
+};
+
+export default TemplateProcessor;

--- a/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
+++ b/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import doT from 'dot';
 import { marked } from 'marked';
+import sanitize from 'sanitize-html';
 
 interface TemplateProcessorProps {
   template: string;
@@ -18,11 +19,12 @@ const TemplateProcessor: React.FC<TemplateProcessorProps> = ({ template, definit
   try {
     const compiledDot = definitions ? doT.template(template, DOT_SETTINGS)(definitions) : template;
     const compiledMd = marked(compiledDot);
+    const sanitized = sanitize(compiledMd);
 
     return (
       <div
         dangerouslySetInnerHTML={{
-          __html: compiledMd
+          __html: sanitized
             .replace(/<ul>/gim, `<ul class="pf-c-list" style="font-size: inherit">`)
             .replace(/<a>/gim, `<a> rel="noopener noreferrer" target="_blank"`)
             .replace(/<\/a>/gim, ` ${externalLinkIcon}</a>`),

--- a/packages/advisor-components/src/TemplateProcessor/index.ts
+++ b/packages/advisor-components/src/TemplateProcessor/index.ts
@@ -1,0 +1,2 @@
+export * from './TemplateProcessor';
+export { default as TemplateProcessor } from './TemplateProcessor';

--- a/packages/advisor-components/src/common.tsx
+++ b/packages/advisor-components/src/common.tsx
@@ -3,6 +3,7 @@ import compact from 'lodash/compact';
 import intersection from 'lodash/intersection';
 
 import { RuleContentRhel, TopicRhel } from './types';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 // eslint-disable-next-line no-undef
 export const barDividedList = (list: JSX.Element[]) =>
@@ -24,3 +25,9 @@ export const topicLinks = (rule: RuleContentRhel, topics: TopicRhel[], Link: any
         )
       )
     : [];
+
+export const ExternalLink = ({ href, content }: { href: string; content: string }) => (
+  <a rel="noopener noreferrer" target="_blank" href={href}>
+    {content} <ExternalLinkAltIcon />
+  </a>
+);

--- a/packages/advisor-components/src/common.tsx
+++ b/packages/advisor-components/src/common.tsx
@@ -3,7 +3,6 @@ import compact from 'lodash/compact';
 import intersection from 'lodash/intersection';
 
 import { RuleContentRhel, TopicRhel } from './types';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 // eslint-disable-next-line no-undef
 export const barDividedList = (list: JSX.Element[]) =>
@@ -28,6 +27,6 @@ export const topicLinks = (rule: RuleContentRhel, topics: TopicRhel[], Link: any
 
 export const ExternalLink = ({ href, content }: { href: string; content: string }) => (
   <a rel="noopener noreferrer" target="_blank" href={href}>
-    {content} <ExternalLinkAltIcon />
+    {content} <i className="fas fa-external-link-alt" />
   </a>
 );

--- a/packages/advisor-components/src/index.ts
+++ b/packages/advisor-components/src/index.ts
@@ -4,3 +4,4 @@ export * from './RuleRating';
 export * from './types';
 export * from './common';
 export * from './constants';
+export * from './ReportDetails';

--- a/packages/advisor-components/src/types.ts
+++ b/packages/advisor-components/src/types.ts
@@ -22,6 +22,7 @@ export interface RuleContent {
     impact: Impact;
     name?: string;
   };
+  reason: string;
 }
 
 export interface RhelResolution {
@@ -56,7 +57,6 @@ export interface RuleContentRhel extends RuleContent {
 }
 
 export interface RuleContentOcp extends RuleContent {
-  reason: string;
   resolution: string;
   risk_of_change: RiskOfChange;
   impacted_clusters_count: number;


### PR DESCRIPTION
This PR adds another component to the advisor-components library: ReportDetails. The component is accountable for rendering rule results for a particular OpenShift cluster. As the next step, this should replace the current implementation at https://github.com/RedHatInsights/insights-advisor-frontend/tree/master/src/PresentationalComponents/ReportDetails.

- [x] Implement the component
- [x] Refactor code and stylesheets
- [x] Add sanitizer step after transforming Markdown files to HTML
- [x] Add basic tests and fixtures
- [x] Add docs

View in cypress:
![Screenshot from 2022-05-25 14-50-56](https://user-images.githubusercontent.com/31385370/170271087-37d316c3-7d88-4e7f-9887-87151b1e682b.png)
![Screenshot from 2022-05-25 14-51-28](https://user-images.githubusercontent.com/31385370/170271082-ce8be1ff-b5b7-421b-8000-b4d384f25e2c.png)

View in RHEL Advisor (local deployment):
![Screenshot 2022-05-25 at 15-10-49 msager-rhel8 - Systems - Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/170271094-93ad4581-3bdb-4810-b579-452079c73a5b.png)
![Screenshot 2022-05-25 at 15-10-56 msager-rhel8 - Systems - Advisor Red Hat Insights](https://user-images.githubusercontent.com/31385370/170271091-bc1b528a-8444-48b3-ae9f-acf6d82640e0.png)

