### PR TITLE
fix(npm): npm audit and axios update because of vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
                 "@types/sanitize-html": "^2.6.2",
                 "@typescript-eslint/eslint-plugin": "^5.38.1",
                 "@typescript-eslint/parser": "^5.38.1",
-                "axios-mock-adapter": "^1.21.2",
+                "axios-mock-adapter": "^1.22.0",
                 "babel-core": "^7.0.0-bridge.0",
                 "babel-jest": "^29.0.0",
                 "babel-plugin-lodash": "^3.3.4",
@@ -7304,23 +7304,23 @@
             }
         },
         "node_modules/@nrwl/cli": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.4.tgz",
-            "integrity": "sha512-FoiGFCLpb/r4HXCM3KYqT0xteP+MRV6bIHjz3bdPHIDLmBNQQnRRaV2K47jtJ6zjh1eOU5UHKyDtDDYf80Idpw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.7.tgz",
+            "integrity": "sha512-1jtHBDuJzA57My5nLzYiM372mJW0NY6rFKxlWt5a0RLsAZdPTHsd8lE3Gs9XinGC1jhXbruWmhhnKyYtZvX/zA==",
             "dev": true,
             "dependencies": {
-                "nx": "15.9.4"
+                "nx": "15.9.7"
             }
         },
         "node_modules/@nrwl/devkit": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.4.tgz",
-            "integrity": "sha512-mUX1kXTuPMdTzFxIzH+MsSNvdppOmstPDOEtiGFZJTuJ625ki0HhNJILO3N2mJ7MeMrLqIlAiNdvelQaObxYsQ==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.7.tgz",
+            "integrity": "sha512-Sb7Am2TMT8AVq8e+vxOlk3AtOA2M0qCmhBzoM1OJbdHaPKc0g0UgSnWRml1kPGg5qfPk72tWclLoZJ5/ut0vTg==",
             "dev": true,
             "dependencies": {
                 "ejs": "^3.1.7",
                 "ignore": "^5.0.4",
-                "semver": "7.3.4",
+                "semver": "7.5.4",
                 "tmp": "~0.2.1",
                 "tslib": "^2.3.0"
             },
@@ -7341,9 +7341,9 @@
             }
         },
         "node_modules/@nrwl/devkit/node_modules/semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7362,9 +7362,9 @@
             "dev": true
         },
         "node_modules/@nrwl/nx-darwin-arm64": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
-            "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.7.tgz",
+            "integrity": "sha512-aBUgnhlkrgC0vu0fK6eb9Vob7eFnkuknrK+YzTjmLrrZwj7FGNAeyGXSlyo1dVokIzjVKjJg2saZZ0WQbfuCJw==",
             "cpu": [
                 "arm64"
             ],
@@ -7378,9 +7378,9 @@
             }
         },
         "node_modules/@nrwl/nx-darwin-x64": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
-            "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.7.tgz",
+            "integrity": "sha512-L+elVa34jhGf1cmn38Z0sotQatmLovxoASCIw5r1CBZZeJ5Tg7Y9nOwjRiDixZxNN56hPKXm6xl9EKlVHVeKlg==",
             "cpu": [
                 "x64"
             ],
@@ -7394,9 +7394,9 @@
             }
         },
         "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
-            "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.7.tgz",
+            "integrity": "sha512-pqmfqqEUGFu6PmmHKyXyUw1Al0Ki8PSaR0+ndgCAb1qrekVDGDfznJfaqxN0JSLeolPD6+PFtLyXNr9ZyPFlFg==",
             "cpu": [
                 "arm"
             ],
@@ -7410,9 +7410,9 @@
             }
         },
         "node_modules/@nrwl/nx-linux-arm64-gnu": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
-            "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.7.tgz",
+            "integrity": "sha512-NYOa/eRrqmM+In5g3M0rrPVIS9Z+q6fvwXJYf/KrjOHqqan/KL+2TOfroA30UhcBrwghZvib7O++7gZ2hzwOnA==",
             "cpu": [
                 "arm64"
             ],
@@ -7426,9 +7426,9 @@
             }
         },
         "node_modules/@nrwl/nx-linux-arm64-musl": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
-            "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.7.tgz",
+            "integrity": "sha512-zyStqjEcmbvLbejdTOrLUSEdhnxNtdQXlmOuymznCzYUEGRv+4f7OAepD3yRoR0a/57SSORZmmGQB7XHZoYZJA==",
             "cpu": [
                 "arm64"
             ],
@@ -7442,9 +7442,9 @@
             }
         },
         "node_modules/@nrwl/nx-linux-x64-gnu": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
-            "integrity": "sha512-q4OyH72mdrE4KellBWtwpr5EwfxHKNoFP9//7FAILO68ROh0rpMd7YQMlTB7T04UEUHjKEEsFGTlVXIee3Viwg==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.7.tgz",
+            "integrity": "sha512-saNK5i2A8pKO3Il+Ejk/KStTApUpWgCxjeUz9G+T8A+QHeDloZYH2c7pU/P3jA9QoNeKwjVO9wYQllPL9loeVg==",
             "cpu": [
                 "x64"
             ],
