### PR TITLE
Scalprum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3521,15 +3521,13 @@
         },
         "node_modules/@frsource/base64": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@frsource/base64/-/base64-1.0.4.tgz",
-            "integrity": "sha512-IphM1ro1cvV5CqJWzX/LvPJcUE26cwgt/zMtBdssvTrfSNhh9KjfS2VXTA8SivkvPHK1DsdPnoMoXitmx8c3Cg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@frsource/cypress-plugin-visual-regression-diff": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@frsource/cypress-plugin-visual-regression-diff/-/cypress-plugin-visual-regression-diff-3.1.3.tgz",
-            "integrity": "sha512-xV/bQymeEG+Lk60Eh9rDqFcg+2gc1DsAfFzl9cduL4Q6iAfOBwBq7HanBkojauCdzyJcqgf/RhujXxRo3RTQUg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@frsource/base64": "1.0.4",
                 "glob": "8.0.3",
@@ -3548,18 +3546,16 @@
         },
         "node_modules/@frsource/cypress-plugin-visual-regression-diff/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@frsource/cypress-plugin-visual-regression-diff/node_modules/glob": {
             "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-            "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -3576,9 +3572,8 @@
         },
         "node_modules/@frsource/cypress-plugin-visual-regression-diff/node_modules/minimatch": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -6313,132 +6308,12 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/@next/swc-android-arm-eabi": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-            "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-android-arm64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-            "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-darwin-arm64": {
-            "version": "12.3.1",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-darwin-x64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-            "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-freebsd-x64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-            "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm-gnueabihf": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-            "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-            "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-            "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-linux-x64-gnu": {
             "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-            "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -6449,59 +6324,13 @@
         },
         "node_modules/@next/swc-linux-x64-musl": {
             "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-            "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-            "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-            "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-            "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": ">= 10"
@@ -7347,8 +7176,7 @@
         },
         "node_modules/@openshift/dynamic-plugin-sdk": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
-            "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "lodash-es": "^4.17.21",
                 "semver": "^7.3.7",
@@ -7361,8 +7189,7 @@
         },
         "node_modules/@openshift/dynamic-plugin-sdk/node_modules/lru-cache": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -7372,8 +7199,7 @@
         },
         "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
             "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -7894,16 +7720,14 @@
         },
         "node_modules/@scalprum/core": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
-            "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@openshift/dynamic-plugin-sdk": "^2.0.1"
             }
         },
         "node_modules/@scalprum/react-core": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-            "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@openshift/dynamic-plugin-sdk": "^2.0.1",
                 "@scalprum/core": "^0.4.1",
@@ -11929,8 +11753,7 @@
         },
         "node_modules/@unleash/proxy-client-react": {
             "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.5.0.tgz",
-            "integrity": "sha512-ucBQM7XIilePpbRZJQJc4G4QMtvCrzxTZtUAheEsHZy//U8Cr7zPMotQztopK/IyStaNHaLtD7h7l4cXNvFuqQ==",
+            "license": "Apache-2.0",
             "peer": true,
             "peerDependencies": {
                 "unleash-proxy-client": "^2.4.0"
@@ -15545,9 +15368,8 @@
         },
         "node_modules/color": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1",
                 "color-string": "^1.9.0"
@@ -15569,9 +15391,8 @@
         },
         "node_modules/color-string": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
@@ -15587,9 +15408,8 @@
         },
         "node_modules/color/node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -15599,9 +15419,8 @@
         },
         "node_modules/color/node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/colord": {
             "version": "2.9.3",
@@ -17296,18 +17115,16 @@
         },
         "node_modules/decode-uri-component": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10"
             }
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -17553,9 +17370,8 @@
         },
         "node_modules/detect-libc": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
             }
@@ -19211,9 +19027,8 @@
         },
         "node_modules/expand-template": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true,
+            "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
             }
@@ -20682,17 +20497,6 @@
             "version": "1.0.0",
             "license": "ISC"
         },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/function-bind": {
             "version": "1.1.1",
             "license": "MIT"
@@ -20748,8 +20552,6 @@
         },
         "node_modules/generic-names/node_modules/loader-utils": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
-            "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -21102,9 +20904,8 @@
         },
         "node_modules/github-from-package": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -21848,9 +21649,8 @@
         },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
@@ -26042,8 +25842,7 @@
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -26657,8 +26456,7 @@
         },
         "node_modules/loader-utils": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "license": "MIT",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -26684,8 +26482,7 @@
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -27551,9 +27348,8 @@
         },
         "node_modules/meta-png": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/meta-png/-/meta-png-1.0.3.tgz",
-            "integrity": "sha512-ts8SCT3qTvHBA723m1NYUKwzGDxYNCkMrHYrX0t7YaIch8giqpX+KyJEpCUFW7XfCWXiX5KSlQr4p3Ci9lrSug==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -28276,9 +28072,8 @@
         },
         "node_modules/mimic-response": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -28547,9 +28342,8 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
@@ -28643,9 +28437,8 @@
         },
         "node_modules/move-file": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.1.0.tgz",
-            "integrity": "sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-exists": "^4.0.0"
             },
@@ -28722,8 +28515,7 @@
         },
         "node_modules/nanoclone": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-            "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+            "license": "MIT"
         },
         "node_modules/nanoid": {
             "version": "3.3.4",
@@ -28758,9 +28550,8 @@
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -28920,9 +28711,8 @@
         },
         "node_modules/node-abi": {
             "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-            "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -28932,9 +28722,8 @@
         },
         "node_modules/node-abi/node_modules/lru-cache": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -28944,9 +28733,8 @@
         },
         "node_modules/node-abi/node_modules/semver": {
             "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -31081,9 +30869,8 @@
         },
         "node_modules/pixelmatch": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-            "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "pngjs": "^6.0.0"
             },
@@ -31103,9 +30890,8 @@
         },
         "node_modules/pngjs": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12.13.0"
             }
@@ -31708,9 +31494,8 @@
         },
         "node_modules/prebuild-install": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-            "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
@@ -31734,15 +31519,13 @@
         },
         "node_modules/prebuild-install/node_modules/chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/prebuild-install/node_modules/tar-fs": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -31959,8 +31742,7 @@
         },
         "node_modules/property-expr": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-            "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+            "license": "MIT"
         },
         "node_modules/property-information": {
             "version": "6.1.1",
@@ -34416,10 +34198,9 @@
         },
         "node_modules/sharp": {
             "version": "0.31.2",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.2.tgz",
-            "integrity": "sha512-DUdNVEXgS5A97cTagSLIIp8dUZ/lZtk78iNVZgHdHbx1qnQR7JAHY0BnXnwwH39Iw+VKhO08CTYhIg0p98vQ5Q==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "color": "^4.2.3",
                 "detect-libc": "^2.0.1",
@@ -34439,15 +34220,13 @@
         },
         "node_modules/sharp/node_modules/chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/sharp/node_modules/lru-cache": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -34457,15 +34236,13 @@
         },
         "node_modules/sharp/node_modules/node-addon-api": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-            "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sharp/node_modules/semver": {
             "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -34478,9 +34255,8 @@
         },
         "node_modules/sharp/node_modules/tar-fs": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -34785,28 +34561,6 @@
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/simple-get": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "funding": [
                 {
@@ -34822,6 +34576,26 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT"
+        },
+        "node_modules/simple-get": {
+            "version": "4.0.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
@@ -34830,18 +34604,16 @@
         },
         "node_modules/simple-swizzle": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.3.1"
             }
         },
         "node_modules/simple-swizzle/node_modules/is-arrayish": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
