### PR TITLE
Add HAC SDK package docs

### DIFF
--- a/packages/docs/pages/hac/index.mdx
+++ b/packages/docs/pages/hac/index.mdx
@@ -1,0 +1,20 @@
+# hac-core
+
+[hac-core](https://github.com/openshift/hac-core/tree/main) manages the connectivity between the ConsoleDot Chrome & the HAC Dynamic Plugins.
+
+# hac-dev
+
+[hac-dev](https://github.com/openshift/hac-dev/tree/main) delivers the UI for App Studio.
+
+# dynamic-plugin-sdk
+
+[dynamic-plugin-sdk](https://github.com/openshift/dynamic-plugin-sdk/tree/main/) provides APIs, utilities and types to develop and run dynamic plugins in host web applications.
+
+## SDK Packages
+
+| Package Name | Overview |
+| ------------ | ------- |
+| `@openshift/dynamic-plugin-sdk` | [lib-core](./lib-core.mdx) |
+| `@openshift/dynamic-plugin-sdk-extensions` | [lib-extensions](./lib-extensions.mdx) |
+| `@openshift/dynamic-plugin-sdk-utils` | [lib-utils](./lib-utils.mdx) |
+| `@openshift/dynamic-plugin-sdk-webpack` | [lib-webpack](./lib-webpack.mdx) |

--- a/packages/docs/pages/hac/lib-core.mdx
+++ b/packages/docs/pages/hac/lib-core.mdx
@@ -4,4 +4,4 @@
 
 # API Report
 
-<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-core.api.md#api-report-file-for-openshiftdynamic-plugin-sdk">API Report</a>
+[API Report](https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-core.api.md#api-report-file-for-openshiftdynamic-plugin-sdk)

--- a/packages/docs/pages/hac/lib-core.mdx
+++ b/packages/docs/pages/hac/lib-core.mdx
@@ -1,0 +1,7 @@
+# Overview
+
+[lib-core](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-core) allows loading, managing and interpreting dynamic plugins
+
+# API Report
+
+<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-core.api.md#api-report-file-for-openshiftdynamic-plugin-sdk">API Report</a>

--- a/packages/docs/pages/hac/lib-extensions.mdx
+++ b/packages/docs/pages/hac/lib-extensions.mdx
@@ -1,0 +1,7 @@
+# Overview
+
+[lib-extensions](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-extensions) provides extension types for dynamic plugins
+
+# API Report
+
+<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-extensions.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-extensions">API Report</a>

--- a/packages/docs/pages/hac/lib-extensions.mdx
+++ b/packages/docs/pages/hac/lib-extensions.mdx
@@ -4,4 +4,4 @@
 
 # API Report
 
-<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-extensions.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-extensions">API Report</a>
+[API Report](https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-extensions.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-extensions)

--- a/packages/docs/pages/hac/lib-utils.mdx
+++ b/packages/docs/pages/hac/lib-utils.mdx
@@ -4,4 +4,4 @@
 
 # API Report
 
-<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-utils.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-utils">API Report</a>
+[API Report](https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-utils.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-utils)

--- a/packages/docs/pages/hac/lib-utils.mdx
+++ b/packages/docs/pages/hac/lib-utils.mdx
@@ -1,0 +1,7 @@
+# Overview
+
+[lib-utils](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-utils) provides React focused dynamic plugin SDK utilities
+
+# API Report
+
+<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-utils.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-utils">API Report</a>

--- a/packages/docs/pages/hac/lib-webpack.mdx
+++ b/packages/docs/pages/hac/lib-webpack.mdx
@@ -1,0 +1,8 @@
+
+# Overview
+
+[lib-webpack](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-webpack) allows building dynamic plugin assets with webpack
+
+# API Report
+
+<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-webpack.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-webpack">API Report</a>

--- a/packages/docs/pages/hac/lib-webpack.mdx
+++ b/packages/docs/pages/hac/lib-webpack.mdx
@@ -1,8 +1,7 @@
-
 # Overview
 
 [lib-webpack](https://github.com/openshift/dynamic-plugin-sdk/tree/main/packages/lib-webpack) allows building dynamic plugin assets with webpack
 
 # API Report
 
-<a href="https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-webpack.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-webpack">API Report</a>
+[API Report](https://github.com/openshift/dynamic-plugin-sdk/blob/main/reports/lib-webpack.api.md#api-report-file-for-openshiftdynamic-plugin-sdk-webpack)


### PR DESCRIPTION
Added a hac directory with some basic overview/links of the related repos for [RHCLOUD-22876](https://issues.redhat.com/browse/RHCLOUD-22876). Individual package API report links can be found under their overview markdowns.