### PR TITLE
utils package: install redux-mock-store and react-intl packages as dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,12 +2453,11 @@
             }
         },
         "node_modules/@formatjs/ecma402-abstract": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.0.tgz",
-            "integrity": "sha512-6ueQTeJZtwKjmh23bdkq/DMqH4l4bmfvtQH98blOSbiXv/OUiyijSW6jU22IT8BNM1ujCaEvJfTtyCYVH38EMQ==",
-            "peer": true,
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+            "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
             "dependencies": {
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
@@ -2466,44 +2465,40 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
             "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/icu-messageformat-parser": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.6.0.tgz",
-            "integrity": "sha512-yT6at0qc0DANw9qM/TU8RZaCtfDXtj4pZM/IC2WnVU80yAcliS3KVDiuUt4jSQAeFL9JS5bc2hARnFmjPdA6qw==",
-            "peer": true,
+            "version": "2.7.8",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+            "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/icu-skeleton-parser": "1.6.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/icu-skeleton-parser": "1.8.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/icu-skeleton-parser": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.6.0.tgz",
-            "integrity": "sha512-eMmxNpoX/J1IPUjPGSZwo0Wh+7CEvdEMddP2Jxg1gQJXfGfht/FdW2D5XDFj3VMbOTUQlDIdZJY7uC6O6gjPoA==",
-            "peer": true,
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+            "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/intl": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.0.tgz",
-            "integrity": "sha512-Ym0trUoC/VO6wQu4YHa0H1VR2tEixFRmwZgADkDLm7nD+vv1Ob+/88mUAoT0pwvirFqYKgUKEwp1tFepqyqvVA==",
-            "peer": true,
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.4.tgz",
+            "integrity": "sha512-56483O+HVcL0c7VucAS2tyH020mt9XTozZO67cwtGg0a7KWDukS/FzW3OnvaHmTHDuYsoPIzO+ZHVfU6fT/bJw==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "@formatjs/fast-memoize": "2.2.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
-                "@formatjs/intl-displaynames": "6.5.0",
-                "@formatjs/intl-listformat": "7.4.0",
-                "intl-messageformat": "10.5.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
+                "@formatjs/intl-displaynames": "6.6.8",
+                "@formatjs/intl-listformat": "7.5.7",
+                "intl-messageformat": "10.5.14",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -2516,32 +2511,29 @@
             }
         },
         "node_modules/@formatjs/intl-displaynames": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.5.0.tgz",
-            "integrity": "sha512-sg/nR8ILEdUl+2sWu6jc1nQ5s04yucGlH1RVfatW8TSJ5uG3Yy3vgigi8NNC/BuhcncUNPWqSpTCSI1hA+rhiw==",
-            "peer": true,
+            "version": "6.6.8",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.8.tgz",
+            "integrity": "sha512-Lgx6n5KxN16B3Pb05z3NLEBQkGoXnGjkTBNCZI+Cn17YjHJ3fhCeEJJUqRlIZmJdmaXQhjcQVDp6WIiNeRYT5g==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/intl-listformat": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.4.0.tgz",
-            "integrity": "sha512-ifupb+balZUAF/Oh3QyGRqPRWGSKwWoMPR0cYZEG7r61SimD+m38oFQqVx/3Fp7LfQFF11m7IS+MlxOo2sKINA==",
-            "peer": true,
+            "version": "7.5.7",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.7.tgz",
+            "integrity": "sha512-MG2TSChQJQT9f7Rlv+eXwUFiG24mKSzmF144PLb8m8OixyXqn4+YWU+5wZracZGCgVTVmx8viCf7IH3QXoiB2g==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@formatjs/intl-localematcher": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.0.tgz",
-            "integrity": "sha512-bRTd+rKomvfdS4QDlVJ6TA/Jx1F2h/TBVO5LjvhQ7QPPHp19oPNMIum7W2CMEReq/zPxpmCeB31F9+5gl/qtvw==",
-            "peer": true,
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+            "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -23808,14 +23800,13 @@
             }
         },
         "node_modules/intl-messageformat": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.0.tgz",
-            "integrity": "sha512-AvojYuOaRb6r2veOKfTVpxH9TrmjSdc5iR9R5RgBwrDZYSmAAFVT+QLbW3C4V7Qsg0OguMp67Q/EoUkxZzXRGw==",
-            "peer": true,
+            "version": "10.5.14",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+            "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "@formatjs/fast-memoize": "2.2.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
                 "tslib": "^2.4.0"
             }
         },
