### PR TITLE
fix(fec): fix missing template.json when running fec dev

### DIFF
--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -7,6 +7,7 @@
     "module": "commonjs",
     "target": "ES5",
     "rootDir": "src",
+    "resolveJsonModule": true,
   },
   "include": ["src/**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.test.jsx", "src/**/*.spec.js", "src/**/*.test.js"]


### PR DESCRIPTION
When running locally with the newly published version of FEC via our NX publish pipeline, we get the error:

![image](https://github.com/user-attachments/assets/e511b495-f813-4a55-8fdb-8bbaa870c7f7)

This should resolve that issue