### PR TITLE
fix(eslint-config): Remove cypress plugin

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -17,7 +17,7 @@ module.exports = {
     },
   },
   plugins: ['prettier', 'rulesdir'],
-  extends: ['eslint:recommended', 'prettier', 'plugin:prettier/recommended', 'plugin:react/recommended', 'plugin:cypress/recommended'],
+  extends: ['eslint:recommended', 'prettier', 'plugin:prettier/recommended', 'plugin:react/recommended'],
   rules: {
     'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'prettier/prettier': ['error', { singleQuote: true }],

--- a/packages/utils/src/CypressUtils/PaginationUtils.js
+++ b/packages/utils/src/CypressUtils/PaginationUtils.js
@@ -1,3 +1,4 @@
+/* global cy */
 import { DROPDOWN_ITEM, DROPDOWN_TOGGLE, PAGINATION_MENU, TOOLBAR } from './selectors';
 
 const DEFAULT_ROW_COUNT = 20;

--- a/packages/utils/src/CypressUtils/TableUtils.js
+++ b/packages/utils/src/CypressUtils/TableUtils.js
@@ -1,3 +1,4 @@
+/* global cy, Cypress */
 import _ from 'lodash';
 
 import { ROW, TABLE, TBODY, TITLE } from './selectors';

--- a/packages/utils/src/CypressUtils/UIFilters.js
+++ b/packages/utils/src/CypressUtils/UIFilters.js
@@ -1,3 +1,4 @@
+/* global cy */
 /*
 Utilities related to URL parameters passed for table filtering
 */


### PR DESCRIPTION
This removes the cypress plugin that will cause linting to break, when no plugin package is installed in a dependent project. 

see also https://github.com/RedHatInsights/frontend-components/issues/1637

cc @gkarat @Fewwy 