### PR TITLE
fix: the --uiEnv arg is assigned incorrectly in fec dev

### DIFF
--- a/packages/config/src/scripts/dev-script.js
+++ b/packages/config/src/scripts/dev-script.js
@@ -44,7 +44,7 @@ async function devScript(argv, cwd) {
     const uiEnvOptions = ['beta', 'stable'];
     if (argv?.clouddotEnv && argv?.uiEnv) {
       if (clouddotEnvOptions.includes(argv.clouddotEnv) && uiEnvOptions.includes(argv.uiEnv)) {
-        process.env.BETA = argv.uiEnv;
+        process.env.BETA = argv.uiEnv === 'beta' ? 'true' : 'false';
         process.env.CLOUDOT_ENV = argv.clouddotEnv;
         process.env.FEC_ROOT_DIR = cwd;
       } else {


### PR DESCRIPTION
When running fec dev with a given `uiEnv` arg
```
fec dev --uiEnv=beta --clouddotEnv=stage
```
The env var `BETA` is assigned  incorrectly - `BETA=beta` instead of `BETA=true` 
