### PR TITLE
feat(cypressUtils): adding custom cypress commands

### DIFF
--- a/packages/utils/src/CypressUtils/CustomCommands.js
+++ b/packages/utils/src/CypressUtils/CustomCommands.js
@@ -1,0 +1,35 @@
+/* global cy, Cypress */
+//to make Cypress commands available you need to initialize them in the file where you import them
+//import { findElementByOuiaId } from 'x';
+//findElementByOuiaId()
+//after that the cypress command is available in the entire file
+/**
+ * this functions adds a .ouiaId command that allows to better find elements by the ouiaId
+ * - ouiaId accepts 3 parameters: (subject, item, el = '')
+ * ${el}[data-ouia-component-id="${item}"]
+ * if the subject is true it wraps it and finds ${el}[data-ouia-component-id="${item}"]
+ * otherwise it runs cy.get(${el}[data-ouia-component-id="${item}"])
+ * @typedef {function} findElementByOuiaId
+ *
+ */
+export function findElementByOuiaId() {
+  Cypress.Commands.add('ouiaId', { prevSubject: 'optional' }, (subject, item, el = '') => {
+    const attr = `${el}[data-ouia-component-id="${item}"]`;
+    return subject ? cy.wrap(subject).find(attr) : cy.get(attr);
+  });
+}
+/**
+ * this functions adds a .ouiaType command that allows to better find elements by the ouiaType
+ * ouiaType accepts 3 parameters: (subject, item, el = '')
+ * ${el}[data-ouia-component-type="${item}"]
+ * if the subject is true it wraps it and finds ${el}[data-ouia-component-type="${item}"]
+ * otherwise it runs cy.get(${el}[data-ouia-component-type="${item}"])
+ * @typedef {function} findElementByOuiaType
+ *
+ */
+export function findElementByOuiaType() {
+  Cypress.Commands.add('ouiaType', { prevSubject: 'optional' }, (subject, item, el = '') => {
+    const attr = `${el}[data-ouia-component-type="${item}"]`;
+    return subject ? cy.wrap(subject).find(attr) : cy.get(attr);
+  });
+}

--- a/packages/utils/src/CypressUtils/TableUtils.js
+++ b/packages/utils/src/CypressUtils/TableUtils.js
@@ -2,6 +2,8 @@
 import _ from 'lodash';
 
 import { ROW, TABLE, TBODY, TITLE } from './selectors';
+import { findElementByOuiaId } from './CustomCommands';
+findElementByOuiaId();
 
 export function checkTableHeaders(expectedHeaders) {
   /* patternfly/react-table-4.71.16, for some reason, renders extra empty `th` container;

--- a/packages/utils/src/CypressUtils/UIFilters.js
+++ b/packages/utils/src/CypressUtils/UIFilters.js
@@ -6,6 +6,8 @@ Utilities related to URL parameters passed for table filtering
 import _ from 'lodash';
 
 import { CHIP, CHIP_GROUP, FILTERS_DROPDOWN, FILTER_TOGGLE } from './selectors';
+import { findElementByOuiaId } from './CustomCommands';
+findElementByOuiaId();
 
 /**
  * A filter configuration

--- a/packages/utils/src/CypressUtils/index.js
+++ b/packages/utils/src/CypressUtils/index.js
@@ -2,3 +2,4 @@ export * from './selectors';
 export * from './UIFilters';
 export * from './TableUtils';
 export * from './PaginationUtils';
+export * from './CustomCommands';


### PR DESCRIPTION
To make custom commands accessible as an import, we have to declare them differently.
I tried these changes on OCP Advisor and RHEL Advisor, and both projects haven't failed a single test. 
Please update the version after you merge this PR so we can test how it works on a live project.