### PR TITLE
Disbale RH fonts when rendering PDFs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35743,6 +35743,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/style-inject": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
+            "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
+            "dev": true
+        },
         "node_modules/style-loader": {
             "version": "3.3.1",
             "dev": true,
@@ -39794,7 +39800,8 @@
                 "rollup-plugin-node-globals": "^1.4.0",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-replace": "^2.2.0",
-                "rollup-plugin-terser": "^7.0.2"
+                "rollup-plugin-terser": "^7.0.2",
+                "style-inject": "0.3.0"
             }
         },
         "packages/pdf-generator/node_modules/@patternfly/react-icons": {
@@ -45639,7 +45646,8 @@
                 "rollup-plugin-node-globals": "^1.4.0",
                 "rollup-plugin-postcss": "^4.0.2",
                 "rollup-plugin-replace": "^2.2.0",
-                "rollup-plugin-terser": "^7.0.2"
+                "rollup-plugin-terser": "^7.0.2",
+                "style-inject": "0.3.0"
             },
             "dependencies": {
                 "@patternfly/react-icons": {
@@ -63582,6 +63590,12 @@
                 "minimist": "^1.2.0",
                 "through": "^2.3.4"
             }
+        },
+        "style-inject": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
+            "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
+            "dev": true
         },
         "style-loader": {
             "version": "3.3.1",

--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -4,7 +4,6 @@
     "description": "Common components for RedHat Cloud Services project to generate PDF from JS.",
     "browser": "dist/js/index.js",
     "module": "dist/esm/index.js",
-    "private": true,
     "sideEffects": [
         "./**/*.css",
         "./**/*.scss"
@@ -46,6 +45,7 @@
         "@scalprum/react-core": "^0.1.7"
     },
     "devDependencies": {
+        "style-inject": "0.3.0",
         "rollup": "^2.46.0",
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-node-globals": "^1.4.0",

--- a/packages/pdf-generator/rollup.config.js
+++ b/packages/pdf-generator/rollup.config.js
@@ -24,7 +24,10 @@ const globals = {
 
 const commonjsOptions = {
     ignoreGlobal: true,
-    include: /node_modules/
+    include: /node_modules/,
+    namedExports: {
+      'react/jsx-runtime': ['jsx', 'jsxs'],
+    }
 };
 
 const babelOptions = {

--- a/packages/pdf-generator/src/utils/styles.js
+++ b/packages/pdf-generator/src/utils/styles.js
@@ -34,14 +34,11 @@ export default (style = {}) =>
     ...style,
     page: {
       fontWeight: 500,
-      fontFamily: 'RedHatText',
       height: '100%',
       padding: '20 50',
       lineHeight: 1.5,
     },
-    displayFont: {
-      fontFamily: 'RedHatDisplay',
-    },
+    displayFont: {},
     headerContainer: {
       display: 'flex',
       flexDirection: 'row',


### PR DESCRIPTION
### Description

There's an issue when downloading PDF generated with old PDF generator. It tries to load RH fonts, but fails on calculating glyphs. I've spent some time trying to fix the issue, but looks like it's hidden deep in pdf renderer and since we have a replacement service for it let's not waste no more time on this issue. 