### PR TITLE
Pin charts version so pdf generator works correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7406,37 +7406,6 @@
                 "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
-        "node_modules/@patternfly/react-charts": {
-            "version": "6.92.0",
-            "license": "MIT",
-            "dependencies": {
-                "@patternfly/react-styles": "^4.89.0",
-                "@patternfly/react-tokens": "^4.91.0",
-                "hoist-non-react-statics": "^3.3.0",
-                "lodash": "^4.17.19",
-                "tslib": "^2.0.0",
-                "victory-area": "^36.2.1",
-                "victory-axis": "^36.2.1",
-                "victory-bar": "^36.2.1",
-                "victory-chart": "^36.2.1",
-                "victory-core": "^36.2.1",
-                "victory-create-container": "^36.2.1",
-                "victory-cursor-container": "^36.2.1",
-                "victory-group": "^36.2.1",
-                "victory-legend": "^36.2.1",
-                "victory-line": "^36.2.1",
-                "victory-pie": "^36.2.1",
-                "victory-scatter": "^36.2.1",
-                "victory-stack": "^36.2.1",
-                "victory-tooltip": "^36.2.1",
-                "victory-voronoi-container": "^36.2.1",
-                "victory-zoom-container": "^36.2.1"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0"
-            }
-        },
         "node_modules/@patternfly/react-core": {
             "version": "4.247.1",
             "license": "MIT",
@@ -11208,51 +11177,6 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/d3-array": {
-            "version": "3.0.3",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-color": {
-            "version": "3.1.0",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-ease": {
-            "version": "3.0.0",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-interpolate": {
-            "version": "3.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-color": "*"
-            }
-        },
-        "node_modules/@types/d3-path": {
-            "version": "3.0.0",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-scale": {
-            "version": "4.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-time": "*"
-            }
-        },
-        "node_modules/@types/d3-shape": {
-            "version": "3.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "@types/d3-path": "*"
-            }
-        },
-        "node_modules/@types/d3-time": {
-            "version": "3.0.0",
-            "license": "MIT"
-        },
-        "node_modules/@types/d3-timer": {
-            "version": "3.0.0",
-            "license": "MIT"
         },
         "node_modules/@types/debounce-promise": {
             "version": "3.1.4",
@@ -17518,13 +17442,6 @@
             "version": "4.0.1",
             "license": "ISC"
         },
-        "node_modules/delaunay-find": {
-            "version": "0.0.6",
-            "license": "ISC",
-            "dependencies": {
-                "delaunator": "^4.0.0"
-            }
-        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "license": "MIT",
@@ -22480,13 +22397,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/internmap": {
-            "version": "2.0.3",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/interpret": {
@@ -32361,10 +32271,6 @@
                 "react": ">=16.13.1"
             }
         },
-        "node_modules/react-fast-compare": {
-            "version": "3.2.0",
-            "license": "MIT"
-        },
         "node_modules/react-final-form": {
             "version": "6.5.9",
             "license": "MIT",
@@ -37727,355 +37633,590 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/victory-area": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+            "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "victory-area": "^34.3.12",
+                "victory-axis": "^34.3.12",
+                "victory-bar": "^34.3.12",
+                "victory-box-plot": "^34.3.12",
+                "victory-brush-container": "^34.3.12",
+                "victory-brush-line": "^34.3.12",
+                "victory-candlestick": "^34.3.12",
+                "victory-chart": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-create-container": "^34.3.12",
+                "victory-cursor-container": "^34.3.12",
+                "victory-errorbar": "^34.3.12",
+                "victory-group": "^34.3.12",
+                "victory-histogram": "^34.3.12",
+                "victory-legend": "^34.3.12",
+                "victory-line": "^34.3.12",
+                "victory-pie": "^34.3.12",
+                "victory-polar-axis": "^34.3.12",
+                "victory-scatter": "^34.3.12",
+                "victory-selection-container": "^34.3.12",
+                "victory-shared-events": "^34.3.12",
+                "victory-stack": "^34.3.12",
+                "victory-tooltip": "^34.3.12",
+                "victory-voronoi": "^34.3.12",
+                "victory-voronoi-container": "^34.3.12",
+                "victory-zoom-container": "^34.3.12"
             }
         },
