### PR TITLE
Open http server for static on all interfaces

### DIFF
--- a/packages/config-utils/serve-federated.js
+++ b/packages/config-utils/serve-federated.js
@@ -25,7 +25,7 @@ function federate(argv, cwd) {
 
       concurrently([
         `${WEBPACK_PATH} --config ${configPath} --watch --output-path ${path.join(outputPath, config.output.publicPath)}`,
-        `${HTTP_SERVER_PATH} ${outputPath} -p ${argv.port || 8003} -c-1`,
+        `${HTTP_SERVER_PATH} ${outputPath} -p ${argv.port || 8003} -c-1 -a ::`,
       ]);
     });
   } catch (error) {

--- a/packages/config/bin/fec.js
+++ b/packages/config/bin/fec.js
@@ -16,6 +16,7 @@ do
     then
         echo "Adding $host to /etc/hosts"
         echo "127.0.0.1 $host" >>/etc/hosts
+        echo "::1 $host" >>/etc/hosts
     fi
 done
 `


### PR DESCRIPTION
### Description

Since node version 17 (LTS is now 18) node prefers ipv6[1]. However http-server by default opens on 0.0.0.0 address[2] and that's causing issues as we can't connect from ipv6 to ipv4 (we'd have to set `NODE_OPTIONS=--dns-result-order=ipv4first` which is hacky). So let's use address `::` when running http-server as it means any available address[3].

Also let's add ipv6 localhost loopback to /etc/hosts.

### Steps to test

* Run static server
* Access server on `127.0.0.1:8003` address
* Access server on `[::1]:8003` address

[1] https://github.com/nodejs/node/pull/39987
[2] https://github.com/http-party/http-server/blob/master/bin/http-server#L69
[3] https://www.rfc-editor.org/rfc/rfc4291#section-2.2