### PR TITLE
fix(ConditionalFilter): Remove Number casting of text filter value

### DIFF
--- a/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
@@ -129,7 +129,7 @@ const ConditionalFilter: React.FunctionComponent<ConditionalFilterProps> = ({
               <TextFilter
                 id={id}
                 isDisabled={isDisabled}
-                onChange={(e) => onChangeCallback(e as FormEvent<HTMLInputElement>, Number((e.target as HTMLInputElement).value))}
+                onChange={(e) => onChangeCallback(e as FormEvent<HTMLInputElement>, (e.target as HTMLInputElement).value)}
                 placeholder={placeholder}
                 value={currentValue ? String(currentValue) : undefined}
                 widget-type="InsightsInput"


### PR DESCRIPTION
Casting to the `Number` seems to have been accidentally added when migrating to TypeScript.

See JS version before migration: https://github.com/RedHatInsights/frontend-components/blob/c6e65cab4a5f9b392c83ebc08e961f17457c4573/packages/components/src/ConditionalFilter/ConditionalFilter.js#L102