### PR TITLE
Use chrome containers instead of chrome build repo.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,6 +2619,19 @@
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
             "dev": true
         },
+        "node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        },
+        "node_modules/@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -7527,28 +7540,28 @@
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
-            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+            "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.0.0",
-                "@octokit/request": "^8.0.2",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^5.0.0",
+                "@octokit/graphql": "^8.0.0",
+                "@octokit/request": "^9.0.0",
+                "@octokit/request-error": "^6.0.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^3.0.2",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core/node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+            "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
             "dev": true,
             "peer": true,
             "engines": {
@@ -7556,73 +7569,76 @@
             }
         },
         "node_modules/@octokit/core/node_modules/@octokit/endpoint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+            "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+            "version": "22.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+            "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
             "dev": true,
             "peer": true
         },
         "node_modules/@octokit/core/node_modules/@octokit/request": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
-            "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+            "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/endpoint": "^9.0.0",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.1.0",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^10.0.0",
+                "@octokit/request-error": "^6.0.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core/node_modules/@octokit/request-error": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+            "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^13.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core/node_modules/@octokit/types": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+            "version": "13.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+            "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/openapi-types": "^22.2.0"
             }
         },
+        "node_modules/@octokit/core/node_modules/before-after-hook": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@octokit/core/node_modules/universal-user-agent": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
             "dev": true,
             "peer": true
         },
@@ -7644,88 +7660,84 @@
             "dev": true
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
-            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+            "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/request": "^8.0.1",
-                "@octokit/types": "^11.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^9.0.0",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-            "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+            "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-            "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+            "version": "22.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+            "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
             "dev": true,
             "peer": true
         },
         "node_modules/@octokit/graphql/node_modules/@octokit/request": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
-            "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+            "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/endpoint": "^9.0.0",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.1.0",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^10.0.0",
+                "@octokit/request-error": "^6.0.1",
+                "@octokit/types": "^13.1.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql/node_modules/@octokit/request-error": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-            "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+            "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/types": "^11.0.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^13.0.0"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql/node_modules/@octokit/types": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-            "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+            "version": "13.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+            "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
             "dev": true,
             "peer": true,
             "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/openapi-types": "^22.2.0"
             }
         },
         "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
             "dev": true,
             "peer": true
         },
@@ -8772,6 +8784,24 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@sideway/address": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@sideway/formula": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+        },
+        "node_modules/@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
         },
         "node_modules/@simonsmith/cypress-image-snapshot": {
             "version": "8.0.2",
@@ -13045,6 +13075,15 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
             "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
+        },
+        "node_modules/@types/wait-on": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
+            "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/webpack": {
             "version": "4.41.33",
@@ -27138,6 +27177,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/joi": {
+            "version": "17.13.1",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.1.tgz",
+            "integrity": "sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==",
+            "dependencies": {
+                "@hapi/hoek": "^9.3.0",
+                "@hapi/topo": "^5.1.0",
+                "@sideway/address": "^4.1.5",
+                "@sideway/formula": "^3.0.1",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
         "node_modules/js-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
@@ -40975,6 +41026,34 @@
             "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
             "dev": true
         },
+        "node_modules/wait-on": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+            "dependencies": {
+                "axios": "^1.6.1",
+                "joi": "^17.11.0",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.8",
+                "rxjs": "^7.8.1"
+            },
+            "bin": {
+                "wait-on": "bin/wait-on"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/wait-on/node_modules/axios": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
         "node_modules/walk-up-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
@@ -42625,9 +42704,11 @@
                 "source-map-loader": "^3.0.1",
                 "stream-browserify": "^3.0.0",
                 "swc-loader": "^0.2.3",
+                "tree-kill": "^1.2.2",
                 "ts-loader": "^9.4.4",
                 "url": "^0.11.0",
                 "util": "^0.12.4",
+                "wait-on": "^7.2.0",
                 "webpack": "^5.88.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "4.15.1",
@@ -42637,7 +42718,8 @@
                 "fec": "bin/fec.js"
             },
             "devDependencies": {
-                "@types/inquirer": "^9.0.3"
+                "@types/inquirer": "^9.0.3",
+                "@types/wait-on": "^5.3.4"
             }
         },
         "packages/config-utils": {
@@ -42848,7 +42930,8 @@
         },
         "packages/config/node_modules/js-yaml": {
             "version": "4.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -45575,6 +45658,19 @@
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
             "dev": true
+        },
+        "@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+        },
+        "@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "requires": {
+                "@hapi/hoek": "^9.0.0"
+            }
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.10",
@@ -49243,87 +49339,90 @@
             }
         },
         "@octokit/core": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.0.tgz",
