### PR TITLE
add ouiaId to pageheader and title

### DIFF
--- a/packages/components/src/PageHeader/PageHeader.tsx
+++ b/packages/components/src/PageHeader/PageHeader.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import { DarkContext } from '../Dark';
 import './page-header.scss';
-import { useOUIAId } from '@patternfly/react-core/dist/dynamic/helpers/OUIA';
+import { useOUIAId } from '@patternfly/react-core';
 
 export interface PageHeaderProps {
   className?: string;

--- a/packages/components/src/PageHeader/PageHeader.tsx
+++ b/packages/components/src/PageHeader/PageHeader.tsx
@@ -3,15 +3,24 @@ import classNames from 'classnames';
 
 import { DarkContext } from '../Dark';
 import './page-header.scss';
+import { useOUIAId } from '@patternfly/react-core/dist/dynamic/helpers/OUIA';
 
 export interface PageHeaderProps {
   className?: string;
+  ouiaId?: string;
+  ouiaSafe?: boolean;
 }
 
 /**
  * This is a page header that mimics the patternfly layout for a header section
  */
-const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHeaderProps>> = ({ className, children, ...props }) => {
+const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHeaderProps>> = ({
+  className,
+  children,
+  ouiaId,
+  ouiaSafe = true,
+  ...props
+}) => {
   const pageHeaderClasses = classNames(
     className,
     'pf-v5-l-page-header',
@@ -19,6 +28,8 @@ const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHeaderProp
     'pf-v5-l-page__main-section',
     'pf-v5-c-page__main-section'
   );
+  const ouiaComponentType = 'RHI/Header';
+  const ouiaFinalId = useOUIAId(ouiaComponentType, ouiaId, ouiaSafe as unknown as string);
 
   return (
     <DarkContext.Consumer>
@@ -26,7 +37,14 @@ const PageHeader: React.FunctionComponent<React.PropsWithChildren<PageHeaderProp
         const themeClasses = classNames({ [`pf-m-${theme}-200`]: theme === 'dark' }, { [`pf-m-light`]: theme === 'light' });
 
         return (
-          <section {...props} className={`${pageHeaderClasses} ${themeClasses}`} widget-type="InsightsPageHeader">
+          <section
+            data-ouia-component-type={ouiaComponentType}
+            data-ouia-component-id={ouiaFinalId}
+            data-ouia-safe={ouiaSafe}
+            {...props}
+            className={`${pageHeaderClasses} ${themeClasses}`}
+            widget-type="InsightsPageHeader"
+          >
             {children}
           </section>
         );

--- a/packages/components/src/PageHeader/PageHeaderTitle.tsx
+++ b/packages/components/src/PageHeader/PageHeaderTitle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
 import { TitleProps } from '@patternfly/react-core/dist/dynamic/components/Title';
-import { useOUIAId } from '@patternfly/react-core/dist/dynamic/helpers/OUIA';
+import { useOUIAId } from '@patternfly/react-core';
 
 export interface PageHeaderTitleProps extends Omit<TitleProps, 'title' | 'headingLevel'> {
   title: React.ReactNode;

--- a/packages/components/src/PageHeader/PageHeaderTitle.tsx
+++ b/packages/components/src/PageHeader/PageHeaderTitle.tsx
@@ -1,19 +1,34 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Title, TitleProps } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
+import { TitleProps } from '@patternfly/react-core/dist/dynamic/components/Title';
+import { useOUIAId } from '@patternfly/react-core/dist/dynamic/helpers/OUIA';
 
 export interface PageHeaderTitleProps extends Omit<TitleProps, 'title' | 'headingLevel'> {
   title: React.ReactNode;
+  ouiaId?: string;
+  ouiaSafe?: boolean;
 }
 
 /**
  * This is the title section of the pageHeader
  */
-const PageHeaderTitle: React.FunctionComponent<PageHeaderTitleProps> = ({ className, title }) => {
+const PageHeaderTitle: React.FunctionComponent<PageHeaderTitleProps> = ({ className, title, ouiaId, ouiaSafe = true, ...props }) => {
   const pageHeaderTitleClasses = classNames(className);
+  const ouiaComponentType = 'RHI/Header';
+  const ouiaFinalId = useOUIAId(ouiaComponentType, ouiaId, ouiaSafe as unknown as string);
 
   return (
-    <Title headingLevel="h1" size="2xl" className={pageHeaderTitleClasses} widget-type="InsightsPageHeaderTitle">
+    <Title
+      headingLevel="h1"
+      size="2xl"
+      className={pageHeaderTitleClasses}
+      widget-type="InsightsPageHeaderTitle"
+      data-ouia-component-type={ouiaComponentType}
+      data-ouia-component-id={ouiaFinalId}
+      data-ouia-safe={ouiaSafe}
+      {...props}
+    >
       {title}
     </Title>
   );

--- a/packages/components/src/PageHeader/__snapshots__/PageHeader.test.js.snap
+++ b/packages/components/src/PageHeader/__snapshots__/PageHeader.test.js.snap
@@ -4,6 +4,9 @@ exports[`PageHeader component should render 1`] = `
 <PageHeader>
   <section
     className="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
+    data-ouia-component-type="RHI/Header"
+    data-ouia-safe={true}
     widget-type="InsightsPageHeader"
   >
     Something

--- a/packages/components/src/PageHeader/__snapshots__/PageHeaderTitle.test.js.snap
+++ b/packages/components/src/PageHeader/__snapshots__/PageHeaderTitle.test.js.snap
@@ -20,14 +20,17 @@ exports[`PageHeader component should render 1`] = `
         >
           <Title
             className=""
+            data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
+            data-ouia-component-type="RHI/Header"
+            data-ouia-safe={true}
             headingLevel="h1"
             size="2xl"
             widget-type="InsightsPageHeaderTitle"
           >
             <h1
               className="pf-v5-c-title pf-m-2xl"
-              data-ouia-component-id="OUIA-Generated-Title-1"
-              data-ouia-component-type="PF5/Title"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
+              data-ouia-component-type="RHI/Header"
               data-ouia-safe={true}
               widget-type="InsightsPageHeaderTitle"
             >


### PR DESCRIPTION
adds ouia id support to PageHeaderTitle

Here's an example
![image](https://github.com/RedHatInsights/frontend-components/assets/16109803/6e94adaa-2817-4c14-9c83-7b80d2caf1f8)
