### PR TITLE
Revert "Use content hash for JS chunks."

### DIFF
--- a/packages/config-utils/federated-modules.js
+++ b/packages/config-utils/federated-modules.js
@@ -43,7 +43,7 @@ module.exports = ({
 
   const { dependencies, insights } = require(resolve(root, './package.json')) || {};
   const appName = moduleName || (insights && jsVarName(insights.appname));
-  const filename = `${appName}.${useFileHash ? `[contenthash].` : ''}js`;
+  const filename = `${appName}.${useFileHash ? `[fullhash].` : ''}js`;
 
   let sharedDeps = Object.entries(include)
     .filter(([key]) => dependencies[key] && !exclude.includes(key))

--- a/packages/config/src/config.js
+++ b/packages/config/src/config.js
@@ -47,7 +47,7 @@ module.exports = ({
   // additional node_modules dirs for searchIgnoredStyles, usefull in monorepo scenario
   nodeModulesDirectories = [],
 } = {}) => {
-  const filenameMask = `js/[name].${!_unstableHotReload && useFileHash ? `[contenthash].` : ''}js`;
+  const filenameMask = `js/[name].${!_unstableHotReload && useFileHash ? `[fullhash].` : ''}js`;
   if (betaEnv) {
     env = `${betaEnv}-beta`;
     console.warn('betaEnv is deprecated in favor of env');
@@ -165,7 +165,7 @@ module.exports = ({
           test: /\.(woff(2)?|ttf|jpg|png|eot|gif|svg)(\?v=\d+\.\d+\.\d+)?$/,
           type: 'asset/resource',
           generator: {
-            filename: 'assets/[name][ext]',
+            filename: 'fonts/[name][ext]',
           },
         },
         {

--- a/packages/config/src/config.test.js
+++ b/packages/config/src/config.test.js
@@ -30,10 +30,10 @@ describe('should create dummy config with no options', () => {
 
   test('output', () => {
     expect(output).toEqual({
-      filename: expect.stringMatching(/js\/\[name\]\.\[contenthash\]\.js/),
+      filename: expect.stringMatching(/js\/\[name\]\.\[fullhash\]\.js/),
       path: '/dist',
       publicPath: undefined,
-      chunkFilename: expect.stringMatching(/js\/\[name\]\.\[contenthash\]\.js/),
+      chunkFilename: expect.stringMatching(/js\/\[name\]\.\[fullhash\]\.js/),
     });
   });
 


### PR DESCRIPTION
Reverts RedHatInsights/frontend-components#1761

There's currently problem with `contenthash` not matching what's actually built by the webpack.