### PR TITLE
Add _unstableHotReload to chunk mapper.

### DIFF
--- a/packages/config-utils/chunk-mapper.js
+++ b/packages/config-utils/chunk-mapper.js
@@ -1,35 +1,59 @@
+const hotChunkRegex = RegExp('\\.hot-update\\.js$');
 class ChunkMapper {
   constructor(options) {
+    const { _unstableHotReload, ...rest } = options;
     this.config = {};
-    this.options = options || {};
+    this.options = rest || {};
+    this._unstableHotReload = _unstableHotReload;
   }
 
   apply(compiler) {
     compiler.hooks.emit.tap('ChunkMapper', (compilation) => {
       const prefix = this.options.prefix || (RegExp('^/.*/$').test(compiler.options.output.publicPath) ? compiler.options.output.publicPath : '/');
-      compilation.chunks.forEach(({ name, files, runtime }) => {
+      if (this._unstableHotReload) {
         const modules = Array.isArray(this.options.modules) ? this.options.modules : [this.options.modules];
-        if (modules.find((oneEntry) => RegExp(`${oneEntry}$`).test(runtime))) {
-          this.config[runtime] = {
-            ...(this.config[runtime] || {}),
-            ...(name === runtime
-              ? {
-                  entry: Array.from(files)
-                    .map((item) => `${prefix}${item}`)
-                    .filter((file, _index, array) => {
-                      if (array.find((item) => !RegExp('\\.hot-update\\.js$').test(item))) {
-                        return !RegExp('\\.hot-update\\.js$').test(file);
-                      }
+        // TODO: Investigate if it is possible we could use the same script for normal builds
+        const hotEntries = Array.from(compilation.chunks)
+          .filter(({ name, runtime }) => !!modules.find((moduleName) => moduleName === name) || name === runtime)
+          .map(({ files }) =>
+            Array.from(files)
+              .filter((file) => !hotChunkRegex.test(file))
+              .map((file) => `${prefix}${file}`)
+          )
+          .flat();
 
-                      return true;
-                    }),
-                }
-              : {
-                  modules: [...(this.config[runtime].modules || []), ...Array.from(files).map((item) => `${prefix}${item}`)],
-                }),
+        modules.forEach((name) => {
+          this.config = {
+            [name]: {
+              entry: hotEntries,
+            },
           };
-        }
-      });
+        });
+      } else {
+        compilation.chunks.forEach(({ name, files, runtime }) => {
+          const modules = Array.isArray(this.options.modules) ? this.options.modules : [this.options.modules];
+          if (modules.find((oneEntry) => RegExp(`${oneEntry}$`).test(runtime))) {
+            this.config[runtime] = {
+              ...(this.config[runtime] || {}),
+              ...(name === runtime
+                ? {
+                    entry: Array.from(files)
+                      .map((item) => `${prefix}${item}`)
+                      .filter((file, _index, array) => {
+                        if (array.find((item) => !hotChunkRegex.test(item))) {
+                          return !hotChunkRegex.test(file);
+                        }
+
+                        return true;
+                      }),
+                  }
+                : {
+                    modules: [...(this.config[runtime].modules || []), ...Array.from(files).map((item) => `${prefix}${item}`)],
+                  }),
+            };
+          }
+        });
+      }
 
       compilation.assets['fed-mods.json'] = {
         source: () => JSON.stringify(this.config, null, 4),


### PR DESCRIPTION
Prerequisite for hot loading for module development.

Hot reload requires only a single runtime chunk which breaks our chunk mapper (no entry chunk is found).

Added new _**Unstable**_ way to look for entry chunks:

```JSON
{
  "starter": {
    "entry": [
      "/beta/apps/starter/starter.js",
      "/beta/apps/starter/js/runtime.js"
    ]
  }
}
```

Entry runtime chunks are now two, one for federated modules and one for global runtime. The federated module entry chunk is a part of the runtime chunk and requires it in order to initialize the webpack sharing scope.

These two should be now separate to not break existing builds but there is a possibility that we could use the same method for finding chunks in bot scenarios.