### PR TITLE
fix: Support arrays in resource definition value

### DIFF
--- a/packages/utils/src/RBAC/RBAC.test.js
+++ b/packages/utils/src/RBAC/RBAC.test.js
@@ -525,6 +525,54 @@ describe('RBAC utilities', () => {
         ];
         expect(doesHavePermissions(userPermissions, requiredPermissions, true)).toBe(false);
       });
+
+      it('recognizes array syntax for IN value, 1', () => {
+        requiredPermissions = [
+          {
+            permission: 'inventory:hosts:read',
+            resourceDefinitions: [],
+          },
+        ];
+        userPermissions = [
+          {
+            permission: 'inventory:hosts:read',
+            resourceDefinitions: [
+              {
+                attributeFilter: {
+                  key: 'system-id',
+                  operation: 'in',
+                  value: [123, 456],
+                },
+              },
+            ],
+          },
+        ];
+        expect(doesHavePermissions(userPermissions, requiredPermissions, true)).toBe(false);
+      });
+
+      it('recognizes array syntax for IN value, 2', () => {
+        requiredPermissions = [
+          {
+            permission: 'inventory:hosts:read',
+            resourceDefinitions: [
+              {
+                attributeFilter: {
+                  key: 'system-id',
+                  operation: 'in',
+                  value: [123, 456],
+                },
+              },
+            ],
+          },
+        ];
+        userPermissions = [
+          {
+            permission: 'inventory:hosts:read',
+            resourceDefinitions: [],
+          },
+        ];
+        expect(doesHavePermissions(userPermissions, requiredPermissions, true)).toBe(true);
+      });
     });
   });
   describe('has all permissions', () => {

--- a/packages/utils/src/RBAC/RBAC.ts
+++ b/packages/utils/src/RBAC/RBAC.ts
@@ -34,7 +34,13 @@ function extractResourceDefinitionValues(rds: ResourceDefinition[]) {
     const { key, operation, value } = cur.attributeFilter;
 
     if (operation === ResourceDefinitionFilterOperationEnum.In) {
-      return [...acc, ...value.split(',').map((value) => `${key}:${value}`)];
+      return [
+        ...acc,
+        ...value
+          .toString()
+          .split(',')
+          .map((value) => `${key}:${value}`),
+      ];
     }
 
     if (operation === ResourceDefinitionFilterOperationEnum.Equal) {


### PR DESCRIPTION
Sometimes, RBAC services/consumers use the array type to provide the values in resource definitions together with IN operator. However, the utilities might crash because of that. This adds support for arrays, so that the utils work both with strings (split by comma), and arrays.