@@ -7458,9 +7458,9 @@
             }
         },
         "node_modules/@nrwl/nx-linux-x64-musl": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
-            "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.7.tgz",
+            "integrity": "sha512-extIUThYN94m4Vj4iZggt6hhMZWQSukBCo8pp91JHnDcryBg7SnYmnikwtY1ZAFyyRiNFBLCKNIDFGkKkSrZ9Q==",
             "cpu": [
                 "x64"
             ],
@@ -7474,9 +7474,9 @@
             }
         },
         "node_modules/@nrwl/nx-win32-arm64-msvc": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
-            "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.7.tgz",
+            "integrity": "sha512-GSQ54hJ5AAnKZb4KP4cmBnJ1oC4ILxnrG1mekxeM65c1RtWg9NpBwZ8E0gU3xNrTv8ZNsBeKi/9UhXBxhsIh8A==",
             "cpu": [
                 "arm64"
             ],
@@ -7490,9 +7490,9 @@
             }
         },
         "node_modules/@nrwl/nx-win32-x64-msvc": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
-            "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.7.tgz",
+            "integrity": "sha512-x6URof79RPd8AlapVbPefUD3ynJZpmah3tYaYZ9xZRMXojVtEHV8Qh5vysKXQ1rNYJiiB8Ah6evSKWLbAH60tw==",
             "cpu": [
                 "x64"
             ],
@@ -7506,12 +7506,12 @@
             }
         },
         "node_modules/@nrwl/tao": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
-            "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.7.tgz",
+            "integrity": "sha512-OBnHNvQf3vBH0qh9YnvBQQWyyFZ+PWguF6dJ8+1vyQYlrLVk/XZ8nJ4ukWFb+QfPv/O8VBmqaofaOI9aFC4yTw==",
             "dev": true,
             "dependencies": {
-                "nx": "15.9.4"
+                "nx": "15.9.7"
             },
             "bin": {
                 "tao": "index.js"
@@ -7992,21 +7992,20 @@
             "dev": true
         },
         "node_modules/@patternfly/quickstarts": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-5.0.0.tgz",
-            "integrity": "sha512-G1nb0x+jmO/F2fVv+bymadvjO+RZWwY3foU+1VBqvI28vtr7M6isLj81Cz8cjjT0t0Z2CdMSVVfkwxoKQxMOgA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-5.1.0.tgz",
+            "integrity": "sha512-ql5Q8IlW+Yp1Y7rqDqrsoDhYrSv3/HTp+1BYg7n4vyOsTc9QL+PxW4+PI8mLLk/tB6Z93yS7l76b5gaACPgH2g==",
             "dev": true,
             "dependencies": {
                 "@patternfly/react-catalog-view-extension": "^5.0.0",
                 "dompurify": "^2.2.6",
-                "history": "^5.0.0",
-                "showdown": "1.8.6"
+                "history": "^5.0.0"
             },
             "peerDependencies": {
-                "@patternfly/react-core": ">=4.115.2",
+                "@patternfly/react-core": ">=5.0.0",
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0",
-                "showdown": ">=1.8.6"
+                "showdown": ">=2.1.0"
             }
         },
         "node_modules/@patternfly/quickstarts/node_modules/history": {
@@ -8303,9 +8302,9 @@
             "link": true
         },
         "node_modules/@redhat-cloud-services/host-inventory-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.2.5.tgz",
-            "integrity": "sha512-KsTrEZuCeOYnEmZL/Yp0koN0BX8DYzvtwuPaJLrhvK0wZYlElaMJpDV36BnZjGEIQfP0RvKbhflCnFsIfcQNeA==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.2.13.tgz",
+            "integrity": "sha512-orFj70qmmFKwF6rz4SoVFbegPVAA30LSTzKdASuxvr1OloMjA9Fx/LaBrbFoymU/I9NAhuLnx3uSHXrNq2M7/g==",
             "dependencies": {
                 "axios": "^0.27.2"
             }
@@ -8320,9 +8319,9 @@
             }
         },
         "node_modules/@redhat-cloud-services/rbac-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.5.tgz",
-            "integrity": "sha512-RTz3bvMum1jUUgLTzJ/7jl7H1g3h2hU4F1XorAxG+MJC0fnNI8+M7j27EhGNSDc0gJNs9+gK5E6eMsuaJ4aWxQ==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.13.tgz",
+            "integrity": "sha512-kinsQjNyoJScNlUonnK9zH7gDnFqLQKCn22qOSBJU/LEOY+5wLiVSPfdeHOr2eBZrli2YYxJ90rIyMg4oBSygQ==",
             "dependencies": {
                 "axios": "^0.27.2"
             }
@@ -13581,13 +13580,16 @@
             "dev": true
         },
         "node_modules/@yarnpkg/parsers": {
-            "version": "3.0.0-rc.48.1",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.48.1.tgz",
-            "integrity": "sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==",
+            "version": "3.0.0-rc.46",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
+            "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
             "dev": true,
             "dependencies": {
                 "js-yaml": "^3.10.0",
                 "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=14.15.0"
             }
         },
         "node_modules/@zkochan/js-yaml": {
@@ -14406,19 +14408,19 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/axios-mock-adapter": {
-            "version": "1.21.5",
-            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
-            "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
+            "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -16222,15 +16224,6 @@
                 "node": ">= 0.12.0"
             }
         },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/codesandbox": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/codesandbox/-/codesandbox-2.2.3.tgz",