-        "node_modules/victory-axis": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-box-plot": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+            "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-bar": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-box-plot/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-brush-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-box-plot/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory-box-plot/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-chart": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-brush-line": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+            "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-axis": "^36.6.8",
-                "victory-core": "^36.6.8",
-                "victory-polar-axis": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-core": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-brush-line/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "lodash": "^4.17.21",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-vendor": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-create-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-brush-line/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory-brush-line/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "victory-brush-container": "^36.6.8",
-                "victory-core": "^36.6.8",
-                "victory-cursor-container": "^36.6.8",
-                "victory-selection-container": "^36.6.8",
-                "victory-voronoi-container": "^36.6.8",
-                "victory-zoom-container": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-cursor-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-candlestick": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+            "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-group": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-candlestick/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-legend": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-candlestick/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory-candlestick/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-line": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-errorbar": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+            "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-pie": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-errorbar/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-polar-axis": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-errorbar/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory-errorbar/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-scatter": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-histogram": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+            "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^2.4.0",
+                "d3-scale": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-bar": "^34.3.12",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-selection-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-histogram/node_modules/d3-array": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "internmap": "^1.0.0"
             }
         },
-        "node_modules/victory-shared-events": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-histogram/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-stack": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-histogram/node_modules/d3-scale/node_modules/d3-array": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+            "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+        },
+        "node_modules/victory-histogram/node_modules/internmap": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+        },
+        "node_modules/victory-histogram/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory-histogram/node_modules/victory-bar": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-tooltip": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory-histogram/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-vendor": {
-            "version": "36.6.8",
-            "license": "MIT AND ISC",
+        "node_modules/victory-voronoi": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+            "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
             "dependencies": {
-                "@types/d3-array": "^3.0.3",
-                "@types/d3-ease": "^3.0.0",
-                "@types/d3-interpolate": "^3.0.1",
-                "@types/d3-scale": "^4.0.2",
-                "@types/d3-shape": "^3.1.0",
-                "@types/d3-time": "^3.0.0",
-                "@types/d3-timer": "^3.0.0",
-                "d3-array": "^3.1.6",
-                "d3-ease": "^3.0.1",
-                "d3-interpolate": "^3.0.1",
-                "d3-scale": "^4.0.2",
-                "d3-shape": "^3.1.0",
-                "d3-time": "^3.0.0",
-                "d3-timer": "^3.0.1"
+                "d3-voronoi": "^1.1.2",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-array": {
-            "version": "3.2.0",
-            "license": "ISC",
+        "node_modules/victory-voronoi/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "internmap": "1 - 2"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-ease": {
-            "version": "3.0.1",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=12"
-            }
+        "node_modules/victory-voronoi/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
         },
-        "node_modules/victory-vendor/node_modules/d3-interpolate": {
-            "version": "3.0.1",
-            "license": "ISC",
+        "node_modules/victory-voronoi/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
             "dependencies": {
-                "d3-color": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-scale": {
-            "version": "4.0.2",
-            "license": "ISC",
+        "node_modules/victory/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dependencies": {
-                "d3-array": "2.10.0 - 3",
-                "d3-format": "1 - 3",
-                "d3-interpolate": "1.2.0 - 3",
-                "d3-time": "2.1.1 - 3",
-                "d3-time-format": "2 - 4"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-shape": {
-            "version": "3.1.0",
-            "license": "ISC",
+        "node_modules/victory/node_modules/delaunay-find": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+            "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
             "dependencies": {
-                "d3-path": "1 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "delaunator": "^4.0.0"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-time": {
-            "version": "3.0.0",
-            "license": "ISC",
+        "node_modules/victory/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "node_modules/victory/node_modules/victory-area": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+            "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
             "dependencies": {
-                "d3-array": "2 - 3"
-            },
-            "engines": {
-                "node": ">=12"
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-vendor/node_modules/d3-timer": {
-            "version": "3.0.1",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/victory-voronoi-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory/node_modules/victory-axis": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+            "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
             "dependencies": {
-                "delaunay-find": "0.0.6",
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-tooltip": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
-        "node_modules/victory-zoom-container": {
-            "version": "36.6.8",
-            "license": "MIT",
+        "node_modules/victory/node_modules/victory-bar": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
             "dependencies": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            },
-            "peerDependencies": {
-                "react": ">=16.6.0"
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-brush-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+            "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-chart": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+            "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-axis": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-polar-axis": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "dependencies": {
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
+            }
+        },
+        "node_modules/victory/node_modules/victory-create-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+            "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "victory-brush-container": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-cursor-container": "^34.3.12",
+                "victory-selection-container": "^34.3.12",
+                "victory-voronoi-container": "^34.3.12",
+                "victory-zoom-container": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-cursor-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+            "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-group": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+            "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-legend": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+            "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-line": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+            "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+            "dependencies": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-pie": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+            "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+            "dependencies": {
+                "d3-shape": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-polar-axis": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+            "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-scatter": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+            "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-selection-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+            "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-shared-events": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+            "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-stack": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+            "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-tooltip": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+            "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-voronoi-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+            "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+            "dependencies": {
+                "delaunay-find": "0.0.5",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-tooltip": "^34.3.12"
+            }
+        },
+        "node_modules/victory/node_modules/victory-zoom-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+            "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
         "node_modules/vlq": {
@@ -39483,7 +39624,7 @@
         },
         "packages/config-utils": {
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
-            "version": "1.5.25",
+            "version": "1.5.26",
             "license": "Apache-2.0",
             "dependencies": {
                 "node-fetch": "2.6.7"
@@ -39779,10 +39920,10 @@
         },
         "packages/pdf-generator": {
             "name": "@redhat-cloud-services/frontend-components-pdf-generator",
-            "version": "2.6.12",
+            "version": "2.6.16",
             "license": "Apache-2.0",
             "dependencies": {
-                "@patternfly/react-charts": "^6.3.9",
+                "@patternfly/react-charts": "6.3.9",
                 "@patternfly/react-core": "^4.18.5",
                 "@patternfly/react-icons": "^3.15.3",
                 "@patternfly/react-styles": "^4.3.4",
@@ -39802,6 +39943,48 @@
                 "rollup-plugin-replace": "^2.2.0",
                 "rollup-plugin-terser": "^7.0.2",
                 "style-inject": "0.3.0"
+            }
+        },
+        "packages/pdf-generator/node_modules/@patternfly/patternfly": {
+            "version": "4.10.31",
+            "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+            "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A==",
+            "engines": {
+                "node": ">=8.0.0",
+                "npm": ">=5.0.0"
+            }
+        },
+        "packages/pdf-generator/node_modules/@patternfly/react-charts": {
+            "version": "6.3.9",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+            "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
+            "dependencies": {
+                "@patternfly/patternfly": "4.10.31",
+                "@patternfly/react-styles": "^4.3.4",
+                "@patternfly/react-tokens": "^4.4.4",
+                "hoist-non-react-statics": "^3.3.0",
+                "lodash": "^4.17.15",
+                "tslib": "^1.11.1",
+                "victory": "^34.3.9",
+                "victory-area": "^34.3.8",
+                "victory-axis": "^34.3.8",
+                "victory-bar": "^34.3.8",
+                "victory-chart": "^34.3.9",
+                "victory-core": "^34.3.8",
+                "victory-create-container": "^34.3.8",
+                "victory-group": "^34.3.9",
+                "victory-legend": "^34.3.8",
+                "victory-line": "^34.3.8",
+                "victory-pie": "^34.3.8",
+                "victory-scatter": "^34.3.8",
+                "victory-stack": "^34.3.9",
+                "victory-tooltip": "^34.3.8",
+                "victory-voronoi-container": "^34.3.8",
+                "victory-zoom-container": "^34.3.8"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0",
+                "react-dom": "^16.8.0"
             }
         },
         "packages/pdf-generator/node_modules/@patternfly/react-icons": {
@@ -39826,6 +40009,28 @@
             "peerDependencies": {
                 "react": ">=16.8.0 || >=17.0.0",
                 "react-dom": ">=16.8.0 || >=17.0.0"
+            }
+        },
+        "packages/pdf-generator/node_modules/d3-scale": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "dependencies": {
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
+            }
+        },
+        "packages/pdf-generator/node_modules/delaunay-find": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+            "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+            "dependencies": {
+                "delaunator": "^4.0.0"
             }
         },
         "packages/pdf-generator/node_modules/react": {
@@ -39853,12 +40058,248 @@
                 "react": "^16.0.0"
             }
         },
+        "packages/pdf-generator/node_modules/react-fast-compare": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
         "packages/pdf-generator/node_modules/scheduler": {
             "version": "0.18.0",
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
+            }
+        },
+        "packages/pdf-generator/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "packages/pdf-generator/node_modules/victory-area": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+            "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+            "dependencies": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-axis": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+            "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-bar": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+            "dependencies": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-brush-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+            "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-chart": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+            "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-axis": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-polar-axis": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-core": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "dependencies": {
+                "d3-ease": "^1.0.0",
+                "d3-interpolate": "^1.1.1",
+                "d3-scale": "^1.0.0",
+                "d3-shape": "^1.2.0",
+                "d3-timer": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-create-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+            "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "victory-brush-container": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-cursor-container": "^34.3.12",
+                "victory-selection-container": "^34.3.12",
+                "victory-voronoi-container": "^34.3.12",
+                "victory-zoom-container": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-cursor-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+            "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-group": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+            "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-legend": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+            "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-line": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+            "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+            "dependencies": {
+                "d3-shape": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-pie": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+            "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+            "dependencies": {
+                "d3-shape": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-polar-axis": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+            "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-scatter": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+            "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-selection-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+            "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-shared-events": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+            "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-stack": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+            "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-shared-events": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-tooltip": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+            "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-voronoi-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+            "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+            "dependencies": {
+                "delaunay-find": "0.0.5",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12",
+                "victory-tooltip": "^34.3.12"
+            }
+        },
+        "packages/pdf-generator/node_modules/victory-zoom-container": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+            "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
             }
         },
         "packages/remediations": {
@@ -45137,32 +45578,6 @@
                 "classnames": "^2.2.5"
             }
         },
