### PR TITLE
Use AlertProps['variant'] to set variant type

### DIFF
--- a/packages/notifications/src/Notification/Notification.tsx
+++ b/packages/notifications/src/Notification/Notification.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Alert, TextContent, Text, TextVariants, AlertActionCloseButton, AlertVariant } from '@patternfly/react-core';
+import { Alert, TextContent, Text, TextVariants, AlertActionCloseButton, AlertProps } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
 import './notification.scss';
 
@@ -23,7 +23,7 @@ export interface NotificationProps {
   /**
    * Alert variant. <a href="https://www.patternfly.org/v4/components/alert#types" target="_blank">More info.</a>
    */
-  variant: AlertVariant;
+  variant: AlertProps['variant'];
   /**
    * Alert title
    */

--- a/packages/notifications/src/Portal/Portal.tsx
+++ b/packages/notifications/src/Portal/Portal.tsx
@@ -3,14 +3,14 @@ import { createPortal } from 'react-dom';
 
 import Notification from '../Notification';
 import NotificationPagination from '../NotificationPagination';
-import { AlertVariant } from '@patternfly/react-core';
+import { AlertProps } from '@patternfly/react-core';
 
 import './portal.scss';
 
 export type PortalNotificationConfig = {
   id: string | number;
   title: React.ReactNode;
-  variant: AlertVariant;
+  variant: AlertProps['variant'];
   description?: React.ReactNode;
   dismissable?: boolean;
 };


### PR DESCRIPTION
`enum` cannot be used as a type

**After**

![Screenshot 2022-06-21 at 16 53 18](https://user-images.githubusercontent.com/32869456/174830537-32e9b28c-72cc-471c-b3df-38a89f1f62fd.png)

