### PR TITLE
fix(docs): Replace `_unstableHotReload` with `hotReload`

### DIFF
--- a/packages/docs/pages/fec/modules/config/prod.webpack.config-_unstableHotReload.mdx
+++ b/packages/docs/pages/fec/modules/config/prod.webpack.config-_unstableHotReload.mdx
@@ -1,3 +1,3 @@
 # _unstableHotReload
 
-Do not use HMR for production builds
+Do not use HMR for production builds. Deprecated in favor of `hotReload`.

--- a/packages/docs/pages/frontend-components-config/hot-module-replacement.mdx
+++ b/packages/docs/pages/frontend-components-config/hot-module-replacement.mdx
@@ -12,7 +12,7 @@ Hot Module Replacement (HMR) exchanges, adds, or removes modules while an applic
 
 HMR **is disabled by default**. That is because HMR and module federation can be a bit flaky. Even though it worked in several applications during testing, we keep this feature opt-in, before the stability was validated on more projects.
 
-To enable the HRM, go to your `fec.config.js` or `dev.webpack.config.js` and add the `_unstableHotReload` flag.
+To enable the HRM, go to your `fec.config.js` or `dev.webpack.config.js` and add the `hotReload` flag. This flag replaces the deprecated `_unstableHotReload` flag.
 
 <Alert isInline className="pf-u-mt-md pf-u-mb-md" variant="danger" title="Do not add the flag to production webpack config!" />
 
@@ -21,6 +21,6 @@ To enable the HRM, go to your `fec.config.js` or `dev.webpack.config.js` and add
 {
   // application config
   ...
-  _unstableHotReload: true
+  hotReload: true
 }
 ```


### PR DESCRIPTION
`_unstableHotReload` with `hotReload` has been deprecated according to

https://github.com/RedHatInsights/frontend-components/blob/4ef5accbd645b6a416f2e2bd31096b05771056ec/packages/config/src/lib/createConfig.ts#L46

and

https://github.com/RedHatInsights/frontend-components/blob/bbef2f308320b4b879020ac43f46a23d07df0574/packages/config/src/bin/webpack.plugins.ts#L10