### PR TITLE
fix(CCXDEV-12932): update express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42577,7 +42577,7 @@
                 "clean-webpack-plugin": "^3.0.0",
                 "concurrently": "^7.4.0",
                 "css-loader": "^5.2.7",
-                "express": "^4.18.1",
+                "express": "^4.19.2",
                 "fork-ts-checker-webpack-plugin": "^7.2.13",
                 "git-revision-webpack-plugin": "^3.0.6",
                 "glob": "^7.2.3",
@@ -43557,11 +43557,8 @@
         },
         "packages/translations": {
             "name": "@redhat-cloud-services/frontend-components-translations",
-            "version": "3.2.3",
+            "version": "3.2.8",
             "license": "Apache-2.0",
-            "dependencies": {
-                "@redhat-cloud-services/frontend-components-utilities": "^4.0.13"
-            },
             "devDependencies": {
                 "@formatjs/cli": "^6.1.3",
                 "glob": "10.3.3"
@@ -43578,7 +43575,7 @@
         },
         "packages/tsc-transform-imports": {
             "name": "@redhat-cloud-services/tsc-transform-imports",
-            "version": "1.0.12",
+            "version": "1.0.14",
             "dependencies": {
                 "glob": "10.3.3"
             },
@@ -49893,7 +49890,7 @@
                 "clean-webpack-plugin": "^3.0.0",
                 "concurrently": "^7.4.0",
                 "css-loader": "^5.2.7",
-                "express": "^4.18.1",
+                "express": "^4.19.2",
                 "fork-ts-checker-webpack-plugin": "^7.2.13",
                 "git-revision-webpack-plugin": "^3.0.6",
                 "glob": "^7.2.3",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -41,7 +41,7 @@
         "clean-webpack-plugin": "^3.0.0",
         "concurrently": "^7.4.0",
         "css-loader": "^5.2.7",
-        "express": "^4.18.1",
+        "express": "^4.19.2",
         "fork-ts-checker-webpack-plugin": "^7.2.13",
         "git-revision-webpack-plugin": "^3.0.6",
         "glob": "^7.2.3",


### PR DESCRIPTION
We need to update express to version 4.19.2 details in the ticket
https://issues.redhat.com/browse/CCXDEV-12932