### PR TITLE
Do not validate FEC config for build with custom webpack config.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42391,7 +42391,7 @@
         },
         "packages/chrome": {
             "name": "@redhat-cloud-services/chrome",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash": "^4.17.21"
@@ -42410,7 +42410,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "4.2.0",
+            "version": "4.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-component-groups": "^5.0.0-prerelease.7",
@@ -43160,7 +43160,7 @@
         },
         "packages/pdf-generator": {
             "name": "@redhat-cloud-services/frontend-components-pdf-generator",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-charts": "6.3.9",

--- a/packages/config/src/bin/build-script.ts
+++ b/packages/config/src/bin/build-script.ts
@@ -5,11 +5,12 @@ const { resolve } = require('path');
 import { spawn } from 'child_process';
 
 export function buildScript(argv: { [name: string]: string }, cwd: string) {
-  validateFECConfig(cwd);
   let configPath;
   if (typeof argv.webpackConfig !== 'undefined') {
     configPath = getWebpackConfigPath(argv.webpackConfig, cwd);
   } else {
+    // validate the FEC config only if a custom webpack config is not provided
+    validateFECConfig(cwd);
     configPath = resolve(__dirname, './prod.webpack.config.js');
   }
   process.env.NODE_ENV = 'production';

--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -37,13 +37,14 @@ async function devScript(
   cwd: string
 ) {
   try {
-    validateFECConfig(cwd);
-
-    const fecConfig = require(process.env.FEC_CONFIG_PATH!);
+    let fecConfig: any = {};
     let configPath;
     if (typeof argv.webpackConfig !== 'undefined') {
       configPath = getWebpackConfigPath(argv.webpackConfig, cwd);
     } else {
+      // validate the FEC config only if a custom webpack config is not provided
+      validateFECConfig(cwd);
+      fecConfig = require(process.env.FEC_CONFIG_PATH!);
       configPath = resolve(__dirname, './dev.webpack.config.js');
     }
 

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -9,7 +9,6 @@ import './tsconfig.template.json';
 
 const devScript = require('./dev-script');
 const buildScript = require('./build-script');
-const { validateFECConfig } = require('./common');
 const { fecLogger, LogType } = require('@redhat-cloud-services/frontend-components-config-utilities');
 
 function patchHosts() {
@@ -121,13 +120,10 @@ const argv = yargs
 
 const scripts: { [name: string]: (...args: any[]) => void } = {
   static: (argv: any, cwd: string) => {
-    // set fec config
-    validateFECConfig(cwd);
     serveStatic(argv, cwd);
   },
   'patch-etc-hosts': patchHosts,
   dev: (argv: any, cwd: string) => {
-    validateFECConfig(cwd);
     devScript(argv, cwd);
   },
   build: buildScript,


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-28860

fec.config.js validation for runs with custom webpack config is not necessary because the values from the config file are not used.

The `static` command uses an entirely custom configuration.