-        "@patternfly/react-charts": {
-            "version": "6.92.0",
-            "requires": {
-                "@patternfly/react-styles": "^4.89.0",
-                "@patternfly/react-tokens": "^4.91.0",
-                "hoist-non-react-statics": "^3.3.0",
-                "lodash": "^4.17.19",
-                "tslib": "^2.0.0",
-                "victory-area": "^36.2.1",
-                "victory-axis": "^36.2.1",
-                "victory-bar": "^36.2.1",
-                "victory-chart": "^36.2.1",
-                "victory-core": "^36.2.1",
-                "victory-create-container": "^36.2.1",
-                "victory-cursor-container": "^36.2.1",
-                "victory-group": "^36.2.1",
-                "victory-legend": "^36.2.1",
-                "victory-line": "^36.2.1",
-                "victory-pie": "^36.2.1",
-                "victory-scatter": "^36.2.1",
-                "victory-stack": "^36.2.1",
-                "victory-tooltip": "^36.2.1",
-                "victory-voronoi-container": "^36.2.1",
-                "victory-zoom-container": "^36.2.1"
-            }
-        },
         "@patternfly/react-core": {
             "version": "4.247.1",
             "requires": {
@@ -45630,7 +46045,7 @@
         "@redhat-cloud-services/frontend-components-pdf-generator": {
             "version": "file:packages/pdf-generator",
             "requires": {
-                "@patternfly/react-charts": "^6.3.9",
+                "@patternfly/react-charts": "6.3.9",
                 "@patternfly/react-core": "^4.18.5",
                 "@patternfly/react-icons": "^3.15.3",
                 "@patternfly/react-styles": "^4.3.4",
@@ -45650,6 +46065,40 @@
                 "style-inject": "0.3.0"
             },
             "dependencies": {
+                "@patternfly/patternfly": {
+                    "version": "4.10.31",
+                    "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
+                    "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A=="
+                },
+                "@patternfly/react-charts": {
+                    "version": "6.3.9",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
+                    "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
+                    "requires": {
+                        "@patternfly/patternfly": "4.10.31",
+                        "@patternfly/react-styles": "^4.3.4",
+                        "@patternfly/react-tokens": "^4.4.4",
+                        "hoist-non-react-statics": "^3.3.0",
+                        "lodash": "^4.17.15",
+                        "tslib": "^1.11.1",
+                        "victory": "^34.3.9",
+                        "victory-area": "^34.3.8",
+                        "victory-axis": "^34.3.8",
+                        "victory-bar": "^34.3.8",
+                        "victory-chart": "^34.3.9",
+                        "victory-core": "^34.3.8",
+                        "victory-create-container": "^34.3.8",
+                        "victory-group": "^34.3.9",
+                        "victory-legend": "^34.3.8",
+                        "victory-line": "^34.3.8",
+                        "victory-pie": "^34.3.8",
+                        "victory-scatter": "^34.3.8",
+                        "victory-stack": "^34.3.9",
+                        "victory-tooltip": "^34.3.8",
+                        "victory-voronoi-container": "^34.3.8",
+                        "victory-zoom-container": "^34.3.8"
+                    }
+                },
                 "@patternfly/react-icons": {
                     "version": "3.15.17",
                     "requires": {
@@ -45661,6 +46110,28 @@
                     "requires": {
                         "@scalprum/core": "^0.1.1",
                         "lodash": "^4.17.0"
+                    }
+                },
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "delaunay-find": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+                    "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+                    "requires": {
+                        "delaunator": "^4.0.0"
                     }
                 },
                 "react": {
@@ -45680,11 +46151,247 @@
                         "scheduler": "^0.18.0"
                     }
                 },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
                 "scheduler": {
                     "version": "0.18.0",
                     "requires": {
                         "loose-envify": "^1.1.0",
                         "object-assign": "^4.1.1"
+                    }
+                },
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                },
+                "victory-area": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+                    "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-axis": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+                    "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-bar": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-brush-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+                    "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-chart": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+                    "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-axis": "^34.3.12",
+                        "victory-core": "^34.3.12",
+                        "victory-polar-axis": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                },
+                "victory-create-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+                    "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "victory-brush-container": "^34.3.12",
+                        "victory-core": "^34.3.12",
+                        "victory-cursor-container": "^34.3.12",
+                        "victory-selection-container": "^34.3.12",
+                        "victory-voronoi-container": "^34.3.12",
+                        "victory-zoom-container": "^34.3.12"
+                    }
+                },
+                "victory-cursor-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+                    "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-group": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+                    "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-legend": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+                    "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-line": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+                    "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-pie": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+                    "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+                    "requires": {
+                        "d3-shape": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-polar-axis": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+                    "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-scatter": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+                    "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-selection-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+                    "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-shared-events": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+                    "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-stack": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+                    "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-tooltip": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+                    "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-voronoi-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+                    "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+                    "requires": {
+                        "delaunay-find": "0.0.5",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-tooltip": "^34.3.12"
+                    }
+                },
+                "victory-zoom-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+                    "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
                     }
                 }
             }
