### PR TITLE
fix(RHINENG-8385): Unblock opening menu by toggle click

### DIFF
--- a/packages/components/src/ConditionalFilter/GroupFilter.tsx
+++ b/packages/components/src/ConditionalFilter/GroupFilter.tsx
@@ -160,9 +160,9 @@ const GroupFilter: React.FunctionComponent<GroupFilterProps> = (props) => {
 
     const clickedInsideInput = inputRef.current?.contains(event.target as Node);
     const clickedInsideMenu = menuRef.current?.contains(event.target as Node);
+    const clickedToggle = toggleRef.current?.contains(event.target as Node);
 
-    if (clickedInsideInput || clickedInsideMenu) return;
-
+    if (clickedInsideInput || clickedInsideMenu || clickedToggle) return;
     setIsOpen(false);
   };
 


### PR DESCRIPTION
This is going to help with preventing opening menu when toggle is clicked even for the first time. We need to consider it as we are clicking inside and do nothing