### PR TITLE
Add children to rule details prop

### DIFF
--- a/packages/advisor-components/src/RuleDetails/RuleDetails.tsx
+++ b/packages/advisor-components/src/RuleDetails/RuleDetails.tsx
@@ -45,6 +45,7 @@ export interface RuleDetailsProps {
   resolutionRiskDesc?: string;
   header?: React.ReactNode;
   isDetailsPage: boolean;
+  children?: React.ReactNode;
   topics?: TopicRhel[];
   /**
    * onVoteClick - a callback used to update the rating of a particular rule


### PR DESCRIPTION
### Description

Children were missing in rule details props and this was braking the documentation site generator.