### PR TITLE
chore: add TimestampFormat component into COMPONENTS_CACHE list

### DIFF
--- a/packages/tsc-transform-imports/src/index.ts
+++ b/packages/tsc-transform-imports/src/index.ts
@@ -109,6 +109,7 @@ if (CORE_DIRECTORIES.length > 0) {
     useWizardContext: getModuleExplicitLocation(CORE_DIRECTORIES, 'components/Wizard'),
     DataListWrapModifier: getModuleExplicitLocation(CORE_DIRECTORIES, 'components/DataList'),
     MenuToggleElement: getModuleExplicitLocation(CORE_DIRECTORIES, 'components/MenuToggle'),
+    TimestampFormat: getModuleExplicitLocation(CORE_DIRECTORIES, 'components/Timestamp'),
   };
 }
 


### PR DESCRIPTION
resolves following issue related to the new ts transformer by adding TimestampFormat component into the COMPONENTS_CACHE list.

![image](https://github.com/RedHatInsights/frontend-components/assets/59481011/7b2b8571-71a0-4e85-b1fb-a0630e576a59)


