### PR TITLE
fix(RBAC): Correctly set and pass checkAll when using context

### DIFF
--- a/packages/components/src/RBACProvider/RBACProvider.tsx
+++ b/packages/components/src/RBACProvider/RBACProvider.tsx
@@ -11,7 +11,7 @@ import {
 } from '@redhat-cloud-services/frontend-components-utilities/RBAC';
 
 const hasAccessWithUserPermissions = (userPermissions: (Access | string)[]) => {
-  return (requiredPermissions: (Access | string)[], checkAll = true): boolean => {
+  return (requiredPermissions: (Access | string)[], checkAll?: boolean): boolean => {
     return checkAll ? hasAllPermissions(userPermissions, requiredPermissions) : doesHavePermissions(userPermissions, requiredPermissions);
   };
 };

--- a/packages/utils/src/RBACHook/RBACHook.ts
+++ b/packages/utils/src/RBACHook/RBACHook.ts
@@ -30,12 +30,12 @@ export function usePermissions(appName: string, permissionsList: string[], disab
   return permissions;
 }
 
-export const usePermissionsWithContext = (requiredPermissions: string[]) => {
+export const usePermissionsWithContext = (requiredPermissions: string[], checkAll?: boolean) => {
   const { hasAccess, ...permissionState } = useContext(RBACContext);
 
   return {
     ...permissionState,
-    hasAccess: hasAccess?.(requiredPermissions) || false,
+    hasAccess: hasAccess?.(requiredPermissions, checkAll) || false,
   };
 };
 


### PR DESCRIPTION
When using the context hook with RBAC the `checkAll` parameter is not passed along and will cause incorrect permissions. 