### PR TITLE
fix: Override resourceDefinitions within RBACContext

### DIFF
--- a/packages/components/src/RBACProvider/RBACProvider.tsx
+++ b/packages/components/src/RBACProvider/RBACProvider.tsx
@@ -11,10 +11,10 @@ import {
 } from '@redhat-cloud-services/frontend-components-utilities/RBAC';
 
 const hasAccessWithUserPermissions = (userPermissions: (Access | string)[], checkResourceDefinitions: boolean) => {
-  return (requiredPermissions: (Access | string)[], checkAll?: boolean): boolean => {
+  return (requiredPermissions: (Access | string)[], checkAll?: boolean, checkResourceDefinitionsOverride?: boolean): boolean => {
     return checkAll
-      ? hasAllPermissions(userPermissions, requiredPermissions, checkResourceDefinitions)
-      : doesHavePermissions(userPermissions, requiredPermissions, checkResourceDefinitions);
+      ? hasAllPermissions(userPermissions, requiredPermissions, checkResourceDefinitionsOverride ?? checkResourceDefinitions)
+      : doesHavePermissions(userPermissions, requiredPermissions, checkResourceDefinitionsOverride ?? checkResourceDefinitions);
   };
 };
 

--- a/packages/utils/src/RBAC/RBAC.ts
+++ b/packages/utils/src/RBAC/RBAC.ts
@@ -135,7 +135,7 @@ export interface UsePermissionsContextState {
   isLoading?: boolean;
   isOrgAdmin: boolean;
   permissions: (string | Access)[];
-  hasAccess?: (requiredPermissions: (Access | string)[], checkAll?: boolean) => boolean;
+  hasAccess?: (requiredPermissions: (Access | string)[], checkAll?: boolean, checkResourceDefinitionsOverride?: boolean) => boolean;
 }
 
 export const initialPermissions: UsePermissionsContextState = {

--- a/packages/utils/src/RBACHook/RBACHook.ts
+++ b/packages/utils/src/RBACHook/RBACHook.ts
@@ -39,12 +39,16 @@ export function usePermissions(
   return permissions;
 }
 
-export const usePermissionsWithContext = (requiredPermissions: (Access | string)[], checkAll?: boolean) => {
+export const usePermissionsWithContext = (
+  requiredPermissions: (Access | string)[],
+  checkAll?: boolean,
+  checkResourceDefinitionsOverride?: boolean
+) => {
   const { hasAccess, ...permissionState } = useContext(RBACContext);
 
   return {
     ...permissionState,
-    hasAccess: hasAccess?.(requiredPermissions, checkAll) || false,
+    hasAccess: hasAccess?.(requiredPermissions, checkAll, checkResourceDefinitionsOverride) || false,
   };
 };
 


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/ESSNTL-5239.

Complement hasAccess function with another parameter that allows to override resource definitions check. The parameter ignores the value set in the RBACContext which provides more flexibility for some edge cases.