### PR TITLE
Bump @redhat-cloud-services/rbac-client to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8319,21 +8319,43 @@
                 "form-data": "^4.0.0"
             }
         },
-        "node_modules/@redhat-cloud-services/rbac-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.5.tgz",
-            "integrity": "sha512-RTz3bvMum1jUUgLTzJ/7jl7H1g3h2hU4F1XorAxG+MJC0fnNI8+M7j27EhGNSDc0gJNs9+gK5E6eMsuaJ4aWxQ==",
+        "node_modules/@redhat-cloud-services/javascript-clients-shared": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/javascript-clients-shared/-/javascript-clients-shared-1.2.3.tgz",
+            "integrity": "sha512-ymuDBCCj9FSP9NsoOTNFVpNTUEqbkKA+6ouBkL3X3tkM4Wgwg0fCjTl4kznSWeY8r2Kh2bgaPGZmBQGHfIGBcA==",
             "dependencies": {
-                "axios": "^0.27.2"
+                "axios": "^1.7.2",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@redhat-cloud-services/javascript-clients-shared/node_modules/axios": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/@redhat-cloud-services/rbac-client": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.0.3.tgz",
+            "integrity": "sha512-aBvojrpP5pFjuQVgcF7oo0FqdYVwK2GcVte+Adyxh002Pv9McU60FoZBzGSk+hJ9NztW7aFeyS+HmGau/iqYGg==",
+            "dependencies": {
+                "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
+                "axios": "^1.7.2",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@redhat-cloud-services/rbac-client/node_modules/axios": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
             "dependencies": {
-                "follow-redirects": "^1.14.9",
-                "form-data": "^4.0.0"
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/@redhat-cloud-services/rule-components": {
@@ -42480,7 +42502,7 @@
             "peerDependencies": {
                 "@patternfly/react-core": "^5.0.0",
                 "@patternfly/react-table": "^5.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
+                "@redhat-cloud-services/rbac-client": "^2.0.3",
                 "cypress": ">=12.0.0 < 13.0.0",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
@@ -42567,7 +42589,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "6.0.15",
+            "version": "6.0.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
@@ -42620,7 +42642,7 @@
         },
         "packages/config-utils": {
             "name": "@redhat-cloud-services/frontend-components-config-utilities",
-            "version": "3.0.6",
+            "version": "3.0.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -43467,7 +43489,7 @@
             "peerDependencies": {
                 "@patternfly/react-core": "^5.0.0",
                 "@patternfly/react-table": "^5.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
+                "@redhat-cloud-services/rbac-client": "^2.0.3",
                 "cypress": ">=12.0.0 < 13.0.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -43655,13 +43677,19 @@
             "peerDependencies": {
                 "@patternfly/react-core": "^4.239.0",
                 "@patternfly/react-table": "^4.108.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
+                "@redhat-cloud-services/rbac-client": "^2.0.3",
                 "cypress": ">=10.0.0 < 13.0.0",
                 "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
                 "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
                 "react-redux": ">=7.0.0",
                 "react-router-dom": "^5.0.0 || ^6.0.0"
             }
+        },
+        "packages/translations/node_modules/@redhat-cloud-services/types": {
+            "version": "0.0.24",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+            "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg==",
+            "optional": true
         },
         "packages/translations/node_modules/attr-accept": {
             "version": "1.1.3",
@@ -43757,7 +43785,7 @@
             "license": "Apache-2.0",
             "devDependencies": {
                 "@patternfly/quickstarts": "^5.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.111",
+                "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
                 "@segment/analytics-next": "^1.43.2",
                 "glob": "10.3.3",
                 "history": "^4.10.1"
@@ -43768,7 +43796,7 @@
             "version": "4.0.11",
             "license": "Apache-2.0",
             "dependencies": {
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
+                "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
                 "@redhat-cloud-services/types": "^1.0.9",
                 "@sentry/browser": "^5.30.0",
                 "awesome-debounce-promise": "^2.1.0",
@@ -50600,6 +50628,12 @@
                         "react-content-loader": "^6.2.0"
                     }
                 },
+                "@redhat-cloud-services/types": {
+                    "version": "0.0.24",
+                    "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+                    "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg==",
+                    "optional": true
+                },
                 "attr-accept": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
@@ -50671,7 +50705,7 @@
         "@redhat-cloud-services/frontend-components-utilities": {
             "version": "file:packages/utils",
             "requires": {
-                "@redhat-cloud-services/rbac-client": "^1.0.100",
+                "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
                 "@redhat-cloud-services/types": "^1.0.9",
                 "@sentry/browser": "^5.30.0",
                 "@types/react": "^18.0.0",
@@ -50708,21 +50742,45 @@
                 }
             }
         },
-        "@redhat-cloud-services/rbac-client": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.5.tgz",
-            "integrity": "sha512-RTz3bvMum1jUUgLTzJ/7jl7H1g3h2hU4F1XorAxG+MJC0fnNI8+M7j27EhGNSDc0gJNs9+gK5E6eMsuaJ4aWxQ==",
+        "@redhat-cloud-services/javascript-clients-shared": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/javascript-clients-shared/-/javascript-clients-shared-1.2.3.tgz",
+            "integrity": "sha512-ymuDBCCj9FSP9NsoOTNFVpNTUEqbkKA+6ouBkL3X3tkM4Wgwg0fCjTl4kznSWeY8r2Kh2bgaPGZmBQGHfIGBcA==",
             "requires": {
-                "axios": "^0.27.2"
+                "axios": "^1.7.2",
+                "tslib": "^2.6.2"
             },
             "dependencies": {
                 "axios": {
-                    "version": "0.27.2",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-                    "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+                    "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
                     "requires": {
-                        "follow-redirects": "^1.14.9",
-                        "form-data": "^4.0.0"
+                        "follow-redirects": "^1.15.6",
+                        "form-data": "^4.0.0",
+                        "proxy-from-env": "^1.1.0"
+                    }
+                }
+            }
+        },
+        "@redhat-cloud-services/rbac-client": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.0.3.tgz",
+            "integrity": "sha512-aBvojrpP5pFjuQVgcF7oo0FqdYVwK2GcVte+Adyxh002Pv9McU60FoZBzGSk+hJ9NztW7aFeyS+HmGau/iqYGg==",
+            "requires": {
+                "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
+                "axios": "^1.7.2",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "1.7.2",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+                    "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+                    "requires": {
+                        "follow-redirects": "^1.15.6",
+                        "form-data": "^4.0.0",
+                        "proxy-from-env": "^1.1.0"
                     }
                 }
             }
@@ -50779,7 +50837,7 @@
             "version": "file:packages/types",
             "requires": {
                 "@patternfly/quickstarts": "^5.0.0",
-                "@redhat-cloud-services/rbac-client": "^1.0.111",
+                "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
                 "@segment/analytics-next": "^1.43.2",
                 "glob": "10.3.3",
                 "history": "^4.10.1"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,7 @@
     "scripts": {},
     "devDependencies": {
         "@patternfly/quickstarts": "^5.0.0",
-        "@redhat-cloud-services/rbac-client": "^1.0.111",
+        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
         "history": "^4.10.1",
         "glob": "10.3.3",
         "@segment/analytics-next": "^1.43.2"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
         "react-router-dom": "^5.0.0 || ^6.0.0"
     },
     "dependencies": {
-        "@redhat-cloud-services/rbac-client": "^1.0.100",
+        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
         "@redhat-cloud-services/types": "^1.0.9",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",


### PR DESCRIPTION
Update rbac-client so we stop pulling old axios client.

This pulls mostly https://github.com/RedHatInsights/javascript-clients/pull/261