### PR TITLE
replace deprecated onSetupMiddleware proxy confing

### DIFF
--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -360,7 +360,7 @@ const proxy = ({
         console.log('\u001b[0m');
       }
     },
-    onBeforeSetupMiddleware({ app, compiler, options }) {
+    setupMiddlewares(middlewares, { app, compiler, options }) {
       app?.enable('strict routing'); // trailing slashes are mean
 
       if (shouldBounceProdRequests) {
@@ -411,6 +411,8 @@ const proxy = ({
           config: standaloneConfig,
         })
       );
+
+      return middlewares;
     },
   };
 

--- a/packages/config/src/lib/config.test.js
+++ b/packages/config/src/lib/config.test.js
@@ -39,7 +39,7 @@ describe('should create dummy config with no options', () => {
 
   test('devServer', () => {
     expect(devServer).toEqual({
-      onBeforeSetupMiddleware: expect.any(Function),
+      setupMiddlewares: expect.any(Function),
       onListening: expect.any(Function),
       static: {
         directory: '/dist',


### PR DESCRIPTION
A pre-requisite for enabling spy configuration option and updating webpack