### PR TITLE
feat(fec): Allow passing a port option to dev script

### DIFF
--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -33,6 +33,7 @@ async function devScript(
     webpackConfig?: string;
     clouddotEnv?: string;
     uiEnv?: string;
+    port?: string;
   },
   cwd: string
 ) {
@@ -67,6 +68,10 @@ async function devScript(
       }
     } else {
       await setEnv(cwd);
+    }
+
+    if (argv.port) {
+      process.env.PORT = argv.port;
     }
 
     spawn(`npm exec -- webpack serve -c ${configPath}`, [], {

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -88,7 +88,7 @@ const argv = yargs
         alias: 'c',
         describe: 'Path to webpack config',
       })
-      .positional('port', {
+      .option('port', {
         type: 'number',
         alias: 'p',
         describe: 'Asset server port',
@@ -97,10 +97,17 @@ const argv = yargs
   })
   .command('patch-etc-hosts', "You may have to run this as 'sudo'. Setup your etc/hosts allow development hosts in your browser")
   .command('dev', 'Start development server', (yargs) => {
-    yargs.positional('webpack-config', {
-      type: 'string',
-      describe: 'Path to webpack config',
-    });
+    yargs
+      .positional('webpack-config', {
+        type: 'string',
+        describe: 'Path to webpack config',
+      })
+      .option('port', {
+        type: 'number',
+        alias: 'p',
+        describe: 'Asset server port',
+        default: 1337,
+      });
   })
   .command('build', 'Build production bundle', (yargs) => {
     yargs.positional('webpack-config', {


### PR DESCRIPTION
This adds a `port` option for the `fec dev` command to allow running webpack dev server or proxy via `npm run start -- --port=8004` (or `npm run start:proxy -- --port=8004`)