### PR TITLE
chore(deps): Correct utils package deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28396,8 +28396,7 @@
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -35957,7 +35956,6 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
             "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
-            "dev": true,
             "dependencies": {
                 "lodash.isplainobject": "^4.0.6"
             }
@@ -44009,13 +44007,13 @@
                 "commander": "^2.20.3",
                 "mkdirp": "^1.0.4",
                 "p-all": "^5.0.0",
-                "react-content-loader": "^6.2.0"
+                "react-content-loader": "^6.2.0",
+                "react-intl": "^6.6.8",
+                "redux-mock-store": "^1.5.4"
             },
             "devDependencies": {
                 "@types/react": "^18.0.0",
-                "glob": "10.3.3",
-                "react-intl": "^6.6.8",
-                "redux-mock-store": "^1.5.4"
+                "glob": "10.3.3"
             },
             "peerDependencies": {
                 "@patternfly/react-core": "^5.0.0",
@@ -65402,8 +65400,7 @@
         "lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -71066,7 +71063,6 @@
             "version": "1.5.4",
             "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
             "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
-            "dev": true,
             "requires": {
                 "lodash.isplainobject": "^4.0.6"
             }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,13 +43,13 @@
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
         "p-all": "^5.0.0",
-        "react-content-loader": "^6.2.0"
+        "react-content-loader": "^6.2.0",
+        "react-intl": "^6.6.8",
+        "redux-mock-store": "^1.5.4"
     },
     "devDependencies": {
         "@types/react": "^18.0.0",
-        "glob": "10.3.3",
-        "react-intl": "^6.6.8",
-        "redux-mock-store": "^1.5.4"
+        "glob": "10.3.3"
     },
     "sideEffects": false
 }


### PR DESCRIPTION
react-intl and redux mock store are used in the `TestWrapper` component and should be proper dependencies.