@@ -47239,42 +47946,6 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
-        },
-        "@types/d3-array": {
-            "version": "3.0.3"
-        },
-        "@types/d3-color": {
-            "version": "3.1.0"
-        },
-        "@types/d3-ease": {
-            "version": "3.0.0"
-        },
-        "@types/d3-interpolate": {
-            "version": "3.0.1",
-            "requires": {
-                "@types/d3-color": "*"
-            }
-        },
-        "@types/d3-path": {
-            "version": "3.0.0"
-        },
-        "@types/d3-scale": {
-            "version": "4.0.2",
-            "requires": {
-                "@types/d3-time": "*"
-            }
-        },
-        "@types/d3-shape": {
-            "version": "3.1.0",
-            "requires": {
-                "@types/d3-path": "*"
-            }
-        },
-        "@types/d3-time": {
-            "version": "3.0.0"
-        },
-        "@types/d3-timer": {
-            "version": "3.0.0"
         },
         "@types/debounce-promise": {
             "version": "3.1.4"
@@ -51614,12 +52285,6 @@
         "delaunator": {
             "version": "4.0.1"
         },
-        "delaunay-find": {
-            "version": "0.0.6",
-            "requires": {
-                "delaunator": "^4.0.0"
-            }
-        },
         "delayed-stream": {
             "version": "1.0.0"
         },
@@ -54950,9 +55615,6 @@
                 "has": "^1.0.3",
                 "side-channel": "^1.0.4"
             }
