### PR TITLE
fix(OCPADVISOR-82): Fix the "view affected clusters" link

### DIFF
--- a/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
+++ b/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
@@ -14,12 +14,12 @@ const ViewAffectedLink: React.FC<ViewAffectedLinkProps> = ({ messages, product, 
   <React.Fragment>
     {product === AdvisorProduct.ocp
       ? (rule as RuleContentOcp).impacted_clusters_count > 0 && (
-          <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
+          <Link key={`${rule.rule_id}-link`} to={`/openshift/insights/advisor/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedClusters}
           </Link>
         )
       : (rule as RuleContentRhel).impacted_systems_count > 0 && (
-          <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
+          <Link key={`${rule.rule_id}-link`} to={`/openshift/insights/advisor/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedSystems}
           </Link>
         )}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPADVISOR-82.

This fixes the ViewAffectedLink component and make it compatible with react-router-dom of version >6. The pathname of the link now also includes the basename of OCP Advisor application.