### PR TITLE
feat: make fec compatible with monorepo setups

### DIFF
--- a/packages/config/src/scripts/dev-script.js
+++ b/packages/config/src/scripts/dev-script.js
@@ -40,9 +40,8 @@ async function devScript(argv, cwd) {
     } else {
       configPath = resolve(__dirname, './dev.webpack.config.js');
     }
-    processArgs.push(`node_modules/.bin/webpack serve -c ${configPath}`);
     await setEnv(cwd);
-    spawn('node', processArgs, {
+    spawn(`npm exec -- webpack serve -c ${configPath}`, processArgs, {
       stdio: [process.stdout, process.stdout, process.stdout],
       cwd,
       shell: true,


### PR DESCRIPTION
Use `npm exec` to run `webpack` from wherever it's installed, letting the package manager figure the right path out instead of hardcoding it in the script.

This enables the use of `fec` in projects structured as monorepo.