### PR TITLE
fix: Fix usage of null values in RBAC RDs

### DIFF
--- a/packages/utils/src/RBAC/RBAC.ts
+++ b/packages/utils/src/RBAC/RBAC.ts
@@ -36,8 +36,7 @@ function extractResourceDefinitionValues(rds: ResourceDefinition[]) {
     if (operation === ResourceDefinitionFilterOperationEnum.In) {
       return [
         ...acc,
-        ...value
-          .toString()
+        ...(Array.isArray(value) ? value.map((value) => (value === null ? 'null' : value)).toString() : value)
           .split(',')
           .map((value) => `${key}:${value}`),
       ];


### PR DESCRIPTION
Make sure null values are not left out when RBAC RD value is an array.