### PR TITLE
Copy PF's chart theme utilities since they no longer support it

### DIFF
--- a/packages/pdf-generator/src/components/Chart.js
+++ b/packages/pdf-generator/src/components/Chart.js
@@ -7,15 +7,13 @@ import { ChartBar } from '@patternfly/react-charts/dist/js/components/ChartBar';
 import { ChartPie } from '@patternfly/react-charts/dist/js/components/ChartPie';
 import { ChartDonut } from '@patternfly/react-charts/dist/js/components/ChartDonut';
 import { ChartDonutUtilization } from '@patternfly/react-charts/dist/js/components/ChartDonutUtilization';
-import { getLightThemeColors, getThemeColors } from '@patternfly/react-charts/dist/js/components/ChartUtils/chart-theme';
+import { getLightThemeColors } from '../utils/theme/utils';
 import Table from './Table';
 import styles from '../utils/styles';
 import rgbHex from 'rgb-hex';
 import flatten from 'lodash/flatten';
 import globalPaletteBlack300 from '@patternfly/react-tokens/dist/js/global_palette_black_300';
 import globalPaletteBlack700 from '@patternfly/react-tokens/dist/js/global_palette_black_700';
-
-const getColors = (...props) => getLightThemeColors?.(...props) || getThemeColors?.(...props);
 
 const appliedStyles = styles();
 const chartMapper = {
@@ -56,7 +54,7 @@ const chartMapper = {
   donutUtilization: {
     component: ChartDonutUtilization,
     width: 80,
-    colorScale: ([color]) => [color, ...getColors('gray').voronoi.colorScale],
+    colorScale: ([color]) => [color, ...getLightThemeColors('gray').voronoi.colorScale],
     translate: {
       x: 100,
       y: 100,
@@ -128,7 +126,9 @@ class Chart extends React.Component {
     const { data, chartType, colorSchema, legendHeader, ...props } = this.props;
     const currChart = chartMapper[chartType] || chartMapper.pie;
 
-    const colors = currChart.colorScale ? currChart.colorScale(getColors(colorSchema).voronoi.colorScale) : getColors(colorSchema).voronoi.colorScale;
+    const colors = currChart.colorScale
+      ? currChart.colorScale(getLightThemeColors(colorSchema).voronoi.colorScale)
+      : getLightThemeColors(colorSchema).voronoi.colorScale;
 
     const [paths, texts] = this.getChartData(currChart);
 

--- a/packages/pdf-generator/src/utils/theme/chartTheme.js
+++ b/packages/pdf-generator/src/utils/theme/chartTheme.js
@@ -1,0 +1,84 @@
+import { AxisTheme } from './themes/axis-theme';
+import { BaseTheme } from './themes/base-theme';
+import {
+  BulletComparativeErrorMeasureTheme,
+  BulletComparativeMeasureTheme,
+  BulletComparativeWarningMeasureTheme,
+  BulletGroupTitleTheme,
+  BulletPrimaryDotMeasureTheme,
+  BulletPrimaryNegativeMeasureTheme,
+  BulletPrimarySegmentedMeasureTheme,
+  BulletQualitativeRangeTheme,
+  BulletTheme,
+} from './themes/bullet-theme';
+import { DonutTheme } from './themes/donut-theme';
+import { ThresholdTheme } from './themes/threshold-theme';
+import { DonutThresholdDynamicTheme, DonutThresholdStaticTheme } from './themes/donut-threshold-theme';
+import { DonutUtilizationDynamicTheme, DonutUtilizationStaticTheme } from './themes/donut-utilization-theme';
+
+/**
+ * The color family to be applied to a theme. For example, 'blue' represents an ordered list of colors
+ * (i.e., a color scale) composed from the blue color family defined by PatternFly core.
+ *
+ * For example, the 'blue' color scale looks like:
+ *
+ * chart_color_blue_100
+ * chart_color_blue_200
+ * chart_color_blue_300
+ * chart_color_blue_400
+ * chart_color_blue_500
+ *
+ * In this case, the chart_color_blue_100 value would be applied to the first data point in a chart.
+ * The chart_color_blue_200 value would be applied to the second data point in a chart. And so on...
+ *
+ * If legend data is provided to a chart, those colors would be synced with the legend as well.
+ *
+ * The 'multiOrdered' color family is intended for ordered charts; donut, pie, bar, & stack
+ * The 'multiUnordered' color family is intended for unordered charts; area & line
+ * The 'multi' defaults to the 'multiOrdered' color family
+ *
+ * Note: These values are not intended to be applied directly as a component's fill style. For example, "multi" would
+ * not be a valid fill color. Please use chart variables from PatternFly core (e.g., via the react-charts package)
+ */
+export const ChartThemeColor = {
+  blue: 'blue',
+  cyan: 'cyan',
+  default: 'blue',
+  gold: 'gold',
+  gray: 'gray',
+  green: 'green',
+  multi: 'multi',
+  multiOrdered: 'multi-ordered',
+  multiUnordered: 'multi-unordered',
+  orange: 'orange',
+  purple: 'purple',
+};
+
+/**
+ * The variant to be applied to a theme.
+ *
+ * Note: Only the light variant is currently supported
+ */
+export const ChartThemeVariant = {
+  dark: 'dark',
+  default: 'light',
+  light: 'light',
+};
+
+export const ChartAxisTheme = AxisTheme;
+export const ChartBaseTheme = BaseTheme;
+export const ChartBulletComparativeErrorMeasureTheme = BulletComparativeErrorMeasureTheme;
+export const ChartBulletComparativeMeasureTheme = BulletComparativeMeasureTheme;
+export const ChartBulletComparativeWarningMeasureTheme = BulletComparativeWarningMeasureTheme;
+export const ChartBulletGroupTitleTheme = BulletGroupTitleTheme;
+export const ChartBulletPrimaryDotMeasureTheme = BulletPrimaryDotMeasureTheme;
+export const ChartBulletPrimaryNegativeMeasureTheme = BulletPrimaryNegativeMeasureTheme;
+export const ChartBulletPrimarySegmentedMeasureTheme = BulletPrimarySegmentedMeasureTheme;
+export const ChartBulletTheme = BulletTheme;
+export const ChartBulletQualitativeRangeTheme = BulletQualitativeRangeTheme;
+export const ChartDonutUtilizationDynamicTheme = DonutUtilizationDynamicTheme;
+export const ChartDonutUtilizationStaticTheme = DonutUtilizationStaticTheme;
+export const ChartDonutTheme = DonutTheme;
+export const ChartDonutThresholdDynamicTheme = DonutThresholdDynamicTheme;
+export const ChartDonutThresholdStaticTheme = DonutThresholdStaticTheme;
+export const ChartThresholdTheme = ThresholdTheme;

--- a/packages/pdf-generator/src/utils/theme/themes/axis-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/axis-theme.js
@@ -1,0 +1,17 @@
+/* eslint-disable camelcase */
+import chart_axis_grid_stroke_Color from '@patternfly/react-tokens/dist/js/chart_axis_grid_stroke_Color';
+import chart_axis_tick_stroke_Color from '@patternfly/react-tokens/dist/js/chart_axis_tick_stroke_Color';
+
+// Axis theme
+export const AxisTheme = {
+  axis: {
+    style: {
+      grid: {
+        stroke: chart_axis_grid_stroke_Color.value,
+      },
+      ticks: {
+        stroke: chart_axis_tick_stroke_Color.value,
+      },
+    },
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/base-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/base-theme.js
@@ -1,0 +1,365 @@
+/* eslint-disable camelcase */
+import chart_global_FontFamily from '@patternfly/react-tokens/dist/js/chart_global_FontFamily';
+import chart_global_letter_spacing from '@patternfly/react-tokens/dist/js/chart_global_letter_spacing';
+import chart_global_FontSize_sm from '@patternfly/react-tokens/dist/js/chart_global_FontSize_sm';
+import chart_global_label_Padding from '@patternfly/react-tokens/dist/js/chart_global_label_Padding';
+import chart_global_label_stroke from '@patternfly/react-tokens/dist/js/chart_global_label_stroke';
+import chart_global_label_text_anchor from '@patternfly/react-tokens/dist/js/chart_global_label_text_anchor';
+import chart_global_layout_Padding from '@patternfly/react-tokens/dist/js/chart_global_layout_Padding';
+import chart_global_layout_Height from '@patternfly/react-tokens/dist/js/chart_global_layout_Height';
+import chart_global_layout_Width from '@patternfly/react-tokens/dist/js/chart_global_layout_Width';
+import chart_global_stroke_line_cap from '@patternfly/react-tokens/dist/js/chart_global_stroke_line_cap';
+import chart_global_stroke_line_join from '@patternfly/react-tokens/dist/js/chart_global_stroke_line_join';
+import chart_area_data_Fill from '@patternfly/react-tokens/dist/js/chart_area_data_Fill';
+import chart_area_Opacity from '@patternfly/react-tokens/dist/js/chart_area_Opacity';
+import chart_area_stroke_Width from '@patternfly/react-tokens/dist/js/chart_area_stroke_Width';
+import chart_axis_axis_stroke_Width from '@patternfly/react-tokens/dist/js/chart_axis_axis_stroke_Width';
+import chart_axis_axis_stroke_Color from '@patternfly/react-tokens/dist/js/chart_axis_axis_stroke_Color';
+import chart_axis_axis_Fill from '@patternfly/react-tokens/dist/js/chart_axis_axis_Fill';
+import chart_axis_axis_label_Padding from '@patternfly/react-tokens/dist/js/chart_axis_axis_label_Padding';
+import chart_axis_axis_label_stroke_Color from '@patternfly/react-tokens/dist/js/chart_axis_axis_label_stroke_Color';
+import chart_axis_grid_Fill from '@patternfly/react-tokens/dist/js/chart_axis_grid_Fill';
+import chart_axis_grid_PointerEvents from '@patternfly/react-tokens/dist/js/chart_axis_grid_PointerEvents';
+import chart_axis_tick_Fill from '@patternfly/react-tokens/dist/js/chart_axis_tick_Fill';
+import chart_axis_tick_Size from '@patternfly/react-tokens/dist/js/chart_axis_tick_Size';
+import chart_axis_tick_stroke_Color from '@patternfly/react-tokens/dist/js/chart_axis_tick_stroke_Color';
+import chart_axis_tick_Width from '@patternfly/react-tokens/dist/js/chart_axis_tick_Width';
+import chart_axis_tick_label_Fill from '@patternfly/react-tokens/dist/js/chart_axis_tick_label_Fill';
+import chart_bar_Width from '@patternfly/react-tokens/dist/js/chart_bar_Width';
+import chart_bar_data_stroke from '@patternfly/react-tokens/dist/js/chart_bar_data_stroke';
+import chart_bar_data_Fill from '@patternfly/react-tokens/dist/js/chart_bar_data_Fill';
+import chart_bar_data_Padding from '@patternfly/react-tokens/dist/js/chart_bar_data_Padding';
+import chart_bar_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_bar_data_stroke_Width';
+import chart_boxplot_max_Padding from '@patternfly/react-tokens/dist/js/chart_boxplot_max_Padding';
+import chart_boxplot_max_stroke_Color from '@patternfly/react-tokens/dist/js/chart_boxplot_max_stroke_Color';
+import chart_boxplot_max_stroke_Width from '@patternfly/react-tokens/dist/js/chart_boxplot_max_stroke_Width';
+import chart_boxplot_median_Padding from '@patternfly/react-tokens/dist/js/chart_boxplot_median_Padding';
+import chart_boxplot_median_stroke_Color from '@patternfly/react-tokens/dist/js/chart_boxplot_median_stroke_Color';
+import chart_boxplot_median_stroke_Width from '@patternfly/react-tokens/dist/js/chart_boxplot_median_stroke_Width';
+import chart_boxplot_min_Padding from '@patternfly/react-tokens/dist/js/chart_boxplot_min_Padding';
+import chart_boxplot_min_stroke_Width from '@patternfly/react-tokens/dist/js/chart_boxplot_min_stroke_Width';
+import chart_boxplot_min_stroke_Color from '@patternfly/react-tokens/dist/js/chart_boxplot_min_stroke_Color';
+import chart_boxplot_lower_quartile_Padding from '@patternfly/react-tokens/dist/js/chart_boxplot_lower_quartile_Padding';
+import chart_boxplot_lower_quartile_Fill from '@patternfly/react-tokens/dist/js/chart_boxplot_lower_quartile_Fill';
+import chart_boxplot_upper_quartile_Padding from '@patternfly/react-tokens/dist/js/chart_boxplot_upper_quartile_Padding';
+import chart_boxplot_upper_quartile_Fill from '@patternfly/react-tokens/dist/js/chart_boxplot_upper_quartile_Fill';
+import chart_boxplot_box_Width from '@patternfly/react-tokens/dist/js/chart_boxplot_box_Width';
+import chart_candelstick_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_candelstick_data_stroke_Width';
+import chart_candelstick_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_candelstick_data_stroke_Color';
+import chart_candelstick_candle_positive_Color from '@patternfly/react-tokens/dist/js/chart_candelstick_candle_positive_Color';
+import chart_candelstick_candle_negative_Color from '@patternfly/react-tokens/dist/js/chart_candelstick_candle_negative_Color';
+import chart_errorbar_BorderWidth from '@patternfly/react-tokens/dist/js/chart_errorbar_BorderWidth';
+import chart_errorbar_data_Fill from '@patternfly/react-tokens/dist/js/chart_errorbar_data_Fill';
+import chart_errorbar_data_Opacity from '@patternfly/react-tokens/dist/js/chart_errorbar_data_Opacity';
+import chart_errorbar_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_errorbar_data_stroke_Width';
+import chart_errorbar_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_errorbar_data_stroke_Color';
+import chart_legend_gutter_Width from '@patternfly/react-tokens/dist/js/chart_legend_gutter_Width';
+import chart_legend_orientation from '@patternfly/react-tokens/dist/js/chart_legend_orientation';
+import chart_legend_title_orientation from '@patternfly/react-tokens/dist/js/chart_legend_title_orientation';
+import chart_legend_data_type from '@patternfly/react-tokens/dist/js/chart_legend_data_type';
+import chart_legend_title_Padding from '@patternfly/react-tokens/dist/js/chart_legend_title_Padding';
+import chart_line_data_Fill from '@patternfly/react-tokens/dist/js/chart_line_data_Fill';
+import chart_line_data_Opacity from '@patternfly/react-tokens/dist/js/chart_line_data_Opacity';
+import chart_line_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_line_data_stroke_Width';
+import chart_line_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_line_data_stroke_Color';
+import chart_pie_Padding from '@patternfly/react-tokens/dist/js/chart_pie_Padding';
+import chart_pie_data_Padding from '@patternfly/react-tokens/dist/js/chart_pie_data_Padding';
+import chart_pie_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_pie_data_stroke_Width';
+import chart_pie_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_pie_data_stroke_Color';
+import chart_pie_labels_Padding from '@patternfly/react-tokens/dist/js/chart_pie_labels_Padding';
+import chart_pie_Height from '@patternfly/react-tokens/dist/js/chart_pie_Height';
+import chart_pie_Width from '@patternfly/react-tokens/dist/js/chart_pie_Width';
+import chart_scatter_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_scatter_data_stroke_Color';
+import chart_scatter_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_scatter_data_stroke_Width';
+import chart_scatter_data_Opacity from '@patternfly/react-tokens/dist/js/chart_scatter_data_Opacity';
+import chart_scatter_data_Fill from '@patternfly/react-tokens/dist/js/chart_scatter_data_Fill';
+import chart_stack_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_stack_data_stroke_Width';
+import chart_tooltip_corner_radius from '@patternfly/react-tokens/dist/js/chart_tooltip_corner_radius';
+import chart_tooltip_pointer_length from '@patternfly/react-tokens/dist/js/chart_tooltip_pointer_length';
+import chart_tooltip_Fill from '@patternfly/react-tokens/dist/js/chart_tooltip_Fill';
+import chart_tooltip_flyoutStyle_corner_radius from '@patternfly/react-tokens/dist/js/chart_tooltip_flyoutStyle_corner_radius';
+import chart_tooltip_flyoutStyle_stroke_Width from '@patternfly/react-tokens/dist/js/chart_tooltip_flyoutStyle_stroke_Width';
+import chart_tooltip_flyoutStyle_PointerEvents from '@patternfly/react-tokens/dist/js/chart_tooltip_flyoutStyle_PointerEvents';
+import chart_tooltip_flyoutStyle_stroke_Color from '@patternfly/react-tokens/dist/js/chart_tooltip_flyoutStyle_stroke_Color';
+import chart_tooltip_flyoutStyle_Fill from '@patternfly/react-tokens/dist/js/chart_tooltip_flyoutStyle_Fill';
+import chart_tooltip_pointer_Width from '@patternfly/react-tokens/dist/js/chart_tooltip_pointer_Width';
+import chart_tooltip_Padding from '@patternfly/react-tokens/dist/js/chart_tooltip_Padding';
+import chart_tooltip_PointerEvents from '@patternfly/react-tokens/dist/js/chart_tooltip_PointerEvents';
+import chart_voronoi_data_Fill from '@patternfly/react-tokens/dist/js/chart_voronoi_data_Fill';
+import chart_voronoi_data_stroke_Color from '@patternfly/react-tokens/dist/js/chart_voronoi_data_stroke_Color';
+import chart_voronoi_data_stroke_Width from '@patternfly/react-tokens/dist/js/chart_voronoi_data_stroke_Width';
+import chart_voronoi_labels_Fill from '@patternfly/react-tokens/dist/js/chart_voronoi_labels_Fill';
+import chart_voronoi_labels_Padding from '@patternfly/react-tokens/dist/js/chart_voronoi_labels_Padding';
+import chart_voronoi_labels_PointerEvents from '@patternfly/react-tokens/dist/js/chart_voronoi_labels_PointerEvents';
+import chart_voronoi_flyout_stroke_Width from '@patternfly/react-tokens/dist/js/chart_voronoi_flyout_stroke_Width';
+import chart_voronoi_flyout_PointerEvents from '@patternfly/react-tokens/dist/js/chart_voronoi_flyout_PointerEvents';
+import chart_voronoi_flyout_stroke_Color from '@patternfly/react-tokens/dist/js/chart_voronoi_flyout_stroke_Color';
+import chart_voronoi_flyout_stroke_Fill from '@patternfly/react-tokens/dist/js/chart_voronoi_flyout_stroke_Fill';
+
+// Note: Values must be in pixles
+
+// Typography
+const TYPOGRAPHY_FONT_FAMILY = chart_global_FontFamily.var;
+const TYPOGRAPHY_LETTER_SPACING = chart_global_letter_spacing.var;
+const TYPOGRAPHY_FONT_SIZE = chart_global_FontSize_sm.value;
+
+// Labels
+const LABEL_PROPS = {
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
+  padding: chart_global_label_Padding.value,
+  stroke: chart_global_label_stroke.value,
+};
+const LABEL_CENTERED_PROPS = {
+  ...LABEL_PROPS,
+  textAnchor: chart_global_label_text_anchor.value,
+};
+
+// Layout
+const LAYOUT_PROPS = {
+  padding: chart_global_layout_Padding.value,
+  height: chart_global_layout_Height.value,
+  width: chart_global_layout_Width.value,
+};
+
+// Strokes
+const STROKE_LINE_CAP = chart_global_stroke_line_cap.value;
+const STROKE_LINE_JOIN = chart_global_stroke_line_join.value;
+
+// Victory theme properties only
+export const BaseTheme = {
+  area: {
+    ...LAYOUT_PROPS,
+    style: {
+      data: {
+        fill: chart_area_data_Fill.value,
+        fillOpacity: chart_area_Opacity.value,
+        // Omit stroke to add a line border from color scale
+        // stroke: chart_global_label_stroke.value,
+        strokeWidth: chart_area_stroke_Width.value,
+      },
+      labels: LABEL_CENTERED_PROPS,
+    },
+  },
+  axis: {
+    ...LAYOUT_PROPS,
+    style: {
+      axis: {
+        fill: chart_axis_axis_Fill.value,
+        strokeWidth: chart_axis_axis_stroke_Width.value,
+        stroke: chart_axis_axis_stroke_Color.value,
+        strokeLinecap: STROKE_LINE_CAP,
+        strokeLinejoin: STROKE_LINE_JOIN,
+      },
+      axisLabel: {
+        ...LABEL_CENTERED_PROPS,
+        padding: chart_axis_axis_label_Padding.value,
+        stroke: chart_axis_axis_label_stroke_Color.value,
+      },
+      grid: {
+        fill: chart_axis_grid_Fill.value,
+        stroke: 'none',
+        pointerEvents: chart_axis_grid_PointerEvents.value,
+        strokeLinecap: STROKE_LINE_CAP,
+        strokeLinejoin: STROKE_LINE_JOIN,
+      },
+      ticks: {
+        fill: chart_axis_tick_Fill.value,
+        size: chart_axis_tick_Size.value,
+        stroke: chart_axis_tick_stroke_Color.value,
+        strokeLinecap: STROKE_LINE_CAP,
+        strokeLinejoin: STROKE_LINE_JOIN,
+        strokeWidth: chart_axis_tick_Width.value,
+      },
+      tickLabels: {
+        ...LABEL_PROPS,
+        fill: chart_axis_tick_label_Fill.value,
+      },
+    },
+  },
+  bar: {
+    ...LAYOUT_PROPS,
+    barWidth: chart_bar_Width.value,
+    style: {
+      data: {
+        fill: chart_bar_data_Fill.value,
+        padding: chart_bar_data_Padding.value,
+        stroke: chart_bar_data_stroke.value,
+        strokeWidth: chart_bar_data_stroke_Width.value,
+      },
+      labels: LABEL_PROPS,
+    },
+  },
+  boxplot: {
+    ...LAYOUT_PROPS,
+    style: {
+      max: {
+        padding: chart_boxplot_max_Padding.value,
+        stroke: chart_boxplot_max_stroke_Color.value,
+        strokeWidth: chart_boxplot_max_stroke_Width.value,
+      },
+      maxLabels: LABEL_PROPS,
+      median: {
+        padding: chart_boxplot_median_Padding.value,
+        stroke: chart_boxplot_median_stroke_Color.value,
+        strokeWidth: chart_boxplot_median_stroke_Width.value,
+      },
+      medianLabels: LABEL_PROPS,
+      min: {
+        padding: chart_boxplot_min_Padding.value,
+        stroke: chart_boxplot_min_stroke_Color.value,
+        strokeWidth: chart_boxplot_min_stroke_Width.value,
+      },
+      minLabels: LABEL_PROPS,
+      q1: {
+        fill: chart_boxplot_lower_quartile_Fill.value,
+        padding: chart_boxplot_lower_quartile_Padding.value,
+      },
+      q1Labels: LABEL_PROPS,
+      q3: {
+        fill: chart_boxplot_upper_quartile_Fill.value,
+        padding: chart_boxplot_upper_quartile_Padding.value,
+      },
+      q3Labels: LABEL_PROPS,
+    },
+    boxWidth: chart_boxplot_box_Width.value,
+  },
+  candlestick: {
+    ...LAYOUT_PROPS,
+    candleColors: {
+      positive: chart_candelstick_candle_positive_Color.value,
+      negative: chart_candelstick_candle_negative_Color.value,
+    },
+    style: {
+      data: {
+        stroke: chart_candelstick_data_stroke_Color.value,
+        strokeWidth: chart_candelstick_data_stroke_Width.value,
+      },
+      labels: LABEL_CENTERED_PROPS,
+    },
+  },
+  chart: {
+    ...LAYOUT_PROPS,
+  },
+  errorbar: {
+    ...LAYOUT_PROPS,
+    borderWidth: chart_errorbar_BorderWidth.value,
+    style: {
+      data: {
+        fill: chart_errorbar_data_Fill.value,
+        opacity: chart_errorbar_data_Opacity.value,
+        stroke: chart_errorbar_data_stroke_Color.value,
+        strokeWidth: chart_errorbar_data_stroke_Width.value,
+      },
+      labels: LABEL_CENTERED_PROPS,
+    },
+  },
+  group: {
+    ...LAYOUT_PROPS,
+  },
+  legend: {
+    gutter: chart_legend_gutter_Width.value,
+    orientation: chart_legend_orientation.value,
+    titleOrientation: chart_legend_title_orientation.value,
+    style: {
+      data: {
+        type: chart_legend_data_type.value,
+      },
+      labels: LABEL_PROPS,
+      title: {
+        ...LABEL_PROPS,
+        fontSize: TYPOGRAPHY_FONT_SIZE,
+        padding: chart_legend_title_Padding.value,
+      },
+    },
+  },
+  line: {
+    ...LAYOUT_PROPS,
+    style: {
+      data: {
+        fill: chart_line_data_Fill.value,
+        opacity: chart_line_data_Opacity.value,
+        stroke: chart_line_data_stroke_Color.value,
+        strokeWidth: chart_line_data_stroke_Width.value,
+      },
+      labels: LABEL_CENTERED_PROPS,
+    },
+  },
+  pie: {
+    padding: chart_pie_Padding.value,
+    style: {
+      data: {
+        padding: chart_pie_data_Padding.value,
+        stroke: chart_pie_data_stroke_Color.value,
+        strokeWidth: chart_pie_data_stroke_Width.value,
+      },
+      labels: {
+        ...LABEL_PROPS,
+        padding: chart_pie_labels_Padding.value,
+      },
+    },
+    height: chart_pie_Height.value,
+    width: chart_pie_Width.value,
+  },
+  scatter: {
+    ...LAYOUT_PROPS,
+    style: {
+      data: {
+        fill: chart_scatter_data_Fill.value,
+        opacity: chart_scatter_data_Opacity.value,
+        stroke: chart_scatter_data_stroke_Color.value,
+        strokeWidth: chart_scatter_data_stroke_Width.value,
+      },
+      labels: LABEL_CENTERED_PROPS,
+    },
+  },
+  stack: {
+    ...LAYOUT_PROPS,
+    style: {
+      data: {
+        strokeWidth: chart_stack_data_stroke_Width.value,
+      },
+    },
+  },
+  tooltip: {
+    cornerRadius: chart_tooltip_corner_radius.value,
+    flyoutStyle: {
+      cornerRadius: chart_tooltip_flyoutStyle_corner_radius.value,
+      fill: chart_tooltip_flyoutStyle_Fill.value, // background
+      pointerEvents: chart_tooltip_flyoutStyle_PointerEvents.value,
+      stroke: chart_tooltip_flyoutStyle_stroke_Color.value, // border
+      strokeWidth: chart_tooltip_flyoutStyle_stroke_Width.value,
+    },
+    pointerLength: chart_tooltip_pointer_length.value,
+    pointerWidth: chart_tooltip_pointer_Width.value,
+    style: {
+      fill: chart_tooltip_Fill.value, // text
+      padding: chart_tooltip_Padding.value,
+      pointerEvents: chart_tooltip_PointerEvents.value,
+    },
+  },
+  voronoi: {
+    ...LAYOUT_PROPS,
+    style: {
+      data: {
+        fill: chart_voronoi_data_Fill.value,
+        stroke: chart_voronoi_data_stroke_Color.value,
+        strokeWidth: chart_voronoi_data_stroke_Width.value,
+      },
+      labels: {
+        ...LABEL_CENTERED_PROPS,
+        fill: chart_voronoi_labels_Fill.value, // text
+        padding: chart_voronoi_labels_Padding.value,
+        pointerEvents: chart_voronoi_labels_PointerEvents.value,
+      },
+      // Note: These properties override tooltip
+      flyout: {
+        fill: chart_voronoi_flyout_stroke_Fill.value, // background
+        pointerEvents: chart_voronoi_flyout_PointerEvents.value,
+        stroke: chart_voronoi_flyout_stroke_Color.value, // border
+        strokeWidth: chart_voronoi_flyout_stroke_Width.value,
+      },
+    },
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/bullet-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/bullet-theme.js
@@ -1,0 +1,140 @@
+/* eslint-disable camelcase */
+import chart_bullet_Height from '@patternfly/react-tokens/dist/js/chart_bullet_Height';
+import chart_bullet_comparative_measure_Fill_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_Fill_Color';
+import chart_bullet_comparative_measure_stroke_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_stroke_Color';
+import chart_bullet_comparative_measure_stroke_Width from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_stroke_Width';
+import chart_bullet_comparative_measure_error_Fill_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_error_Fill_Color';
+import chart_bullet_comparative_measure_error_stroke_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_error_stroke_Color';
+import chart_bullet_comparative_measure_error_stroke_Width from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_error_stroke_Width';
+import chart_bullet_comparative_measure_warning_Fill_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_warning_Fill_Color';
+import chart_bullet_comparative_measure_warning_stroke_Color from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_warning_stroke_Color';
+import chart_bullet_comparative_measure_warning_stroke_Width from '@patternfly/react-tokens/dist/js/chart_bullet_comparative_measure_warning_stroke_Width';
+import chart_bullet_group_title_divider_Fill_Color from '@patternfly/react-tokens/dist/js/chart_bullet_group_title_divider_Fill_Color';
+import chart_bullet_group_title_divider_stroke_Color from '@patternfly/react-tokens/dist/js/chart_bullet_group_title_divider_stroke_Color';
+import chart_bullet_group_title_divider_stroke_Width from '@patternfly/react-tokens/dist/js/chart_bullet_group_title_divider_stroke_Width';
+import chart_color_black_100 from '@patternfly/react-tokens/dist/js/chart_color_black_100';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import chart_color_black_300 from '@patternfly/react-tokens/dist/js/chart_color_black_300';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import chart_color_red_100 from '@patternfly/react-tokens/dist/js/chart_color_red_100';
+import chart_color_red_200 from '@patternfly/react-tokens/dist/js/chart_color_red_200';
+import chart_color_red_300 from '@patternfly/react-tokens/dist/js/chart_color_red_300';
+import chart_color_red_400 from '@patternfly/react-tokens/dist/js/chart_color_red_400';
+import chart_color_red_500 from '@patternfly/react-tokens/dist/js/chart_color_red_500';
+import chart_global_layout_Padding from '@patternfly/react-tokens/dist/js/chart_global_layout_Padding';
+
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit#
+// See https://www.patternfly.org/v3/pattern-library/data-visualization/bullet-chart/#design
+
+// Bullet theme
+export const BulletTheme = {
+  chart: {
+    height: chart_bullet_Height.value,
+  },
+};
+
+// Bullet comparative measure error theme
+export const BulletComparativeErrorMeasureTheme = {
+  bar: {
+    height: chart_bullet_Height.value,
+    style: {
+      data: {
+        fill: chart_bullet_comparative_measure_error_Fill_Color.value,
+        stroke: chart_bullet_comparative_measure_error_stroke_Color.value,
+        strokeWidth: chart_bullet_comparative_measure_error_stroke_Width.value,
+      },
+    },
+  },
+};
+
+// Bullet comparative measure theme
+export const BulletComparativeMeasureTheme = {
+  bar: {
+    height: chart_bullet_Height.value,
+    style: {
+      data: {
+        fill: chart_bullet_comparative_measure_Fill_Color.value,
+        stroke: chart_bullet_comparative_measure_stroke_Color.value,
+        strokeWidth: chart_bullet_comparative_measure_stroke_Width.value,
+      },
+    },
+  },
+};
+
+// Bullet comparative measure warning theme
+export const BulletComparativeWarningMeasureTheme = {
+  bar: {
+    height: chart_bullet_Height.value,
+    style: {
+      data: {
+        fill: chart_bullet_comparative_measure_warning_Fill_Color.value,
+        stroke: chart_bullet_comparative_measure_warning_stroke_Color.value,
+        strokeWidth: chart_bullet_comparative_measure_warning_stroke_Width.value,
+      },
+    },
+  },
+};
+
+// Bullet group title theme
+export const BulletGroupTitleTheme = {
+  chart: {
+    padding: {
+      bottom: 0,
+      left: 0,
+      right: 0,
+      top: chart_global_layout_Padding.value,
+    },
+  },
+  line: {
+    style: {
+      data: {
+        fill: chart_bullet_group_title_divider_Fill_Color.value,
+        stroke: chart_bullet_group_title_divider_stroke_Color.value,
+        strokeWidth: chart_bullet_group_title_divider_stroke_Width.value,
+      },
+    },
+  },
+};
+
+// Bullet primary dot measure theme
+export const BulletPrimaryDotMeasureTheme = {
+  group: {
+    height: chart_bullet_Height.value,
+  },
+};
+
+// Bullet primary negative measure theme
+export const BulletPrimaryNegativeMeasureTheme = {
+  group: {
+    colorScale: [
+      chart_color_red_100.value,
+      chart_color_red_200.value,
+      chart_color_red_300.value,
+      chart_color_red_400.value,
+      chart_color_red_500.value,
+    ],
+    height: chart_bullet_Height.value,
+  },
+};
+
+// Bullet primary segmented measure theme
+export const BulletPrimarySegmentedMeasureTheme = {
+  group: {
+    height: chart_bullet_Height.value,
+  },
+};
+
+// Bullet qualitative range theme
+export const BulletQualitativeRangeTheme = {
+  group: {
+    colorScale: [
+      chart_color_black_100.value,
+      chart_color_black_200.value,
+      chart_color_black_300.value,
+      chart_color_black_400.value,
+      chart_color_black_500.value,
+    ],
+    height: chart_bullet_Height.value,
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/color-theme.js
@@ -1,0 +1,64 @@
+// Victory theme properties only
+export const ColorTheme = (props) => {
+  const { COLOR_SCALE } = props;
+
+  return {
+    area: {
+      colorScale: COLOR_SCALE,
+      style: {
+        data: {
+          fill: COLOR_SCALE[0],
+        },
+      },
+    },
+    axis: {
+      colorScale: COLOR_SCALE,
+    },
+    bar: {
+      colorScale: COLOR_SCALE,
+      style: {
+        data: {
+          fill: COLOR_SCALE[0],
+        },
+      },
+    },
+    boxplot: {
+      colorScale: COLOR_SCALE,
+    },
+    candlestick: {
+      colorScale: COLOR_SCALE,
+    },
+    chart: {
+      colorScale: COLOR_SCALE,
+    },
+    errorbar: {
+      colorScale: COLOR_SCALE,
+    },
+    group: {
+      colorScale: COLOR_SCALE,
+    },
+    legend: {
+      colorScale: COLOR_SCALE,
+    },
+    line: {
+      colorScale: COLOR_SCALE,
+      style: {
+        data: {
+          stroke: COLOR_SCALE[0],
+        },
+      },
+    },
+    pie: {
+      colorScale: COLOR_SCALE,
+    },
+    scatter: {
+      colorScale: COLOR_SCALE,
+    },
+    stack: {
+      colorScale: COLOR_SCALE,
+    },
+    voronoi: {
+      colorScale: COLOR_SCALE,
+    },
+  };
+};

--- a/packages/pdf-generator/src/utils/theme/themes/dark/blue-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/blue-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_blue_100.value,
+  chart_color_blue_500.value,
+  chart_color_blue_200.value,
+  chart_color_blue_400.value,
+];
+
+export const DarkBlueColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/cyan-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/cyan-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_cyan_300.value,
+  chart_color_cyan_100.value,
+  chart_color_cyan_500.value,
+  chart_color_cyan_200.value,
+  chart_color_cyan_400.value,
+];
+
+export const DarkCyanColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/gold-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/gold-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_gold_300.value,
+  chart_color_gold_100.value,
+  chart_color_gold_500.value,
+  chart_color_gold_200.value,
+  chart_color_gold_400.value,
+];
+
+export const DarkGoldColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/gray-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/gray-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_black_100 from '@patternfly/react-tokens/dist/js/chart_color_black_100';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import chart_color_black_300 from '@patternfly/react-tokens/dist/js/chart_color_black_300';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_black_300.value,
+  chart_color_black_100.value,
+  chart_color_black_500.value,
+  chart_color_black_200.value,
+  chart_color_black_400.value,
+];
+
+export const DarkGrayColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/green-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/green-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_green_300.value,
+  chart_color_green_100.value,
+  chart_color_green_500.value,
+  chart_color_green_200.value,
+  chart_color_green_400.value,
+];
+
+export const DarkGreenColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/multi-color-ordered-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/multi-color-ordered-theme.js
@@ -1,0 +1,61 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import { ColorTheme } from '../color-theme';
+
+// The color order below (minus the purple color family) improves the color contrast in ordered charts; donut, pie, bar, & stack
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_green_300.value,
+  chart_color_cyan_300.value,
+  chart_color_gold_300.value,
+  chart_color_orange_300.value,
+  chart_color_blue_100.value,
+  chart_color_green_500.value,
+  chart_color_cyan_100.value,
+  chart_color_gold_100.value,
+  chart_color_orange_500.value,
+  chart_color_blue_500.value,
+  chart_color_green_100.value,
+  chart_color_cyan_500.value,
+  chart_color_gold_500.value,
+  chart_color_orange_100.value,
+  chart_color_blue_200.value,
+  chart_color_green_400.value,
+  chart_color_cyan_200.value,
+  chart_color_gold_200.value,
+  chart_color_orange_400.value,
+  chart_color_blue_400.value,
+  chart_color_green_200.value,
+  chart_color_cyan_400.value,
+  chart_color_gold_400.value,
+  chart_color_orange_200.value,
+];
+
+export const DarkMultiColorOrderedTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/multi-color-unordered-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/multi-color-unordered-theme.js
@@ -1,0 +1,81 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import chart_color_purple_100 from '@patternfly/react-tokens/dist/js/chart_color_purple_100';
+import chart_color_purple_200 from '@patternfly/react-tokens/dist/js/chart_color_purple_200';
+import chart_color_purple_300 from '@patternfly/react-tokens/dist/js/chart_color_purple_300';
+import chart_color_purple_400 from '@patternfly/react-tokens/dist/js/chart_color_purple_400';
+import chart_color_purple_500 from '@patternfly/react-tokens/dist/js/chart_color_purple_500';
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import chart_color_black_100 from '@patternfly/react-tokens/dist/js/chart_color_black_100';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import chart_color_black_300 from '@patternfly/react-tokens/dist/js/chart_color_black_300';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import { ColorTheme } from '../color-theme';
+
+// The color order below improves the color contrast in unordered charts; area & line
+// See https://github.com/patternfly/patternfly-next/issues/1551
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_gold_300.value,
+  chart_color_green_300.value,
+  chart_color_purple_300.value,
+  chart_color_orange_300.value,
+  chart_color_cyan_300.value,
+  chart_color_black_300.value,
+  chart_color_blue_100.value,
+  chart_color_gold_500.value,
+  chart_color_green_100.value,
+  chart_color_purple_500.value,
+  chart_color_orange_100.value,
+  chart_color_cyan_500.value,
+  chart_color_black_100.value,
+  chart_color_blue_500.value,
+  chart_color_gold_100.value,
+  chart_color_green_500.value,
+  chart_color_purple_100.value,
+  chart_color_orange_500.value,
+  chart_color_cyan_100.value,
+  chart_color_black_500.value,
+  chart_color_blue_200.value,
+  chart_color_gold_400.value,
+  chart_color_green_200.value,
+  chart_color_purple_400.value,
+  chart_color_orange_200.value,
+  chart_color_cyan_400.value,
+  chart_color_black_200.value,
+  chart_color_blue_400.value,
+  chart_color_gold_200.value,
+  chart_color_green_400.value,
+  chart_color_purple_200.value,
+  chart_color_orange_400.value,
+  chart_color_cyan_200.value,
+  chart_color_black_400.value,
+];
+
+export const DarkMultiColorUnorderedTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/orange-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/orange-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_orange_300.value,
+  chart_color_orange_100.value,
+  chart_color_orange_500.value,
+  chart_color_orange_200.value,
+  chart_color_orange_400.value,
+];
+
+export const DarkOrangeColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/dark/purple-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/dark/purple-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_purple_100 from '@patternfly/react-tokens/dist/js/chart_color_purple_100';
+import chart_color_purple_200 from '@patternfly/react-tokens/dist/js/chart_color_purple_200';
+import chart_color_purple_300 from '@patternfly/react-tokens/dist/js/chart_color_purple_300';
+import chart_color_purple_400 from '@patternfly/react-tokens/dist/js/chart_color_purple_400';
+import chart_color_purple_500 from '@patternfly/react-tokens/dist/js/chart_color_purple_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_purple_300.value,
+  chart_color_purple_100.value,
+  chart_color_purple_500.value,
+  chart_color_purple_200.value,
+  chart_color_purple_400.value,
+];
+
+export const DarkPurpleColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/donut-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/donut-theme.js
@@ -1,0 +1,15 @@
+/* eslint-disable camelcase */
+import chart_donut_pie_Height from '@patternfly/react-tokens/dist/js/chart_donut_pie_Height';
+import chart_donut_pie_angle_Padding from '@patternfly/react-tokens/dist/js/chart_donut_pie_angle_Padding';
+import chart_donut_pie_Padding from '@patternfly/react-tokens/dist/js/chart_donut_pie_Padding';
+import chart_donut_pie_Width from '@patternfly/react-tokens/dist/js/chart_donut_pie_Width';
+
+// Donut theme
+export const DonutTheme = {
+  pie: {
+    height: chart_donut_pie_Height.value,
+    padding: chart_donut_pie_Padding.value,
+    padAngle: chart_donut_pie_angle_Padding.value,
+    width: chart_donut_pie_Width.value,
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/donut-threshold-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/donut-threshold-theme.js
@@ -1,0 +1,34 @@
+/* eslint-disable camelcase */
+import chart_donut_threshold_first_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_first_Color';
+import chart_donut_threshold_second_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_second_Color';
+import chart_donut_threshold_third_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_third_Color';
+import chart_donut_threshold_dynamic_pie_Height from '@patternfly/react-tokens/dist/js/chart_donut_threshold_dynamic_pie_Height';
+import chart_donut_threshold_dynamic_pie_Padding from '@patternfly/react-tokens/dist/js/chart_donut_threshold_dynamic_pie_Padding';
+import chart_donut_threshold_dynamic_pie_Width from '@patternfly/react-tokens/dist/js/chart_donut_threshold_dynamic_pie_Width';
+import chart_donut_threshold_static_pie_Height from '@patternfly/react-tokens/dist/js/chart_donut_threshold_static_pie_Height';
+import chart_donut_threshold_static_pie_angle_Padding from '@patternfly/react-tokens/dist/js/chart_donut_threshold_static_pie_angle_Padding';
+import chart_donut_threshold_static_pie_Padding from '@patternfly/react-tokens/dist/js/chart_donut_threshold_static_pie_Padding';
+import chart_donut_threshold_static_pie_Width from '@patternfly/react-tokens/dist/js/chart_donut_threshold_static_pie_Width';
+
+// Donut threshold dynamic theme
+export const DonutThresholdDynamicTheme = {
+  legend: {
+    colorScale: [chart_donut_threshold_second_Color.value, chart_donut_threshold_third_Color.value],
+  },
+  pie: {
+    height: chart_donut_threshold_dynamic_pie_Height.value,
+    padding: chart_donut_threshold_dynamic_pie_Padding.value,
+    width: chart_donut_threshold_dynamic_pie_Width.value,
+  },
+};
+
+// Donut threshold static theme
+export const DonutThresholdStaticTheme = {
+  pie: {
+    colorScale: [chart_donut_threshold_first_Color.value, chart_donut_threshold_second_Color.value, chart_donut_threshold_third_Color.value],
+    height: chart_donut_threshold_static_pie_Height.value,
+    padAngle: chart_donut_threshold_static_pie_angle_Padding.value,
+    padding: chart_donut_threshold_static_pie_Padding.value,
+    width: chart_donut_threshold_static_pie_Width.value,
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/donut-utilization-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/donut-utilization-theme.js
@@ -1,0 +1,30 @@
+/* eslint-disable camelcase */
+import chart_donut_threshold_first_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_first_Color';
+import chart_donut_threshold_second_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_second_Color';
+import chart_donut_threshold_third_Color from '@patternfly/react-tokens/dist/js/chart_donut_threshold_third_Color';
+import chart_donut_utilization_dynamic_pie_Height from '@patternfly/react-tokens/dist/js/chart_donut_utilization_dynamic_pie_Height';
+import chart_donut_utilization_dynamic_pie_angle_Padding from '@patternfly/react-tokens/dist/js/chart_donut_utilization_dynamic_pie_angle_Padding';
+import chart_donut_utilization_dynamic_pie_Padding from '@patternfly/react-tokens/dist/js/chart_donut_utilization_dynamic_pie_Padding';
+import chart_donut_utilization_dynamic_pie_Width from '@patternfly/react-tokens/dist/js/chart_donut_utilization_dynamic_pie_Width';
+import chart_donut_utilization_static_pie_Padding from '@patternfly/react-tokens/dist/js/chart_donut_utilization_static_pie_Padding';
+
+// Donut utilization dynamic theme
+export const DonutUtilizationDynamicTheme = {
+  pie: {
+    height: chart_donut_utilization_dynamic_pie_Height.value,
+    padding: chart_donut_utilization_dynamic_pie_Padding.value,
+    padAngle: chart_donut_utilization_dynamic_pie_angle_Padding.value,
+    width: chart_donut_utilization_dynamic_pie_Width.value,
+  },
+};
+
+// Donut utilization static theme
+export const DonutUtilizationStaticTheme = {
+  legend: {
+    colorScale: [chart_donut_threshold_first_Color.value, chart_donut_threshold_second_Color.value, chart_donut_threshold_third_Color.value],
+  },
+  pie: {
+    colorScale: [chart_donut_threshold_first_Color.value],
+    padding: chart_donut_utilization_static_pie_Padding.value,
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/themes/light/blue-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/blue-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_blue_100.value,
+  chart_color_blue_500.value,
+  chart_color_blue_200.value,
+  chart_color_blue_400.value,
+];
+
+export const LightBlueColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/cyan-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/cyan-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_cyan_300.value,
+  chart_color_cyan_100.value,
+  chart_color_cyan_500.value,
+  chart_color_cyan_200.value,
+  chart_color_cyan_400.value,
+];
+
+export const LightCyanColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/gold-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/gold-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_gold_300.value,
+  chart_color_gold_100.value,
+  chart_color_gold_500.value,
+  chart_color_gold_200.value,
+  chart_color_gold_400.value,
+];
+
+export const LightGoldColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/gray-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/gray-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_black_100 from '@patternfly/react-tokens/dist/js/chart_color_black_100';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import chart_color_black_300 from '@patternfly/react-tokens/dist/js/chart_color_black_300';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_black_300.value,
+  chart_color_black_100.value,
+  chart_color_black_500.value,
+  chart_color_black_200.value,
+  chart_color_black_400.value,
+];
+
+export const LightGrayColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/green-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/green-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_green_300.value,
+  chart_color_green_100.value,
+  chart_color_green_500.value,
+  chart_color_green_200.value,
+  chart_color_green_400.value,
+];
+
+export const LightGreenColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/multi-color-ordered-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/multi-color-ordered-theme.js
@@ -1,0 +1,61 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import { ColorTheme } from '../color-theme';
+
+// The color order below (minus the purple color family) improves the color contrast in ordered charts; donut, pie, bar, & stack
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_green_300.value,
+  chart_color_cyan_300.value,
+  chart_color_gold_300.value,
+  chart_color_orange_300.value,
+  chart_color_blue_100.value,
+  chart_color_green_500.value,
+  chart_color_cyan_100.value,
+  chart_color_gold_100.value,
+  chart_color_orange_500.value,
+  chart_color_blue_500.value,
+  chart_color_green_100.value,
+  chart_color_cyan_500.value,
+  chart_color_gold_500.value,
+  chart_color_orange_100.value,
+  chart_color_blue_200.value,
+  chart_color_green_400.value,
+  chart_color_cyan_200.value,
+  chart_color_gold_200.value,
+  chart_color_orange_400.value,
+  chart_color_blue_400.value,
+  chart_color_green_200.value,
+  chart_color_cyan_400.value,
+  chart_color_gold_400.value,
+  chart_color_orange_200.value,
+];
+
+export const LightMultiColorOrderedTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/multi-color-unordered-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/multi-color-unordered-theme.js
@@ -1,0 +1,81 @@
+/* eslint-disable camelcase */
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import chart_color_blue_200 from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import chart_color_blue_400 from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import chart_color_green_100 from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import chart_color_green_200 from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import chart_color_green_500 from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import chart_color_cyan_100 from '@patternfly/react-tokens/dist/js/chart_color_cyan_100';
+import chart_color_cyan_200 from '@patternfly/react-tokens/dist/js/chart_color_cyan_200';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/js/chart_color_cyan_300';
+import chart_color_cyan_400 from '@patternfly/react-tokens/dist/js/chart_color_cyan_400';
+import chart_color_cyan_500 from '@patternfly/react-tokens/dist/js/chart_color_cyan_500';
+import chart_color_purple_100 from '@patternfly/react-tokens/dist/js/chart_color_purple_100';
+import chart_color_purple_200 from '@patternfly/react-tokens/dist/js/chart_color_purple_200';
+import chart_color_purple_300 from '@patternfly/react-tokens/dist/js/chart_color_purple_300';
+import chart_color_purple_400 from '@patternfly/react-tokens/dist/js/chart_color_purple_400';
+import chart_color_purple_500 from '@patternfly/react-tokens/dist/js/chart_color_purple_500';
+import chart_color_gold_100 from '@patternfly/react-tokens/dist/js/chart_color_gold_100';
+import chart_color_gold_200 from '@patternfly/react-tokens/dist/js/chart_color_gold_200';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/js/chart_color_gold_300';
+import chart_color_gold_400 from '@patternfly/react-tokens/dist/js/chart_color_gold_400';
+import chart_color_gold_500 from '@patternfly/react-tokens/dist/js/chart_color_gold_500';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import chart_color_black_100 from '@patternfly/react-tokens/dist/js/chart_color_black_100';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import chart_color_black_300 from '@patternfly/react-tokens/dist/js/chart_color_black_300';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/js/chart_color_black_400';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import { ColorTheme } from '../color-theme';
+
+// The color order below improves the color contrast in unordered charts; area & line
+// See https://github.com/patternfly/patternfly-next/issues/1551
+const COLOR_SCALE = [
+  chart_color_blue_300.value,
+  chart_color_gold_300.value,
+  chart_color_green_300.value,
+  chart_color_purple_300.value,
+  chart_color_orange_300.value,
+  chart_color_cyan_300.value,
+  chart_color_black_300.value,
+  chart_color_blue_100.value,
+  chart_color_gold_500.value,
+  chart_color_green_100.value,
+  chart_color_purple_500.value,
+  chart_color_orange_100.value,
+  chart_color_cyan_500.value,
+  chart_color_black_100.value,
+  chart_color_blue_500.value,
+  chart_color_gold_100.value,
+  chart_color_green_500.value,
+  chart_color_purple_100.value,
+  chart_color_orange_500.value,
+  chart_color_cyan_100.value,
+  chart_color_black_500.value,
+  chart_color_blue_200.value,
+  chart_color_gold_400.value,
+  chart_color_green_200.value,
+  chart_color_purple_400.value,
+  chart_color_orange_200.value,
+  chart_color_cyan_400.value,
+  chart_color_black_200.value,
+  chart_color_blue_400.value,
+  chart_color_gold_200.value,
+  chart_color_green_400.value,
+  chart_color_purple_200.value,
+  chart_color_orange_400.value,
+  chart_color_cyan_200.value,
+  chart_color_black_400.value,
+];
+
+export const LightMultiColorUnorderedTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/orange-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/orange-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/js/chart_color_orange_100';
+import chart_color_orange_200 from '@patternfly/react-tokens/dist/js/chart_color_orange_200';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/js/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/js/chart_color_orange_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_orange_300.value,
+  chart_color_orange_100.value,
+  chart_color_orange_500.value,
+  chart_color_orange_200.value,
+  chart_color_orange_400.value,
+];
+
+export const LightOrangeColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/light/purple-color-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/light/purple-color-theme.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+import chart_color_purple_100 from '@patternfly/react-tokens/dist/js/chart_color_purple_100';
+import chart_color_purple_200 from '@patternfly/react-tokens/dist/js/chart_color_purple_200';
+import chart_color_purple_300 from '@patternfly/react-tokens/dist/js/chart_color_purple_300';
+import chart_color_purple_400 from '@patternfly/react-tokens/dist/js/chart_color_purple_400';
+import chart_color_purple_500 from '@patternfly/react-tokens/dist/js/chart_color_purple_500';
+import { ColorTheme } from '../color-theme';
+
+// Color scale
+// See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
+const COLOR_SCALE = [
+  chart_color_purple_300.value,
+  chart_color_purple_100.value,
+  chart_color_purple_500.value,
+  chart_color_purple_200.value,
+  chart_color_purple_400.value,
+];
+
+export const LightPurpleColorTheme = ColorTheme({
+  COLOR_SCALE,
+});

--- a/packages/pdf-generator/src/utils/theme/themes/threshold-theme.js
+++ b/packages/pdf-generator/src/utils/theme/themes/threshold-theme.js
@@ -1,0 +1,15 @@
+/* eslint-disable camelcase */
+import chart_threshold_stroke_dash_array from '@patternfly/react-tokens/dist/js/chart_threshold_stroke_dash_array';
+import chart_threshold_stroke_Width from '@patternfly/react-tokens/dist/js/chart_threshold_stroke_Width';
+
+// Threshold theme
+export const ThresholdTheme = {
+  line: {
+    style: {
+      data: {
+        strokeDasharray: chart_threshold_stroke_dash_array.value,
+        strokeWidth: chart_threshold_stroke_Width.value,
+      },
+    },
+  },
+};

--- a/packages/pdf-generator/src/utils/theme/utils.js
+++ b/packages/pdf-generator/src/utils/theme/utils.js
@@ -1,0 +1,188 @@
+import cloneDeep from 'lodash/cloneDeep';
+import merge from 'lodash/merge';
+import { DarkBlueColorTheme } from './themes/dark/blue-color-theme';
+import { DarkCyanColorTheme } from './themes/dark/cyan-color-theme';
+import { DarkGoldColorTheme } from './themes/dark/gold-color-theme';
+import { DarkGrayColorTheme } from './themes/dark/gray-color-theme';
+import { DarkGreenColorTheme } from './themes/dark/green-color-theme';
+import { DarkMultiColorOrderedTheme } from './themes/dark/multi-color-ordered-theme';
+import { DarkMultiColorUnorderedTheme } from './themes/dark/multi-color-unordered-theme';
+import { DarkOrangeColorTheme } from './themes/dark/orange-color-theme';
+import { DarkPurpleColorTheme } from './themes/dark/purple-color-theme';
+import { LightBlueColorTheme } from './themes/light/blue-color-theme';
+import { LightCyanColorTheme } from './themes/light/cyan-color-theme';
+import { LightGoldColorTheme } from './themes/light/gold-color-theme';
+import { LightGrayColorTheme } from './themes/light/gray-color-theme';
+import { LightGreenColorTheme } from './themes/light/green-color-theme';
+import { LightMultiColorOrderedTheme } from './themes/light/multi-color-ordered-theme';
+import { LightMultiColorUnorderedTheme } from './themes/light/multi-color-unordered-theme';
+import { LightOrangeColorTheme } from './themes/light/orange-color-theme';
+import { LightPurpleColorTheme } from './themes/light/purple-color-theme';
+import {
+  ChartAxisTheme,
+  ChartBaseTheme,
+  ChartBulletComparativeErrorMeasureTheme,
+  ChartBulletComparativeMeasureTheme,
+  ChartBulletComparativeWarningMeasureTheme,
+  ChartBulletGroupTitleTheme,
+  ChartBulletPrimaryDotMeasureTheme,
+  ChartBulletPrimaryNegativeMeasureTheme,
+  ChartBulletPrimarySegmentedMeasureTheme,
+  ChartBulletQualitativeRangeTheme,
+  ChartBulletTheme,
+  ChartDonutTheme,
+  ChartDonutThresholdDynamicTheme,
+  ChartDonutThresholdStaticTheme,
+  ChartDonutUtilizationDynamicTheme,
+  ChartDonutUtilizationStaticTheme,
+  ChartThemeColor,
+  ChartThemeVariant,
+  ChartThresholdTheme,
+} from './chartTheme';
+
+// Apply custom properties to base and color themes
+export const getCustomTheme = (themeColor, themeVariant, customTheme) => merge(getTheme(themeColor, themeVariant), customTheme);
+
+// Returns axis theme
+export const getAxisTheme = (themeColor, themeVariant) => getCustomTheme(themeColor, themeVariant, ChartAxisTheme);
+
+// Returns bullet chart theme
+export const getBulletTheme = (themeColor, themeVariant) => getCustomTheme(themeColor, themeVariant, ChartBulletTheme);
+
+// Returns comparative error measure theme for bullet chart
+export const getBulletComparativeErrorMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletComparativeErrorMeasureTheme);
+
+// Returns comparative measure theme for bullet chart
+export const getBulletComparativeMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletComparativeMeasureTheme);
+
+// Returns comparative warning measure theme for bullet chart
+export const getBulletComparativeWarningMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletComparativeWarningMeasureTheme);
+
+// Returns group title theme for bullet chart
+export const getBulletGroupTitleTheme = (themeColor, themeVariant) => getCustomTheme(themeColor, themeVariant, ChartBulletGroupTitleTheme);
+
+// Returns primary dot measure theme for bullet chart
+export const getBulletPrimaryDotMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletPrimaryDotMeasureTheme);
+
+// Returns primary negative measure theme for bullet chart
+export const getBulletPrimaryNegativeMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletPrimaryNegativeMeasureTheme);
+
+// Returns primary segmented measure theme for bullet chart
+export const getBulletPrimarySegmentedMeasureTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletPrimarySegmentedMeasureTheme);
+
+// Returns qualitative range theme for bullet chart
+export const getBulletQualitativeRangeTheme = (themeColor, themeVariant) =>
+  getCustomTheme(themeColor, themeVariant, ChartBulletQualitativeRangeTheme);
+
+// Returns donut theme
+export const getDonutTheme = (themeColor, themeVariant) => getCustomTheme(themeColor, themeVariant, ChartDonutTheme);
+
+// Returns dynamic donut threshold theme
+export const getDonutThresholdDynamicTheme = (themeColor, themeVariant) => {
+  const theme = getCustomTheme(themeColor, themeVariant, ChartDonutThresholdDynamicTheme);
+
+  // Merge just the first color of dynamic (blue, green, etc.) with static (grey) for expected colorScale
+  theme.legend.colorScale = [theme.pie.colorScale[0], ...ChartDonutThresholdDynamicTheme.legend.colorScale];
+
+  // Merge the threshold colors in case users want to show the unused data
+  theme.pie.colorScale = [theme.pie.colorScale[0], ...ChartDonutThresholdStaticTheme.pie.colorScale];
+  return theme;
+};
+
+// Returns static donut threshold theme
+export const getDonutThresholdStaticTheme = (themeColor, themeVariant, invert) => {
+  const staticTheme = cloneDeep(ChartDonutThresholdStaticTheme);
+  if (invert) {
+    staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
+  }
+  return getCustomTheme(themeColor, themeVariant, staticTheme);
+};
+
+// Returns donut utilization theme
+export const getDonutUtilizationTheme = (themeColor, themeVariant) => {
+  const theme = getCustomTheme(themeColor, themeVariant, ChartDonutUtilizationDynamicTheme);
+
+  // Merge just the first color of dynamic (blue, green, etc.) with static (grey) for expected colorScale
+  theme.pie.colorScale = [theme.pie.colorScale[0], ...ChartDonutUtilizationStaticTheme.pie.colorScale];
+  theme.legend.colorScale = [theme.legend.colorScale[0], ...ChartDonutUtilizationStaticTheme.legend.colorScale];
+  return theme;
+};
+
+// Returns dark theme colors
+export const getDarkThemeColors = (themeColor) => {
+  switch (themeColor) {
+    case ChartThemeColor.blue:
+      return DarkBlueColorTheme;
+    case ChartThemeColor.cyan:
+      return DarkCyanColorTheme;
+    case ChartThemeColor.gold:
+      return DarkGoldColorTheme;
+    case ChartThemeColor.gray:
+      return DarkGrayColorTheme;
+    case ChartThemeColor.green:
+      return DarkGreenColorTheme;
+    case ChartThemeColor.multi:
+    case ChartThemeColor.multiOrdered:
+      return DarkMultiColorOrderedTheme;
+    case ChartThemeColor.multiUnordered:
+      return DarkMultiColorUnorderedTheme;
+    case ChartThemeColor.orange:
+      return DarkOrangeColorTheme;
+    case ChartThemeColor.purple:
+      return DarkPurpleColorTheme;
+    default:
+      return DarkBlueColorTheme;
+  }
+};
+
+// Returns light theme colors
+export const getLightThemeColors = (themeColor) => {
+  switch (themeColor) {
+    case ChartThemeColor.blue:
+      return LightBlueColorTheme;
+    case ChartThemeColor.cyan:
+      return LightCyanColorTheme;
+    case ChartThemeColor.gold:
+      return LightGoldColorTheme;
+    case ChartThemeColor.gray:
+      return LightGrayColorTheme;
+    case ChartThemeColor.green:
+      return LightGreenColorTheme;
+    case ChartThemeColor.multi:
+    case ChartThemeColor.multiOrdered:
+      return LightMultiColorOrderedTheme;
+    case ChartThemeColor.multiUnordered:
+      return LightMultiColorUnorderedTheme;
+    case ChartThemeColor.orange:
+      return LightOrangeColorTheme;
+    case ChartThemeColor.purple:
+      return LightPurpleColorTheme;
+    default:
+      return LightBlueColorTheme;
+  }
+};
+
+// Applies theme color and variant to base theme
+export const getTheme = (themeColor, themeVariant) => {
+  // Deep clone
+  const baseTheme = {
+    ...JSON.parse(JSON.stringify(ChartBaseTheme)),
+  };
+  switch (themeVariant) {
+    case ChartThemeVariant.dark:
+      return merge(baseTheme, getDarkThemeColors(themeColor));
+    case ChartThemeVariant.light:
+      return merge(baseTheme, getLightThemeColors(themeColor));
+    default:
+      return merge(baseTheme, getLightThemeColors(themeColor));
+  }
+};
+
+// Returns threshold theme
+export const getThresholdTheme = (themeColor, themeVariant) => getCustomTheme(themeColor, themeVariant, ChartThresholdTheme);


### PR DESCRIPTION
### Descritpion

PF no longer supports chart theme utils and that leads to a lot of problems in our appliacations. This PR copies what was previously in public package's API so we don't have to deal with breaking changes on their side.