@@ -17763,12 +17756,12 @@
             "dev": true
         },
         "node_modules/cypress": {
-            "version": "12.17.3",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-            "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+            "version": "12.17.4",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+            "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
             "hasInstallScript": true,
             "dependencies": {
-                "@cypress/request": "^2.88.11",
+                "@cypress/request": "2.88.12",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/node": "^16.18.39",
                 "@types/sinonjs__fake-timers": "8.1.1",
@@ -17803,6 +17796,7 @@
                 "minimist": "^1.2.8",
                 "ospath": "^1.2.2",
                 "pretty-bytes": "^5.6.0",
+                "process": "^0.11.10",
                 "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
                 "semver": "^7.5.3",
@@ -23796,15 +23790,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "node_modules/invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/ip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -27612,18 +27597,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-            "dev": true,
-            "dependencies": {
-                "invert-kv": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/lerna": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/lerna/-/lerna-5.6.2.tgz",
@@ -28995,27 +28968,6 @@
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha512-nOBDrc/wgpkd3X/JOhMqYR+/eLqlfLP4oQfoBA6QExIxEl+GU01oyEkwWyueyO8110pUKijtiHGhEmYoOn88oQ==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/mem/node_modules/mimic-fn": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/memfs": {
@@ -30663,9 +30615,9 @@
             "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "funding": [
                 {
                     "type": "github",
@@ -31800,15 +31752,6 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/nwsapi": {
             "version": "2.2.7",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -31816,17 +31759,17 @@
             "dev": true
         },
         "node_modules/nx": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
-            "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.7.tgz",
+            "integrity": "sha512-1qlEeDjX9OKZEryC8i4bA+twNg+lB5RKrozlNwWx/lLJHqWPUfvUTvxh+uxlPYL9KzVReQjUuxMLFMsHNqWUrA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@nrwl/cli": "15.9.4",
-                "@nrwl/tao": "15.9.4",
+                "@nrwl/cli": "15.9.7",
+                "@nrwl/tao": "15.9.7",
                 "@parcel/watcher": "2.0.4",
                 "@yarnpkg/lockfile": "^1.1.0",
-                "@yarnpkg/parsers": "^3.0.0-rc.18",
+                "@yarnpkg/parsers": "3.0.0-rc.46",
                 "@zkochan/js-yaml": "0.0.6",
                 "axios": "^1.0.0",
                 "chalk": "^4.1.0",
@@ -31847,7 +31790,7 @@
                 "minimatch": "3.0.5",
                 "npm-run-path": "^4.0.1",
                 "open": "^8.4.0",
-                "semver": "7.3.4",
+                "semver": "7.5.4",
                 "string-width": "^4.2.3",
                 "strong-log-transformer": "^2.1.0",
                 "tar-stream": "~2.2.0",
@@ -31862,15 +31805,15 @@
                 "nx": "bin/nx.js"
             },
             "optionalDependencies": {
-                "@nrwl/nx-darwin-arm64": "15.9.4",
-                "@nrwl/nx-darwin-x64": "15.9.4",
-                "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
-                "@nrwl/nx-linux-arm64-gnu": "15.9.4",
-                "@nrwl/nx-linux-arm64-musl": "15.9.4",
-                "@nrwl/nx-linux-x64-gnu": "15.9.4",
-                "@nrwl/nx-linux-x64-musl": "15.9.4",
-                "@nrwl/nx-win32-arm64-msvc": "15.9.4",
-                "@nrwl/nx-win32-x64-msvc": "15.9.4"
+                "@nrwl/nx-darwin-arm64": "15.9.7",
+                "@nrwl/nx-darwin-x64": "15.9.7",
+                "@nrwl/nx-linux-arm-gnueabihf": "15.9.7",
+                "@nrwl/nx-linux-arm64-gnu": "15.9.7",
+                "@nrwl/nx-linux-arm64-musl": "15.9.7",
+                "@nrwl/nx-linux-x64-gnu": "15.9.7",
+                "@nrwl/nx-linux-x64-musl": "15.9.7",
+                "@nrwl/nx-win32-arm64-msvc": "15.9.7",
+                "@nrwl/nx-win32-x64-msvc": "15.9.7"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.4.2",
@@ -31905,17 +31848,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
-        },
-        "node_modules/nx/node_modules/axios": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-            "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-            "dev": true,
-            "dependencies": {
-                "follow-redirects": "^1.15.4",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "node_modules/nx/node_modules/chalk": {
             "version": "4.1.2",
@@ -32073,9 +32005,9 @@
             }
         },
         "node_modules/nx/node_modules/semver": {
-            "version": "7.3.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-            "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -32483,137 +32415,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-            "dev": true,
-            "dependencies": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/os-locale/node_modules/cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
-        "node_modules/os-locale/node_modules/execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/os-locale/node_modules/get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/os-locale/node_modules/is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/os-locale/node_modules/lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "dev": true,
-            "dependencies": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "node_modules/os-locale/node_modules/npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/os-locale/node_modules/path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/os-locale/node_modules/shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/os-locale/node_modules/shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/os-locale/node_modules/which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "which": "bin/which"
-            }
-        },
-        "node_modules/os-locale/node_modules/yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-            "dev": true
         },
         "node_modules/os-name": {
             "version": "3.1.0",
@@ -33945,9 +33746,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.27",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+            "version": "8.4.37",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.37.tgz",
+            "integrity": "sha512-7iB/v/r7Woof0glKLH8b1SPHrsX7uhdO+Geb41QpF/+mWZHU3uxxSlN+UXGVit1PawOYDToO+AbZzhBzWRDwbQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -33963,9 +33764,9 @@
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.6",
+                "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -37229,252 +37030,30 @@
             "dev": true
         },
         "node_modules/showdown": {
-            "version": "1.8.6",
-            "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
-            "integrity": "sha512-cOmS+LUIiyMxFo7OU3cgV+zTv43GItwlTwUPrpUd5dqdlZh8CJMVb8KxAMhr42J6exQwKTCHMxUiG74vamV1kA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "yargs": "^10.0.3"
+                "commander": "^9.0.0"
             },
             "bin": {
                 "showdown": "bin/showdown.js"
-            }
-        },
-        "node_modules/showdown/node_modules/ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/cliui": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-            }
-        },
-        "node_modules/showdown/node_modules/find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^2.0.0"
             },
