### PR TITLE
DRAFT: enable source map generation for prod-beta env without source urls

### DIFF
--- a/packages/config/index.js
+++ b/packages/config/index.js
@@ -6,7 +6,7 @@ const gitRevisionPlugin = new (require('git-revision-webpack-plugin'))({
   branch: true,
 });
 const betaBranches = ['master', 'qa-beta', 'ci-beta', 'prod-beta', 'main', 'devel', 'stage-beta'];
-const akamaiBranches = ['prod-beta', 'prod-stable'];
+const akamaiBranches = ['prod-stable'];
 
 const getAppEntry = (rootFolder, isProd) => {
   // Use entry-dev if it exists

--- a/packages/config/src/plugins.js
+++ b/packages/config/src/plugins.js
@@ -17,6 +17,7 @@ module.exports = ({ rootFolder, insights, generateSourceMaps, plugins, definePlu
             test: 'js',
             exclude: /(node_modules|bower_components)/i,
             filename: !fileHash ? 'sourcemaps/[name].js.map' : 'sourcemaps/[name].[contenthash].js.map',
+            append: false,
           }),
         ]
       : []),


### PR DESCRIPTION
This is a part of effort to try uploading source maps using sentry-cli during release pipeline. Further PRs are to be created to demo the change. I have verified that `append:false` inside webpack config prevents adding sourmap urls into source files.

[Here](https://github.com/RedHatInsights/patchman-ui/pull/1068) is another PR in tenant app that gives a bit more insight how those apps will upload the sourcemaps.