### PR TITLE
fix(eslint): do not emit declaration files

### DIFF
--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -3,6 +3,6 @@
     "include": ["index.js", "lib/**/*.js"],
     "rootDir": "./src",
     "compilerOptions": {
-        "declaration": true,
+        "declaration": false,
     }
 }


### PR DESCRIPTION
Fixes issue with eslint trying to resolve `.d.ts` files in node_modules