### PR TITLE
Add quay fallback for chrome image sha.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42133,7 +42133,7 @@
         },
         "packages/components": {
             "name": "@redhat-cloud-services/frontend-components",
-            "version": "4.2.13",
+            "version": "4.2.14",
             "license": "Apache-2.0",
             "dependencies": {
                 "@patternfly/react-component-groups": "^5.0.0",
@@ -42172,7 +42172,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "6.2.2",
+            "version": "6.2.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-34649

TLDR, GH api rate limiting can sometimes prevent us from getting the commit. We will get latest sha from quay. It might not match the current latest version, but better than nothing.