### PR TITLE
chore(README): Remove react & react-dom symlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ module.exports = {
               }
             },
             'react-icons'
-          
+
     ]
 }
 
@@ -122,20 +122,8 @@ There are two ways to test changes from packages in this repository in other app
 ### Using `npm link`
 
 1. Run `npm install` in the root of the `frontend-components` working copy
-2. Remove `react` and `react-dom` from `node_modules`
-  ```
-  rm -rf node_modules/react; rm -rf node_modules/react-dom
-  ```
-  This is because we want to use hooks and different reacts are not playing nicely with hooks [facebook/react/issues/15315](https://github.com/facebook/react/issues/15315)
-
-3. Link `react` and `react-dom` from your application. Running from folder that contains your application and frontend components. Running `ls` in this folder would yield `<application-folder>  insights-proxy  frontend-components`
-```
-ln -s $PWD/<application-folder>/node_modules/react frontend-components/node_modules/react
-ln -s $PWD/<application-folder>/node_modules/react-dom frontend-components/node_modules/react-dom
-```
-
-4. Change into the directory of the package you are working on, for example `cd packages/components` and run `npm link`*
-5. Change into the directory of the application you'd like to include the package and run `npm link @redhat-cloud-services/frontend-components`*
+2. Change into the directory of the package you are working on, for example `cd packages/components` and run `npm link`*
+3. Change into the directory of the application you'd like to include the package and run `npm link @redhat-cloud-services/frontend-components`*
 
 After these steps the package you want to test should be linked and the last `npm link` command should have returned the paths it linked the package from.
 


### PR DESCRIPTION
The linking of react and react-dom should not be needed anymore. If it is, it is more likely that some configuration is faulty and symlinking it this way should be a workaround, but not the recommended way.