### PR TITLE
fix(RHINENG-13796): Fix vertical alignment Inv tags badge

### DIFF
--- a/packages/components/src/FilterHooks/tagFilterHook.scss
+++ b/packages/components/src/FilterHooks/tagFilterHook.scss
@@ -9,7 +9,9 @@
     }
     .pf-v5-c-badge {
       margin-left: auto;
-      padding-top: 0.2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
   .pf-v5-c-select__menu-group-title:empty { display: none; }


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/fb7bff0a-4ab8-4083-990e-b46d16e75571)

after:
![image](https://github.com/user-attachments/assets/99ad81d0-44a7-4cd4-99fe-1f00df6e35ec)
