### PR TITLE
Fix GroupFilter styling on inputs

### DIFF
--- a/packages/components/src/ConditionalFilter/group-filter.scss
+++ b/packages/components/src/ConditionalFilter/group-filter.scss
@@ -1,7 +1,7 @@
 @import '~@redhat-cloud-services/frontend-components-utilities/styles/_all.scss';
 
-button.ins-c-group-menu-toggle {
-    padding: 0;
+button.ins-c-group-menu-toggle .pf-c-form-control {
+    margin: -1rem 0 -1rem 0;
 }
 
 button.pf-c-menu-toggle {


### PR DESCRIPTION
[ESSNTL-2639](https://issues.redhat.com/browse/ESSNTL-2639)

This is a fix for my [previous fix](https://github.com/RedHatInsights/frontend-components/pull/1715). I didn't notice, it broke the 'Operation system' filter in Inventory, sorry about that.

I wanted to do:
`button.ins-c-group-menu-toggle:has(input) {
    padding: 0;
}`
but `:has()` selector is not supported in Firefox yet

Before:
![image](https://user-images.githubusercontent.com/20592948/234873343-1361c9dd-09aa-45ad-9c42-ea598b073107.png)

After:
![image](https://user-images.githubusercontent.com/20592948/234873499-300aa2ab-643d-4bbe-a584-e5252bd41ca5.png)

All other filters are displayed correctly
![image](https://user-images.githubusercontent.com/20592948/234887963-e36d78e5-0dd5-4ecb-8aae-152295ac4aba.png)