-            "integrity": "sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+            "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
             "dev": true,
             "peer": true,
             "requires": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.0.0",
-                "@octokit/request": "^8.0.2",
-                "@octokit/request-error": "^5.0.0",
-                "@octokit/types": "^11.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^5.0.0",
+                "@octokit/graphql": "^8.0.0",
+                "@octokit/request": "^9.0.0",
+                "@octokit/request-error": "^6.0.1",
+                "@octokit/types": "^13.0.0",
+                "before-after-hook": "^3.0.2",
+                "universal-user-agent": "^7.0.0"
             },
             "dependencies": {
                 "@octokit/auth-token": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-                    "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+                    "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
                     "dev": true,
                     "peer": true
                 },
                 "@octokit/endpoint": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-                    "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+                    "version": "10.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+                    "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/types": "^11.0.0",
-                        "is-plain-object": "^5.0.0",
-                        "universal-user-agent": "^6.0.0"
+                        "@octokit/types": "^13.0.0",
+                        "universal-user-agent": "^7.0.2"
                     }
                 },
                 "@octokit/openapi-types": {
-                    "version": "18.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-                    "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+                    "version": "22.2.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+                    "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
                     "dev": true,
                     "peer": true
                 },
                 "@octokit/request": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
-                    "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+                    "version": "9.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+                    "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/endpoint": "^9.0.0",
-                        "@octokit/request-error": "^5.0.0",
-                        "@octokit/types": "^11.1.0",
-                        "is-plain-object": "^5.0.0",
-                        "universal-user-agent": "^6.0.0"
+                        "@octokit/endpoint": "^10.0.0",
+                        "@octokit/request-error": "^6.0.1",
+                        "@octokit/types": "^13.1.0",
+                        "universal-user-agent": "^7.0.2"
                     }
                 },
                 "@octokit/request-error": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-                    "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+                    "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/types": "^11.0.0",
-                        "deprecation": "^2.0.0",
-                        "once": "^1.4.0"
+                        "@octokit/types": "^13.0.0"
                     }
                 },
                 "@octokit/types": {
-                    "version": "11.1.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-                    "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+                    "version": "13.5.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+                    "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/openapi-types": "^18.0.0"
+                        "@octokit/openapi-types": "^22.2.0"
                     }
                 },
+                "before-after-hook": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+                    "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+                    "dev": true,
+                    "peer": true
+                },
                 "universal-user-agent": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-                    "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+                    "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
                     "dev": true,
                     "peer": true
                 }
@@ -49349,76 +49448,72 @@
             }
         },
         "@octokit/graphql": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.1.tgz",
-            "integrity": "sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+            "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
             "dev": true,
             "peer": true,
             "requires": {
-                "@octokit/request": "^8.0.1",
-                "@octokit/types": "^11.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^9.0.0",
+                "@octokit/types": "^13.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "dependencies": {
                 "@octokit/endpoint": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.0.tgz",
-                    "integrity": "sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==",
+                    "version": "10.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+                    "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/types": "^11.0.0",
-                        "is-plain-object": "^5.0.0",
-                        "universal-user-agent": "^6.0.0"
+                        "@octokit/types": "^13.0.0",
+                        "universal-user-agent": "^7.0.2"
                     }
                 },
                 "@octokit/openapi-types": {
-                    "version": "18.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-                    "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+                    "version": "22.2.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+                    "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
                     "dev": true,
                     "peer": true
                 },
                 "@octokit/request": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.1.tgz",
