### PR TITLE
fix(BulkSelect): RHINENG-9831 - Don't override passed in children

### DIFF
--- a/packages/components/src/BulkSelect/BulkSelect.test.js
+++ b/packages/components/src/BulkSelect/BulkSelect.test.js
@@ -162,5 +162,23 @@ describe('BulkSelect', () => {
       );
       expect(screen.getByRole('button', { expanded: false })).toBeDisabled();
     });
+
+    it('should not override children passed in via toggleProps', () => {
+      render(
+        <BulkSelect
+          items={[
+            {
+              title: 'Select all',
+              onClick: jest.fn(),
+            },
+          ]}
+          toggleProps={{
+            children: ['10 selected'],
+          }}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: '10 selected' })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/components/src/BulkSelect/BulkSelect.tsx
+++ b/packages/components/src/BulkSelect/BulkSelect.tsx
@@ -79,27 +79,31 @@ const BulkSelect: React.FunctionComponent<BulkSelectProps> = ({
               onClick={() => setIsOpen((prev) => !prev)}
               data-ouia-component-id={dropdownOuiaId ?? 'BulkSelect'}
             >
-              <Fragment key="split-checkbox">
-                {hasError ? (
-                  <MenuToggleCheckbox
-                    id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
-                    aria-label="Select all"
-                    onChange={onSelect}
-                    isChecked={checked}
-                    ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
-                  />
-                ) : (
-                  <MenuToggleCheckbox
-                    id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
-                    aria-label="Select all"
-                    onChange={onSelect}
-                    isChecked={checked}
-                    ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
-                  >
-                    {count ? `${count} selected` : ''}
-                  </MenuToggleCheckbox>
-                )}
-              </Fragment>
+              {toggleProps?.children ? (
+                toggleProps?.children
+              ) : (
+                <Fragment key="split-checkbox">
+                  {hasError ? (
+                    <MenuToggleCheckbox
+                      id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
+                      aria-label="Select all"
+                      onChange={onSelect}
+                      isChecked={checked}
+                      ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
+                    />
+                  ) : (
+                    <MenuToggleCheckbox
+                      id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
+                      aria-label="Select all"
+                      onChange={onSelect}
+                      isChecked={checked}
+                      ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
+                    >
+                      {count ? `${count} selected` : ''}
+                    </MenuToggleCheckbox>
+                  )}
+                </Fragment>
+              )}
             </MenuToggle>
           )}
           isOpen={isOpen}


### PR DESCRIPTION
Through the change to PF5 components a bug was introduced to the BulkSelect in the frontend components that overrides children passed in via the toggleProps. Since a number of applications use this to show a loading icon or the number of items selected, etc, we should not be overriding these when passed in.