@@ -35721,9 +35493,8 @@
         },
         "node_modules/style-inject": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
-            "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/style-loader": {
             "version": "3.3.1",
@@ -36392,8 +36163,7 @@
         },
         "node_modules/tiny-emitter": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/tiny-hashes": {
@@ -36516,8 +36286,7 @@
         },
         "node_modules/toposort": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+            "license": "MIT"
         },
         "node_modules/tough-cookie": {
             "version": "4.1.2",
@@ -36755,9 +36524,8 @@
         },
         "node_modules/tsconfig-paths/node_modules/json5": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -36914,8 +36682,6 @@
         },
         "node_modules/ua-parser-js": {
             "version": "0.7.33",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-            "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -36926,6 +36692,7 @@
                     "url": "https://paypal.me/faisalman"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": "*"
             }
@@ -37223,8 +36990,7 @@
         },
         "node_modules/unleash-proxy-client": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.4.0.tgz",
-            "integrity": "sha512-+kvO50Q/hFzrUIecIno9SLaDaKEadX6lOL4cd7kzLG54YqGHii97zEhkqJa1443DJ7oXsj7HjRWXlPycQjpNaQ==",
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "tiny-emitter": "^2.1.0",
@@ -37727,8 +37493,7 @@
         },
         "node_modules/victory": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
-            "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
+            "license": "MIT",
             "dependencies": {
                 "victory-area": "^34.3.12",
                 "victory-axis": "^34.3.12",
@@ -37760,8 +37525,7 @@
         },
         "node_modules/victory-box-plot": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
-            "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -37771,8 +37535,7 @@
         },
         "node_modules/victory-box-plot/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -37785,13 +37548,11 @@
         },
         "node_modules/victory-box-plot/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-box-plot/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -37805,8 +37566,7 @@
         },
         "node_modules/victory-brush-line": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
-            "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -37816,8 +37576,7 @@
         },
         "node_modules/victory-brush-line/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -37830,13 +37589,11 @@
         },
         "node_modules/victory-brush-line/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-brush-line/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -37850,8 +37607,7 @@
         },
         "node_modules/victory-candlestick": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
-            "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -37860,8 +37616,7 @@
         },
         "node_modules/victory-candlestick/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -37874,13 +37629,11 @@
         },
         "node_modules/victory-candlestick/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-candlestick/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -37894,8 +37647,7 @@
         },
         "node_modules/victory-errorbar": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
-            "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -37904,8 +37656,7 @@
         },
         "node_modules/victory-errorbar/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -37918,13 +37669,11 @@
         },
         "node_modules/victory-errorbar/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-errorbar/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -37938,8 +37687,7 @@
         },
         "node_modules/victory-histogram": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
-            "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
+            "license": "MIT",
             "dependencies": {
                 "d3-array": "^2.4.0",
                 "d3-scale": "^1.0.0",
@@ -37952,16 +37700,14 @@
         },
         "node_modules/victory-histogram/node_modules/d3-array": {
             "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "internmap": "^1.0.0"
             }
         },
         "node_modules/victory-histogram/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -37974,23 +37720,19 @@
         },
         "node_modules/victory-histogram/node_modules/d3-scale/node_modules/d3-array": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-            "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+            "license": "BSD-3-Clause"
         },
         "node_modules/victory-histogram/node_modules/internmap": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+            "license": "ISC"
         },
         "node_modules/victory-histogram/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-histogram/node_modules/victory-bar": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -38000,8 +37742,7 @@
         },
         "node_modules/victory-histogram/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -38015,8 +37756,7 @@
         },
         "node_modules/victory-voronoi": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
-            "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-voronoi": "^1.1.2",
                 "lodash": "^4.17.15",
@@ -38026,8 +37766,7 @@
         },
         "node_modules/victory-voronoi/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -38040,13 +37779,11 @@
         },
         "node_modules/victory-voronoi/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory-voronoi/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -38060,8 +37797,7 @@
         },
         "node_modules/victory/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -38074,21 +37810,18 @@
         },
         "node_modules/victory/node_modules/delaunay-find": {
             "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
-            "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+            "license": "ISC",
             "dependencies": {
                 "delaunator": "^4.0.0"
             }
         },
         "node_modules/victory/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "node_modules/victory/node_modules/victory-area": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
-            "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -38098,8 +37831,7 @@
         },
         "node_modules/victory/node_modules/victory-axis": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
-            "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38108,8 +37840,7 @@
         },
         "node_modules/victory/node_modules/victory-bar": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -38119,8 +37850,7 @@
         },
         "node_modules/victory/node_modules/victory-brush-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
-            "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38130,8 +37860,7 @@
         },
         "node_modules/victory/node_modules/victory-chart": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
-            "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38144,8 +37873,7 @@
         },
         "node_modules/victory/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -38159,8 +37887,7 @@
         },
         "node_modules/victory/node_modules/victory-create-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
-            "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "victory-brush-container": "^34.3.12",
@@ -38173,8 +37900,7 @@
         },
         "node_modules/victory/node_modules/victory-cursor-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
-            "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38183,8 +37909,7 @@
         },
         "node_modules/victory/node_modules/victory-group": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
-            "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38195,8 +37920,7 @@
         },
         "node_modules/victory/node_modules/victory-legend": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
-            "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38205,8 +37929,7 @@
         },
         "node_modules/victory/node_modules/victory-line": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
-            "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -38216,8 +37939,7 @@
         },
         "node_modules/victory/node_modules/victory-pie": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
-            "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.0.0",
                 "lodash": "^4.17.15",
@@ -38227,8 +37949,7 @@
         },
         "node_modules/victory/node_modules/victory-polar-axis": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
-            "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38237,8 +37958,7 @@
         },
         "node_modules/victory/node_modules/victory-scatter": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
-            "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38247,8 +37967,7 @@
         },
         "node_modules/victory/node_modules/victory-selection-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
-            "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38257,8 +37976,7 @@
         },
         "node_modules/victory/node_modules/victory-shared-events": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
-            "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38268,8 +37986,7 @@
         },
         "node_modules/victory/node_modules/victory-stack": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
-            "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38280,8 +37997,7 @@
         },
         "node_modules/victory/node_modules/victory-tooltip": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
-            "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -38290,8 +38006,7 @@
         },
         "node_modules/victory/node_modules/victory-voronoi-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
-            "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+            "license": "MIT",
             "dependencies": {
                 "delaunay-find": "0.0.5",
                 "lodash": "^4.17.15",
@@ -38303,8 +38018,7 @@
         },
         "node_modules/victory/node_modules/victory-zoom-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
