### PR TITLE
Propagate build process status

### DIFF
--- a/packages/config/src/bin/build-script.ts
+++ b/packages/config/src/bin/build-script.ts
@@ -23,11 +23,13 @@ export function buildScript(argv: { [name: string]: string }, cwd: string) {
     fecLogger(LogType.error, err);
     process.exit(1);
   });
-  subprocess.on('exit', (code: string | null, signal: string) => {
+  subprocess.on('exit', (code: number | null, signal: string) => {
     if (code) {
       fecLogger(LogType.error, 'Exited with code', code);
+      process.exit(code);
     } else if (signal) {
       fecLogger(LogType.error, 'Exited with signal', signal);
+      process.exit(1);
     } else {
       fecLogger(LogType.info, 'Exited Okay');
     }


### PR DESCRIPTION
Build process is hiding away the status and doesn't propagate it to `fec build` status code, resulting in hiding away CI errors.

Fixes #2040