### PR TITLE
chore(deps): updating range for cypress versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39458,7 +39458,7 @@
         },
         "packages/chrome": {
             "name": "@redhat-cloud-services/chrome",
-            "version": "0.0.0",
+            "version": "0.0.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "react": "^17.0.2",
@@ -39474,7 +39474,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.9.28",
+            "version": "3.9.29",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
@@ -39622,7 +39622,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "4.6.34",
+            "version": "4.6.36",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
@@ -39966,7 +39966,7 @@
         },
         "packages/pdf-generator": {
             "name": "@redhat-cloud-services/frontend-components-pdf-generator",
-            "version": "2.6.16",
+            "version": "2.6.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-charts": "6.3.9",
@@ -40508,7 +40508,7 @@
                 "@patternfly/react-core": "^4.239.0",
                 "@patternfly/react-table": "^4.108.0",
                 "@redhat-cloud-services/rbac-client": "^1.0.100",
-                "cypress": ">=10.0.0 < 12.0.0",
+                "cypress": ">=10.0.0 < 13.0.0",
                 "react": "^16.14.0 || ^17.0.0",
                 "react-dom": "^16.14.0 || ^17.0.0",
                 "react-redux": ">=7.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
         "react-dom": "^16.14.0 || ^17.0.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0",
-        "cypress": ">=10.0.0 < 12.0.0"
+        "cypress": ">=10.0.0 < 13.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/types": "^0.0.17",


### PR DESCRIPTION
The cypress version is bigger than the 12.0.0 so I had to update the range in the package.json