### PR TITLE
chore: remove description length limits

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -3,4 +3,6 @@ module.exports ={
     // Ignore rules can be found here
     // https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts
     defaultIgnores: true,
+    'body-max-length': Infinity,
+    'body-max-line-length': Infinity,
 }


### PR DESCRIPTION
Should not mess with dependabot and we can use more detail in descriptions.