### PR TITLE
Bug: fix small issue preventing docker from being used locally

### DIFF
--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -51,13 +51,19 @@ function checkContainerRuntime(): ContainerRuntime {
     if (execSync('which podman').toString().trim().length > 0) {
       return 'podman';
     }
+  } catch (_) {
+    // Ignore!
+  }
+
+  try {
     if (execSync('which docker').toString().trim().length > 0) {
       return 'docker';
     }
-  } catch (error) {
-    throw new Error('No container runtime found');
+  } catch (_) {
+    // Ignore!
   }
 
+  // Neither found!
   throw new Error('No container runtime found');
 }
 


### PR DESCRIPTION
Currently, if you don’t have podman installed the checkContainerRuntime throws the follow error, skipping over the docker check:  Error: Command failed: which podman

This change simply wraps a try/catch around both the execSync calls to allow fall-through logic to work correctly for us docker folks! 