-            "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -39304,8 +39018,7 @@
         },
         "node_modules/yargs": {
             "version": "17.6.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -39373,8 +39086,7 @@
         },
         "node_modules/yup": {
             "version": "0.32.11",
-            "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-            "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.15.4",
                 "@types/lodash": "^4.14.175",
@@ -39595,8 +39307,7 @@
         },
         "packages/components/node_modules/@redhat-cloud-services/types": {
             "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-            "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+            "license": "Apache-2.0"
         },
         "packages/components/node_modules/@scalprum/core": {
             "version": "0.2.3",
@@ -40054,8 +39765,8 @@
                 "@patternfly/react-styles": "^4.3.4",
                 "@patternfly/react-tokens": "^4.4.4",
                 "@react-pdf/renderer": "^1.6.8",
-                "@redhat-cloud-services/frontend-components": "^3.9.29",
-                "@scalprum/react-core": "^0.4.0",
+                "@redhat-cloud-services/frontend-components": "^3.0.0",
+                "@scalprum/react-core": "^0.1.7",
                 "react": "16.12.0",
                 "react-dom": "16.12.0",
                 "rgb-hex": "^3.0.0"
@@ -40072,8 +39783,7 @@
         },
         "packages/pdf-generator/node_modules/@patternfly/patternfly": {
             "version": "4.10.31",
-            "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
-            "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.0.0",
                 "npm": ">=5.0.0"
@@ -40081,8 +39791,7 @@
         },
         "packages/pdf-generator/node_modules/@patternfly/react-charts": {
             "version": "6.3.9",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
-            "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
+            "license": "MIT",
             "dependencies": {
                 "@patternfly/patternfly": "4.10.31",
                 "@patternfly/react-styles": "^4.3.4",
@@ -40124,10 +39833,21 @@
                 "react-dom": "^15.6.2 || ^16.4.0"
             }
         },
+        "packages/pdf-generator/node_modules/@scalprum/react-core": {
+            "version": "0.1.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@scalprum/core": "^0.1.1",
+                "lodash": "^4.17.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 || >=17.0.0",
+                "react-dom": ">=16.8.0 || >=17.0.0"
+            }
+        },
         "packages/pdf-generator/node_modules/d3-scale": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-            "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "d3-array": "^1.2.0",
                 "d3-collection": "1",
@@ -40140,8 +39860,7 @@
         },
         "packages/pdf-generator/node_modules/delaunay-find": {
             "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
-            "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
+            "license": "ISC",
             "dependencies": {
                 "delaunator": "^4.0.0"
             }
@@ -40173,8 +39892,7 @@
         },
         "packages/pdf-generator/node_modules/react-fast-compare": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-            "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+            "license": "MIT"
         },
         "packages/pdf-generator/node_modules/scheduler": {
             "version": "0.18.0",
@@ -40186,13 +39904,11 @@
         },
         "packages/pdf-generator/node_modules/tslib": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "license": "0BSD"
         },
         "packages/pdf-generator/node_modules/victory-area": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
-            "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -40202,8 +39918,7 @@
         },
         "packages/pdf-generator/node_modules/victory-axis": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
-            "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40212,8 +39927,7 @@
         },
         "packages/pdf-generator/node_modules/victory-bar": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-            "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -40223,8 +39937,7 @@
         },
         "packages/pdf-generator/node_modules/victory-brush-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
-            "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40234,8 +39947,7 @@
         },
         "packages/pdf-generator/node_modules/victory-chart": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
-            "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40248,8 +39960,7 @@
         },
         "packages/pdf-generator/node_modules/victory-core": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-            "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
+            "license": "MIT",
             "dependencies": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -40263,8 +39974,7 @@
         },
         "packages/pdf-generator/node_modules/victory-create-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
-            "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "victory-brush-container": "^34.3.12",
@@ -40277,8 +39987,7 @@
         },
         "packages/pdf-generator/node_modules/victory-cursor-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
-            "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40287,8 +39996,7 @@
         },
         "packages/pdf-generator/node_modules/victory-group": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
-            "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40299,8 +40007,7 @@
         },
         "packages/pdf-generator/node_modules/victory-legend": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
-            "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40309,8 +40016,7 @@
         },
         "packages/pdf-generator/node_modules/victory-line": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
-            "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -40320,8 +40026,7 @@
         },
         "packages/pdf-generator/node_modules/victory-pie": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
-            "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
+            "license": "MIT",
             "dependencies": {
                 "d3-shape": "^1.0.0",
                 "lodash": "^4.17.15",
@@ -40331,8 +40036,7 @@
         },
         "packages/pdf-generator/node_modules/victory-polar-axis": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
-            "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40341,8 +40045,7 @@
         },
         "packages/pdf-generator/node_modules/victory-scatter": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
-            "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40351,8 +40054,7 @@
         },
         "packages/pdf-generator/node_modules/victory-selection-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
-            "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40361,8 +40063,7 @@
         },
         "packages/pdf-generator/node_modules/victory-shared-events": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
-            "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40372,8 +40073,7 @@
         },
         "packages/pdf-generator/node_modules/victory-stack": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
-            "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40384,8 +40084,7 @@
         },
         "packages/pdf-generator/node_modules/victory-tooltip": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
-            "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40394,8 +40093,7 @@
         },
         "packages/pdf-generator/node_modules/victory-voronoi-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
-            "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
+            "license": "MIT",
             "dependencies": {
                 "delaunay-find": "0.0.5",
                 "lodash": "^4.17.15",
@@ -40407,8 +40105,7 @@
         },
         "packages/pdf-generator/node_modules/victory-zoom-container": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
-            "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -40584,8 +40281,7 @@
         },
         "packages/utils/node_modules/@redhat-cloud-services/types": {
             "version": "0.0.17",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-            "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+            "license": "Apache-2.0"
         },
         "packages/utils/node_modules/@types/node": {
             "version": "14.18.31",
@@ -43042,14 +42738,10 @@
         },
         "@frsource/base64": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@frsource/base64/-/base64-1.0.4.tgz",
-            "integrity": "sha512-IphM1ro1cvV5CqJWzX/LvPJcUE26cwgt/zMtBdssvTrfSNhh9KjfS2VXTA8SivkvPHK1DsdPnoMoXitmx8c3Cg==",
             "dev": true
         },
         "@frsource/cypress-plugin-visual-regression-diff": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/@frsource/cypress-plugin-visual-regression-diff/-/cypress-plugin-visual-regression-diff-3.1.3.tgz",
-            "integrity": "sha512-xV/bQymeEG+Lk60Eh9rDqFcg+2gc1DsAfFzl9cduL4Q6iAfOBwBq7HanBkojauCdzyJcqgf/RhujXxRo3RTQUg==",
             "dev": true,
             "requires": {
                 "@frsource/base64": "1.0.4",
@@ -43063,8 +42755,6 @@
             "dependencies": {
                 "brace-expansion": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
                     "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
@@ -43072,8 +42762,6 @@
                 },
                 "glob": {
                     "version": "8.0.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-                    "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -43085,8 +42773,6 @@
                 },
                 "minimatch": {
                     "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
@@ -44928,80 +44614,12 @@
                 }
             }
         },
-        "@next/swc-android-arm-eabi": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-            "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
-            "optional": true
-        },
-        "@next/swc-android-arm64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-            "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
-            "optional": true
-        },
-        "@next/swc-darwin-arm64": {
-            "version": "12.3.1",
-            "optional": true
-        },
-        "@next/swc-darwin-x64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-            "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
-            "optional": true
-        },
-        "@next/swc-freebsd-x64": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-            "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
-            "optional": true
-        },
-        "@next/swc-linux-arm-gnueabihf": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-            "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
-            "optional": true
-        },
-        "@next/swc-linux-arm64-gnu": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-            "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
-            "optional": true
-        },
-        "@next/swc-linux-arm64-musl": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-            "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
-            "optional": true
-        },
         "@next/swc-linux-x64-gnu": {
             "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-            "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
             "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-            "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
-            "optional": true
-        },
-        "@next/swc-win32-arm64-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-            "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
-            "optional": true
-        },
-        "@next/swc-win32-ia32-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-            "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
-            "optional": true
-        },
-        "@next/swc-win32-x64-msvc": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-            "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
             "optional": true
         },
         "@nicolo-ribaudo/chokidar-2": {
@@ -45652,8 +45270,6 @@
         },
         "@openshift/dynamic-plugin-sdk": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
