### PR TITLE
feat(devtool): Ability to pass custom devtool option to config

### DIFF
--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -97,7 +97,7 @@ export const createConfig = ({
   nodeModulesDirectories = [],
   stripAllPfStyles = false,
   blockLegacyChrome,
-  devtool,
+  devtool = false,
 }: CreateConfigOptions): Configuration => {
   if (typeof _unstableHotReload !== 'undefined') {
     fecLogger(LogType.warn, `The _unstableHotReload option in shared webpack config is deprecated. Use hotReload config instead.`);
@@ -119,7 +119,7 @@ export const createConfig = ({
   const devServerPort = typeof port === 'number' ? port : useProxy || standalone ? 1337 : 8002;
   return {
     mode: mode || (isProd ? 'production' : 'development'),
-    devtool: devtool || false,
+    devtool: devtool,
     ...(useCache
       ? {
           cache: {

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -53,6 +53,7 @@ export interface CreateConfigOptions extends CommonConfigOptions {
   resolve?: ResolveOptions;
   stripAllPfStyles?: boolean;
   blockLegacyChrome?: boolean;
+  devtool?: Configuration['devtool'];
 }
 
 export const createConfig = ({
@@ -96,6 +97,7 @@ export const createConfig = ({
   nodeModulesDirectories = [],
   stripAllPfStyles = false,
   blockLegacyChrome,
+  devtool,
 }: CreateConfigOptions): Configuration => {
   if (typeof _unstableHotReload !== 'undefined') {
     fecLogger(LogType.warn, `The _unstableHotReload option in shared webpack config is deprecated. Use hotReload config instead.`);
@@ -117,7 +119,7 @@ export const createConfig = ({
   const devServerPort = typeof port === 'number' ? port : useProxy || standalone ? 1337 : 8002;
   return {
     mode: mode || (isProd ? 'production' : 'development'),
-    devtool: false,
+    devtool: devtool || false,
     ...(useCache
       ? {
           cache: {


### PR DESCRIPTION
Because apps now use fec as the default config, I want to add the ability to pass in a devtool option. With this we can pass in 'hidden-source-map' for apps that will use sentry. Eventually I want this to just be the default value but I want to use advisor as a test application first.
Now that more of the sentry efforts are unblocked this can move along much faster.

https://github.com/RedHatInsights/insights-advisor-frontend/pull/1268 related PR