### PR TITLE
chore: set AsyncComponent height to full while loading

### DIFF
--- a/packages/components/src/AsyncComponent/index.tsx
+++ b/packages/components/src/AsyncComponent/index.tsx
@@ -3,7 +3,6 @@ import { ScalprumComponent, ScalprumComponentProps } from '@scalprum/react-core'
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import classNames from 'classnames';
 import { ChromeAPI } from '@redhat-cloud-services/types';
-
 export type ExcludeModulesKeys = 'appName' | 'module' | 'scope';
 
 export interface AsyncComponentProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
@@ -49,7 +48,7 @@ const BaseAsyncComponent: React.FunctionComponent<BaseAsyncComponentProps> = ({
     ...props,
   };
   return (
-    <Cmp className={classNames(className, appName)}>
+    <Cmp className={classNames(className, appName, 'pf-v5-u-h-100')}>
       <ScalprumComponent {...SCProps} />
     </Cmp>
   );


### PR DESCRIPTION
This is a minor fix to properly lay the loading icon in the center of the page. Previously, due to missing height, the loading icon was displayed on top of the page. Ping me if screen video is needed to explain what this fix is




