### PR TITLE
add enablePackagesDebug type into ChromApi type

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -229,6 +229,7 @@ export interface ChromeAPI {
       };
     }) => T
   ) => T;
+  enablePackagesDebug: () => void;
 }
 
 declare global {


### PR DESCRIPTION
Adds **enablePackagesDebug** type into ChromeApi. This is intended for: https://github.com/RedHatInsights/insights-chrome/pull/2414