### PR TITLE
Allow router v6 in peer dependencies.

### DIFF
--- a/packages/advisor-components/package.json
+++ b/packages/advisor-components/package.json
@@ -32,7 +32,7 @@
         "prop-types": "^15.6.2",
         "react": "^16.14.0 || ^17.0.0",
         "react-dom": "^16.14.0 || ^17.0.0",
-        "react-router-dom": "^5.0.0"
+        "react-router-dom": "^5.0.0 || ^6.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/frontend-components": "^3.9.12",

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -31,7 +31,7 @@
         "prop-types": "^15.6.2",
         "react": "^16.14.0 || ^17.0.0",
         "react-dom": "^16.14.0 || ^17.0.0",
-        "react-router-dom": "^5.0.0"
+        "react-router-dom": "^5.0.0 || ^6.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
         "react-dom": "^16.14.0 || ^17.0.0",
         "react-content-loader": "^6.2.0",
         "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0",
+        "react-router-dom": "^5.0.0 || ^6.0.0",
         "lodash": "^4.17.15"
     },
     "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
         "react": "^16.14.0 || ^17.0.0",
         "react-dom": "^16.14.0 || ^17.0.0",
         "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0",
+        "react-router-dom": "^5.0.0 || ^6.0.0",
         "cypress": ">=10.0.0 < 11.0.0"
     },
     "dependencies": {


### PR DESCRIPTION
This change will be necessary for router v6 upgrades