-            "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
             "requires": {
                 "lodash-es": "^4.17.21",
                 "semver": "^7.3.7",
@@ -45663,16 +45279,12 @@
             "dependencies": {
                 "lru-cache": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "requires": {
                         "yallist": "^4.0.0"
                     }
                 },
                 "semver": {
                     "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -45938,9 +45550,7 @@
                     "dev": true
                 },
                 "@redhat-cloud-services/types": {
-                    "version": "0.0.17",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-                    "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+                    "version": "0.0.17"
                 },
                 "@scalprum/core": {
                     "version": "0.2.3"
@@ -46201,8 +45811,8 @@
                 "@patternfly/react-styles": "^4.3.4",
                 "@patternfly/react-tokens": "^4.4.4",
                 "@react-pdf/renderer": "^1.6.8",
-                "@redhat-cloud-services/frontend-components": "^3.9.29",
-                "@scalprum/react-core": "^0.4.0",
+                "@redhat-cloud-services/frontend-components": "^3.0.0",
+                "@scalprum/react-core": "^0.1.7",
                 "react": "16.12.0",
                 "react-dom": "16.12.0",
                 "rgb-hex": "^3.0.0",
@@ -46216,14 +45826,10 @@
             },
             "dependencies": {
                 "@patternfly/patternfly": {
-                    "version": "4.10.31",
-                    "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.10.31.tgz",
-                    "integrity": "sha512-UxdZ/apWRowXYZ5qPz5LPfXwyB4YGpomrCJPX7c36+Zg8jFpYyVqgVYainL8Yf/GrChtC2LKyoHg7UUTtMtp4A=="
+                    "version": "4.10.31"
                 },
                 "@patternfly/react-charts": {
                     "version": "6.3.9",
-                    "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.3.9.tgz",
-                    "integrity": "sha512-eo1++UvE0vGsHcBkfVDB0XPxqm2s6QGjxmumRRcqTCXl3OgiBHxIH1j1nd/ycDWiIg07neu29ty+rfJfmj+FEw==",
                     "requires": {
                         "@patternfly/patternfly": "4.10.31",
                         "@patternfly/react-styles": "^4.3.4",
@@ -46255,10 +45861,15 @@
                         "@fortawesome/free-brands-svg-icons": "^5.8.1"
                     }
                 },
+                "@scalprum/react-core": {
+                    "version": "0.1.7",
+                    "requires": {
+                        "@scalprum/core": "^0.1.1",
+                        "lodash": "^4.17.0"
+                    }
+                },
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -46271,8 +45882,6 @@
                 },
                 "delaunay-find": {
                     "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
-                    "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
                     "requires": {
                         "delaunator": "^4.0.0"
                     }
@@ -46295,9 +45904,7 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "scheduler": {
                     "version": "0.18.0",
@@ -46307,14 +45914,10 @@
                     }
                 },
                 "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "version": "1.14.1"
                 },
                 "victory-area": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
-                    "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -46324,8 +45927,6 @@
                 },
                 "victory-axis": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
-                    "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46334,8 +45935,6 @@
                 },
                 "victory-bar": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -46345,8 +45944,6 @@
                 },
                 "victory-brush-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
-                    "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46356,8 +45953,6 @@
                 },
                 "victory-chart": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
-                    "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46370,8 +45965,6 @@
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -46385,8 +45978,6 @@
                 },
                 "victory-create-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
-                    "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "victory-brush-container": "^34.3.12",
@@ -46399,8 +45990,6 @@
                 },
                 "victory-cursor-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
-                    "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46409,8 +45998,6 @@
                 },
                 "victory-group": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
-                    "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46421,8 +46008,6 @@
                 },
                 "victory-legend": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
-                    "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46431,8 +46016,6 @@
                 },
                 "victory-line": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
-                    "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -46442,8 +46025,6 @@
                 },
                 "victory-pie": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
-                    "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
                     "requires": {
                         "d3-shape": "^1.0.0",
                         "lodash": "^4.17.15",
@@ -46453,8 +46034,6 @@
                 },
                 "victory-polar-axis": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
-                    "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46463,8 +46042,6 @@
                 },
                 "victory-scatter": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
-                    "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46473,8 +46050,6 @@
                 },
                 "victory-selection-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
-                    "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46483,8 +46058,6 @@
                 },
                 "victory-shared-events": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
-                    "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46494,8 +46067,6 @@
                 },
                 "victory-stack": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
-                    "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46506,8 +46077,6 @@
                 },
                 "victory-tooltip": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
-                    "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46516,8 +46085,6 @@
                 },
                 "victory-voronoi-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
-                    "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
                     "requires": {
                         "delaunay-find": "0.0.5",
                         "lodash": "^4.17.15",
@@ -46529,8 +46096,6 @@
                 },
                 "victory-zoom-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
-                    "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -46581,9 +46146,7 @@
             },
             "dependencies": {
                 "@redhat-cloud-services/types": {
-                    "version": "0.0.17",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-                    "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+                    "version": "0.0.17"
                 },
                 "@types/node": {
                     "version": "14.18.31",
@@ -46890,16 +46453,12 @@
         },
         "@scalprum/core": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
-            "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
             "requires": {
                 "@openshift/dynamic-plugin-sdk": "^2.0.1"
             }
         },
         "@scalprum/react-core": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-            "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
             "requires": {
                 "@openshift/dynamic-plugin-sdk": "^2.0.1",
                 "@scalprum/core": "^0.4.1",
@@ -48606,8 +48165,6 @@
         },
         "@unleash/proxy-client-react": {
             "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.5.0.tgz",
-            "integrity": "sha512-ucBQM7XIilePpbRZJQJc4G4QMtvCrzxTZtUAheEsHZy//U8Cr7zPMotQztopK/IyStaNHaLtD7h7l4cXNvFuqQ==",
             "peer": true,
             "requires": {}
         },
@@ -51065,8 +50622,6 @@
         },
         "color": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "dev": true,
             "requires": {
                 "color-convert": "^2.0.1",
@@ -51075,8 +50630,6 @@
             "dependencies": {
                 "color-convert": {
                     "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
@@ -51084,8 +50637,6 @@
                 },
                 "color-name": {
                     "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 }
             }
@@ -51101,8 +50652,6 @@
         },
         "color-string": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
             "dev": true,
             "requires": {
                 "color-name": "^1.0.0",
@@ -52309,14 +51858,10 @@
         },
         "decode-uri-component": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "dev": true
         },
         "decompress-response": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "requires": {
                 "mimic-response": "^3.1.0"
@@ -52467,8 +52012,6 @@
         },
         "detect-libc": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
             "dev": true
         },
         "detect-newline": {
@@ -53590,8 +53133,6 @@
         },
         "expand-template": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "dev": true
         },
         "expand-tilde": {
@@ -54606,10 +54147,6 @@
         "fs.realpath": {
             "version": "1.0.0"
         },
-        "fsevents": {
-            "version": "2.3.2",
-            "optional": true
-        },
         "function-bind": {
             "version": "1.1.1"
         },
@@ -54648,8 +54185,6 @@
             "dependencies": {
                 "loader-utils": {
                     "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
-                    "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
                     "dev": true
                 }
             }
@@ -54885,8 +54420,6 @@
         },
         "github-from-package": {
             "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true
         },
         "glob": {
@@ -55390,8 +54923,6 @@
         },
         "http-cache-semantics": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
             "dev": true
         },
         "http-deceiver": {
@@ -58124,9 +57655,7 @@
             "version": "5.0.1"
         },
         "json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+            "version": "2.2.3"
         },
         "jsonc-parser": {
             "version": "3.2.0",
@@ -58566,8 +58095,6 @@
         },
         "loader-utils": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -58584,9 +58111,7 @@
             "version": "4.17.21"
         },
         "lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+            "version": "4.17.21"
         },
         "lodash.camelcase": {
             "version": "4.3.0",
@@ -59157,8 +58682,6 @@
         },
         "meta-png": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/meta-png/-/meta-png-1.0.3.tgz",
