### PR TITLE
dev-script.ts: fix starting non-interactively

### DIFF
--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -29,7 +29,6 @@ async function devScript(
   argv: {
     webpackConfig?: string;
     clouddotEnv?: string;
-    uiEnv?: string;
     port?: string;
     chromeServerPort?: number | string;
   },
@@ -59,7 +58,7 @@ async function devScript(
     }
 
     const clouddotEnvOptions = ['stage', 'prod'];
-    if (argv?.clouddotEnv && argv?.uiEnv) {
+    if (argv?.clouddotEnv) {
       if (clouddotEnvOptions.includes(argv.clouddotEnv)) {
         process.env.CLOUDOT_ENV = argv.clouddotEnv;
         process.env.FEC_ROOT_DIR = cwd;


### PR DESCRIPTION
commandline argument `--uiEnv` seems obsolete due to #2042
so it should be remove here to allow the commandline
`fec dev --clouddotEnv=stage`
(as documented in `--help`) to work?