-        },
-        "internmap": {
-            "version": "2.0.3"
         },
         "interpret": {
             "version": "2.2.0"
@@ -61308,9 +61970,6 @@
                 "@babel/runtime": "^7.12.5"
             }
         },
-        "react-fast-compare": {
-            "version": "3.2.0"
-        },
         "react-final-form": {
             "version": "6.5.9",
             "requires": {
@@ -64839,248 +65498,606 @@
                 "unist-util-stringify-position": "^3.0.0"
             }
         },
-        "victory-area": {
-            "version": "36.6.8",
+        "victory": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
+            "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
             "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            }
-        },
-        "victory-axis": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-bar": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            }
-        },
-        "victory-brush-container": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-chart": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-axis": "^36.6.8",
-                "victory-core": "^36.6.8",
-                "victory-polar-axis": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            }
-        },
-        "victory-core": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.21",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-vendor": "^36.6.8"
-            }
-        },
-        "victory-create-container": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "victory-brush-container": "^36.6.8",
-                "victory-core": "^36.6.8",
-                "victory-cursor-container": "^36.6.8",
-                "victory-selection-container": "^36.6.8",
-                "victory-voronoi-container": "^36.6.8",
-                "victory-zoom-container": "^36.6.8"
-            }
-        },
-        "victory-cursor-container": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-group": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            }
-        },
-        "victory-legend": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-line": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            }
-        },
-        "victory-pie": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8",
-                "victory-vendor": "^36.6.8"
-            }
-        },
-        "victory-polar-axis": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-scatter": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-selection-container": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-shared-events": {
-            "version": "36.6.8",
-            "requires": {
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-stack": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-shared-events": "^36.6.8"
-            }
-        },
-        "victory-tooltip": {
-            "version": "36.6.8",
-            "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
-            }
-        },
-        "victory-vendor": {
-            "version": "36.6.8",
-            "requires": {
-                "@types/d3-array": "^3.0.3",
-                "@types/d3-ease": "^3.0.0",
-                "@types/d3-interpolate": "^3.0.1",
-                "@types/d3-scale": "^4.0.2",
-                "@types/d3-shape": "^3.1.0",
-                "@types/d3-time": "^3.0.0",
-                "@types/d3-timer": "^3.0.0",
-                "d3-array": "^3.1.6",
-                "d3-ease": "^3.0.1",
-                "d3-interpolate": "^3.0.1",
-                "d3-scale": "^4.0.2",
-                "d3-shape": "^3.1.0",
-                "d3-time": "^3.0.0",
-                "d3-timer": "^3.0.1"
+                "victory-area": "^34.3.12",
+                "victory-axis": "^34.3.12",
+                "victory-bar": "^34.3.12",
+                "victory-box-plot": "^34.3.12",
+                "victory-brush-container": "^34.3.12",
+                "victory-brush-line": "^34.3.12",
+                "victory-candlestick": "^34.3.12",
+                "victory-chart": "^34.3.12",
+                "victory-core": "^34.3.12",
+                "victory-create-container": "^34.3.12",
+                "victory-cursor-container": "^34.3.12",
+                "victory-errorbar": "^34.3.12",
+                "victory-group": "^34.3.12",
+                "victory-histogram": "^34.3.12",
+                "victory-legend": "^34.3.12",
+                "victory-line": "^34.3.12",
+                "victory-pie": "^34.3.12",
+                "victory-polar-axis": "^34.3.12",
+                "victory-scatter": "^34.3.12",
+                "victory-selection-container": "^34.3.12",
+                "victory-shared-events": "^34.3.12",
+                "victory-stack": "^34.3.12",
+                "victory-tooltip": "^34.3.12",
+                "victory-voronoi": "^34.3.12",
+                "victory-voronoi-container": "^34.3.12",
+                "victory-zoom-container": "^34.3.12"
             },
             "dependencies": {
-                "d3-array": {
-                    "version": "3.2.0",
-                    "requires": {
-                        "internmap": "1 - 2"
-                    }
-                },
-                "d3-ease": {
-                    "version": "3.0.1"
-                },
-                "d3-interpolate": {
-                    "version": "3.0.1",
-                    "requires": {
-                        "d3-color": "1 - 3"
-                    }
-                },
                 "d3-scale": {
-                    "version": "4.0.2",
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
-                        "d3-array": "2.10.0 - 3",
-                        "d3-format": "1 - 3",
-                        "d3-interpolate": "1.2.0 - 3",
-                        "d3-time": "2.1.1 - 3",
-                        "d3-time-format": "2 - 4"
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
                     }
                 },
-                "d3-shape": {
-                    "version": "3.1.0",
+                "delaunay-find": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
+                    "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
                     "requires": {
-                        "d3-path": "1 - 3"
+                        "delaunator": "^4.0.0"
                     }
                 },
-                "d3-time": {
-                    "version": "3.0.0",
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-area": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
+                    "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
                     "requires": {
-                        "d3-array": "2 - 3"
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
                     }
                 },
-                "d3-timer": {
-                    "version": "3.0.1"
+                "victory-axis": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
+                    "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-bar": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-brush-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
+                    "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-chart": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
+                    "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-axis": "^34.3.12",
+                        "victory-core": "^34.3.12",
+                        "victory-polar-axis": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                },
+                "victory-create-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
+                    "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "victory-brush-container": "^34.3.12",
+                        "victory-core": "^34.3.12",
+                        "victory-cursor-container": "^34.3.12",
+                        "victory-selection-container": "^34.3.12",
+                        "victory-voronoi-container": "^34.3.12",
+                        "victory-zoom-container": "^34.3.12"
+                    }
+                },
+                "victory-cursor-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
+                    "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-group": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
+                    "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-legend": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
+                    "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-line": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
+                    "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-pie": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
+                    "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+                    "requires": {
+                        "d3-shape": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-polar-axis": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
+                    "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-scatter": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
+                    "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-selection-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
+                    "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-shared-events": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
+                    "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-stack": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
+                    "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-shared-events": "^34.3.12"
+                    }
+                },
+                "victory-tooltip": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
+                    "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-voronoi-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
+                    "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+                    "requires": {
+                        "delaunay-find": "0.0.5",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0",
+                        "victory-core": "^34.3.12",
+                        "victory-tooltip": "^34.3.12"
+                    }
+                },
+                "victory-zoom-container": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
+                    "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+                    "requires": {
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
                 }
             }
         },
