### PR TITLE
Use better image linking so mdx provider can intercept it

### DIFF
--- a/packages/chrome/src/ChromeProvider/ChromeProvider.tsx
+++ b/packages/chrome/src/ChromeProvider/ChromeProvider.tsx
@@ -20,7 +20,7 @@ const useLastPageVisitedUploader = (providerState: ReturnType<typeof chromeState
   }, [pathname]);
 };
 
-const ChromeProvider: React.FC<{ bundle?: string }> = ({ children, bundle }) => {
+const ChromeProvider: React.FC<{ bundle?: string; children?: React.ReactNode }> = ({ children, bundle }) => {
   const isMounted = useRef(false);
   const [initialRequest, setInitialRequest] = useState(false);
   const providerState = useRef<ReturnType<typeof chromeState>>();

--- a/packages/docs/pages/feature-flags/managing-feature-flags.mdx
+++ b/packages/docs/pages/feature-flags/managing-feature-flags.mdx
@@ -17,20 +17,20 @@
 - Go to [stage unleash](https://insights-stage.unleash.devshift.net) or [prod unleash](https://insights.unleash.devshift.net/)
 - Click on the *New feature toggle*
 
-<img src="/feature-flags/unleash-new.png" alt="Open new unleash feature flag page" />
+![Open new unleash feature flag page](/feature-flags/unleash-new.png)
 
 - Give your feature flag a name
   - **Make sure the flag has an accurate and unique name**
   - eg: `platform.chrome.env.production`
 - Click the *Create Feature* button
 
-<img src="/feature-flags/features-create.png" alt="Create new unleash feature flag" />
+![Create new unleash feature flag](/feature-flags/features-create.png)
 
 - You will be redirected to the feature detail
 - Add the feature flag strategy
 
-<img src="/feature-flags/features-strategy.png" alt="Alter feature flag strategy" />
+![Alter feature flag strategy](/feature-flags/features-strategy.png)
 
 - Update the feature flag status
 
-<img src="/feature-flags/update-status.png" alt="Alter feature flag status" />
+![Alter feature flag status](/feature-flags/update-status.png)


### PR DESCRIPTION
#### Description

MDX provider has a bit of hard time finding linked img elements. That's because we used directly `<img>` component. It's better to use direct imports `![]()` instead so we can intercept them when building the docs site.