### PR TITLE
Fix bad Origin header in the dev proxy

### DIFF
--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -331,7 +331,8 @@ const proxy = ({
         headers: {
           // Staging Akamai CORS gives 403s for non-GET requests from non-origin hosts
           Host: target.replace('https://', ''),
-          Origin: target,
+          // Origin format is protocol://hostname:port only, remove any trailing slash
+          Origin: target.replace(/\/$/, ''),
         },
       }),
     });


### PR DESCRIPTION
We found that our service, at `/api/rhsm-subscriptions/v1` was rejecting requests made by the dev proxy due to a bad `Origin` header.

I discovered it is because the proxy generates an `Origin` value with a trailing slash.

This change strips the trailing slash.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin