### PR TITLE
fix(docs): Generate docs more memory efficient

### DIFF
--- a/packages/docs/generators/docgen.js
+++ b/packages/docs/generators/docgen.js
@@ -70,9 +70,10 @@ if (args.includes('-w') || args.includes('--watch')) {
   const watcher = chokidar.watch(files);
   watcher.on('change', async (path) => {
     console.log(`Compiling file: ${path}`);
-    const currentContent = fse.readJSONSync(componentsTarget);
-    await parseFile(path, currentContent);
-    fse.writeJSONSync(componentsTarget, currentContent, { spaces: '\t' });
+    const contents = await parseFile(path);
+    await appendToJSON(componentsTarget, {
+      [path]: contents,
+    });
   });
 } else {
   run(files);


### PR DESCRIPTION
When running `npm run generate:components` the tasks could require up to 3GB+ (and probably more if it would not get stopped by heap limits). This makes it a bit more efficient. Memory usage still increases (and gets GCed), but stays manageable.