### PR TITLE
Add new releaser bot to trigger travis releases from labels or comments

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,19 @@
+name: Releaser
+on:
+  pull_request:
+    types: [ labeled, closed ]
+  issue_comment:
+    types: [ created, edited ]
+
+jobs:
+  pr_merged:
+    runs-on: ubuntu-latest
+    name: Trigger job on comment, merge or label
+    steps:
+      - name: Trigger release
+        id: release
+        uses: RedHatInsights/frontend-releaser@v1
+        with:
+          gh-bot-token: ${{ secrets.GH_BOT_TOKEN }}
+          travis-config: '{"token":"${{ secrets.TRAVIS_TOKEN }}"}'
+          allowed-users: '["karelhala", "ryelo", "Hyperkid123", "fhlavac"]'


### PR DESCRIPTION
### Description

Since heroku no longer supports free tier we should start using different approach when new release is required. New github action has been created at https://github.com/RedHatInsights/frontend-releaser so let's use it in this repository (all tokens has been updated)