### PR TITLE
Add generic type to chrome.on function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35628,7 +35628,7 @@
         },
         "packages/notifications": {
             "name": "@redhat-cloud-services/frontend-components-notifications",
-            "version": "3.2.7",
+            "version": "3.2.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": "*",
@@ -36622,7 +36622,7 @@
         },
         "packages/utils": {
             "name": "@redhat-cloud-services/frontend-components-utilities",
-            "version": "3.2.18",
+            "version": "3.2.20",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/types": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36612,7 +36612,7 @@
         },
         "packages/types": {
             "name": "@redhat-cloud-services/types",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@patternfly/quickstarts": "^1.4.1-rc.1",

--- a/packages/components/src/useChrome/useChrome.ts
+++ b/packages/components/src/useChrome/useChrome.ts
@@ -3,7 +3,7 @@ import { useScalprum } from '@scalprum/react-core';
 
 export type UseChromeSelector<T = any> = (chromeState: ChromeAPI) => T;
 
-const useChrome = (selector?: UseChromeSelector) => {
+const useChrome = <T = ChromeAPI>(selector?: UseChromeSelector<T>): ChromeAPI | T => {
   const state = useScalprum<{ initialized: boolean; api: { chrome: ChromeAPI } }>();
   let chrome: ChromeAPI = state.api?.chrome || {};
   chrome = {

--- a/packages/components/src/usePendoFeedback/usePendoFeedback.ts
+++ b/packages/components/src/usePendoFeedback/usePendoFeedback.ts
@@ -1,7 +1,8 @@
+import { ChromeAPI } from '@redhat-cloud-services/types';
 import useChrome from '../useChrome';
 
-const usePendoFeedback = (...args: any[]) => {
-  const { usePendoFeedback: usePendoFeedbackInternal } = useChrome();
+const usePendoFeedback = () => {
+  const { usePendoFeedback: usePendoFeedbackInternal } = useChrome<ChromeAPI>();
   /**
    * Return no-op in case the chrome changes are not avaiable in current env.
    */
@@ -9,8 +10,7 @@ const usePendoFeedback = (...args: any[]) => {
     console.warn('The "usePendoFeedback" hook is not available in this enviroment. Default feedback form will be used. Wait for chrome updates.');
     return;
   }
-
-  return usePendoFeedbackInternal(...args);
+  return usePendoFeedbackInternal();
 };
 
 export default usePendoFeedback;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -55,6 +55,28 @@ declare type VisibilityFunctions = {
 /**
  * TODO: Once chrome is migrated to TS, sychronize with chrome typings
  */
+export type NavDOMEvent = {
+  href: string;
+  id: string;
+  navId: string;
+  type: string;
+  target?: HTMLAnchorElement | null;
+};
+
+export type AppNavigationCB = (navEvent: { navId?: string; domEvent: NavDOMEvent }) => void;
+export type GenericCB = (...args: unknown[]) => void;
+
+export type OnEventCallbacks = {
+  APP_NAVIGATION: AppNavigationCB;
+  NAVIGATION_TOGGLE: GenericCB;
+  GLOBAL_FILTER_UPDATE: GenericCB;
+};
+
+declare function OnChromeEvent<K extends 'APP_NAVIGATION' | 'NAVIGATION_TOGGLE' | 'GLOBAL_FILTER_UPDATE'>(
+  event: K,
+  callback: OnEventCallbacks[K]
+): () => void;
+
 export interface ChromeAPI {
   /** @deprecated will be removed from useChrome hook */
   $internal: any;
@@ -127,8 +149,14 @@ export interface ChromeAPI {
   mapGlobalFilter: (...args: any[]) => any;
   /** @deprecated this function has no effect. */
   navigation: () => void;
-  /** TODO: Deprecate this function */
-  on: (...args: any[]) => any;
+  /**
+   * Example usage
+   * on<'APP_NAVIGATION'>('APP_NAVIGATION', (navEvent) => {
+   * navEvent.domEvent.href;
+   * navEvent.navId;
+   * });
+   */
+  on: typeof OnChromeEvent;
   registerModule: (module: string, manifest: string) => void;
   /** @duplicate of "hideGlobalFilter" TODO: deprecate this function */
   removeGlobalFilter: (isHidden: boolean) => {


### PR DESCRIPTION
Example usage: 
```TS
on<'APP_NAVIGATION'>('APP_NAVIGATION', (navEvent) => {
  navEvent.domEvent.href;
  navEvent.navId;
});

```

Should remove the need of creating custom types in applications for the on event: https://github.com/RedHatInsights/frontend-starter-app/pull/566/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R37