-            "integrity": "sha512-ts8SCT3qTvHBA723m1NYUKwzGDxYNCkMrHYrX0t7YaIch8giqpX+KyJEpCUFW7XfCWXiX5KSlQr4p3Ci9lrSug==",
             "dev": true
         },
         "methods": {
@@ -59530,8 +59053,6 @@
         },
         "mimic-response": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true
         },
         "min-indent": {
@@ -59715,8 +59236,6 @@
         },
         "mkdirp-classic": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true
         },
         "mkdirp-infer-owner": {
@@ -59795,8 +59314,6 @@
         },
         "move-file": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.1.0.tgz",
-            "integrity": "sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==",
             "dev": true,
             "requires": {
                 "path-exists": "^4.0.0"
@@ -59843,9 +59360,7 @@
             "version": "0.0.8"
         },
         "nanoclone": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-            "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+            "version": "0.2.1"
         },
         "nanoid": {
             "version": "3.3.4"
@@ -59869,8 +59384,6 @@
         },
         "napi-build-utils": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
             "dev": true
         },
         "natural-compare": {
@@ -59970,8 +59483,6 @@
         },
         "node-abi": {
             "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
-            "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
             "dev": true,
             "requires": {
                 "semver": "^7.3.5"
@@ -59979,8 +59490,6 @@
             "dependencies": {
                 "lru-cache": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "dev": true,
                     "requires": {
                         "yallist": "^4.0.0"
@@ -59988,8 +59497,6 @@
                 },
                 "semver": {
                     "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -61384,8 +60891,6 @@
         },
         "pixelmatch": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-            "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
             "dev": true,
             "requires": {
                 "pngjs": "^6.0.0"
@@ -61399,8 +60904,6 @@
         },
         "pngjs": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
             "dev": true
         },
         "popper.js": {
@@ -61722,8 +61225,6 @@
         },
         "prebuild-install": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-            "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
             "dev": true,
             "requires": {
                 "detect-libc": "^2.0.0",
@@ -61742,14 +61243,10 @@
             "dependencies": {
                 "chownr": {
                     "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
                     "dev": true
                 },
                 "tar-fs": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-                    "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
                     "dev": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -61890,9 +61387,7 @@
             }
         },
         "property-expr": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-            "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+            "version": "2.0.5"
         },
         "property-information": {
             "version": "6.1.1"
@@ -63531,8 +63026,6 @@
         },
         "sharp": {
             "version": "0.31.2",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.2.tgz",
-            "integrity": "sha512-DUdNVEXgS5A97cTagSLIIp8dUZ/lZtk78iNVZgHdHbx1qnQR7JAHY0BnXnwwH39Iw+VKhO08CTYhIg0p98vQ5Q==",
             "dev": true,
             "requires": {
                 "color": "^4.2.3",
@@ -63547,14 +63040,10 @@
             "dependencies": {
                 "chownr": {
                     "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
                     "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "dev": true,
                     "requires": {
                         "yallist": "^4.0.0"
@@ -63562,14 +63051,10 @@
                 },
                 "node-addon-api": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
                     "dev": true
                 },
                 "semver": {
                     "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -63577,8 +63062,6 @@
                 },
                 "tar-fs": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-                    "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
                     "dev": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -63797,14 +63280,10 @@
         },
         "simple-concat": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true
         },
         "simple-get": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "requires": {
                 "decompress-response": "^6.0.0",
@@ -63814,8 +63293,6 @@
         },
         "simple-swizzle": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
             "dev": true,
             "requires": {
                 "is-arrayish": "^0.3.1"
@@ -63823,8 +63300,6 @@
             "dependencies": {
                 "is-arrayish": {
                     "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
                     "dev": true
                 }
             }
@@ -64421,8 +63896,6 @@
         },
         "style-inject": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
-            "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
             "dev": true
         },
         "style-loader": {
@@ -64853,8 +64326,6 @@
         },
         "tiny-emitter": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
             "peer": true
         },
         "tiny-hashes": {
@@ -64941,9 +64412,7 @@
             "version": "1.0.1"
         },
         "toposort": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+            "version": "2.0.2"
         },
         "tough-cookie": {
             "version": "4.1.2",
@@ -65084,8 +64553,6 @@
             "dependencies": {
                 "json5": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-                    "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
                     "dev": true,
                     "requires": {
                         "minimist": "^1.2.0"
@@ -65183,9 +64650,7 @@
             "version": "4.8.4"
         },
         "ua-parser-js": {
-            "version": "0.7.33",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-            "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
+            "version": "0.7.33"
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -65369,8 +64834,6 @@
         },
         "unleash-proxy-client": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.4.0.tgz",
-            "integrity": "sha512-+kvO50Q/hFzrUIecIno9SLaDaKEadX6lOL4cd7kzLG54YqGHii97zEhkqJa1443DJ7oXsj7HjRWXlPycQjpNaQ==",
             "peer": true,
             "requires": {
                 "tiny-emitter": "^2.1.0",
@@ -65692,8 +65155,6 @@
         },
         "victory": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory/-/victory-34.3.12.tgz",
-            "integrity": "sha512-rFbIEFN27r8cmL8ZdMCFq1c7b91fmKTz4cp/yvg6dGwxpvKGXxJybSeq+wy0BTPXa2FBIZGT2ajR2B7edrOtMQ==",
             "requires": {
                 "victory-area": "^34.3.12",
                 "victory-axis": "^34.3.12",
@@ -65725,8 +65186,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -65739,21 +65198,15 @@
                 },
                 "delaunay-find": {
                     "version": "0.0.5",
-                    "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.5.tgz",
-                    "integrity": "sha512-7yAJ/wmKWj3SgqjtkGqT/RCwI0HWAo5YnHMoF5nYXD8cdci+YSo23iPmgrZUNOpDxRWN91PqxUvMMr2lKpjr+w==",
                     "requires": {
                         "delaunator": "^4.0.0"
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-area": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-34.3.12.tgz",
-                    "integrity": "sha512-DhD3zeYQyEME5ZH5VtJRSs10bKbyP6WJfaG8mLhtVezPsUFuI6QMKzn2kkrxHnVHa5d7ZS92LV+T9/i0DWZW7w==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -65763,8 +65216,6 @@
                 },
                 "victory-axis": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-34.3.12.tgz",
-                    "integrity": "sha512-e9gN88e1Z+/KIqaWgwTYbpV9T5nGIivfU4X/2MKm6ImQpffgNVQL04hWDn2Cm125F9qYUu17ov+fsMfM4nGS3Q==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65773,8 +65224,6 @@
                 },
                 "victory-bar": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -65784,8 +65233,6 @@
                 },
                 "victory-brush-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-34.3.12.tgz",
-                    "integrity": "sha512-2whQOzu3uX2wa1yjjUkCuzLRuhf9i0+7WYoKhSsl42OTw8RQM/aMqQWItDrgoZg7swaeWFK9Fjk/TObiXdn7ng==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65795,8 +65242,6 @@
                 },
                 "victory-chart": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-34.3.12.tgz",
