### PR TITLE
Fixing some @patternfly/react-core import statements

### DIFF
--- a/packages/components/src/BulkSelect/BulkSelect.tsx
+++ b/packages/components/src/BulkSelect/BulkSelect.tsx
@@ -9,8 +9,8 @@ import {
   DropdownToggleCheckbox,
   DropdownToggleCheckboxProps,
   DropdownToggleProps,
+  getDefaultOUIAId,
 } from '@patternfly/react-core';
-import { getDefaultOUIAId } from '@patternfly/react-core/';
 import './bulk-select.scss';
 
 export type BulkSelectItem = {

--- a/packages/components/src/Filters/FilterDropdown.tsx
+++ b/packages/components/src/Filters/FilterDropdown.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { getDefaultOUIAId } from '@patternfly/react-core/';
-import { Dropdown, DropdownToggle, Level } from '@patternfly/react-core';
+import { Dropdown, DropdownToggle, Level, getDefaultOUIAId } from '@patternfly/react-core';
 import FilterInput from './FilterInput';
 import './filter-dropdown.scss';
 

--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { useOUIAId } from '@patternfly/react-core/';
+import { useOUIAId } from '@patternfly/react-core';
 
 export interface InputProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, 'capture'> {
   type?: string;

--- a/packages/components/src/TableToolbar/TableToolbar.tsx
+++ b/packages/components/src/TableToolbar/TableToolbar.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react';
-import { Toolbar, ToolbarProps } from '@patternfly/react-core';
-import { useOUIAId } from '@patternfly/react-core/';
+import { Toolbar, ToolbarProps, useOUIAId } from '@patternfly/react-core';
 import classNames from 'classnames';
 
 import './TableToolbar.scss';


### PR DESCRIPTION
As a part of some testing in OCM products alongside some new patternfly export updates, I noticed some trailing slashes in some of these components and an opportunity to consolidate imports in a couple spots.