### PR TITLE
import v4 css for demo

### DIFF
--- a/packages/demo/src/index.html
+++ b/packages/demo/src/index.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly@latest/patternfly-base.css"/>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly@latest/patternfly-addons.css"/>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly@4.224.5/patternfly-base.css"/>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@patternfly/patternfly@4.224.5/patternfly-addons.css"/>
     <!--
         manifest.json provides metadata used when your web app is added to the
         homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
Demo package was pulling the latest patternfly stylesheets instead of explicitly v4 stylesheets.