### PR TITLE
Bump version of components/@redhat-cloud-services/types to 0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35748,11 +35748,11 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.9.9",
+            "version": "3.9.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-                "@redhat-cloud-services/types": "^0.0.5",
+                "@redhat-cloud-services/types": "^0.0.10",
                 "@scalprum/core": "^0.1.1",
                 "@scalprum/react-core": "^0.1.7",
                 "sanitize-html": "^2.3.2"
@@ -35782,11 +35782,6 @@
                 "react-redux": ">=5.0.7",
                 "react-router-dom": ">=4.2.2"
             }
-        },
-        "packages/components/node_modules/@redhat-cloud-services/types": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.5.tgz",
-            "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
         },
         "packages/components/node_modules/@scalprum/react-core": {
             "version": "0.1.7",
@@ -41959,7 +41954,7 @@
                 "@cypress/webpack-dev-server": "^1.8.4",
                 "@patternfly/patternfly": ">=4.102.2",
                 "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
-                "@redhat-cloud-services/types": "^0.0.5",
+                "@redhat-cloud-services/types": "^0.0.10",
                 "@scalprum/core": "^0.1.1",
                 "@scalprum/react-core": "^0.1.7",
                 "@types/react": "^16.9.34",
@@ -41972,11 +41967,6 @@
                 "style-loader": "^3.3.1"
             },
             "dependencies": {
-                "@redhat-cloud-services/types": {
-                    "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.5.tgz",
-                    "integrity": "sha512-K2EgxRwszLzvch2nh72wNm8HOlcp6ljTNzUT3bcSfHRNN0poUHtslfcaJTE9EHbWglIH4rwKEhHkHQJGGtcexw=="
-                },
                 "@scalprum/react-core": {
                     "version": "0.1.7",
                     "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.1.7.tgz",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
         "sanitize-html": "^2.3.2",
         "@scalprum/core": "^0.1.1",
         "@scalprum/react-core": "^0.1.7",
-        "@redhat-cloud-services/types": "^0.0.5"
+        "@redhat-cloud-services/types": "^0.0.10"
     },
     "devDependencies": {
         "@patternfly/patternfly": ">=4.102.2",


### PR DESCRIPTION
Should resolve https://github.com/RedHatInsights/frontend-components/issues/1611

We added helpTopics type here: https://github.com/RedHatInsights/frontend-components/pull/1583

But we need to expose the new types through the useChrome hook