### PR TITLE
Configure proxy to download development version of chrome.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34418,7 +34418,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.9.1",
+            "version": "3.9.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
@@ -35426,7 +35426,7 @@
         },
         "packages/notifications": {
             "name": "@redhat-cloud-services/frontend-components-notifications",
-            "version": "3.2.6",
+            "version": "3.2.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": "*",

--- a/packages/config-utils/proxy.js
+++ b/packages/config-utils/proxy.js
@@ -38,6 +38,7 @@ module.exports = ({
   onBeforeSetupMiddleware = () => {},
   bounceProd = false,
   useAgent = true,
+  useDevBuild = true,
 }) => {
   const proxy = [];
   const majorEnv = env.split('-')[0];
@@ -284,8 +285,9 @@ module.exports = ({
             defaultServices.chrome = defaultServices.chrome({});
           }
 
+          const chromeEnv = useDevBuild ? (env.includes('-beta') ? 'dev-beta' : 'dev-stable') : env;
           chromePath = checkoutRepo({
-            repo: `${defaultServices.chrome.path}#${env}`,
+            repo: `${defaultServices.chrome.path}#${chromeEnv}`,
             reposDir,
             overwrite: true,
           });

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -38,6 +38,7 @@ module.exports = ({
   useChromeTemplate = true,
   bounceProd,
   useAgent,
+  useDevBuild = true,
 } = {}) => {
   const filenameMask = `js/[name]${useFileHash ? `.${Date.now()}.[fullhash]` : ''}.js`;
   if (betaEnv) {
@@ -202,6 +203,7 @@ module.exports = ({
         },
         bounceProd,
         useAgent,
+        useDevBuild,
       }),
     },
   };

--- a/packages/docs/pages/proxies/webpack-proxy.mdx
+++ b/packages/docs/pages/proxies/webpack-proxy.mdx
@@ -10,6 +10,7 @@
   - [useProxy](#useproxy)
     - [Attributes](#attributes)
       - [useChromeTemplate](#useChromeTemplate)
+      - [useDevBuild](#useDevBuild)
       - [localChrome](#localchrome)
       - [registry](#registry)
       - [Custom routes](#custom-routes)
@@ -58,6 +59,7 @@ const { config: webpackConfig, plugins } = config({
 |[useProxy](#useproxy)|`boolean`|Enables webpack proxy.|
 |[proxyURL](#proxyURL)|`string`|URL to proxy Akamai environment requests to.|
 |[useChromeTemplate](#useChromeTemplate)|`boolean`|Load chrome HTMl template.|
+|[useDevBuild](#useDevBuild)|`boolean`|Use chrome development build.|
 |[localChrome](#localChrome)|`string`|Path to your local chrome build folder.|
 |[keycloakUri](#keycloakUri)|`string`|Uri to inject into proxied chrome assets.|
 |[registry](#registry)|`(({ app, server, compiler, standaloneConfig }) => void)[]`|Express middleware to register.|
@@ -86,11 +88,33 @@ const { config: webpackConfig, plugins } = config({
 });
 ```
 
+#### useDevBuild
+
+*boolean*
+
+Defaults to **true**. Flag to disable loading of development version of chrome. Has effect only in production environment.
+
+Pass this option to the shared config or directly to the proxy function.
+
+```js
+const config = require('@redhat-cloud-services/frontend-components-config');
+
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  useProxy: true,
+  useDevBuild: false
+  ...
+});
+```
+
 #### localChrome
 
 You can also easily run you application with a local build of Chrome by adding `localChrome: <absolute_path_to_chrome_build_folder>`.
 
 ```jsx
+const config = require('@redhat-cloud-services/frontend-components-config');
+
+const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
   useFileHash: false,


### PR DESCRIPTION
part of: https://issues.redhat.com/browse/RHCLOUD-19837

Downloads chrome from `dev-beta` or `dev-stable` branches to enable React development environment.

### TODO
- [x] wait for dev-stable to be published