### PR TITLE
proxy: try authorization Bearer token when no cs_jwt cookie present

### DIFF
--- a/packages/config-utils/cookieTransform.js
+++ b/packages/config-utils/cookieTransform.js
@@ -13,8 +13,9 @@ const defaultEntitlements = {
 };
 
 function cookieTransform(proxyReq, req, _res, { entitlements = defaultEntitlements, user, internal, identity: customIdentity }) {
-  const cookie = req.headers.cookie;
-  const match = cookie && cookie.match(/cs_jwt=([^;]+)/);
+  const { cookie, authorization } = req.headers;
+  const match = cookie?.match(/cs_jwt=([^;]+)/) || authorization?.match(/^Bearer (.*)$/);
+
   if (match) {
     const cs_jwt = match[1];
     const { payload } = jws.decode(cs_jwt);


### PR DESCRIPTION
Before:

`cookieTranform` reads the `cs_jwt` cookie from the browser
and uses it to create a `x-rh-identity` header that the API can use for auth

After:

it still reads the `cs_jwt` cookie from the browser
but also tries the bearer token from the `authorization` header, if present
and uses those to create the `x-rh-identity` header

WDYT? :)

---

This enables the use of api clients with token in addition to using the browser - helps with test automation.