### PR TITLE
fix(config-utils): Also check env for BETA to choose deployment

### DIFF
--- a/packages/config/src/lib/index.ts
+++ b/packages/config/src/lib/index.ts
@@ -61,7 +61,10 @@ const createFecConfig = (
     fecLogger(LogType.info, 'no git branch detected, using main for webpack "main" config.');
     gitBranch = 'main';
   }
-  const appDeployment = configurations.deployment || (isProd && betaBranches.includes(gitBranch) ? 'beta/apps' : 'apps');
+  const appDeployment =
+    typeof configurations.deployment === 'string'
+      ? configurations.deployment
+      : configurations.deployment || ((isProd && betaBranches.includes(gitBranch)) || process.env.BETA === 'true' ? 'beta/apps' : 'apps');
 
   const publicPath = `/${appDeployment}/${insights.appname}/`;
   const appEntry = configurations.appEntry || getAppEntry(configurations.rootFolder, isProd);


### PR DESCRIPTION
This adds another check that will help prevent apps failing to deploy containers properly for preview environments, since we now set wether or not it is preview via the env variable and not the branch names.