### PR TITLE
fix(deps): classnames should be proper dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42536,6 +42536,7 @@
                 "@redhat-cloud-services/types": "^0.0.24",
                 "@scalprum/core": "^0.7.0",
                 "@scalprum/react-core": "^0.7.0",
+                "classnames": "^2.2.5",
                 "sanitize-html": "^2.7.2"
             },
             "devDependencies": {
@@ -42555,7 +42556,6 @@
                 "@patternfly/react-core": "^5.0.0",
                 "@patternfly/react-icons": "^5.0.0",
                 "@patternfly/react-table": "^5.0.0",
-                "classnames": "^2.2.5",
                 "lodash": "^4.17.15",
                 "prop-types": "^15.6.2",
                 "react": "^18.2.0",
@@ -49869,6 +49869,7 @@
                 "@scalprum/core": "^0.7.0",
                 "@scalprum/react-core": "^0.7.0",
                 "@types/react": "^18.0.0",
+                "classnames": "^2.2.5",
                 "css-loader": "^6.7.1",
                 "cypress": "^12.17.3",
                 "eslint-plugin-cypress": "^2.12.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,6 @@
         "@patternfly/react-core": "^5.0.0",
         "@patternfly/react-icons": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
-        "classnames": "^2.2.5",
         "lodash": "^4.17.15",
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
@@ -52,6 +51,7 @@
         "@patternfly/react-component-groups": "^5.0.0",
         "@scalprum/core": "^0.7.0",
         "@scalprum/react-core": "^0.7.0",
+        "classnames": "^2.2.5",
         "sanitize-html": "^2.7.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Installing the package in apps without the classnames as a dependency already will trigger errors like this:

![Screenshot 2024-03-11 at 23 04 04](https://github.com/RedHatInsights/frontend-components/assets/7757/7eaf9b89-f126-474d-b806-dd5d301fbfdf)
