### PR TITLE
fix(RHINENG-956): Fix the react router link for affected entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39315,7 +39315,7 @@
         },
         "packages/advisor-components": {
             "name": "@redhat-cloud-services/frontend-components-advisor-components",
-            "version": "1.0.11",
+            "version": "1.0.13",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": "^3.9.12",
@@ -39468,7 +39468,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "3.9.37",
+            "version": "3.11.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
@@ -39607,7 +39607,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
@@ -39655,7 +39655,7 @@
         },
         "packages/config-utils": {
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@openshift/dynamic-plugin-sdk-webpack": "^3.0.0",
@@ -40497,7 +40497,7 @@
         },
         "packages/utils": {
             "name": "@redhat-cloud-services/frontend-components-utilities",
-            "version": "3.5.1",
+            "version": "3.7.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/types": "^0.0.24",
@@ -45927,7 +45927,7 @@
                 "react-markdown": "^8.0.3",
                 "rehype-raw": "^6.1.1",
                 "rehype-sanitize": "^5.0.1",
-                "sanitize-html": "*",
+                "sanitize-html": "^2.10.0",
                 "sass-loader": "^12.6.0",
                 "style-loader": "^3.3.1"
             },

--- a/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
+++ b/packages/advisor-components/src/ViewAffectedLink/ViewAffectedLink.tsx
@@ -14,12 +14,12 @@ const ViewAffectedLink: React.FC<ViewAffectedLinkProps> = ({ messages, product, 
   <React.Fragment>
     {product === AdvisorProduct.ocp
       ? (rule as RuleContentOcp).impacted_clusters_count > 0 && (
-          <Link key={`${rule.rule_id}-link`} to={`/openshift/insights/advisor/recommendations/${rule.rule_id}`}>
+          <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedClusters}
           </Link>
         )
       : (rule as RuleContentRhel).impacted_systems_count > 0 && (
-          <Link key={`${rule.rule_id}-link`} to={`/openshift/insights/advisor/recommendations/${rule.rule_id}`}>
+          <Link key={`${rule.rule_id}-link`} to={`/recommendations/${rule.rule_id}`}>
             {messages.viewAffectedSystems}
           </Link>
         )}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-956.

This is a quick fix for the issue with incorrect URLs for "View affected ..." links.

## How to test

Link the package to local RHEL Advisor and run the app. The view affected systems links should be pointing to the right path.