### PR TITLE
Revert "fix: typo in version check"

### DIFF
--- a/packages/config-utils/src/federated-modules.ts
+++ b/packages/config-utils/src/federated-modules.ts
@@ -41,7 +41,7 @@ function hasVersionSpecified(config: { [module: string]: WebpackSharedConfig }):
     requiredVersion: string;
   };
 } {
-  return Object.values(config).every((c) => typeof c.requiredVersion === 'string');
+  return Object.values(config).every((c) => typeof c.version === 'string');
 }
 
 const federatedModules = ({
@@ -76,7 +76,7 @@ const federatedModules = ({
   shared.forEach((dep) => {
     if (!hasVersionSpecified(dep)) {
       const invalidDeps = Object.entries(dep)
-        .filter(([, { requiredVersion }]) => typeof requiredVersion !== 'string')
+        .filter(([, { version }]) => typeof version !== 'string')
         .map(([moduleName]) => moduleName);
       throw new Error('Some of your shared dependencies do not have version specified! Dependencies with no version: ' + invalidDeps);
     }


### PR DESCRIPTION
Reverts RedHatInsights/frontend-components#2076

We are seeing this error on our local environment provided. This affecting our workflow. Thus, I am opening this revert change. I believe there should be more investigation to fix the actual issue in #2076.


![image](https://github.com/user-attachments/assets/82b64510-3278-4fa0-8abd-17d0eb244a09)
