### PR TITLE
fix(notifications): use latest version of fec packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36647,7 +36647,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "2.0.3",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.1",
@@ -37075,7 +37075,7 @@
     },
     "packages/chrome": {
       "name": "@redhat-cloud-services/chrome",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -37136,7 +37136,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "5.0.3",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.5.5",
@@ -39007,11 +39007,11 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "4.1.3",
+      "version": "4.1.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-cloud-services/frontend-components": "^4.0.9",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
+        "@redhat-cloud-services/frontend-components": "^5.0.5",
+        "@redhat-cloud-services/frontend-components-utilities": "^5.0.4",
         "redux-promise-middleware": "6.1.3"
       },
       "devDependencies": {
@@ -39027,64 +39027,6 @@
         "react-redux": "^7.2.9",
         "redux": ">=4.2.0"
       }
-    },
-    "packages/notifications/node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.22.tgz",
-      "integrity": "sha512-FEDxxNHF0Jg6thM1IIFxHZSVbsS5Eq4QxOuPvbhlXA7ijvxzkgh5hDwBZyRSYhL2za+sZPqZzYTgwwu1Mb3MNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@patternfly/react-component-groups": "^5.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@scalprum/core": "^0.8.1",
-        "@scalprum/react-core": "^0.9.1",
-        "classnames": "^2.2.5",
-        "sanitize-html": "^2.13.1"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.2",
-        "react": "^18.2.0",
-        "react-content-loader": "^6.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "packages/notifications/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.19.tgz",
-      "integrity": "sha512-CD3tp/fHWK/qiHfxsbiKW+odlUrQM8hQ+XxhkMzLcIJFBGbH3CTSpP9ALXdO+3UsaE5h3Hk3LRoFCYWp0Aajxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@sentry/browser": "^7.119.1",
-        "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.1 || ^1.7.0",
-        "commander": "^2.20.3",
-        "mkdirp": "^1.0.4",
-        "p-all": "^5.0.0",
-        "react-content-loader": "^6.2.0"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "packages/notifications/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
     },
     "packages/notifications/node_modules/glob": {
       "version": "10.3.3",
@@ -39128,18 +39070,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "packages/notifications/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/pdf-generator": {
       "name": "@redhat-cloud-services/frontend-components-pdf-generator",
       "version": "4.0.7",
@@ -39170,7 +39100,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "3.2.15",
+      "version": "3.2.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.21.0",
@@ -39262,7 +39192,7 @@
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "3.2.12",
+      "version": "3.2.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",
@@ -39353,7 +39283,7 @@
     },
     "packages/translations": {
       "name": "@redhat-cloud-services/frontend-components-translations",
-      "version": "3.2.12",
+      "version": "3.2.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "@formatjs/cli": "^6.1.3",
@@ -39509,7 +39439,7 @@
     },
     "packages/types": {
       "name": "@redhat-cloud-services/types",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@patternfly/quickstarts": "^5.0.0",
@@ -39563,7 +39493,7 @@
     },
     "packages/utils": {
       "name": "@redhat-cloud-services/frontend-components-utilities",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "redux-promise-middleware": "6.1.3",
-    "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
-    "@redhat-cloud-services/frontend-components": "^4.0.9"
+    "@redhat-cloud-services/frontend-components-utilities": "^5.0.4",
+    "@redhat-cloud-services/frontend-components": "^5.0.5"
   },
   "devDependencies": {
     "glob": "10.3.3",


### PR DESCRIPTION
The notification package was still referencing the previous major version of frontend components and utils packages which breaks component with context.