### PR TITLE
fix(fec): fix missing locales/data.json when running fec dev

### DIFF
--- a/packages/translations/tsconfig.esm.json
+++ b/packages/translations/tsconfig.esm.json
@@ -7,6 +7,7 @@
     "module": "ES2015",
     "target": "ES5",
     "rootDir": "./src",
+    "resolveJsonModule": true,
   },
   "include": ["./src/**/*.ts", "./src/**/*.js"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.spec.js", "src/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.test.jsx"]


### PR DESCRIPTION
This change will cause the `data.json` locales file to be included in the built output. Resolves https://issues.redhat.com/browse/RHCLOUD-36558