### PR TITLE
fix(deps): Make rbac-client proper dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43748,6 +43748,7 @@
             "version": "4.0.5",
             "license": "Apache-2.0",
             "dependencies": {
+                "@redhat-cloud-services/rbac-client": "^1.0.100",
                 "@redhat-cloud-services/types": "^0.0.24",
                 "@sentry/browser": "^5.30.0",
                 "awesome-debounce-promise": "^2.1.0",
@@ -43763,7 +43764,6 @@
             "peerDependencies": {
                 "@patternfly/react-core": "^5.0.0",
                 "@patternfly/react-table": "^5.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
                 "cypress": ">=12.0.0 < 14.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -50662,6 +50662,7 @@
         "@redhat-cloud-services/frontend-components-utilities": {
             "version": "file:packages/utils",
             "requires": {
+                "@redhat-cloud-services/rbac-client": "^1.0.100",
                 "@redhat-cloud-services/types": "^0.0.24",
                 "@sentry/browser": "^5.30.0",
                 "@types/react": "^18.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -29,7 +29,6 @@
     "peerDependencies": {
         "@patternfly/react-core": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
-        "@redhat-cloud-services/rbac-client": "^1.0.100",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
@@ -37,6 +36,7 @@
         "cypress": ">=12.0.0 < 14.0.0"
     },
     "dependencies": {
+        "@redhat-cloud-services/rbac-client": "^1.0.100",
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",


### PR DESCRIPTION
Both the `RBAC` and the `RBACHook`[0] modules import from `@redhat-cloud-services/rbac-client`.

Using the hook without having the `rbac-client` already as a dependency or installed in a project will cause a module not found error.


[0] https://github.com/RedHatInsights/frontend-components/blob/master/packages/utils/src/RBACHook/RBACHook.ts#L3