@@ -34981,20 +34972,19 @@
             }
         },
         "node_modules/react-intl": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.4.4.tgz",
-            "integrity": "sha512-/C9Sl/5//ohfkNG6AWlJuf4BhTXsbzyk93K62A4zRhSPANyOGpKZ+fWhN+TLfFd5YjDUHy+exU/09y0w1bO4Xw==",
-            "peer": true,
+            "version": "6.6.8",
+            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.6.8.tgz",
+            "integrity": "sha512-M0pkhzcgV31h++2901BiRXWl69hp2zPyLxRrSwRjd1ErXbNoubz/f4M6DrRTd4OiSUrT4ajRQzrmtS5plG4FtA==",
             "dependencies": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
-                "@formatjs/intl": "2.9.0",
-                "@formatjs/intl-displaynames": "6.5.0",
-                "@formatjs/intl-listformat": "7.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
+                "@formatjs/intl": "2.10.4",
+                "@formatjs/intl-displaynames": "6.6.8",
+                "@formatjs/intl-listformat": "7.5.7",
                 "@types/hoist-non-react-statics": "^3.3.1",
                 "@types/react": "16 || 17 || 18",
                 "hoist-non-react-statics": "^3.3.2",
-                "intl-messageformat": "10.5.0",
+                "intl-messageformat": "10.5.14",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -42172,7 +42162,7 @@
         },
         "packages/config": {
             "name": "@redhat-cloud-services/frontend-components-config",
-            "version": "6.2.3",
+            "version": "6.2.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
@@ -43222,7 +43212,9 @@
             },
             "devDependencies": {
                 "@types/react": "^18.0.0",
-                "glob": "10.3.3"
+                "glob": "10.3.3",
+                "react-intl": "^6.6.8",
+                "redux-mock-store": "^1.5.4"
             },
             "peerDependencies": {
                 "@patternfly/react-core": "^5.0.0",
@@ -44845,12 +44837,11 @@
             "requires": {}
         },
         "@formatjs/ecma402-abstract": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.0.tgz",
-            "integrity": "sha512-6ueQTeJZtwKjmh23bdkq/DMqH4l4bmfvtQH98blOSbiXv/OUiyijSW6jU22IT8BNM1ujCaEvJfTtyCYVH38EMQ==",
-            "peer": true,
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+            "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
             "requires": {
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
@@ -44858,74 +44849,67 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
             "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
-            "peer": true,
             "requires": {
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/icu-messageformat-parser": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.6.0.tgz",
-            "integrity": "sha512-yT6at0qc0DANw9qM/TU8RZaCtfDXtj4pZM/IC2WnVU80yAcliS3KVDiuUt4jSQAeFL9JS5bc2hARnFmjPdA6qw==",
-            "peer": true,
+            "version": "2.7.8",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+            "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/icu-skeleton-parser": "1.6.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/icu-skeleton-parser": "1.8.2",
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/icu-skeleton-parser": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.6.0.tgz",
-            "integrity": "sha512-eMmxNpoX/J1IPUjPGSZwo0Wh+7CEvdEMddP2Jxg1gQJXfGfht/FdW2D5XDFj3VMbOTUQlDIdZJY7uC6O6gjPoA==",
-            "peer": true,
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+            "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/intl": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.0.tgz",
-            "integrity": "sha512-Ym0trUoC/VO6wQu4YHa0H1VR2tEixFRmwZgADkDLm7nD+vv1Ob+/88mUAoT0pwvirFqYKgUKEwp1tFepqyqvVA==",
-            "peer": true,
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.4.tgz",
+            "integrity": "sha512-56483O+HVcL0c7VucAS2tyH020mt9XTozZO67cwtGg0a7KWDukS/FzW3OnvaHmTHDuYsoPIzO+ZHVfU6fT/bJw==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "@formatjs/fast-memoize": "2.2.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
-                "@formatjs/intl-displaynames": "6.5.0",
-                "@formatjs/intl-listformat": "7.4.0",
-                "intl-messageformat": "10.5.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
+                "@formatjs/intl-displaynames": "6.6.8",
+                "@formatjs/intl-listformat": "7.5.7",
+                "intl-messageformat": "10.5.14",
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/intl-displaynames": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.5.0.tgz",
-            "integrity": "sha512-sg/nR8ILEdUl+2sWu6jc1nQ5s04yucGlH1RVfatW8TSJ5uG3Yy3vgigi8NNC/BuhcncUNPWqSpTCSI1hA+rhiw==",
-            "peer": true,
+            "version": "6.6.8",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.8.tgz",
+            "integrity": "sha512-Lgx6n5KxN16B3Pb05z3NLEBQkGoXnGjkTBNCZI+Cn17YjHJ3fhCeEJJUqRlIZmJdmaXQhjcQVDp6WIiNeRYT5g==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/intl-listformat": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.4.0.tgz",
-            "integrity": "sha512-ifupb+balZUAF/Oh3QyGRqPRWGSKwWoMPR0cYZEG7r61SimD+m38oFQqVx/3Fp7LfQFF11m7IS+MlxOo2sKINA==",
-            "peer": true,
+            "version": "7.5.7",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.5.7.tgz",
+            "integrity": "sha512-MG2TSChQJQT9f7Rlv+eXwUFiG24mKSzmF144PLb8m8OixyXqn4+YWU+5wZracZGCgVTVmx8viCf7IH3QXoiB2g==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/intl-localematcher": "0.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/intl-localematcher": "0.5.4",
                 "tslib": "^2.4.0"
             }
         },
         "@formatjs/intl-localematcher": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.0.tgz",
