### PR TITLE
chore(deps): updating cypress version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42000,7 +42000,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-component-groups": "^1.0.13",
@@ -43227,7 +43227,7 @@
                 "@patternfly/react-core": "^5.0.0",
                 "@patternfly/react-table": "^5.0.0",
                 "@redhat-cloud-services/rbac-client": "^1.0.100",
-                "cypress": ">=12.0.0 < 13.0.0",
+                "cypress": ">=12.0.0 < 14.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-redux": ">=7.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
         "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0",
-        "cypress": ">=12.0.0 < 13.0.0"
+        "cypress": ">=12.0.0 < 14.0.0"
     },
     "dependencies": {
         "@redhat-cloud-services/types": "^0.0.24",


### PR DESCRIPTION
Consumer apps are blocked if they want to update to the "newest" cypress version
This could be necessary for the react 18 updated coming this fall
![image](https://github.com/RedHatInsights/frontend-components/assets/62722417/95f07f6c-e56d-448d-ae1d-0e0b70495c03)
