### PR TITLE
fix: Block hook from updating unmounted component

### DIFF
--- a/packages/utils/src/RBACHook/RBACHook.ts
+++ b/packages/utils/src/RBACHook/RBACHook.ts
@@ -14,17 +14,24 @@ export function usePermissions(appName: string, permissionsList: string[], disab
     permissions: [],
   });
   useEffect(() => {
+    let ignore = false;
     setPermissions((prev) => ({ ...prev, isLoading: true }));
     (async () => {
       const { isOrgAdmin, permissions: userPermissions } = await getRBAC(appName, disableCache);
-      setPermissions({
-        isLoading: false,
-        isOrgAdmin,
-        permissions: userPermissions,
-        hasAccess: checkAll ? hasAllPermissions(userPermissions, permissionsList) : doesHavePermissions(userPermissions, permissionsList),
-      });
+      !ignore &&
+        setPermissions({
+          isLoading: false,
+          isOrgAdmin,
+          permissions: userPermissions,
+          hasAccess: checkAll ? hasAllPermissions(userPermissions, permissionsList) : doesHavePermissions(userPermissions, permissionsList),
+        });
     })();
+
+    return () => {
+      ignore = true;
+    };
   }, [appName, disableCache]);
+
   return permissions;
 }
 


### PR DESCRIPTION
On occasion (mildly put) the timing is off and the RBAC hook tries to update a component that is unmounted. 
![Screenshot 2022-06-29 at 10 41 18](https://user-images.githubusercontent.com/7757/176403228-7d740660-9522-4866-a126-a749d97e35f0.png)


This change will prevent that from happening.