-            "integrity": "sha512-bRTd+rKomvfdS4QDlVJ6TA/Jx1F2h/TBVO5LjvhQ7QPPHp19oPNMIum7W2CMEReq/zPxpmCeB31F9+5gl/qtvw==",
-            "peer": true,
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+            "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
             "requires": {
                 "tslib": "^2.4.0"
             }
@@ -50003,7 +49987,9 @@
                 "glob": "10.3.3",
                 "mkdirp": "^1.0.4",
                 "p-all": "^5.0.0",
-                "react-content-loader": "^6.2.0"
+                "react-content-loader": "^6.2.0",
+                "react-intl": "^6.6.8",
+                "redux-mock-store": "^1.5.4"
             },
             "dependencies": {
                 "commander": {
@@ -61084,14 +61070,13 @@
             "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ=="
         },
         "intl-messageformat": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.0.tgz",
-            "integrity": "sha512-AvojYuOaRb6r2veOKfTVpxH9TrmjSdc5iR9R5RgBwrDZYSmAAFVT+QLbW3C4V7Qsg0OguMp67Q/EoUkxZzXRGw==",
-            "peer": true,
+            "version": "10.5.14",
+            "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+            "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
                 "@formatjs/fast-memoize": "2.2.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
                 "tslib": "^2.4.0"
             }
         },
@@ -69440,20 +69425,19 @@
             }
         },
         "react-intl": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.4.4.tgz",
-            "integrity": "sha512-/C9Sl/5//ohfkNG6AWlJuf4BhTXsbzyk93K62A4zRhSPANyOGpKZ+fWhN+TLfFd5YjDUHy+exU/09y0w1bO4Xw==",
-            "peer": true,
+            "version": "6.6.8",
+            "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.6.8.tgz",
+            "integrity": "sha512-M0pkhzcgV31h++2901BiRXWl69hp2zPyLxRrSwRjd1ErXbNoubz/f4M6DrRTd4OiSUrT4ajRQzrmtS5plG4FtA==",
             "requires": {
-                "@formatjs/ecma402-abstract": "1.17.0",
-                "@formatjs/icu-messageformat-parser": "2.6.0",
-                "@formatjs/intl": "2.9.0",
-                "@formatjs/intl-displaynames": "6.5.0",
-                "@formatjs/intl-listformat": "7.4.0",
+                "@formatjs/ecma402-abstract": "2.0.0",
+                "@formatjs/icu-messageformat-parser": "2.7.8",
+                "@formatjs/intl": "2.10.4",
+                "@formatjs/intl-displaynames": "6.6.8",
+                "@formatjs/intl-listformat": "7.5.7",
                 "@types/hoist-non-react-statics": "^3.3.1",
                 "@types/react": "16 || 17 || 18",
                 "hoist-non-react-statics": "^3.3.2",
-                "intl-messageformat": "10.5.0",
+                "intl-messageformat": "10.5.14",
                 "tslib": "^2.4.0"
             }
         },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -47,7 +47,9 @@
     },
     "devDependencies": {
         "@types/react": "^18.0.0",
-        "glob": "10.3.3"
+        "glob": "10.3.3",
+        "react-intl": "^6.6.8",
+        "redux-mock-store": "^1.5.4"
     },
     "sideEffects": false
 }


### PR DESCRIPTION
This is to install redux-mock-store and react-intl packages as dev dependencies. The reason is that the new TestWrapper requires those packages to be present. Some apps that may use the component may not have these packages available
