### PR TITLE
[RHCLOUD-21728] Remove timestamps from generated files

### DIFF
--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -25,6 +25,7 @@ module.exports = ({ root, exposes, shared = [], debug, moduleName, useFileHash =
 
   const { dependencies, insights } = require(resolve(root, './package.json')) || {};
   const appName = moduleName || (insights && jsVarName(insights.appname));
+  const filename = `${appName}.${useFileHash ? `[fullhash].` : ''}js`;
 
   const sharedDeps = Object.entries(include)
     .filter(([key]) => dependencies[key] && !exclude.includes(key))
@@ -64,7 +65,7 @@ module.exports = ({ root, exposes, shared = [], debug, moduleName, useFileHash =
 
   return new ModuleFederationPlugin({
     name: appName,
-    filename: `${appName}${useFileHash ? `.${Date.now()}.[fullhash]` : ''}.js`,
+    filename: filename,
     library: { type: libType, name: libName || appName },
     exposes: {
       ...(exposes || {

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -44,7 +44,7 @@ module.exports = ({
   _unstableHotReload = false,
   resolve = {},
 } = {}) => {
-  const filenameMask = `js/[name]${!_unstableHotReload && useFileHash ? `.${Date.now()}.[fullhash]` : ''}.js`;
+  const filenameMask = `js/[name].${!_unstableHotReload && useFileHash ? `[fullhash].` : ''}js`;
   if (betaEnv) {
     env = `${betaEnv}-beta`;
     console.warn('betaEnv is deprecated in favor of env');

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -30,10 +30,10 @@ describe('should create dummy config with no options', () => {
 
   test('output', () => {
     expect(output).toEqual({
-      filename: expect.stringMatching(/js\/\[name\]\.\d+\.\[fullhash\]\.js/),
+      filename: expect.stringMatching(/js\/\[name\]\.\[fullhash\]\.js/),
       path: '/dist',
       publicPath: undefined,
-      chunkFilename: expect.stringMatching(/js\/\[name\]\.\d+\.\[fullhash\]\.js/),
+      chunkFilename: expect.stringMatching(/js\/\[name\]\.\[fullhash\]\.js/),
     });
   });
 
@@ -119,4 +119,9 @@ describe('port', () => {
 test('https', () => {
   const { devServer } = configBuilder({ https: true });
   expect(devServer.https).toBe(true);
+});
+
+test('noFileHash', () => {
+  const { output } = configBuilder({ useFileHash: false });
+  expect(output.filename).toBe('js/[name].js');
 });


### PR DESCRIPTION
* Removes timestamps from generated filenames
* Adds tests for timestamp removal and `useFileHash` options.

returns `js/[name].[fullhash].js`  or  `js/[name].js`

generates fed-mods with rbac as:

``` json
{
    "rbac": {
        "entry": [
            "/beta/apps/rbac/rbac.5301862932bb2afa7124.js"
        ],
        "modules": [
            "/beta/apps/rbac/js/832.5301862932bb2afa7124.js",
            "/beta/apps/rbac/css/832.4f0f4b061e35f2c8b0e7.css"
        ]
    }
}
```