-                    "integrity": "sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==",
+                    "version": "9.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+                    "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/endpoint": "^9.0.0",
-                        "@octokit/request-error": "^5.0.0",
-                        "@octokit/types": "^11.1.0",
-                        "is-plain-object": "^5.0.0",
-                        "universal-user-agent": "^6.0.0"
+                        "@octokit/endpoint": "^10.0.0",
+                        "@octokit/request-error": "^6.0.1",
+                        "@octokit/types": "^13.1.0",
+                        "universal-user-agent": "^7.0.2"
                     }
                 },
                 "@octokit/request-error": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.0.tgz",
-                    "integrity": "sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==",
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+                    "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/types": "^11.0.0",
-                        "deprecation": "^2.0.0",
-                        "once": "^1.4.0"
+                        "@octokit/types": "^13.0.0"
                     }
                 },
                 "@octokit/types": {
-                    "version": "11.1.0",
-                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.1.0.tgz",
-                    "integrity": "sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==",
+                    "version": "13.5.0",
+                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+                    "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
                     "dev": true,
                     "peer": true,
                     "requires": {
-                        "@octokit/openapi-types": "^18.0.0"
+                        "@octokit/openapi-types": "^22.2.0"
                     }
                 },
                 "universal-user-agent": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-                    "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+                    "version": "7.0.2",
+                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+                    "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
                     "dev": true,
                     "peer": true
                 }
@@ -50065,6 +50160,7 @@
                 "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
                 "@swc/core": "^1.3.76",
                 "@types/inquirer": "^9.0.3",
+                "@types/wait-on": "^5.3.4",
                 "assert": "^2.0.0",
                 "axios": "^0.28.1",
                 "browserify-zlib": "^0.2.0",
@@ -50094,9 +50190,11 @@
                 "source-map-loader": "^3.0.1",
                 "stream-browserify": "^3.0.0",
                 "swc-loader": "^0.2.3",
+                "tree-kill": "^1.2.2",
                 "ts-loader": "^9.4.4",
                 "url": "^0.11.0",
                 "util": "^0.12.4",
+                "wait-on": "^7.2.0",
                 "webpack": "^5.88.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "4.15.1",
@@ -50171,6 +50269,8 @@
                 },
                 "js-yaml": {
                     "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
                     "requires": {
                         "argparse": "^2.0.1"
                     }
@@ -51198,6 +51298,24 @@
                     "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
+        },
+        "@sideway/address": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+            "requires": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "@sideway/formula": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+        },
+        "@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
         },
         "@simonsmith/cypress-image-snapshot": {
             "version": "8.0.2",
@@ -53339,6 +53457,15 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
             "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
+        },
+        "@types/wait-on": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/@types/wait-on/-/wait-on-5.3.4.tgz",
+            "integrity": "sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/webpack": {
             "version": "4.41.33",
@@ -64204,6 +64331,18 @@
                 }
             }
         },
