### PR TITLE
Add fucntion to fetch available bundles in chrome API

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -169,6 +169,7 @@ export interface ChromeAPI {
     type: string;
     payload: string;
   };
+  getAvailableBundles: () => { id: string; title: string }[];
   helpTopics: {
     addHelpTopics: (topics: HelpTopic[], enabled?: boolean) => void;
     enableTopics: (...topicsNames: EnableTopicsArgs) => Promise<HelpTopic[]>;


### PR DESCRIPTION
### Description

We need to pull bookmarked learning resources from all bundles, currently chrome holds information of all available bundles. This PR adds function to chrome API so we can pull this information from it in learning resources widget.