-                    "integrity": "sha512-8jchzdOK3gvpiho2Iob63pf7HVJsljICIrFK9Qcf5983deWLrRg593ghKoQ7haVcIaKafmetC7bmze88fytKvQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65809,8 +65254,6 @@
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -65824,8 +65267,6 @@
                 },
                 "victory-create-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-34.3.12.tgz",
-                    "integrity": "sha512-NMSymIUsr4cFWUopPNPghm+7qhv6TaSx6udiqO8EcUWMwpsQoHWSY2ZP3dztKOzXHqAlKg/T33s/M9sSJIwn1g==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "victory-brush-container": "^34.3.12",
@@ -65838,8 +65279,6 @@
                 },
                 "victory-cursor-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-34.3.12.tgz",
-                    "integrity": "sha512-QerNe5/GCO0jmKUAtrCcF6I0fn0x8MDLlLO8YTbWwbWNHpUX81GUnPY2M23wjAKgyoOG2qwg7XM54MbvYzumbw==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65848,8 +65287,6 @@
                 },
                 "victory-group": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-34.3.12.tgz",
-                    "integrity": "sha512-bXXNmzr/rvegqCLrvczwTWkrPsuODmlUW0+J58x/2HOCABoduvrr0uIQA2++DcT/MxUQiooKWZdFA1wtU9i4zg==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65860,8 +65297,6 @@
                 },
                 "victory-legend": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-34.3.12.tgz",
-                    "integrity": "sha512-uti7LmtukBOuwN+dlW43vrBeswq4Kfl00QwGOjyb+z5KWpq6jzjphjpLA9277MQt0AI30r9Vlf3+S/GLM4zLhA==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65870,8 +65305,6 @@
                 },
                 "victory-line": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-34.3.12.tgz",
-                    "integrity": "sha512-LlrsBFNCOiDDDcp7qpaGFUohbXLnbPFxui8vyW2SCk0TylwXGaB53Wt/aG9Xd+VlXROtuI00gHi/VyS/hv/TYg==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -65881,8 +65314,6 @@
                 },
                 "victory-pie": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-34.3.12.tgz",
-                    "integrity": "sha512-t1+EFMpY8fFq5eubuijUCy5xJ23Oy3VQ11qySSymGdW+bXeXf23jawrAKk1Jj4ltUol/R5JGznQssTX9pdxutg==",
                     "requires": {
                         "d3-shape": "^1.0.0",
                         "lodash": "^4.17.15",
@@ -65892,8 +65323,6 @@
                 },
                 "victory-polar-axis": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-34.3.12.tgz",
-                    "integrity": "sha512-3TQjxELWDIdIUEdqC2ebWP4PyYrws8RSZj8h7az6nrevSzhsftVpsRUibrHK4+BVAqH0WqQP73iEdSZwcNmfMQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65902,8 +65331,6 @@
                 },
                 "victory-scatter": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-34.3.12.tgz",
-                    "integrity": "sha512-QP7wT2rC/4IdAOJP/o+/LOTR4oHtg6CMXFB+peOiwdqCA7PHyx4UAd4ZF38G1QYxTc/3HGSTArptDLuoLHRssQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65912,8 +65339,6 @@
                 },
                 "victory-selection-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-34.3.12.tgz",
-                    "integrity": "sha512-ofJ2E1nwswIufKcFF1ezISzdkuWzrUPX1Duc5gIz2AibqGGpjeuzpIfvKeqJgPCx6te10n87pYwT9GxJ3ZXCRg==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65922,8 +65347,6 @@
                 },
                 "victory-shared-events": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-34.3.12.tgz",
-                    "integrity": "sha512-iQ4lTrpASZXk/Fb1Nt3ByXeZR1A6vmk3t+Hikzr9wVjpddO+gxyToYfoAxWMtQqGKNiOKzcjEuQvFJR+ymAC+g==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65933,8 +65356,6 @@
                 },
                 "victory-stack": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-34.3.12.tgz",
-                    "integrity": "sha512-tq6OKg8d10qF4aGtE9jeeCxMvGqr/Zxb1scjnmAiJhDOIZfUP2KYr9co8YmT2izf+MsdPuwCX8vfgGZZ8ORHvA==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65945,8 +65366,6 @@
                 },
                 "victory-tooltip": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-34.3.12.tgz",
-                    "integrity": "sha512-dj3CquRlDW9pC/5O92H5BSrPKVAWjANB2EbioOLjD6RhdnFgk7CqmWUVMO3OIteJHOOiYKARBqpC6GQEdpn23w==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65955,8 +65374,6 @@
                 },
                 "victory-voronoi-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-34.3.12.tgz",
-                    "integrity": "sha512-wVo+6vd2+h4V7gP851zjH12d88l9Wa833CA+omdniGgGhNmJXrrFPXpNFuWu6Mk56gb4KBknayQsJxw2tGA9cg==",
                     "requires": {
                         "delaunay-find": "0.0.5",
                         "lodash": "^4.17.15",
@@ -65968,8 +65385,6 @@
                 },
                 "victory-zoom-container": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-34.3.12.tgz",
-                    "integrity": "sha512-gOzh6j2cV1VIjvzBQZkjAJN0jJWffGZqiS5J8NTQEojPrIQtcbW5C7I+9gV/T9HIW/tDbcW/65LUg1vSCyMPEQ==",
                     "requires": {
                         "lodash": "^4.17.15",
                         "prop-types": "^15.5.8",
@@ -65980,8 +65395,6 @@
         },
         "victory-box-plot": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-34.3.12.tgz",
-            "integrity": "sha512-KoTx/ukSjhB0iVAK0QrAQWk2z1SO8o2AyJJr6FZGB/oc4vzwV3r7pyIElgmQARrKuOVvDHc4yxduTM6fd4SFzg==",
             "requires": {
                 "d3-array": "^1.2.0",
                 "lodash": "^4.17.15",
@@ -65991,8 +65404,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66004,14 +65415,10 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66027,8 +65434,6 @@
         },
         "victory-brush-line": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-34.3.12.tgz",
-            "integrity": "sha512-rCIHbj7Qnud8H0iZQkiLj7m+rs8UyTYraQ887r1+VNSkKat9y1Lokv/dgaWcqsizfeypFoISvA0Rq5ZLwxOa3g==",
             "requires": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -66038,8 +65443,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66051,14 +65454,10 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66074,8 +65473,6 @@
         },
         "victory-candlestick": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-34.3.12.tgz",
-            "integrity": "sha512-gp5IAnW5s3yKjhSLNOP3H1pkk37/oUQ3nWbTlQq+SYCqrKg1c3pKuetgbQiqI14Gv7j0Z3BTgS4K2t37KFa/rw==",
             "requires": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -66084,8 +65481,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66097,14 +65492,10 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66120,8 +65511,6 @@
         },
         "victory-errorbar": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-34.3.12.tgz",
-            "integrity": "sha512-4aAhJ7TNs0ZT/5YFEoLQDDCDqgUwReNfjOVu0djCObGhCIXe1V4Sur2QXKg/P6U1jNGZXA58Y58UFNbtOKt32Q==",
             "requires": {
                 "lodash": "^4.17.15",
                 "prop-types": "^15.5.8",
@@ -66130,8 +65519,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66143,14 +65530,10 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66166,8 +65549,6 @@
         },
         "victory-histogram": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-34.3.12.tgz",
