### PR TITLE
fix: replace @use with @forward for SCSS modules

### DIFF
--- a/packages/components/src/SimpleTableFilter/simple-table-filter.scss
+++ b/packages/components/src/SimpleTableFilter/simple-table-filter.scss
@@ -1,3 +1,3 @@
 
-@use '~@redhat-cloud-services/frontend-components-utilities/styles/_mixins.scss' as m;
-@import '~@patternfly/patternfly/sass-utilities/all';
+@forward '~@redhat-cloud-services/frontend-components-utilities/styles/_mixins.scss';
+@forward '~@patternfly/patternfly/sass-utilities/all';

--- a/packages/utils/src/styles/_all.scss
+++ b/packages/utils/src/styles/_all.scss
@@ -1,4 +1,4 @@
 // Sass Imports
-@use './_variables.scss' as variables;
-@use './_helpers.scss' as helpers;
-@use './_mixins.scss' as mixins;
+@forward './_variables.scss';
+@forward './_helpers.scss';
+@forward './_mixins.scss';


### PR DESCRIPTION
This replaces @use with @forward rule for the SCSS modules that combine mixins from more stylesheets and export it for furthe consumers.

https://sass-lang.com/documentation/at-rules/forward/