-        "victory-voronoi-container": {
-            "version": "36.6.8",
+        "victory-box-plot": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
+            "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
             "requires": {
-                "delaunay-find": "0.0.6",
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "react-fast-compare": "^3.2.0",
-                "victory-core": "^36.6.8",
-                "victory-tooltip": "^36.6.8"
+                "d3-array": "^1.2.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
             }
         },
-        "victory-zoom-container": {
-            "version": "36.6.8",
+        "victory-brush-line": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
+            "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
             "requires": {
-                "lodash": "^4.17.19",
-                "prop-types": "^15.8.1",
-                "victory-core": "^36.6.8"
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "victory-candlestick": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
+            "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+            "requires": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "victory-errorbar": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
+            "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+            "requires": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "victory-histogram": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
+            "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+            "requires": {
+                "d3-array": "^2.4.0",
+                "d3-scale": "^1.0.0",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "react-fast-compare": "^2.0.0",
+                "victory-bar": "^34.3.12",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "2.12.1",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+                    "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+                    "requires": {
+                        "internmap": "^1.0.0"
+                    }
+                },
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    },
+                    "dependencies": {
+                        "d3-array": {
+                            "version": "1.2.4",
+                            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+                            "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+                        }
+                    }
+                },
+                "internmap": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+                    "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-bar": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
+                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+                    "requires": {
+                        "d3-shape": "^1.2.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "victory-core": "^34.3.12"
+                    }
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "victory-voronoi": {
+            "version": "34.3.12",
+            "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
+            "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
+            "requires": {
+                "d3-voronoi": "^1.1.2",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.8",
+                "victory-core": "^34.3.12"
+            },
+            "dependencies": {
+                "d3-scale": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
+                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+                    "requires": {
+                        "d3-array": "^1.2.0",
+                        "d3-collection": "1",
+                        "d3-color": "1",
+                        "d3-format": "1",
+                        "d3-interpolate": "1",
+                        "d3-time": "1",
+                        "d3-time-format": "2"
+                    }
+                },
+                "react-fast-compare": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                },
+                "victory-core": {
+                    "version": "34.3.12",
+                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
+                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+                    "requires": {
+                        "d3-ease": "^1.0.0",
+                        "d3-interpolate": "^1.1.1",
+                        "d3-scale": "^1.0.0",
+                        "d3-shape": "^1.2.0",
+                        "d3-timer": "^1.0.0",
+                        "lodash": "^4.17.15",
+                        "prop-types": "^15.5.8",
+                        "react-fast-compare": "^2.0.0"
+                    }
+                }
             }
         },
         "vlq": {

--- a/packages/pdf-generator/package.json
+++ b/packages/pdf-generator/package.json
@@ -32,7 +32,7 @@
     "author": "Red Hat",
     "license": "Apache-2.0",
     "dependencies": {
-        "@patternfly/react-charts": "^6.3.9",
+        "@patternfly/react-charts": "6.3.9",
         "@patternfly/react-core": "^4.18.5",
         "@patternfly/react-icons": "^3.15.3",
         "@patternfly/react-styles": "^4.3.4",

--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -7,13 +7,15 @@ import { ChartBar } from '@patternfly/react-charts/dist/js/components/ChartBar';
 import { ChartPie } from '@patternfly/react-charts/dist/js/components/ChartPie';
 import { ChartDonut } from '@patternfly/react-charts/dist/js/components/ChartDonut';
 import { ChartDonutUtilization } from '@patternfly/react-charts/dist/js/components/ChartDonutUtilization';
-import { getThemeColors } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
+import { getLightThemeColors, getThemeColors } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
 import Table from './Table';
 import styles from '../utils/styles';
 import rgbHex from 'rgb-hex';
 import flatten from 'lodash/flatten';
 import globalPaletteBlack300 from '@patternfly/react-tokens/dist/js/global_palette_black_300';
 import globalPaletteBlack700 from '@patternfly/react-tokens/dist/js/global_palette_black_700';
+
+const getColors = (...props) => getLightThemeColors?.(...props) || getThemeColors?.(...props);
 
 const appliedStyles = styles();
 const chartMapper = {
@@ -54,7 +56,7 @@ const chartMapper = {
   donutUtilization: {
     component: ChartDonutUtilization,
     width: 80,
-    colorScale: ([color]) => [color, ...getThemeColors('gray').voronoi.colorScale],
+    colorScale: ([color]) => [color, ...getColors('gray').voronoi.colorScale],
     translate: {
       x: 100,
       y: 100,
@@ -126,9 +128,7 @@ class Chart extends React.Component {
     const { data, chartType, colorSchema, legendHeader, ...props } = this.props;
     const currChart = chartMapper[chartType] || chartMapper.pie;
 
-    const colors = currChart.colorScale
-      ? currChart.colorScale(getThemeColors(colorSchema).voronoi.colorScale)
-      : getThemeColors(colorSchema).voronoi.colorScale;
+    const colors = currChart.colorScale ? currChart.colorScale(getColors(colorSchema).voronoi.colorScale) : getColors(colorSchema).voronoi.colorScale;
 
     const [paths, texts] = this.getChartData(currChart);
 


### PR DESCRIPTION
### Description

Since react-charts started to use hooks from some newer version and we need to have 2 React instances (because of async render) we have to pin the version of charts to some older version.

Since some apps are using aliases or forcing different version of charts we have to pull the theme color from either light theme or theme function.

### Jira

https://issues.redhat.com/browse/RHCLOUD-23657