+        "joi": {
+            "version": "17.13.1",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.1.tgz",
+            "integrity": "sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==",
+            "requires": {
+                "@hapi/hoek": "^9.3.0",
+                "@hapi/topo": "^5.1.0",
+                "@sideway/address": "^4.1.5",
+                "@sideway/formula": "^3.0.1",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
         "js-cookie": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
@@ -74815,6 +74954,30 @@
             "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
             "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
             "dev": true
+        },
+        "wait-on": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+            "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+            "requires": {
+                "axios": "^1.6.1",
+                "joi": "^17.11.0",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.8",
+                "rxjs": "^7.8.1"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+                    "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+                    "requires": {
+                        "follow-redirects": "^1.15.6",
+                        "form-data": "^4.0.0",
+                        "proxy-from-env": "^1.1.0"
+                    }
+                }
+            }
         },
         "walk-up-path": {
             "version": "1.0.0",

--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -114,6 +114,11 @@ export type ProxyOptions = {
   useAgent?: boolean;
   useDevBuild?: boolean;
   localApps?: string;
+  /**
+   * Used to block running chrome from build repos.
+   * Chrome should be running from container from now on.
+   */
+  blockLegacyChrome?: boolean;
 };
 
 const proxy = ({
@@ -140,6 +145,7 @@ const proxy = ({
   useAgent = true,
   useDevBuild = true,
   localApps = process.env.LOCAL_APPS,
+  blockLegacyChrome = false,
 }: ProxyOptions) => {
   const proxy: ProxyConfigItem[] = [];
   const majorEnv = env.split('-')[0];
@@ -369,14 +375,14 @@ const proxy = ({
        * Allow serving chrome assets
        * This will allow running chrome as a host application
        */
-      if (!isChrome) {
+      if (localChrome || (!blockLegacyChrome && !isChrome)) {
         let chromePath = localChrome;
         if (standaloneConfig) {
           if (standaloneConfig.chrome) {
             chromePath = resolvePath(reposDir, standaloneConfig.chrome.path);
             keycloakUri = standaloneConfig.chrome.keycloakUri;
           }
-        } else if (!localChrome && useProxy) {
+        } else if (!blockLegacyChrome && !localChrome && useProxy) {
           const chromeConfig = typeof defaultServices.chrome === 'function' ? defaultServices.chrome({}) : defaultServices.chrome;
 
           const chromeEnv = useDevBuild ? (env.includes('-beta') ? 'dev-beta' : 'dev-stable') : env;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,7 +25,8 @@
     },
     "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#readme",
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "watch": "tsc -w"
     },
     "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
@@ -61,15 +62,18 @@
         "source-map-loader": "^3.0.1",
         "stream-browserify": "^3.0.0",
         "swc-loader": "^0.2.3",
+        "tree-kill": "^1.2.2",
         "ts-loader": "^9.4.4",
         "url": "^0.11.0",
         "util": "^0.12.4",
+        "wait-on": "^7.2.0",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "4.15.1",
         "yargs": "^17.6.2"
     },
     "devDependencies": {
-        "@types/inquirer": "^9.0.3"
+        "@types/inquirer": "^9.0.3",
+        "@types/wait-on": "^5.3.4"
     }
 }

--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -1,8 +1,12 @@
 /* eslint-disable no-console */
 import inquirer from 'inquirer';
 const { resolve } = require('path');
-const { spawn } = require('child_process');
+import { spawn } from 'child_process';
+import treeKill from 'tree-kill';
 import { getWebpackConfigPath, validateFECConfig } from './common';
+import serveChrome from './serve-chrome';
+import { LogType, fecLogger } from '@redhat-cloud-services/frontend-components-config-utilities';
+const DEFAULT_CHROME_SERVER_PORT = 9998;
 
 async function setEnv(cwd: string) {
   return inquirer
@@ -34,18 +38,30 @@ async function devScript(
     clouddotEnv?: string;
     uiEnv?: string;
     port?: string;
+    chromeServerPort?: number | string;
   },
   cwd: string
 ) {
   try {
+    let localChrome = false;
     let fecConfig: any = {};
     let configPath;
+    let chromeHost;
     if (typeof argv.webpackConfig !== 'undefined') {
       configPath = getWebpackConfigPath(argv.webpackConfig, cwd);
+      if (typeof argv.chromeServerPort !== 'undefined') {
+        process.env.FEC_CHROME_PORT = `${argv.chromeServerPort}`;
+      } else {
+        fecLogger(LogType.info, `No chrome server port provided, using default port ${DEFAULT_CHROME_SERVER_PORT}`);
+        process.env.FEC_CHROME_PORT = `${DEFAULT_CHROME_SERVER_PORT}`;
+      }
     } else {
       // validate the FEC config only if a custom webpack config is not provided
       validateFECConfig(cwd);
       fecConfig = require(process.env.FEC_CONFIG_PATH!);
+      localChrome = fecConfig.localChrome;
+      process.env.FEC_CHROME_PORT = fecConfig.chromePort ?? DEFAULT_CHROME_SERVER_PORT;
+      chromeHost = fecConfig.chromeHost;
       configPath = resolve(__dirname, './dev.webpack.config.js');
     }
 
@@ -74,7 +90,54 @@ async function devScript(
       process.env.PORT = argv.port;
     }
 
-    spawn(`npm exec -- webpack serve -c ${configPath}`, [], {
+    let webpackProcess: ReturnType<typeof spawn> | undefined = undefined;
+    let interceptorProcess: ReturnType<typeof spawn> | undefined = undefined;
+
+    if (!chromeHost) {
+      chromeHost = `${process.env.CLOUDOT_ENV === 'prod' ? 'prod' : 'stage'}.foo.redhat.com`;
+    }
+
+    process.env.FEC_CHROME_HOST = chromeHost;
+
+    // ignore chrome server if a localChrome is provided
+    if (!localChrome) {
+      // get the directory if the build
+      // hsa to require here after all FEC env variables are set
+      const devConfig = require('./dev.webpack.config');
+      const outputPath = devConfig.output?.path;
+      // start chrome frontend server
+      try {
+        const handleServerError = (error: Error) => {
+          fecLogger(LogType.error, error);
+          if (webpackProcess?.pid) {
+            treeKill(webpackProcess.pid, 'SIGKILL');
+          }
+
+          if (interceptorProcess?.pid) {
+            treeKill(interceptorProcess.pid, 'SIGKILL');
+          }
+          process.exit(1);
+        };
+
+        await serveChrome(
+          outputPath,
+          chromeHost,
+          handleServerError,
+          process.env.CLOUDOT_ENV === 'prod',
+          argv.uiEnv === 'beta',
+          parseInt(process.env.FEC_CHROME_PORT!)
+        ).catch((error) => {
+          fecLogger(LogType.error, 'Chrome server stopped!');
+          handleServerError(error);
+        });
+      } catch (error) {
+        fecLogger(LogType.error, 'Unable to start local Chrome UI server!');
+        fecLogger(LogType.error, error);
+        process.exit(1);
+      }
+    }
+
+    webpackProcess = spawn(`npm exec -- webpack serve -c ${configPath}`, [], {
       stdio: [process.stdout, process.stdout, process.stdout],
       cwd,
       shell: true,
@@ -83,7 +146,7 @@ async function devScript(
       const interceptorServerPath = resolve(__dirname, './csc-interceptor-server.js');
       const interceptorServerArgs = [interceptorServerPath];
       // Ensure ipv4 DNS is hit first. Currently there are issues with IPV4
-      spawn('NODE_OPTIONS=--dns-result-order=ipv4first node', interceptorServerArgs, {
+      interceptorProcess = spawn('NODE_OPTIONS=--dns-result-order=ipv4first node', interceptorServerArgs, {
         stdio: [process.stdout, process.stdout, process.stdout],
         cwd,
         shell: true,

--- a/packages/config/src/bin/dev.webpack.config.ts
+++ b/packages/config/src/bin/dev.webpack.config.ts
@@ -40,6 +40,9 @@ const { plugins: externalPlugins = [], interceptChromeConfig, routes, ...externa
 
 const internalProxyRoutes: { [endpoint: string]: ProxyConfigArrayItem } = {
   ...routes,
+  '/apps/chrome': {
+    target: `http://${process.env.FEC_CHROME_HOST}:${process.env.FEC_CHROME_PORT}`,
+  },
   ...(interceptChromeConfig === true
     ? {
         '/api/chrome-service/v1/static': {
@@ -60,6 +63,7 @@ const { config: webpackConfig, plugins } = config({
   deployment: isBeta ? 'beta/apps' : 'apps',
   env: `${process.env.CLOUDOT_ENV}-${isBeta === true ? 'beta' : 'stable'}` as FrontendEnv,
   rootFolder: process.env.FEC_ROOT_DIR || process.cwd(),
+  blockLegacyChrome: true,
 });
 plugins.push(...commonPlugins, ...externalPlugins);
 

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -1,0 +1,193 @@
+import axios from 'axios';
+import { execSync, spawn } from 'child_process';
+import { LogType, fecLogger } from '@redhat-cloud-services/frontend-components-config-utilities';
+import waitOn from 'wait-on';
+
+const REPO_OWNER = 'RedHatInsights';
+const REPO_NAME = 'insights-chrome';
+const CONTAINER_PORT = 8000;
+const CONTAINER_NAME = 'fec-chrome-local';
+const IMAGE_REPO = 'quay.io/cloudservices/insights-chrome-frontend';
+const GRAPHQL_ENDPOINT = 'https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql';
+
+type ContainerRuntime = 'docker' | 'podman';
+let execBin: ContainerRuntime | undefined = undefined;
+
+const APPS_QUERY = `{
+  apps: apps_v1 {
+    name
+    parentApp {
+      name
+    }
+    saasFiles {
+      path
+      name
+      parameters
+      resourceTemplates {
+        name
+        path
+        url
+        parameters
+        targets {
+          namespace {
+            name
+            path
+            cluster {
+              name
+            }
+          }
+          ref
+          parameters
+        }
+      }
+    }
+  }
+}`;
+
+// const checkoutCommand = `git archive --remote=${chromeDeploymentConfig.repo}  HEAD ${chromeDeploymentConfig.deployFile} |  tar xvf - -C ${chromeDeploymentConfig.tarTarget}`;
+
+function checkContainerRuntime(): ContainerRuntime {
+  try {
+    if (execSync('which podman').toString().trim().length > 0) {
+      return 'podman';
+    }
+    if (execSync('which docker').toString().trim().length > 0) {
+      return 'docker';
+    }
+  } catch (error) {
+    throw new Error('No container runtime found');
+  }
+
+  throw new Error('No container runtime found');
+}
+
+async function getLatestCommits(): Promise<string> {
+  const { data } = await axios.get(`https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    params: {
+      per_page: 1,
+    },
+  });
+  if (data.length === 0) {
+    throw new Error('No commits for chrome found!');
+  }
+
+  const { sha } = data[0];
+  return sha.substring(0, 7);
+}
+
+type ResourceTemplate = {
+  name: string;
+  targets: { ref: string; namespace: { path: string } }[];
+};
+
+async function getProdRelease() {
+  try {
+    const {
+      data: { data },
+    } = await axios.post<{
+      data: {
+        apps: {
+          name: string;
+          saasFiles: {
+            resourceTemplates: ResourceTemplate[];
+          }[];
+        }[];
+      };
+    }>(GRAPHQL_ENDPOINT, {
+      query: APPS_QUERY,
+    });
+    const base = data.apps.find(({ name }) => name.includes('frontend-base'));
+    if (!base) {
+      throw new Error('No frontend-base found!');
+    }
+    let i = 0;
+    let chromeResourceTemplate: ResourceTemplate | undefined = undefined;
+    while (!chromeResourceTemplate && i < base.saasFiles.length) {
+      chromeResourceTemplate = base.saasFiles[i].resourceTemplates.find(({ name }) => name.includes('insights-chrome'));
+      i += 1;
+    }
+    if (!chromeResourceTemplate) {
+      throw new Error('No insights-chrome resource template found!');
+    }
+
+    const prodTarget = chromeResourceTemplate.targets.find(({ namespace: { path } }) => path.includes('prod-frontends'));
+
+    if (!prodTarget) {
+      throw new Error('Not chrome prod target deployment found!');
+    }
+
+    return prodTarget.ref.substring(0, 7);
+  } catch (error) {
+    fecLogger(LogType.error, error);
+    fecLogger(LogType.warn, 'Unable to find chrome prod deployment! Falling back to latest image.');
+    return getLatestCommits();
+  }
+}
+
+function pullImage(tag: string) {
+  execSync(`${execBin} pull ${IMAGE_REPO}:${tag}`, {
+    stdio: 'inherit',
+  });
+}
+
+async function startServer(tag: string, serverPort: number) {
+  return new Promise<void>((resolve, reject) => {
+    try {
+      execSync(`${execBin} stop ${CONTAINER_NAME}`, {
+        stdio: 'inherit',
+      });
+      execSync(`${execBin} rm ${CONTAINER_NAME}`, {
+        stdio: 'inherit',
+      });
+    } catch (error) {
+      fecLogger(LogType.info, 'No existing chrome container found');
+    }
+    const runCommand = `${execBin} run -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${IMAGE_REPO}:${tag}`;
+    const child = spawn(runCommand, [], {
+      stdio: 'ignore',
+      shell: true,
+    });
+    child.stderr?.on('data', (data) => {
+      reject(data.toString());
+    });
+    child.on('exit', () => {
+      return reject(`Chrome server stopped unexpectedly! The server port ${serverPort} is already in use!`);
+    });
+  });
+}
+
+function copyIndex(path: string, isPreview = false) {
+  const copyCommand = `${execBin} cp ${CONTAINER_NAME}:/opt/app-root/src/build/${isPreview ? 'preview' : 'stable'}/index.html ${path}`;
+  execSync(copyCommand, {
+    stdio: 'inherit',
+  });
+}
+
+async function serveChrome(distPath: string, host: string, onError: (error: Error) => void, isProd = false, isPreview = false, serverPort = 9999) {
+  if (!distPath) {
+    throw new Error('No distPath provided! Provide an absolute path to the UI dist directory.');
+  }
+  fecLogger(LogType.info, 'Starting chrome server...');
+  execBin = checkContainerRuntime();
+  let tag: string;
+  if (isProd) {
+    tag = await getProdRelease();
+  } else {
+    tag = await getLatestCommits();
+  }
+  pullImage(tag);
+  startServer(tag, serverPort).catch((error) => {
+    onError(error);
+    process.exit(1);
+  });
+  await waitOn({
+    resources: [`http://${host}:${serverPort}`],
+  });
+  copyIndex(distPath, isPreview);
+}
+
+export default serveChrome;

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -52,6 +52,7 @@ export interface CreateConfigOptions extends CommonConfigOptions {
   nodeModulesDirectories?: string[];
   resolve?: ResolveOptions;
   stripAllPfStyles?: boolean;
+  blockLegacyChrome?: boolean;
 }
 
 export const createConfig = ({
@@ -94,6 +95,7 @@ export const createConfig = ({
   // additional node_modules dirs for searchIgnoredStyles, usefull in monorepo scenario
   nodeModulesDirectories = [],
   stripAllPfStyles = false,
+  blockLegacyChrome,
 }: CreateConfigOptions): Configuration => {
   if (typeof _unstableHotReload !== 'undefined') {
     fecLogger(LogType.warn, `The _unstableHotReload option in shared webpack config is deprecated. Use hotReload config instead.`);
@@ -305,6 +307,7 @@ export const createConfig = ({
         bounceProd,
         useAgent,
         useDevBuild,
+        blockLegacyChrome,
       }),
     },
   };

--- a/packages/config/src/lib/fec.config.ts
+++ b/packages/config/src/lib/fec.config.ts
@@ -11,6 +11,8 @@ export interface FECConfiguration
   interceptChromeConfig?: boolean;
   moduleFederation: Omit<FederatedModulesConfig, 'root' | 'separateRuntime'>;
   debug?: boolean;
+  chromeHost?: string;
+  chromePort?: number;
 }
 
 export default FECConfiguration;

--- a/packages/config/src/lib/index.ts
+++ b/packages/config/src/lib/index.ts
@@ -43,6 +43,7 @@ type FecConfigurationOptions = Omit<CreateConfigOptions, 'publicPath' | 'appEntr
     deployment?: string;
     debug?: boolean;
     appEntry?: string;
+    blockLegacyChrome?: boolean;
   };
 
 const createFecConfig = (


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-33077

### Changes
- pull Chrome UI from Quay instead of the obsolete build repository
- run Chrome server via docker/podman
- source webpack `index.html` from the Chome UI container
- add fallback variables to use legacy Chrome assets

A version bump of the proxy dependency has to follow asap.