### PR TITLE
tsc-tranform-imports: treat CloudServerIcon the same as other regular…

### DIFF
--- a/packages/tsc-transform-imports/src/index.ts
+++ b/packages/tsc-transform-imports/src/index.ts
@@ -115,7 +115,6 @@ const ICONS_NAME_FIX: {
 } = {
   AnsibeTowerIcon: 'ansibeTower-icon',
   ChartSpikeIcon: 'chartSpike-icon',
-  CloudServerIcon: 'cloudServer-icon',
 };
 
 const ICONS_CACHE: {


### PR DESCRIPTION
… icons

While adopting this transformer to vuln-frontend app, I found out that the build failed due to the special treatment of CloudServerIcon. This icon does not seem to need import syntax change as it can be imported as other regular icons from `/dist/dynamic/icons/cloud-server-icon`.