### PR TITLE
Remove PF styles import from simple table filter

### DIFF
--- a/packages/components/src/SimpleTableFilter/simple-table-filter.scss
+++ b/packages/components/src/SimpleTableFilter/simple-table-filter.scss
@@ -1,7 +1,5 @@
 
 @import '~@patternfly/patternfly/sass-utilities/all';
-@import '~@patternfly/patternfly/components/InputGroup/input-group.scss';
-@import '~@patternfly/patternfly/components/FormControl/form-control.scss';
 @import '~@redhat-cloud-services/frontend-components-utilities/styles/_all.scss';
 
 .pf-c-input-group.ins-c-filter {


### PR DESCRIPTION
The styles should be comming with the component. The styles are also causing issues because if hash params in image URL param.