+            "funding": {
+                "type": "individual",
+                "url": "https://www.paypal.me/tiviesantos"
+            }
+        },
+        "node_modules/showdown/node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "dev": true,
+            "peer": true,
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/get-caller-file": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-            "dev": true
-        },
-        "node_modules/showdown/node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/locate-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/p-limit": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-            "dev": true,
-            "dependencies": {
-                "p-try": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/p-locate": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/p-try": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
-            "dev": true
-        },
-        "node_modules/showdown/node_modules/string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "dev": true,
-            "dependencies": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/showdown/node_modules/wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/showdown/node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/showdown/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-            "dev": true,
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/showdown/node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-            "dev": true,
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/showdown/node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/showdown/node_modules/y18n": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-            "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-            "dev": true
-        },
-        "node_modules/showdown/node_modules/yargs": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-            "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-            "dev": true,
-            "dependencies": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^8.1.0"
-            }
-        },
-        "node_modules/showdown/node_modules/yargs-parser": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-            "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-            "dev": true,
-            "dependencies": {
-                "camelcase": "^4.1.0"
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/side-channel": {
@@ -37717,9 +37296,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -41576,12 +41155,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/which-module": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-            "dev": true
-        },
         "node_modules/which-typed-array": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
@@ -42580,7 +42153,7 @@
                 "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
                 "@swc/core": "^1.3.76",
                 "assert": "^2.0.0",
-                "axios": "^0.28.0",
+                "axios": "^1.6.8",
                 "browserify-zlib": "^0.2.0",
                 "buffer": "^6.0.3",
                 "chalk": "^4.1.2",
@@ -43644,9 +43217,9 @@
             "peer": true
         },
         "packages/translations/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-            "version": "3.7.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.5.tgz",
-            "integrity": "sha512-izNgQpuX93XxrxCQZ702sd7k8kcm/RtOj8pGDWObwHVryFm11bsflX82GdOtSSu/AYtgPiyXSOmmn9Rxw1ZcXQ==",
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.6.tgz",
+            "integrity": "sha512-qXevUW8Clj1AoBLwfZAmS+oFJCWKZaMp8O33cyUhkoGjrwkQaL5eJg28zjLVa1uQhdJAvAdwTNtE+Gt3hJTC1g==",
             "optional": true,
             "dependencies": {
                 "@redhat-cloud-services/types": "^0.0.24",
@@ -43667,6 +43240,12 @@
                 "react-redux": ">=7.0.0",
                 "react-router-dom": "^5.0.0 || ^6.0.0"
             }
+        },
+        "packages/translations/node_modules/@redhat-cloud-services/types": {
+            "version": "0.0.24",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+            "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg==",
+            "optional": true
         },
         "packages/translations/node_modules/attr-accept": {
             "version": "1.1.3",
@@ -43777,7 +43356,7 @@
                 "@redhat-cloud-services/types": "^0.0.24",
                 "@sentry/browser": "^5.30.0",
                 "awesome-debounce-promise": "^2.1.0",
-                "axios": "^0.28.0",
+                "axios": "^1.6.8",
                 "commander": "^2.20.3",
                 "mkdirp": "^1.0.4",
                 "p-all": "^5.0.0",
@@ -49096,23 +48675,23 @@
             }
         },
         "@nrwl/cli": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.4.tgz",
