### PR TITLE
fix(advisor-3041): fix for reportdetails

### DIFF
--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -40,9 +40,9 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({ report, kbaDetail, kbaLoa
   const linkEditor = (url: string) => {
     const linkToArray = url.split('/');
     if (isProd()) {
-      return `https://access.redhat.com/solutions/${linkToArray.at(-1)}`;
+      return `https://access.redhat.com/${linkToArray.at(-2)}/${linkToArray.at(-1)}`;
     } else {
-      return `https://access.stage.redhat.com/solutions/${linkToArray.at(-1)}`;
+      return `https://access.stage.redhat.com/${linkToArray.at(-2)}/${linkToArray.at(-1)}`;
     }
   };
 


### PR DESCRIPTION
In my last PR, I totally forgot that we have both "articles" and "solutions" links
This should remove the hardcoded "solutions" and put "solutions" or "articles" depending on what is returned by the API

System ID to test 1daf9c25-ac62-4d27-a44d-4f59276ed770 in RHEL Advisor