### PR TITLE
Wrap notifications portal with ErrorBoundary and use hooks instead of  connect

### DIFF
--- a/packages/components/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/components/src/ErrorBoundary/ErrorBoundary.tsx
@@ -7,6 +7,7 @@ import Section from '../Section';
 
 interface ErrorPageProps {
   headerTitle: string;
+  silent?: boolean;
   errorTitle?: string;
   errorDescription?: string;
 }
@@ -40,6 +41,9 @@ class ErrorBoundaryPage extends React.Component<ErrorPageProps, ErrorPageState> 
     }
 
     if (this.state.hasError) {
+      if (this.props.silent) {
+        return null;
+      }
       return (
         <div>
           <PageHeader>

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -38,7 +38,8 @@
     },
     "dependencies": {
         "redux-promise-middleware": "6.1.3",
-        "@redhat-cloud-services/frontend-components-utilities": "*"
+        "@redhat-cloud-services/frontend-components-utilities": "*",
+        "@redhat-cloud-services/frontend-components": "*"
     },
     "devDependencies": {
         "typescript": "^4.8.4"

--- a/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
+++ b/packages/notifications/src/NotificationPortal/NotificationPortal.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ReactWrapper, mount } from 'enzyme';
+import { Provider } from 'react-redux';
 import toJson from 'enzyme-to-json';
 import configureStore from 'redux-mock-store';
 import { NotificationsPortal } from '..';
@@ -22,7 +23,13 @@ describe('Notification portal', () => {
   it('should return no component when no notifications given', () => {
     const t = () => {
       try {
-        new ReactWrapper(mount(<NotificationsPortal {...initialProps} />));
+        new ReactWrapper(
+          mount(
+            <Provider store={mockStore({})}>
+              <NotificationsPortal {...initialProps} />
+            </Provider>
+          )
+        );
       } catch (error) {
         throw new TypeError();
       }
@@ -43,24 +50,30 @@ describe('Notification portal', () => {
         },
       ],
     });
-    const wrapper = mount(<NotificationsPortal {...initialProps} store={modifiedStore} />);
+    const wrapper = mount(
+      <Provider store={modifiedStore}>
+        <NotificationsPortal {...initialProps} />
+      </Provider>
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   it('should render notifications given as direct props', () => {
     const wrapper = mount(
-      <NotificationsPortal
-        {...initialProps}
-        notifications={[
-          {
-            id: '0',
-            variant: 'success',
-            title: 'Notification title',
-            description: 'Some meaningfull description',
-            dismissable: true,
-          },
-        ]}
-      />
+      <Provider store={mockStore({})}>
+        <NotificationsPortal
+          {...initialProps}
+          notifications={[
+            {
+              id: '0',
+              variant: 'success',
+              title: 'Notification title',
+              description: 'Some meaningfull description',
+              dismissable: true,
+            },
+          ]}
+        />
+      </Provider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
@@ -79,19 +92,20 @@ describe('Notification portal', () => {
     });
 
     const wrapper = mount(
-      <NotificationsPortal
-        {...initialProps}
-        store={modifiedStore}
-        notifications={[
-          {
-            id: 'Direct notification',
-            variant: 'success',
-            title: 'Notification title',
-            description: 'Some meaningfull description',
-            dismissable: true,
-          },
-        ]}
-      />
+      <Provider store={modifiedStore}>
+        <NotificationsPortal
+          {...initialProps}
+          notifications={[
+            {
+              id: 'Direct notification',
+              variant: 'success',
+              title: 'Notification title',
+              description: 'Some meaningfull description',
+              dismissable: true,
+            },
+          ]}
+        />
+      </Provider>
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
@@ -108,7 +122,11 @@ describe('Notification portal', () => {
         },
       ],
     });
-    const wrapper = mount(<NotificationsPortal {...initialProps} store={modifiedStore} />);
+    const wrapper = mount(
+      <Provider store={modifiedStore}>
+        <NotificationsPortal {...initialProps} />
+      </Provider>
+    );
     wrapper.find(Notification).find('button').simulate('click');
     expect(modifiedStore.getActions()).toEqual([
       expect.objectContaining({
@@ -130,7 +148,11 @@ describe('Notification portal', () => {
       ],
     });
     const dismiss = jest.fn();
-    const wrapper = mount(<NotificationsPortal {...initialProps} store={modifiedStore} removeNotification={dismiss} />);
+    const wrapper = mount(
+      <Provider store={modifiedStore}>
+        <NotificationsPortal {...initialProps} removeNotification={dismiss} />
+      </Provider>
+    );
     wrapper.find(Notification).find('button').simulate('click');
     expect(dismiss).toHaveBeenCalledWith('store notification');
   });
@@ -146,7 +168,11 @@ describe('Notification portal', () => {
       })),
     });
     const clearNotifications = jest.fn();
-    const wrapper = mount(<NotificationsPortal {...initialProps} store={modifiedStore} clearNotifications={clearNotifications} />);
+    const wrapper = mount(
+      <Provider store={modifiedStore}>
+        <NotificationsPortal {...initialProps} clearNotifications={clearNotifications} />
+      </Provider>
+    );
     wrapper.find('.ins-c-pagination__clear-all').last().simulate('click');
     expect(clearNotifications).toHaveBeenCalled();
   });

--- a/packages/notifications/src/NotificationPortal/__snapshots__/NotificationPortal.test.js.snap
+++ b/packages/notifications/src/NotificationPortal/__snapshots__/NotificationPortal.test.js.snap
@@ -1,18 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Notification portal should render notifications given as direct props 1`] = `
-<Connect(Portal)
-  notifications={
-    Array [
-      Object {
-        "description": "Some meaningfull description",
-        "dismissable": true,
-        "id": "0",
-        "title": "Notification title",
-        "variant": "success",
-      },
-    ]
-  }
+<Provider
   store={
     Object {
       "clearActions": [Function],
@@ -24,7 +13,7 @@ exports[`Notification portal should render notifications given as direct props 1
     }
   }
 >
-  <Portal
+  <NotificationPortal
     notifications={
       Array [
         Object {
@@ -36,8 +25,6 @@ exports[`Notification portal should render notifications given as direct props 1
         },
       ]
     }
-    onClearAll={[Function]}
-    removeNotification={[Function]}
     store={
       Object {
         "clearActions": [Function],
@@ -49,273 +36,258 @@ exports[`Notification portal should render notifications given as direct props 1
       }
     }
   >
-    <Portal
-      containerInfo={
-        <body>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-1"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="0"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-2"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="0"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-        </body>
-      }
+    <ErrorBoundaryPage
+      headerTitle="Notifications portal"
+      silent={true}
     >
-      <div
-        className="notifications-portal"
+      <NotificationPortalBase
+        notifications={
+          Array [
+            Object {
+              "description": "Some meaningfull description",
+              "dismissable": true,
+              "id": "0",
+              "title": "Notification title",
+              "variant": "success",
+            },
+          ]
+        }
+        store={
+          Object {
+            "clearActions": [Function],
+            "dispatch": [Function],
+            "getActions": [Function],
+            "getState": [Function],
+            "replaceReducer": [Function],
+            "subscribe": [Function],
+          }
+        }
       >
-        <Notification
-          description="Some meaningfull description"
-          dismissable={true}
-          id="0"
-          key="0"
-          onDismiss={[Function]}
-          title="Notification title"
-          variant="success"
-        >
-          <Alert
-            actionClose={
-              <AlertActionCloseButton
-                aria-label="close-notification"
-                onClick={[Function]}
-                variant="plain"
-              >
-                <CloseIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                />
-              </AlertActionCloseButton>
+        <Portal
+          notifications={
+            Array [
+              Object {
+                "description": "Some meaningfull description",
+                "dismissable": true,
+                "id": "0",
+                "title": "Notification title",
+                "variant": "success",
+              },
+            ]
+          }
+          onClearAll={[Function]}
+          removeNotification={[Function]}
+          store={
+            Object {
+              "clearActions": [Function],
+              "dispatch": [Function],
+              "getActions": [Function],
+              "getState": [Function],
+              "replaceReducer": [Function],
+              "subscribe": [Function],
             }
-            className="notification-item"
-            id="0"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            title="Notification title"
-            variant="success"
+          }
+        >
+          <Portal
+            containerInfo={
+              <body>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="0"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-2"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="0"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+              </body>
+            }
           >
             <div
-              aria-label="Success Alert"
-              className="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-2"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe={true}
-              id="0"
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
+              className="notifications-portal"
             >
-              <AlertIcon
+              <Notification
+                description="Some meaningfull description"
+                dismissable={true}
+                id="0"
+                key="0"
+                onDismiss={[Function]}
+                title="Notification title"
                 variant="success"
               >
-                <div
-                  className="pf-c-alert__icon"
-                >
-                  <CheckCircleIcon
-                    color="currentColor"
-                    noVerticalAlign={false}
-                    size="sm"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style={
-                        Object {
-                          "verticalAlign": "-0.125em",
-                        }
-                      }
-                      viewBox="0 0 512 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                      />
-                    </svg>
-                  </CheckCircleIcon>
-                </div>
-              </AlertIcon>
-              <h4
-                className="pf-c-alert__title"
-              >
-                <span
-                  className="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                className="pf-c-alert__action"
-              >
-                <AlertActionCloseButton
-                  aria-label="close-notification"
-                  onClick={[Function]}
-                  variant="plain"
-                >
-                  <Button
-                    aria-label="close-notification"
-                    onClick={[Function]}
-                    variant="plain"
-                  >
-                    <ButtonBase
+                <Alert
+                  actionClose={
+                    <AlertActionCloseButton
                       aria-label="close-notification"
-                      innerRef={null}
                       onClick={[Function]}
                       variant="plain"
                     >
-                      <button
-                        aria-disabled={false}
-                        aria-label="close-notification"
-                        className="pf-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                        data-ouia-component-type="PF4/Button"
-                        data-ouia-safe={true}
-                        disabled={false}
-                        onClick={[Function]}
-                        role={null}
-                        type="button"
+                      <CloseIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      />
+                    </AlertActionCloseButton>
+                  }
+                  className="notification-item"
+                  id="0"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  title="Notification title"
+                  variant="success"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    className="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-2"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe={true}
+                    id="0"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    <AlertIcon
+                      variant="success"
+                    >
+                      <div
+                        className="pf-c-alert__icon"
                       >
-                        <TimesIcon
+                        <CheckCircleIcon
                           color="currentColor"
                           noVerticalAlign={false}
                           size="sm"
@@ -331,46 +303,105 @@ exports[`Notification portal should render notifications given as direct props 1
                                 "verticalAlign": "-0.125em",
                               }
                             }
-                            viewBox="0 0 352 512"
+                            viewBox="0 0 512 512"
                             width="1em"
                           >
                             <path
-                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
                             />
                           </svg>
-                        </TimesIcon>
-                      </button>
-                    </ButtonBase>
-                  </Button>
-                </AlertActionCloseButton>
-              </div>
-              <div
-                className="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
+                        </CheckCircleIcon>
+                      </div>
+                    </AlertIcon>
+                    <h4
+                      className="pf-c-alert__title"
+                    >
+                      <span
+                        className="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      className="pf-c-alert__action"
+                    >
+                      <AlertActionCloseButton
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
+                      >
+                        <Button
+                          aria-label="close-notification"
+                          onClick={[Function]}
+                          variant="plain"
+                        >
+                          <ButtonBase
+                            aria-label="close-notification"
+                            innerRef={null}
+                            onClick={[Function]}
+                            variant="plain"
+                          >
+                            <button
+                              aria-disabled={false}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </ButtonBase>
+                        </Button>
+                      </AlertActionCloseButton>
+                    </div>
+                    <div
+                      className="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </Alert>
+              </Notification>
             </div>
-          </Alert>
-        </Notification>
-      </div>
-    </Portal>
-  </Portal>
-</Connect(Portal)>
+          </Portal>
+        </Portal>
+      </NotificationPortalBase>
+    </ErrorBoundaryPage>
+  </NotificationPortal>
+</Provider>
 `;
 
 exports[`Notification portal should render notifications given as direct props over store notifications 1`] = `
-<Connect(Portal)
-  notifications={
-    Array [
-      Object {
-        "description": "Some meaningfull description",
-        "dismissable": true,
-        "id": "Direct notification",
-        "title": "Notification title",
-        "variant": "success",
-      },
-    ]
-  }
+<Provider
   store={
     Object {
       "clearActions": [Function],
@@ -382,7 +413,7 @@ exports[`Notification portal should render notifications given as direct props o
     }
   }
 >
-  <Portal
+  <NotificationPortal
     notifications={
       Array [
         Object {
@@ -394,8 +425,6 @@ exports[`Notification portal should render notifications given as direct props o
         },
       ]
     }
-    onClearAll={[Function]}
-    removeNotification={[Function]}
     store={
       Object {
         "clearActions": [Function],
@@ -407,345 +436,330 @@ exports[`Notification portal should render notifications given as direct props o
       }
     }
   >
-    <Portal
-      containerInfo={
-        <body>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-1"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="0"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-2"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="0"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-3"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="Direct notification"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-        </body>
-      }
+    <ErrorBoundaryPage
+      headerTitle="Notifications portal"
+      silent={true}
     >
-      <div
-        className="notifications-portal"
+      <NotificationPortalBase
+        notifications={
+          Array [
+            Object {
+              "description": "Some meaningfull description",
+              "dismissable": true,
+              "id": "Direct notification",
+              "title": "Notification title",
+              "variant": "success",
+            },
+          ]
+        }
+        store={
+          Object {
+            "clearActions": [Function],
+            "dispatch": [Function],
+            "getActions": [Function],
+            "getState": [Function],
+            "replaceReducer": [Function],
+            "subscribe": [Function],
+          }
+        }
       >
-        <Notification
-          description="Some meaningfull description"
-          dismissable={true}
-          id="Direct notification"
-          key="Direct notification"
-          onDismiss={[Function]}
-          title="Notification title"
-          variant="success"
-        >
-          <Alert
-            actionClose={
-              <AlertActionCloseButton
-                aria-label="close-notification"
-                onClick={[Function]}
-                variant="plain"
-              >
-                <CloseIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                />
-              </AlertActionCloseButton>
+        <Portal
+          notifications={
+            Array [
+              Object {
+                "description": "Some meaningfull description",
+                "dismissable": true,
+                "id": "Direct notification",
+                "title": "Notification title",
+                "variant": "success",
+              },
+            ]
+          }
+          onClearAll={[Function]}
+          removeNotification={[Function]}
+          store={
+            Object {
+              "clearActions": [Function],
+              "dispatch": [Function],
+              "getActions": [Function],
+              "getState": [Function],
+              "replaceReducer": [Function],
+              "subscribe": [Function],
             }
-            className="notification-item"
-            id="Direct notification"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            title="Notification title"
-            variant="success"
+          }
+        >
+          <Portal
+            containerInfo={
+              <body>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="0"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-2"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="0"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-3"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="Direct notification"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+              </body>
+            }
           >
             <div
-              aria-label="Success Alert"
-              className="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-3"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe={true}
-              id="Direct notification"
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
+              className="notifications-portal"
             >
-              <AlertIcon
+              <Notification
+                description="Some meaningfull description"
+                dismissable={true}
+                id="Direct notification"
+                key="Direct notification"
+                onDismiss={[Function]}
+                title="Notification title"
                 variant="success"
               >
-                <div
-                  className="pf-c-alert__icon"
-                >
-                  <CheckCircleIcon
-                    color="currentColor"
-                    noVerticalAlign={false}
-                    size="sm"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style={
-                        Object {
-                          "verticalAlign": "-0.125em",
-                        }
-                      }
-                      viewBox="0 0 512 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                      />
-                    </svg>
-                  </CheckCircleIcon>
-                </div>
-              </AlertIcon>
-              <h4
-                className="pf-c-alert__title"
-              >
-                <span
-                  className="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                className="pf-c-alert__action"
-              >
-                <AlertActionCloseButton
-                  aria-label="close-notification"
-                  onClick={[Function]}
-                  variant="plain"
-                >
-                  <Button
-                    aria-label="close-notification"
-                    onClick={[Function]}
-                    variant="plain"
-                  >
-                    <ButtonBase
+                <Alert
+                  actionClose={
+                    <AlertActionCloseButton
                       aria-label="close-notification"
-                      innerRef={null}
                       onClick={[Function]}
                       variant="plain"
                     >
-                      <button
-                        aria-disabled={false}
-                        aria-label="close-notification"
-                        className="pf-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                        data-ouia-component-type="PF4/Button"
-                        data-ouia-safe={true}
-                        disabled={false}
-                        onClick={[Function]}
-                        role={null}
-                        type="button"
+                      <CloseIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      />
+                    </AlertActionCloseButton>
+                  }
+                  className="notification-item"
+                  id="Direct notification"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  title="Notification title"
+                  variant="success"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    className="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-3"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe={true}
+                    id="Direct notification"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    <AlertIcon
+                      variant="success"
+                    >
+                      <div
+                        className="pf-c-alert__icon"
                       >
-                        <TimesIcon
+                        <CheckCircleIcon
                           color="currentColor"
                           noVerticalAlign={false}
                           size="sm"
@@ -761,35 +775,105 @@ exports[`Notification portal should render notifications given as direct props o
                                 "verticalAlign": "-0.125em",
                               }
                             }
-                            viewBox="0 0 352 512"
+                            viewBox="0 0 512 512"
                             width="1em"
                           >
                             <path
-                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
                             />
                           </svg>
-                        </TimesIcon>
-                      </button>
-                    </ButtonBase>
-                  </Button>
-                </AlertActionCloseButton>
-              </div>
-              <div
-                className="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
+                        </CheckCircleIcon>
+                      </div>
+                    </AlertIcon>
+                    <h4
+                      className="pf-c-alert__title"
+                    >
+                      <span
+                        className="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      className="pf-c-alert__action"
+                    >
+                      <AlertActionCloseButton
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
+                      >
+                        <Button
+                          aria-label="close-notification"
+                          onClick={[Function]}
+                          variant="plain"
+                        >
+                          <ButtonBase
+                            aria-label="close-notification"
+                            innerRef={null}
+                            onClick={[Function]}
+                            variant="plain"
+                          >
+                            <button
+                              aria-disabled={false}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </ButtonBase>
+                        </Button>
+                      </AlertActionCloseButton>
+                    </div>
+                    <div
+                      className="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </Alert>
+              </Notification>
             </div>
-          </Alert>
-        </Notification>
-      </div>
-    </Portal>
-  </Portal>
-</Connect(Portal)>
+          </Portal>
+        </Portal>
+      </NotificationPortalBase>
+    </ErrorBoundaryPage>
+  </NotificationPortal>
+</Provider>
 `;
 
 exports[`Notification portal should render notifications given from store 1`] = `
-<Connect(Portal)
+<Provider
   store={
     Object {
       "clearActions": [Function],
@@ -801,20 +885,7 @@ exports[`Notification portal should render notifications given from store 1`] = 
     }
   }
 >
-  <Portal
-    notifications={
-      Array [
-        Object {
-          "description": "Some meaningfull description",
-          "dismissable": true,
-          "id": "0",
-          "title": "Notification title",
-          "variant": "success",
-        },
-      ]
-    }
-    onClearAll={[Function]}
-    removeNotification={[Function]}
+  <NotificationPortal
     store={
       Object {
         "clearActions": [Function],
@@ -826,201 +897,175 @@ exports[`Notification portal should render notifications given from store 1`] = 
       }
     }
   >
-    <Portal
-      containerInfo={
-        <body>
-          <div
-            class="notifications-portal"
-          >
-            <div
-              aria-label="Success Alert"
-              class="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-1"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe="true"
-              id="0"
-            >
-              <div
-                class="pf-c-alert__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="pf-c-alert__title"
-              >
-                <span
-                  class="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                class="pf-c-alert__action"
-              >
-                <button
-                  aria-disabled="false"
-                  aria-label="close-notification"
-                  class="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe="true"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 352 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
-            </div>
-          </div>
-        </body>
-      }
+    <ErrorBoundaryPage
+      headerTitle="Notifications portal"
+      silent={true}
     >
-      <div
-        className="notifications-portal"
+      <NotificationPortalBase
+        store={
+          Object {
+            "clearActions": [Function],
+            "dispatch": [Function],
+            "getActions": [Function],
+            "getState": [Function],
+            "replaceReducer": [Function],
+            "subscribe": [Function],
+          }
+        }
       >
-        <Notification
-          description="Some meaningfull description"
-          dismissable={true}
-          id="0"
-          key="0"
-          onDismiss={[Function]}
-          title="Notification title"
-          variant="success"
-        >
-          <Alert
-            actionClose={
-              <AlertActionCloseButton
-                aria-label="close-notification"
-                onClick={[Function]}
-                variant="plain"
-              >
-                <CloseIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                />
-              </AlertActionCloseButton>
+        <Portal
+          notifications={
+            Array [
+              Object {
+                "description": "Some meaningfull description",
+                "dismissable": true,
+                "id": "0",
+                "title": "Notification title",
+                "variant": "success",
+              },
+            ]
+          }
+          onClearAll={[Function]}
+          removeNotification={[Function]}
+          store={
+            Object {
+              "clearActions": [Function],
+              "dispatch": [Function],
+              "getActions": [Function],
+              "getState": [Function],
+              "replaceReducer": [Function],
+              "subscribe": [Function],
             }
-            className="notification-item"
-            id="0"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            title="Notification title"
-            variant="success"
+          }
+        >
+          <Portal
+            containerInfo={
+              <body>
+                <div
+                  class="notifications-portal"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    class="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                    id="0"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="close-notification"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </div>
+              </body>
+            }
           >
             <div
-              aria-label="Success Alert"
-              className="pf-c-alert pf-m-success notification-item"
-              data-ouia-component-id="OUIA-Generated-Alert-success-1"
-              data-ouia-component-type="PF4/Alert"
-              data-ouia-safe={true}
-              id="0"
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
+              className="notifications-portal"
             >
-              <AlertIcon
+              <Notification
+                description="Some meaningfull description"
+                dismissable={true}
+                id="0"
+                key="0"
+                onDismiss={[Function]}
+                title="Notification title"
                 variant="success"
               >
-                <div
-                  className="pf-c-alert__icon"
-                >
-                  <CheckCircleIcon
-                    color="currentColor"
-                    noVerticalAlign={false}
-                    size="sm"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style={
-                        Object {
-                          "verticalAlign": "-0.125em",
-                        }
-                      }
-                      viewBox="0 0 512 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
-                      />
-                    </svg>
-                  </CheckCircleIcon>
-                </div>
-              </AlertIcon>
-              <h4
-                className="pf-c-alert__title"
-              >
-                <span
-                  className="pf-u-screen-reader"
-                >
-                  Success alert:
-                </span>
-                Notification title
-              </h4>
-              <div
-                className="pf-c-alert__action"
-              >
-                <AlertActionCloseButton
-                  aria-label="close-notification"
-                  onClick={[Function]}
-                  variant="plain"
-                >
-                  <Button
-                    aria-label="close-notification"
-                    onClick={[Function]}
-                    variant="plain"
-                  >
-                    <ButtonBase
+                <Alert
+                  actionClose={
+                    <AlertActionCloseButton
                       aria-label="close-notification"
-                      innerRef={null}
                       onClick={[Function]}
                       variant="plain"
                     >
-                      <button
-                        aria-disabled={false}
-                        aria-label="close-notification"
-                        className="pf-c-button pf-m-plain"
-                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                        data-ouia-component-type="PF4/Button"
-                        data-ouia-safe={true}
-                        disabled={false}
-                        onClick={[Function]}
-                        role={null}
-                        type="button"
+                      <CloseIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      />
+                    </AlertActionCloseButton>
+                  }
+                  className="notification-item"
+                  id="0"
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  title="Notification title"
+                  variant="success"
+                >
+                  <div
+                    aria-label="Success Alert"
+                    className="pf-c-alert pf-m-success notification-item"
+                    data-ouia-component-id="OUIA-Generated-Alert-success-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe={true}
+                    id="0"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    <AlertIcon
+                      variant="success"
+                    >
+                      <div
+                        className="pf-c-alert__icon"
                       >
-                        <TimesIcon
+                        <CheckCircleIcon
                           color="currentColor"
                           noVerticalAlign={false}
                           size="sm"
@@ -1036,29 +1081,99 @@ exports[`Notification portal should render notifications given from store 1`] = 
                                 "verticalAlign": "-0.125em",
                               }
                             }
-                            viewBox="0 0 352 512"
+                            viewBox="0 0 512 512"
                             width="1em"
                           >
                             <path
-                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                              d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
                             />
                           </svg>
-                        </TimesIcon>
-                      </button>
-                    </ButtonBase>
-                  </Button>
-                </AlertActionCloseButton>
-              </div>
-              <div
-                className="pf-c-alert__description"
-              >
-                Some meaningfull description
-              </div>
+                        </CheckCircleIcon>
+                      </div>
+                    </AlertIcon>
+                    <h4
+                      className="pf-c-alert__title"
+                    >
+                      <span
+                        className="pf-u-screen-reader"
+                      >
+                        Success alert:
+                      </span>
+                      Notification title
+                    </h4>
+                    <div
+                      className="pf-c-alert__action"
+                    >
+                      <AlertActionCloseButton
+                        aria-label="close-notification"
+                        onClick={[Function]}
+                        variant="plain"
+                      >
+                        <Button
+                          aria-label="close-notification"
+                          onClick={[Function]}
+                          variant="plain"
+                        >
+                          <ButtonBase
+                            aria-label="close-notification"
+                            innerRef={null}
+                            onClick={[Function]}
+                            variant="plain"
+                          >
+                            <button
+                              aria-disabled={false}
+                              aria-label="close-notification"
+                              className="pf-c-button pf-m-plain"
+                              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </ButtonBase>
+                        </Button>
+                      </AlertActionCloseButton>
+                    </div>
+                    <div
+                      className="pf-c-alert__description"
+                    >
+                      Some meaningfull description
+                    </div>
+                  </div>
+                </Alert>
+              </Notification>
             </div>
-          </Alert>
-        </Notification>
-      </div>
-    </Portal>
-  </Portal>
-</Connect(Portal)>
+          </Portal>
+        </Portal>
+      </NotificationPortalBase>
+    </ErrorBoundaryPage>
+  </NotificationPortal>
+</Provider>
 `;


### PR DESCRIPTION
JIRA: RHCLOUD-23125

### Description

When using Notifications portal there can be a missmatch of react-redux versions. When this happens the UI breaks completely whic is not good for user experience. This PR wraps usage of redux context provider with error boundary and if such missmatch happens it will show an error but not break the entire UI.

There's also a new change to `ErrorBoundary` component - `silent` mode. When any error happens during render the error boundary will catch it and shows rather informative error. Sometimes we don't want to surface this error to customers, but just show it in console. This prop is just for that, not to render anything else other than `null`.