-            "integrity": "sha512-FoiGFCLpb/r4HXCM3KYqT0xteP+MRV6bIHjz3bdPHIDLmBNQQnRRaV2K47jtJ6zjh1eOU5UHKyDtDDYf80Idpw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-15.9.7.tgz",
+            "integrity": "sha512-1jtHBDuJzA57My5nLzYiM372mJW0NY6rFKxlWt5a0RLsAZdPTHsd8lE3Gs9XinGC1jhXbruWmhhnKyYtZvX/zA==",
             "dev": true,
             "requires": {
-                "nx": "15.9.4"
+                "nx": "15.9.7"
             }
         },
         "@nrwl/devkit": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.4.tgz",
-            "integrity": "sha512-mUX1kXTuPMdTzFxIzH+MsSNvdppOmstPDOEtiGFZJTuJ625ki0HhNJILO3N2mJ7MeMrLqIlAiNdvelQaObxYsQ==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.9.7.tgz",
+            "integrity": "sha512-Sb7Am2TMT8AVq8e+vxOlk3AtOA2M0qCmhBzoM1OJbdHaPKc0g0UgSnWRml1kPGg5qfPk72tWclLoZJ5/ut0vTg==",
             "dev": true,
             "requires": {
                 "ejs": "^3.1.7",
                 "ignore": "^5.0.4",
-                "semver": "7.3.4",
+                "semver": "7.5.4",
                 "tmp": "~0.2.1",
                 "tslib": "^2.3.0"
             },
@@ -49127,9 +48706,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -49144,75 +48723,75 @@
             }
         },
         "@nrwl/nx-darwin-arm64": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
-            "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.7.tgz",
+            "integrity": "sha512-aBUgnhlkrgC0vu0fK6eb9Vob7eFnkuknrK+YzTjmLrrZwj7FGNAeyGXSlyo1dVokIzjVKjJg2saZZ0WQbfuCJw==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-darwin-x64": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
-            "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.7.tgz",
+            "integrity": "sha512-L+elVa34jhGf1cmn38Z0sotQatmLovxoASCIw5r1CBZZeJ5Tg7Y9nOwjRiDixZxNN56hPKXm6xl9EKlVHVeKlg==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-linux-arm-gnueabihf": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
-            "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.7.tgz",
+            "integrity": "sha512-pqmfqqEUGFu6PmmHKyXyUw1Al0Ki8PSaR0+ndgCAb1qrekVDGDfznJfaqxN0JSLeolPD6+PFtLyXNr9ZyPFlFg==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-linux-arm64-gnu": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
-            "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.7.tgz",
+            "integrity": "sha512-NYOa/eRrqmM+In5g3M0rrPVIS9Z+q6fvwXJYf/KrjOHqqan/KL+2TOfroA30UhcBrwghZvib7O++7gZ2hzwOnA==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-linux-arm64-musl": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
-            "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.7.tgz",
+            "integrity": "sha512-zyStqjEcmbvLbejdTOrLUSEdhnxNtdQXlmOuymznCzYUEGRv+4f7OAepD3yRoR0a/57SSORZmmGQB7XHZoYZJA==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-linux-x64-gnu": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
-            "integrity": "sha512-q4OyH72mdrE4KellBWtwpr5EwfxHKNoFP9//7FAILO68ROh0rpMd7YQMlTB7T04UEUHjKEEsFGTlVXIee3Viwg==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.7.tgz",
+            "integrity": "sha512-saNK5i2A8pKO3Il+Ejk/KStTApUpWgCxjeUz9G+T8A+QHeDloZYH2c7pU/P3jA9QoNeKwjVO9wYQllPL9loeVg==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-linux-x64-musl": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
-            "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.7.tgz",
+            "integrity": "sha512-extIUThYN94m4Vj4iZggt6hhMZWQSukBCo8pp91JHnDcryBg7SnYmnikwtY1ZAFyyRiNFBLCKNIDFGkKkSrZ9Q==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-win32-arm64-msvc": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
-            "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.7.tgz",
+            "integrity": "sha512-GSQ54hJ5AAnKZb4KP4cmBnJ1oC4ILxnrG1mekxeM65c1RtWg9NpBwZ8E0gU3xNrTv8ZNsBeKi/9UhXBxhsIh8A==",
             "dev": true,
             "optional": true
         },
         "@nrwl/nx-win32-x64-msvc": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
-            "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.7.tgz",
+            "integrity": "sha512-x6URof79RPd8AlapVbPefUD3ynJZpmah3tYaYZ9xZRMXojVtEHV8Qh5vysKXQ1rNYJiiB8Ah6evSKWLbAH60tw==",
             "dev": true,
             "optional": true
         },
         "@nrwl/tao": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.4.tgz",
-            "integrity": "sha512-m90iz8UsXx1rgPm1dxsBQjSrCViWYZIrp8bpwjSCW24j3kifyilYSXGuKaRwZwUn7eNmH/kZcI9/8qeGIPF4Sg==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.9.7.tgz",
+            "integrity": "sha512-OBnHNvQf3vBH0qh9YnvBQQWyyFZ+PWguF6dJ8+1vyQYlrLVk/XZ8nJ4ukWFb+QfPv/O8VBmqaofaOI9aFC4yTw==",
             "dev": true,
             "requires": {
-                "nx": "15.9.4"
+                "nx": "15.9.7"
             }
         },
         "@octokit/auth-token": {
@@ -49644,15 +49223,14 @@
             "dev": true
         },
         "@patternfly/quickstarts": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-5.0.0.tgz",