-            "integrity": "sha512-k4AzZHd4D2OZ0PeYPUryR+We5QkO2CC6dzRWurcpSo9bVes5wWNldljfeAk0080issUFV6OjpSkilAGK8NMsBw==",
             "requires": {
                 "d3-array": "^2.4.0",
                 "d3-scale": "^1.0.0",
@@ -66180,16 +65561,12 @@
             "dependencies": {
                 "d3-array": {
                     "version": "2.12.1",
-                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-                    "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
                     "requires": {
                         "internmap": "^1.0.0"
                     }
                 },
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66201,26 +65578,18 @@
                     },
                     "dependencies": {
                         "d3-array": {
-                            "version": "1.2.4",
-                            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-                            "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+                            "version": "1.2.4"
                         }
                     }
                 },
                 "internmap": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-                    "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+                    "version": "1.0.1"
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-bar": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-34.3.12.tgz",
-                    "integrity": "sha512-jOXB5/tEqhvF7SoTjLuk9jlJfLXw8b4u3AAiKdOlljCnATlnk0a3kBeqjo3+44TVNm98ej70ctAEFl9czUbSYg==",
                     "requires": {
                         "d3-shape": "^1.2.0",
                         "lodash": "^4.17.15",
@@ -66230,8 +65599,6 @@
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66247,8 +65614,6 @@
         },
         "victory-voronoi": {
             "version": "34.3.12",
-            "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-34.3.12.tgz",
-            "integrity": "sha512-YTT5IEnDpGNril8cnqxA+QdalgaoAZkdwNW88o1dPfPK5qiR7ChPBl23DmOIxbZefuQ+w6XnAeNpAJJ3AdBnKg==",
             "requires": {
                 "d3-voronoi": "^1.1.2",
                 "lodash": "^4.17.15",
@@ -66258,8 +65623,6 @@
             "dependencies": {
                 "d3-scale": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-                    "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
                     "requires": {
                         "d3-array": "^1.2.0",
                         "d3-collection": "1",
@@ -66271,14 +65634,10 @@
                     }
                 },
                 "react-fast-compare": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-                    "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+                    "version": "2.0.4"
                 },
                 "victory-core": {
                     "version": "34.3.12",
-                    "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-34.3.12.tgz",
-                    "integrity": "sha512-/HpSwoWNhrY4dyot/20dntnGa31qiKGWBUpLEU+tukQ3CbY5dQeKBrqg+pce8G0KUHS1xyXlrLhvLV4vDr3QzQ==",
                     "requires": {
                         "d3-ease": "^1.0.0",
                         "d3-interpolate": "^1.1.1",
@@ -66914,8 +66273,6 @@
         },
         "yargs": {
             "version": "17.6.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
             "requires": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -66958,8 +66315,6 @@
         },
         "yup": {
             "version": "0.32.11",
-            "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-            "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
             "requires": {
                 "@babel/runtime": "^7.15.4",
                 "@types/lodash": "^4.14.175",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7345,6 +7345,45 @@
                 "@octokit/openapi-types": "^12.11.0"
             }
         },
+        "node_modules/@openshift/dynamic-plugin-sdk": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
+            "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+            "dependencies": {
+                "lodash-es": "^4.17.21",
+                "semver": "^7.3.7",
+                "uuid": "^8.3.2",
+                "yup": "^0.32.11"
+            },
+            "peerDependencies": {
+                "react": "^17.0.2"
+            }
+        },
+        "node_modules/@openshift/dynamic-plugin-sdk/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@parcel/watcher": {
             "version": "2.0.4",
             "dev": true,
@@ -7854,24 +7893,26 @@
             "license": "MIT"
         },
         "node_modules/@scalprum/core": {
-            "version": "0.1.2",
-            "license": "Apache-2.0"
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
+            "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
+            "dependencies": {
+                "@openshift/dynamic-plugin-sdk": "^2.0.1"
+            }
         },
         "node_modules/@scalprum/react-core": {
-            "version": "0.2.4",
-            "license": "Apache-2.0",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+            "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
             "dependencies": {
-                "@scalprum/core": "^0.2.3",
+                "@openshift/dynamic-plugin-sdk": "^2.0.1",
+                "@scalprum/core": "^0.4.1",
                 "lodash": "^4.17.0"
             },
             "peerDependencies": {
                 "react": ">=16.8.0 || >=17.0.0",
                 "react-dom": ">=16.8.0 || >=17.0.0"
             }
-        },
-        "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
-            "version": "0.2.3",
-            "license": "Apache-2.0"
         },
         "node_modules/@segment/analytics-core": {
             "version": "1.1.0",
@@ -11360,7 +11401,6 @@
         },
         "node_modules/@types/lodash": {
             "version": "4.14.186",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/markdown-it": {
@@ -26642,6 +26682,11 @@
             "version": "4.17.21",
             "license": "MIT"
         },
+        "node_modules/lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "dev": true,
@@ -28674,6 +28719,11 @@
         "node_modules/mute-stream": {
             "version": "0.0.8",
             "license": "ISC"
+        },
+        "node_modules/nanoclone": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+            "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "node_modules/nanoid": {
             "version": "3.3.4",
