### PR TITLE
fix(config): Remove obsolete fec config bits

### DIFF
--- a/packages/config-utils/src/federated-modules.ts
+++ b/packages/config-utils/src/federated-modules.ts
@@ -14,7 +14,6 @@ const createIncludes = (eager = false): { [module: string]: WebpackSharedConfig 
   '@redhat-cloud-services/chrome': { singleton: true },
   axios: {},
   lodash: {},
-  'redux-promise-middleware': {},
   react: { singleton: true, eager },
   'react-dom': { singleton: true, eager },
 });

--- a/packages/config/src/bin/empty.ts
+++ b/packages/config/src/bin/empty.ts
@@ -1,2 +1,0 @@
-// Used as an empty module to save bundle size
-module.exports = {};

--- a/packages/config/src/bin/webpack.plugins.ts
+++ b/packages/config/src/bin/webpack.plugins.ts
@@ -1,5 +1,3 @@
-const webpack = require('webpack');
-const { resolve } = require('path');
 import { LogType, fecLogger, federatedModules, generatePFSharedAssetsList } from '@redhat-cloud-services/frontend-components-config-utilities';
 import FECConfiguration from '../lib/fec.config';
 
@@ -32,11 +30,6 @@ const plugins = [
     ],
   }),
 ];
-
-// Save 20kb of bundle size in prod
-if (process.env.NODE_ENV === 'production') {
-  plugins.push(new webpack.NormalModuleReplacementPlugin(/redux-logger/, resolve(__dirname, './empty.js')));
-}
 
 export default plugins;
 module.exports = plugins;


### PR DESCRIPTION
This removes the `redux-promise-middleware` from being shared, as this might cause issues when incompatible versions of `(react-)redux` and `redux-promise-middleware`. 

It also removed the stubbing of `redux-logger` in prod. We should not need to do this, as `redux-logger` should not be imported in a prod asset in the first place. If it is, the apps should properly setup entry points for dev and prod. 