### PR TITLE
fix(config-utils): fix 403s when proxying to stage for fed modules in chrome

### DIFF
--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -241,6 +241,9 @@ const proxy = ({
 
         return null;
       },
+      ...(agent && {
+        agent,
+      }),
     });
   }
 


### PR DESCRIPTION
I believe this bug was introduced during some of our refactoring in support of NX.

While testing https://github.com/RedHatInsights/insights-chrome/pull/2990 locally with @wise-king-sullyman - we were seeing 403's targeting `stage-beta` or `stage-stable` via our `webpack.config.js` proxy settings.

Upon deeper investigation I found that our config utils package was no longer passing the proxy `agent` key through the config object - resulting in these requests throwing 403's with the squid proxy access denied HTML as the response.

### Before:
![Screenshot 2025-01-15 at 6 50 49 PM](https://github.com/user-attachments/assets/cae700ce-4ff0-491a-b714-455f828a4d1e)
![Screenshot 2025-01-15 at 7 03 44 PM](https://github.com/user-attachments/assets/8c643234-d469-4706-b983-fcbf58e86e24)

### After:
![Screenshot 2025-01-15 at 6 53 02 PM](https://github.com/user-attachments/assets/676fc23e-de6e-428d-9334-12d2108caa0b)
