### PR TITLE
chore: Make utils compatible with cypres 11.x

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
         "react-dom": "^16.14.0 || ^17.0.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0",
-        "cypress": ">=10.0.0 < 11.0.0"
+        "cypress": ">=10.0.0 < 12.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/types": "^0.0.15",


### PR DESCRIPTION
This extends the range of cypress peer dependency versions and includes the major version 11.