-            "integrity": "sha512-G1nb0x+jmO/F2fVv+bymadvjO+RZWwY3foU+1VBqvI28vtr7M6isLj81Cz8cjjT0t0Z2CdMSVVfkwxoKQxMOgA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@patternfly/quickstarts/-/quickstarts-5.1.0.tgz",
+            "integrity": "sha512-ql5Q8IlW+Yp1Y7rqDqrsoDhYrSv3/HTp+1BYg7n4vyOsTc9QL+PxW4+PI8mLLk/tB6Z93yS7l76b5gaACPgH2g==",
             "dev": true,
             "requires": {
                 "@patternfly/react-catalog-view-extension": "^5.0.0",
                 "dompurify": "^2.2.6",
-                "history": "^5.0.0",
-                "showdown": "1.8.6"
+                "history": "^5.0.0"
             },
             "dependencies": {
                 "history": {
@@ -50055,7 +49633,7 @@
                 "@swc/core": "^1.3.76",
                 "@types/inquirer": "^9.0.3",
                 "assert": "^2.0.0",
-                "axios": "^0.28.0",
+                "axios": "^1.6.8",
                 "browserify-zlib": "^0.2.0",
                 "buffer": "^6.0.3",
                 "chalk": "^4.1.2",
@@ -50603,9 +50181,9 @@
                     "peer": true
                 },
                 "@redhat-cloud-services/frontend-components-utilities": {
-                    "version": "3.7.5",
-                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.5.tgz",
-                    "integrity": "sha512-izNgQpuX93XxrxCQZ702sd7k8kcm/RtOj8pGDWObwHVryFm11bsflX82GdOtSSu/AYtgPiyXSOmmn9Rxw1ZcXQ==",
+                    "version": "3.7.6",
+                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.6.tgz",
+                    "integrity": "sha512-qXevUW8Clj1AoBLwfZAmS+oFJCWKZaMp8O33cyUhkoGjrwkQaL5eJg28zjLVa1uQhdJAvAdwTNtE+Gt3hJTC1g==",
                     "optional": true,
                     "requires": {
                         "@redhat-cloud-services/types": "^0.0.24",
@@ -50616,6 +50194,12 @@
                         "mkdirp": "^1.0.4",
                         "react-content-loader": "^6.2.0"
                     }
+                },
+                "@redhat-cloud-services/types": {
+                    "version": "0.0.24",
+                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+                    "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg==",
+                    "optional": true
                 },
                 "attr-accept": {
                     "version": "1.1.3",
@@ -50693,7 +50277,7 @@
                 "@sentry/browser": "^5.30.0",
                 "@types/react": "^18.0.0",
                 "awesome-debounce-promise": "^2.1.0",
-                "axios": "^0.28.0",
+                "axios": "^1.6.8",
                 "commander": "^2.20.3",
                 "glob": "10.3.3",
                 "mkdirp": "^1.0.4",
@@ -50712,9 +50296,9 @@
             }
         },
         "@redhat-cloud-services/host-inventory-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.2.5.tgz",
-            "integrity": "sha512-KsTrEZuCeOYnEmZL/Yp0koN0BX8DYzvtwuPaJLrhvK0wZYlElaMJpDV36BnZjGEIQfP0RvKbhflCnFsIfcQNeA==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-1.2.13.tgz",
+            "integrity": "sha512-orFj70qmmFKwF6rz4SoVFbegPVAA30LSTzKdASuxvr1OloMjA9Fx/LaBrbFoymU/I9NAhuLnx3uSHXrNq2M7/g==",
             "requires": {
                 "axios": "^0.27.2"
             },
@@ -50731,9 +50315,9 @@
             }
         },
         "@redhat-cloud-services/rbac-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.5.tgz",
-            "integrity": "sha512-RTz3bvMum1jUUgLTzJ/7jl7H1g3h2hU4F1XorAxG+MJC0fnNI8+M7j27EhGNSDc0gJNs9+gK5E6eMsuaJ4aWxQ==",
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.13.tgz",
+            "integrity": "sha512-kinsQjNyoJScNlUonnK9zH7gDnFqLQKCn22qOSBJU/LEOY+5wLiVSPfdeHOr2eBZrli2YYxJ90rIyMg4oBSygQ==",
             "requires": {
                 "axios": "^0.27.2"
             },
