### PR TITLE
Use getThemeColors instead of getLightThemeColors

### DIFF
--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -7,7 +7,7 @@ import { ChartBar } from '@patternfly/react-charts/dist/js/components/ChartBar';
 import { ChartPie } from '@patternfly/react-charts/dist/js/components/ChartPie';
 import { ChartDonut } from '@patternfly/react-charts/dist/js/components/ChartDonut';
 import { ChartDonutUtilization } from '@patternfly/react-charts/dist/js/components/ChartDonutUtilization';
-import { getLightThemeColors } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
+import { getThemeColors } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
 import Table from './Table';
 import styles from '../utils/styles';
 import rgbHex from 'rgb-hex';
@@ -54,7 +54,7 @@ const chartMapper = {
   donutUtilization: {
     component: ChartDonutUtilization,
     width: 80,
-    colorScale: ([color]) => [color, ...getLightThemeColors('gray').voronoi.colorScale],
+    colorScale: ([color]) => [color, ...getThemeColors('gray').voronoi.colorScale],
     translate: {
       x: 100,
       y: 100,
@@ -127,8 +127,8 @@ class Chart extends React.Component {
     const currChart = chartMapper[chartType] || chartMapper.pie;
 
     const colors = currChart.colorScale
-      ? currChart.colorScale(getLightThemeColors(colorSchema).voronoi.colorScale)
-      : getLightThemeColors(colorSchema).voronoi.colorScale;
+      ? currChart.colorScale(getThemeColors(colorSchema).voronoi.colorScale)
+      : getThemeColors(colorSchema).voronoi.colorScale;
 
     const [paths, texts] = this.getChartData(currChart);
 


### PR DESCRIPTION
### Description

PF removed `lightThemeColor` schema in this PR https://github.com/patternfly/patternfly-react/issues/7369 and every PDF report using it started to fail. This PR fixes such issue by using `getThemeColor`. We should communicate to PF when removing such exports they should first introduce deprecate warning and then remove it instead of plainly removing it and breaking bunch of apps.