### PR TITLE
Remove internal checkbox filter state.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42000,7 +42000,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "4.0.2",
+            "version": "4.0.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-component-groups": "^1.0.13",
@@ -42710,7 +42710,7 @@
         },
         "packages/eslint-config": {
             "name": "@redhat-cloud-services/eslint-config-redhat-cloud-services",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "license": "Apache",
             "dependencies": {
                 "@babel/eslint-parser": "^7.19.1",
@@ -42727,7 +42727,7 @@
         },
         "packages/notifications": {
             "name": "@redhat-cloud-services/frontend-components-notifications",
-            "version": "4.0.0",
+            "version": "4.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": "^4.0.0",

--- a/packages/components/src/ConditionalFilter/CheckboxFilter.test.js
+++ b/packages/components/src/ConditionalFilter/CheckboxFilter.test.js
@@ -96,17 +96,20 @@ describe('Checkbox', () => {
       expect(config.items[0].onClick).toHaveBeenCalled();
     });
 
+    // NO longer internal state
     it('should update selected', async () => {
-      render(<Checkbox {...config} placeholder="some placeholder" />);
+      const onChange = jest.fn();
+      render(<Checkbox {...config} onChange={onChange} placeholder="some placeholder" />);
       await act(async () => await userEvent.click(screen.getByRole('button', { name: 'Options menu' })));
       act(() => {
         userEvent.click(screen.getByRole('checkbox', { name: 'Custom value' }));
       });
-      expect(screen.getByRole('checkbox', { name: 'Custom value' }).checked).toBe(true);
+      expect(onChange).toHaveBeenCalledWith(expect.any(Object), ['some-value'], 'some-value');
     });
 
     it('should update selected with default value', async () => {
-      render(<Checkbox {...config} value={[{ value: 'another-value' }]} placeholder="some placeholder" />);
+      const onChange = jest.fn();
+      render(<Checkbox {...config} onChange={onChange} value={[{ value: 'another-value' }]} placeholder="some placeholder" />);
       await act(async () => {
         await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
       });
@@ -114,8 +117,22 @@ describe('Checkbox', () => {
       act(() => {
         userEvent.click(screen.getByRole('checkbox', { name: 'Custom value' }));
       });
-      expect(screen.getByRole('checkbox', { name: 'Custom value' }).checked).toBe(true);
-      expect(screen.getByRole('checkbox', { name: 'Another' }).checked).toBe(true);
+
+      expect(onChange).toHaveBeenCalledWith(expect.any(Object), [{ value: 'another-value' }, 'some-value'], 'some-value');
+    });
+
+    it('should remove value', async () => {
+      const onChange = jest.fn();
+      render(<Checkbox {...config} onChange={onChange} value={['another-value']} placeholder="some placeholder" />);
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+      });
+
+      act(() => {
+        userEvent.click(screen.getByRole('checkbox', { name: 'Another' }));
+      });
+
+      expect(onChange).toHaveBeenCalledWith(expect.any(Object), [], 'another-value');
     });
   });
 });


### PR DESCRIPTION
The internal state does not match the parent value and causes visual discrepancies with the actual value passed down from the parent.