@@ -53723,9 +53307,9 @@
             "dev": true
         },
         "@yarnpkg/parsers": {
-            "version": "3.0.0-rc.48.1",
-            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.48.1.tgz",
-            "integrity": "sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==",
+            "version": "3.0.0-rc.46",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
+            "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
             "dev": true,
             "requires": {
                 "js-yaml": "^3.10.0",
@@ -54327,19 +53911,19 @@
             "dev": true
         },
         "axios": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-            "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "requires": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
         },
         "axios-mock-adapter": {
-            "version": "1.21.5",
-            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
-            "integrity": "sha512-5NI1V/VK+8+JeTF8niqOowuysA4b8mGzdlMN/QnTnoXbYh4HZSNiopsDclN2g/m85+G++IrEtUdZaQ3GnaMsSA==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
+            "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.3",
@@ -55705,12 +55289,6 @@
             "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
             "dev": true
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-            "dev": true
-        },
         "codesandbox": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/codesandbox/-/codesandbox-2.2.3.tgz",
@@ -56995,11 +56573,11 @@
             "dev": true
         },
         "cypress": {
-            "version": "12.17.3",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-            "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+            "version": "12.17.4",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+            "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
             "requires": {
-                "@cypress/request": "^2.88.11",
+                "@cypress/request": "2.88.12",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/node": "^16.18.39",
                 "@types/sinonjs__fake-timers": "8.1.1",
@@ -57034,6 +56612,7 @@
                 "minimist": "^1.2.8",
                 "ospath": "^1.2.2",
                 "pretty-bytes": "^5.6.0",
+                "process": "^0.11.10",
                 "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
                 "semver": "^7.5.3",
@@ -61774,12 +61353,6 @@
                 "tslib": "^2.4.0"
             }
         },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
-            "dev": true
-        },
         "ip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
@@ -64597,15 +64170,6 @@
             "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
             "dev": true
         },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^1.0.0"
-            }
-        },
         "lerna": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/lerna/-/lerna-5.6.2.tgz",
@@ -65668,23 +65232,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
-        },
-        "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha512-nOBDrc/wgpkd3X/JOhMqYR+/eLqlfLP4oQfoBA6QExIxEl+GU01oyEkwWyueyO8110pUKijtiHGhEmYoOn88oQ==",
-            "dev": true,
-            "requires": {
-                "mimic-fn": "^1.0.0"
-            },
-            "dependencies": {
-                "mimic-fn": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-                    "dev": true
-                }
-            }
         },
         "memfs": {
             "version": "3.5.3",
@@ -66834,9 +66381,9 @@
             "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
         },
         "nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
         },
         "napi-build-utils": {
             "version": "1.0.2",
@@ -67685,12 +67232,6 @@
                 "boolbase": "^1.0.0"
             }
         },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-            "dev": true
