### PR TITLE
PageHeaderTitle: enable passing actions component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42278,7 +42278,7 @@
         },
         "packages/advisor-components": {
             "name": "@redhat-cloud-services/frontend-components-advisor-components",
-            "version": "1.0.17",
+            "version": "1.0.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/frontend-components": "^4.0.0-beta.3",
@@ -43229,7 +43229,7 @@
         },
         "packages/eslint-config": {
             "name": "@redhat-cloud-services/eslint-config-redhat-cloud-services",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "license": "Apache",
             "dependencies": {
                 "@babel/eslint-parser": "^7.19.1",
@@ -43748,7 +43748,7 @@
         },
         "packages/tsc-transform-imports": {
             "name": "@redhat-cloud-services/tsc-transform-imports",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "dependencies": {
                 "glob": "10.3.3"
             },
@@ -43758,7 +43758,7 @@
         },
         "packages/types": {
             "name": "@redhat-cloud-services/types",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@patternfly/quickstarts": "^5.0.0",
@@ -43770,7 +43770,7 @@
         },
         "packages/utils": {
             "name": "@redhat-cloud-services/frontend-components-utilities",
-            "version": "4.0.8",
+            "version": "4.0.10",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redhat-cloud-services/rbac-client": "^1.0.100",

--- a/packages/components/src/PageHeader/PageHeaderTitle.test.js
+++ b/packages/components/src/PageHeader/PageHeaderTitle.test.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import PageHeaderTitle from './PageHeaderTitle';
 
 describe('PageHeader component', () => {
   it('should render', () => {
     const wrapper = mount(<PageHeaderTitle title="Something" />);
     expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('renders children correctly', () => {
+    const title = 'Test Title';
+    const actionsContent = 'Actions content';
+    render(<PageHeaderTitle title={title} actionsContent={actionsContent} />);
+    expect(screen.getByText(actionsContent)).toBeInTheDocument();
   });
 });

--- a/packages/components/src/PageHeader/PageHeaderTitle.tsx
+++ b/packages/components/src/PageHeader/PageHeaderTitle.tsx
@@ -1,21 +1,33 @@
 import React from 'react';
 import classNames from 'classnames';
-import { Title, TitleProps } from '@patternfly/react-core';
+import { 
+  Title, 
+  TitleProps, 
+  Flex, 
+  FlexItem  
+} from '@patternfly/react-core';
+
 
 export interface PageHeaderTitleProps extends Omit<TitleProps, 'title' | 'headingLevel'> {
   title: React.ReactNode;
+  actionsComponent: React.ReactNode;
 }
 
 /**
  * This is the title section of the pageHeader
  */
-const PageHeaderTitle: React.FunctionComponent<PageHeaderTitleProps> = ({ className, title }) => {
+const PageHeaderTitle: React.FunctionComponent<PageHeaderTitleProps> = ({ className, title, actionsComponent }) => {
   const pageHeaderTitleClasses = classNames(className);
 
   return (
-    <Title headingLevel="h1" size="2xl" className={pageHeaderTitleClasses} widget-type="InsightsPageHeaderTitle">
-      {title}
-    </Title>
+   <Flex className="example-border" justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+    <FlexItem>    
+      <Title headingLevel="h1" size="2xl" className={pageHeaderTitleClasses} widget-type="InsightsPageHeaderTitle">
+        {title}
+      </Title>
+    </FlexItem>
+    {actionsComponent && <FlexItem>{actionsComponent}</FlexItem>}
+  </Flex>
   );
 };
 

--- a/packages/components/src/PageHeader/PageHeaderTitle.tsx
+++ b/packages/components/src/PageHeader/PageHeaderTitle.tsx
@@ -1,33 +1,30 @@
 import React from 'react';
 import classNames from 'classnames';
-import { 
-  Title, 
-  TitleProps, 
-  Flex, 
-  FlexItem  
-} from '@patternfly/react-core';
-
+import { Title } from '@patternfly/react-core/dist/dynamic/components/Title';
+import { TitleProps } from '@patternfly/react-core/dist/dynamic/components/Title';
+import { Flex } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
+import { FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 
 export interface PageHeaderTitleProps extends Omit<TitleProps, 'title' | 'headingLevel'> {
   title: React.ReactNode;
-  actionsComponent: React.ReactNode;
+  actionsContent?: React.ReactNode;
 }
 
 /**
  * This is the title section of the pageHeader
  */
-const PageHeaderTitle: React.FunctionComponent<PageHeaderTitleProps> = ({ className, title, actionsComponent }) => {
+const PageHeaderTitle: React.FC<PageHeaderTitleProps> = ({ className, title, actionsContent }) => {
   const pageHeaderTitleClasses = classNames(className);
 
   return (
-   <Flex className="example-border" justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-    <FlexItem>    
-      <Title headingLevel="h1" size="2xl" className={pageHeaderTitleClasses} widget-type="InsightsPageHeaderTitle">
-        {title}
-      </Title>
-    </FlexItem>
-    {actionsComponent && <FlexItem>{actionsComponent}</FlexItem>}
-  </Flex>
+    <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+      <FlexItem>
+        <Title headingLevel="h1" size="2xl" className={pageHeaderTitleClasses} widget-type="InsightsPageHeaderTitle">
+          {title}
+        </Title>
+      </FlexItem>
+      {actionsContent ? <FlexItem>{actionsContent}</FlexItem> : null}
+    </Flex>
   );
 };
 

--- a/packages/components/src/PageHeader/__snapshots__/PageHeaderTitle.test.js.snap
+++ b/packages/components/src/PageHeader/__snapshots__/PageHeaderTitle.test.js.snap
@@ -4,21 +4,39 @@ exports[`PageHeader component should render 1`] = `
 <PageHeaderTitle
   title="Something"
 >
-  <Title
-    className=""
-    headingLevel="h1"
-    size="2xl"
-    widget-type="InsightsPageHeaderTitle"
+  <Flex
+    justifyContent={
+      {
+        "default": "justifyContentSpaceBetween",
+      }
+    }
   >
-    <h1
-      className="pf-v5-c-title pf-m-2xl"
-      data-ouia-component-id="OUIA-Generated-Title-1"
-      data-ouia-component-type="PF5/Title"
-      data-ouia-safe={true}
-      widget-type="InsightsPageHeaderTitle"
+    <div
+      className="pf-v5-l-flex pf-m-justify-content-space-between"
     >
-      Something
-    </h1>
-  </Title>
+      <FlexItem>
+        <div
+          className=""
+        >
+          <Title
+            className=""
+            headingLevel="h1"
+            size="2xl"
+            widget-type="InsightsPageHeaderTitle"
+          >
+            <h1
+              className="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-Title-1"
+              data-ouia-component-type="PF5/Title"
+              data-ouia-safe={true}
+              widget-type="InsightsPageHeaderTitle"
+            >
+              Something
+            </h1>
+          </Title>
+        </div>
+      </FlexItem>
+    </div>
+  </Flex>
 </PageHeaderTitle>
 `;


### PR DESCRIPTION
Enables passing actions component into page header title component. This is needed for this [ticket](https://issues.redhat.com/browse/RHINENG-9249) and probably, we will have such cases in the future as well.