### PR TITLE
fix(tagmodal): revert the PF5/Modal import path change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36617,7 +36617,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.1",
@@ -37045,7 +37045,7 @@
     },
     "packages/chrome": {
       "name": "@redhat-cloud-services/chrome",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -37106,7 +37106,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.5.5",
@@ -37708,7 +37708,7 @@
     },
     "packages/config": {
       "name": "@redhat-cloud-services/frontend-components-config",
-      "version": "6.3.5",
+      "version": "6.3.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
@@ -38878,7 +38878,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.5",
@@ -38971,7 +38971,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "3.2.19",
+      "version": "3.2.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.21.0",
@@ -38993,7 +38993,7 @@
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "3.2.16",
+      "version": "3.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",
@@ -39014,7 +39014,7 @@
     },
     "packages/translations": {
       "name": "@redhat-cloud-services/frontend-components-translations",
-      "version": "3.2.14",
+      "version": "3.2.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@formatjs/cli": "^6.1.3",
@@ -39178,7 +39178,7 @@
     },
     "packages/utils": {
       "name": "@redhat-cloud-services/frontend-components-utilities",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",

--- a/packages/components/src/TagModal/TableWithFilter.tsx
+++ b/packages/components/src/TagModal/TableWithFilter.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '@patternfly/react-core/dist/dynamic/components/Empty
 import { EmptyStateBody } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import { EmptyStateHeader } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { ModalProps } from '@patternfly/react-core/dist/dynamic/next/components/Modal';
+import { ModalProps } from '@patternfly/react-core/dist/dynamic/components/Modal';
 import { Pagination } from '@patternfly/react-core/dist/dynamic/components/Pagination';
 // FIXME: Deal with table after
 import { Table, TableBody, TableHeader, TableProps } from '@patternfly/react-table/deprecated';

--- a/packages/components/src/TagModal/TagModal.test.js
+++ b/packages/components/src/TagModal/TagModal.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import TagModal from './TagModal';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
-describe('TagCount component', () => {
-  it('Render the modal open with row of tags', () => {
+describe('TagModal', () => {
+  it('renders the modal open with row of tags', () => {
     const { container } = render(
       <TagModal
         loaded
@@ -18,7 +18,7 @@ describe('TagCount component', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('Render the modal with a child component', () => {
+  it('renders the modal with a child component', () => {
     const { container } = render(
       <TagModal loaded isOpen={true} systemName={'paul.localhost.com'}>
         <h1>I am a child component</h1>
@@ -27,7 +27,7 @@ describe('TagCount component', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('Should render modal with disabled button', () => {
+  it('should render modal with disabled button', () => {
     const { container } = render(
       <TagModal
         loaded
@@ -59,6 +59,42 @@ describe('TagCount component', () => {
     );
     expect(container).toMatchSnapshot();
   });
+
+  it('should render title with system name', () => {
+    render(
+      <TagModal
+        loaded
+        isOpen={true}
+        systemName={'paul.localhost.com'}
+        rows={[
+          ['key', 'value'],
+          ['thing', 'otherthing'],
+        ]}
+      />
+    );
+
+    screen.getByRole('heading', {
+      name: /tags for paul\.localhost\.com/i,
+    });
+  });
+
+  it('should render title with title prop', () => {
+    render(
+      <TagModal
+        loaded
+        title="title-test"
+        isOpen={true}
+        rows={[
+          ['key', 'value'],
+          ['thing', 'otherthing'],
+        ]}
+      />
+    );
+
+    screen.getByRole('heading', {
+      name: /title-test/i,
+    });
+  });
 });
 
 describe('Two tables', () => {
@@ -89,7 +125,7 @@ describe('Two tables', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('Should render modal with disabled button', () => {
+  it('should render modal with disabled button', () => {
     const { container } = render(
       <TagModal
         isOpen={true}

--- a/packages/components/src/TagModal/TagModal.tsx
+++ b/packages/components/src/TagModal/TagModal.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './tagModal.scss';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
-import { Modal } from '@patternfly/react-core/dist/dynamic/next/components/Modal';
+import { Modal } from '@patternfly/react-core/dist/dynamic/components/Modal';
 import { Tab } from '@patternfly/react-core/dist/dynamic/components/Tabs';
 import { TabTitleText } from '@patternfly/react-core/dist/dynamic/components/Tabs';
 import { Tabs } from '@patternfly/react-core/dist/dynamic/components/Tabs';

--- a/packages/components/src/TagModal/__snapshots__/TagModal.test.js.snap
+++ b/packages/components/src/TagModal/__snapshots__/TagModal.test.js.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TagCount component Render the modal open with row of tags 1`] = `
+exports[`TagModal renders the modal open with row of tags 1`] = `
 <div
   aria-hidden="true"
 />
 `;
 
-exports[`TagCount component Render the modal with a child component 1`] = `
+exports[`TagModal renders the modal with a child component 1`] = `
 <div
   aria-hidden="true"
 />
 `;
 
-exports[`TagCount component Should render modal with disabled button 1`] = `
+exports[`TagModal should render modal with disabled button 1`] = `
 <div
   aria-hidden="true"
 />
 `;
 
-exports[`TagCount component should render modal with enabled button 1`] = `
+exports[`TagModal should render modal with enabled button 1`] = `
 <div
   aria-hidden="true"
 />
 `;
 
-exports[`Two tables Should render modal with disabled button 1`] = `
+exports[`Two tables should render modal with disabled button 1`] = `
 <div
   aria-hidden="true"
 />


### PR DESCRIPTION
This makes the TagModal and related components use the standard PF5/Modal import path. It was changed to use the "next" version of PF5/Modal and I believe it was not an intended change since it breaks the integration with other apps that still use the parameters for the standard version of PF5/Modal.