### PR TITLE
fix(remediations): Widen supported react-redux version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42528,7 +42528,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "4.2.4",
+            "version": "4.2.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-component-groups": "^5.0.0",
@@ -43453,7 +43453,7 @@
                 "prop-types": "^15.6.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-redux": "^7.0.0"
+                "react-redux": ">=7.0.0"
             }
         },
         "packages/remediations/node_modules/@redhat-cloud-services/frontend-components-utilities": {

--- a/packages/remediations/package.json
+++ b/packages/remediations/package.json
@@ -32,7 +32,7 @@
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0"
+        "react-redux": ">=7.0.0"
     },
     "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.21.0",


### PR DESCRIPTION
Widening the range should be ok as other fec packages and console already are on v8.1.3 at least and it should prevent this: 

![Screenshot 2024-03-13 at 12 41 50](https://github.com/RedHatInsights/frontend-components/assets/7757/3b24566b-d6e7-4b40-9dc9-31f8638649b2)