@@ -31906,6 +31956,11 @@
         "node_modules/prop-types/node_modules/react-is": {
             "version": "16.13.1",
             "license": "MIT"
+        },
+        "node_modules/property-expr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+            "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
         },
         "node_modules/property-information": {
             "version": "6.1.1",
@@ -36459,6 +36514,11 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/toposort": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+        },
         "node_modules/tough-cookie": {
             "version": "4.1.2",
             "dev": true,
@@ -39311,6 +39371,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/yup": {
+            "version": "0.32.11",
+            "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+            "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+            "dependencies": {
+                "@babel/runtime": "^7.15.4",
+                "@types/lodash": "^4.14.175",
+                "lodash": "^4.17.21",
+                "lodash-es": "^4.17.21",
+                "nanoclone": "^0.2.1",
+                "property-expr": "^2.0.4",
+                "toposort": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/zwitch": {
             "version": "2.0.2",
             "license": "MIT",
@@ -39482,7 +39559,7 @@
                 "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
                 "@redhat-cloud-services/types": "^0.0.17",
                 "@scalprum/core": "^0.2.3",
-                "@scalprum/react-core": "^0.2.4",
+                "@scalprum/react-core": "^0.4.0",
                 "sanitize-html": "^2.7.2"
             },
             "devDependencies": {
@@ -39672,7 +39749,7 @@
         },
         "packages/config-utils": {
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
-            "version": "1.5.28",
+            "version": "1.5.29",
             "license": "Apache-2.0",
             "dependencies": {
                 "node-fetch": "2.6.7"
@@ -39977,8 +40054,8 @@
                 "@patternfly/react-styles": "^4.3.4",
                 "@patternfly/react-tokens": "^4.4.4",
                 "@react-pdf/renderer": "^1.6.8",
-                "@redhat-cloud-services/frontend-components": "^3.0.0",
-                "@scalprum/react-core": "^0.1.7",
+                "@redhat-cloud-services/frontend-components": "^3.9.29",
+                "@scalprum/react-core": "^0.4.0",
                 "react": "16.12.0",
                 "react-dom": "16.12.0",
                 "rgb-hex": "^3.0.0"
@@ -40045,18 +40122,6 @@
                 "prop-types": "^15.6.1",
                 "react": "^16.4.0",
                 "react-dom": "^15.6.2 || ^16.4.0"
-            }
-        },
-        "packages/pdf-generator/node_modules/@scalprum/react-core": {
-            "version": "0.1.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@scalprum/core": "^0.1.1",
-                "lodash": "^4.17.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0 || >=17.0.0",
-                "react-dom": ">=16.8.0 || >=17.0.0"
             }
         },
         "packages/pdf-generator/node_modules/d3-scale": {
@@ -40357,8 +40422,8 @@
             "dependencies": {
                 "@data-driven-forms/pf4-component-mapper": "^2.24.0",
                 "@data-driven-forms/react-form-renderer": "^2.24.2",
-                "@redhat-cloud-services/frontend-components": "^3.9.12",
-                "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
+                "@redhat-cloud-services/frontend-components": "^3.9.29",
+                "@redhat-cloud-services/frontend-components-utilities": "^3.3.13",
                 "@redhat-cloud-services/host-inventory-client": "^1.0.111",
                 "redux-promise-middleware": "^6.1.3",
                 "urijs": "^1.19.11"
@@ -45585,6 +45650,35 @@
                 "@octokit/openapi-types": "^12.11.0"
             }
         },
+        "@openshift/dynamic-plugin-sdk": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
+            "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+            "requires": {
+                "lodash-es": "^4.17.21",
+                "semver": "^7.3.7",
+                "uuid": "^8.3.2",
+                "yup": "^0.32.11"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
         "@parcel/watcher": {
             "version": "2.0.4",
             "dev": true,
@@ -45828,7 +45922,7 @@
                 "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
                 "@redhat-cloud-services/types": "^0.0.17",
                 "@scalprum/core": "^0.2.3",
-                "@scalprum/react-core": "^0.2.4",
+                "@scalprum/react-core": "^0.4.0",
                 "@types/react": "^16.14.32",
                 "css-loader": "^6.7.1",
                 "cypress": "^9.7.0",
@@ -46107,8 +46201,8 @@
                 "@patternfly/react-styles": "^4.3.4",
                 "@patternfly/react-tokens": "^4.4.4",
                 "@react-pdf/renderer": "^1.6.8",
-                "@redhat-cloud-services/frontend-components": "^3.0.0",
-                "@scalprum/react-core": "^0.1.7",
+                "@redhat-cloud-services/frontend-components": "^3.9.29",
+                "@scalprum/react-core": "^0.4.0",
                 "react": "16.12.0",
                 "react-dom": "16.12.0",
                 "rgb-hex": "^3.0.0",
@@ -46159,13 +46253,6 @@
                     "version": "3.15.17",
                     "requires": {
                         "@fortawesome/free-brands-svg-icons": "^5.8.1"
-                    }
-                },
-                "@scalprum/react-core": {
-                    "version": "0.1.7",
-                    "requires": {
-                        "@scalprum/core": "^0.1.1",
-                        "lodash": "^4.17.0"
                     }
                 },
                 "d3-scale": {
@@ -46457,8 +46544,8 @@
             "requires": {
                 "@data-driven-forms/pf4-component-mapper": "^2.24.0",
                 "@data-driven-forms/react-form-renderer": "^2.24.2",
-                "@redhat-cloud-services/frontend-components": "^3.9.12",
-                "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
+                "@redhat-cloud-services/frontend-components": "^3.9.29",
+                "@redhat-cloud-services/frontend-components-utilities": "^3.3.13",
                 "@redhat-cloud-services/host-inventory-client": "^1.0.111",
                 "redux-promise-middleware": "^6.1.3",
                 "urijs": "^1.19.11"
@@ -46802,18 +46889,21 @@
             "dev": true
         },
         "@scalprum/core": {
-            "version": "0.1.2"
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
+            "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
+            "requires": {
+                "@openshift/dynamic-plugin-sdk": "^2.0.1"
+            }
         },
         "@scalprum/react-core": {
-            "version": "0.2.4",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+            "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
             "requires": {
-                "@scalprum/core": "^0.2.3",
+                "@openshift/dynamic-plugin-sdk": "^2.0.1",
+                "@scalprum/core": "^0.4.1",
                 "lodash": "^4.17.0"
-            },
-            "dependencies": {
-                "@scalprum/core": {
-                    "version": "0.2.3"
-                }
             }
         },
         "@segment/analytics-core": {
@@ -48153,8 +48243,7 @@
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.186",
-            "dev": true
+            "version": "4.14.186"
         },
         "@types/markdown-it": {
             "version": "12.2.3",
@@ -58494,6 +58583,11 @@
         "lodash": {
             "version": "4.17.21"
         },
+        "lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+        },
         "lodash.camelcase": {
             "version": "4.3.0",
             "dev": true
@@ -59747,6 +59841,11 @@
         },
         "mute-stream": {
             "version": "0.0.8"
+        },
+        "nanoclone": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+            "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "nanoid": {
             "version": "3.3.4"
@@ -61789,6 +61888,11 @@
                     "version": "16.13.1"
                 }
             }
+        },
+        "property-expr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+            "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
         },
         "property-information": {
             "version": "6.1.1"
@@ -64836,6 +64940,11 @@
         "toidentifier": {
             "version": "1.0.1"
         },
+        "toposort": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+            "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+        },
         "tough-cookie": {
             "version": "4.1.2",
             "dev": true,
@@ -66846,6 +66955,20 @@
         },
         "yocto-queue": {
             "version": "0.1.0"
+        },
+        "yup": {
+            "version": "0.32.11",
+            "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+            "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+            "requires": {
+                "@babel/runtime": "^7.15.4",
+                "@types/lodash": "^4.14.175",
+                "lodash": "^4.17.21",
+                "lodash-es": "^4.17.21",
+                "nanoclone": "^0.2.1",
+                "property-expr": "^2.0.4",
+                "toposort": "^2.0.2"
+            }
         },
         "zwitch": {
             "version": "2.0.2"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "sanitize-html": "^2.7.2",
         "@scalprum/core": "^0.2.3",
-        "@scalprum/react-core": "^0.2.4",
+        "@scalprum/react-core": "^0.4.0",
         "@redhat-cloud-services/types": "^0.0.17"
     },
     "devDependencies": {

--- a/packages/config-utils/package.json
+++ b/packages/config-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@redhat-cloud-services/frontend-components-config-utilities",
-    "version": "1.5.28",
+    "version": "1.5.29",
     "description": "Utilities for shared config used in RedHat Cloud Services project.",
     "main": "index.js",
     "publishConfig": {

--- a/packages/remediations/package.json
+++ b/packages/remediations/package.json
@@ -37,8 +37,8 @@
     "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^2.24.0",
         "@data-driven-forms/react-form-renderer": "^2.24.2",
-        "@redhat-cloud-services/frontend-components": "^3.9.12",
-        "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
+        "@redhat-cloud-services/frontend-components": "^3.9.29",
+        "@redhat-cloud-services/frontend-components-utilities": "^3.3.13",
         "@redhat-cloud-services/host-inventory-client": "^1.0.111",
         "redux-promise-middleware": "^6.1.3",
         "urijs": "^1.19.11"


### PR DESCRIPTION
This PR bumps the scalprum core package version in components and remediation packages. I have found out that as the current versions do not match the chrome one, there are 3 instances of the same package in the browser. This PR removes one of them. One more instance could be removed if pdf-generator package had the same version, but upgrading it seems to break change and I am not able to fix the issue.

![image](https://user-images.githubusercontent.com/59481011/221893369-9a581c06-e3ca-463f-996b-b29fb306e40b.png)