-        },
         "nwsapi": {
             "version": "2.2.7",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -67698,25 +67239,25 @@
             "dev": true
         },
         "nx": {
-            "version": "15.9.4",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.4.tgz",
-            "integrity": "sha512-P1G4t59UvE/lkHyruLeSOB5ZuNyh01IwU0tTUOi8f9s/NbP7+OQ8MYVwDV74JHTr6mQgjlS+n+4Eox8tVm9itA==",
+            "version": "15.9.7",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-15.9.7.tgz",
+            "integrity": "sha512-1qlEeDjX9OKZEryC8i4bA+twNg+lB5RKrozlNwWx/lLJHqWPUfvUTvxh+uxlPYL9KzVReQjUuxMLFMsHNqWUrA==",
             "dev": true,
             "requires": {
-                "@nrwl/cli": "15.9.4",
-                "@nrwl/nx-darwin-arm64": "15.9.4",
-                "@nrwl/nx-darwin-x64": "15.9.4",
-                "@nrwl/nx-linux-arm-gnueabihf": "15.9.4",
-                "@nrwl/nx-linux-arm64-gnu": "15.9.4",
-                "@nrwl/nx-linux-arm64-musl": "15.9.4",
-                "@nrwl/nx-linux-x64-gnu": "15.9.4",
-                "@nrwl/nx-linux-x64-musl": "15.9.4",
-                "@nrwl/nx-win32-arm64-msvc": "15.9.4",
-                "@nrwl/nx-win32-x64-msvc": "15.9.4",
-                "@nrwl/tao": "15.9.4",
+                "@nrwl/cli": "15.9.7",
+                "@nrwl/nx-darwin-arm64": "15.9.7",
+                "@nrwl/nx-darwin-x64": "15.9.7",
+                "@nrwl/nx-linux-arm-gnueabihf": "15.9.7",
+                "@nrwl/nx-linux-arm64-gnu": "15.9.7",
+                "@nrwl/nx-linux-arm64-musl": "15.9.7",
+                "@nrwl/nx-linux-x64-gnu": "15.9.7",
+                "@nrwl/nx-linux-x64-musl": "15.9.7",
+                "@nrwl/nx-win32-arm64-msvc": "15.9.7",
+                "@nrwl/nx-win32-x64-msvc": "15.9.7",
+                "@nrwl/tao": "15.9.7",
                 "@parcel/watcher": "2.0.4",
                 "@yarnpkg/lockfile": "^1.1.0",
-                "@yarnpkg/parsers": "^3.0.0-rc.18",
+                "@yarnpkg/parsers": "3.0.0-rc.46",
                 "@zkochan/js-yaml": "0.0.6",
                 "axios": "^1.0.0",
                 "chalk": "^4.1.0",
@@ -67737,7 +67278,7 @@
                 "minimatch": "3.0.5",
                 "npm-run-path": "^4.0.1",
                 "open": "^8.4.0",
-                "semver": "7.3.4",
+                "semver": "7.5.4",
                 "string-width": "^4.2.3",
                 "strong-log-transformer": "^2.1.0",
                 "tar-stream": "~2.2.0",
@@ -67763,17 +67304,6 @@
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
                     "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
                     "dev": true
-                },
-                "axios": {
-                    "version": "1.6.7",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-                    "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-                    "dev": true,
-                    "requires": {
-                        "follow-redirects": "^1.15.4",
-                        "form-data": "^4.0.0",
-                        "proxy-from-env": "^1.1.0"
-                    }
                 },
                 "chalk": {
                     "version": "4.1.2",
@@ -67892,9 +67422,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.4",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+                    "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -68194,112 +67724,6 @@
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
             "dev": true
-        },
-        "os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-            "dev": true,
-            "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-            },
-            "dependencies": {
-                "cross-spawn": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-                    "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
-                "execa": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-                    "integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                    "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
-                    "dev": true
-                },
-                "is-stream": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                    "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-                    "dev": true
-                },
-                "lru-cache": {
-                    "version": "4.1.5",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
-                    }
-                },
-                "npm-run-path": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-                    "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
-                    "dev": true,
-                    "requires": {
-                        "path-key": "^2.0.0"
-                    }
-                },
-                "path-key": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-                    "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-                    "dev": true
-                },
-                "shebang-command": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-                    "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-                    "dev": true,
-                    "requires": {
-                        "shebang-regex": "^1.0.0"
-                    }
-                },
-                "shebang-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                    "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-                    "dev": true
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                    "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-                    "dev": true
-                }
-            }
         },
         "os-name": {
             "version": "3.1.0",
@@ -69421,13 +68845,13 @@
             }
         },
         "postcss": {
-            "version": "8.4.27",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+            "version": "8.4.37",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.37.tgz",
+            "integrity": "sha512-7iB/v/r7Woof0glKLH8b1SPHrsX7uhdO+Geb41QpF/+mWZHU3uxxSlN+UXGVit1PawOYDToO+AbZzhBzWRDwbQ==",
             "requires": {
-                "nanoid": "^3.3.6",
+                "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             }
         },
         "postcss-calc": {
@@ -71869,204 +71293,21 @@
             }
         },
         "showdown": {
-            "version": "1.8.6",
-            "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
-            "integrity": "sha512-cOmS+LUIiyMxFo7OU3cgV+zTv43GItwlTwUPrpUd5dqdlZh8CJMVb8KxAMhr42J6exQwKTCHMxUiG74vamV1kA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
             "dev": true,
+            "peer": true,
             "requires": {
-                "yargs": "^10.0.3"
+                "commander": "^9.0.0"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-                    "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+                "commander": {
+                    "version": "9.5.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+                    "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
                     "dev": true,
-                    "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
-                    }
-                },
-                "find-up": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^2.0.0"
-                    }
-                },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-                    "dev": true
-                },
-                "locate-path": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-                    "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                    "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^1.1.0"
-                    }
-                },
-                "p-try": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-                    "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-                    "dev": true
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-                    "dev": true
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "ansi-regex": {
-                            "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-                            "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-                            "dev": true,
-                            "requires": {
-                                "number-is-nan": "^1.0.0"
-                            }
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-                            "dev": true,
-                            "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
-                            }
-                        },
-                        "strip-ansi": {
-                            "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^2.0.0"
-                            }
-                        }
-                    }
-                },
-                "y18n": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-                    "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "10.1.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-                    "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^8.1.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-                    "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^4.1.0"
-                    }
+                    "peer": true
                 }
             }
         },
@@ -72244,9 +71485,9 @@
             "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
         },
         "source-map-loader": {
             "version": "3.0.2",
@@ -75213,12 +74454,6 @@
                 "is-weakmap": "^2.0.1",
                 "is-weakset": "^2.0.1"
             }
-        },
-        "which-module": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-            "dev": true
         },
         "which-typed-array": {
             "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@types/sanitize-html": "^2.6.2",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
-        "axios-mock-adapter": "^1.21.2",
+        "axios-mock-adapter": "^1.22.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^29.0.0",
         "babel-plugin-lodash": "^3.3.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -33,7 +33,7 @@
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
-        "axios": "^0.28.0",
+        "axios": "^1.6.8",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -39,7 +39,7 @@
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.0",
+        "axios": "^1.6.8",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
         "p-all": "^5.0.0",


### PR DESCRIPTION
There is a CVE about axios version,
https://issues.redhat.com/browse/RHINENG-8636
 I think it would be better to update frontend components to the newer axios.
In addition to that I ran "npm audit fix"
Before
![image](https://github.com/RedHatInsights/frontend-components/assets/62722417/1353437c-93f7-46fb-86cb-8ca5dd7a39d5)

After
![image](https://github.com/RedHatInsights/frontend-components/assets/62722417/d28c441e-a86b-44dc-b992-41292cecba89)
