### PR TITLE
feat: add single select filter component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36617,7 +36617,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.1",
@@ -37106,7 +37106,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.5.5",
@@ -37708,7 +37708,7 @@
     },
     "packages/config": {
       "name": "@redhat-cloud-services/frontend-components-config",
-      "version": "6.3.6",
+      "version": "6.3.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
@@ -37764,7 +37764,7 @@
     },
     "packages/config-utils": {
       "name": "@redhat-cloud-services/frontend-components-config-utilities",
-      "version": "4.0.4",
+      "version": "4.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -38878,7 +38878,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.5",
@@ -38971,7 +38971,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "3.2.20",
+      "version": "3.2.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.21.0",
@@ -38993,7 +38993,7 @@
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "3.2.17",
+      "version": "3.2.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",

--- a/packages/components/doc/conditionalFilter.md
+++ b/packages/components/doc/conditionalFilter.md
@@ -294,7 +294,7 @@ class SomeCmp extends Component {
 }
 ```
 
-### *) Custom component
+### 5) Custom component
 If you want to display some custom component, for instance color picker, date picker or something more complicated you can use this type.
 
 ```JSX
@@ -321,3 +321,51 @@ class SomeCmp extends Component {
 {
     children: Proptypes.node
 }
+```
+
+### 6) Single select component
+This component is similiar to `Radio` with a slight variation that you can select only one value. Props passed to this component are same as with `Radio`.
+```JSX
+import React, { Component, useState } from 'react';
+import { ConditionalFilter, conditionalFilterType } from '@redhat-cloud-services/frontend-components';
+
+class SomeCmp extends Component {
+    render() {
+        const [ value, onChange ] = useState();
+        return (
+            <ConditionalFilter items={[{
+                type: conditionalFilterType.singleSelect,
+                label: 'Single Select',
+                value: 'singleSelect',
+                filterValues: {
+                    onChange: (event, value) => onChange(value),
+                    value,
+                    items: [
+                        { label: 'First value', value: 'first' },
+                        { label: 'Second value', value: 'second' },
+                        { label: 'Third value', value: 'third' }
+                    ],
+                    placeholder: 'placeholder'
+                }
+            }]}
+            />
+        );
+    }
+}
+```
+* `onChange` - callback has parameters `event`, `selection` where `selection` is curently selected value.
+* Props - passed from `filterValues`
+```JS
+{
+    onChange: PropTypes.func,
+    value: PropTypes.oneOfType([ PropTypes.string, PropTypes.shape({
+        label: PropTypes.node,
+        value: PropTypes.string
+    }) ]),
+    placeholder: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.node
+    }))
+}
+```

--- a/packages/components/doc/filters.md
+++ b/packages/components/doc/filters.md
@@ -9,7 +9,7 @@ Import FilterInput from this package. The `type` of input can be `radio` or `che
 
 ```JSX
 import React from 'react';
-import { FilterInput } from '@redhat-cloud-services/frontend-components';
+import { FilterInput } from '@redhat-cloud-services/frontend-components/Filters';
 
 class YourCmp extends React.Component {
   render() {
@@ -38,7 +38,7 @@ Import FilterDropdown from this package.
 
 ```JSX
 import React from 'react';
-import { FilterDropdown } from '@redhat-cloud-services/frontend-components';
+import { FilterDropdown } from '@redhat-cloud-services/frontend-components/Filters';
 
 class YourCmp extends React.Component {
   render() {
@@ -53,4 +53,3 @@ class YourCmp extends React.Component {
   }
 }
 ```
-

--- a/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
@@ -19,6 +19,7 @@ import RadioFilter, { RadioFilterProps } from './RadioFilter';
 import CheckboxFilter, { CheckboxFilterProps } from './CheckboxFilter';
 import GroupFilter, { GroupFilterProps } from './GroupFilter';
 import './conditional-filter.scss';
+import SingleSelectFilter, { SingleSelectFilterProps } from './SingleSelectFilter';
 
 export type FilterValues = TextInputProps &
   RadioFilterProps &
@@ -64,6 +65,10 @@ export type ConditionalFilterItem = {
   | {
       type: 'group';
       filterValues: GroupFilterProps;
+    }
+  | {
+      type: 'singleSelect';
+      filterValues: RadioFilterProps;
     }
   | {
       type: 'custom';
@@ -141,6 +146,10 @@ const ConditionalFilter: React.FunctionComponent<ConditionalFilterProps> = ({
           placeholder={placeholder || activeItem.placeholder || `Filter by ${activeItem.label}`}
           {...activeItem.filterValues}
         />
+      );
+    } else if (activeItem.type === 'singleSelect' && identifyComponent<SingleSelectFilterProps>(activeItem.type, activeItem.filterValues)) {
+      return (
+        <SingleSelectFilter placeholder={placeholder || activeItem.placeholder || `Filter by ${activeItem.label}`} {...activeItem.filterValues} />
       );
     } else if (activeItem.type === 'custom' && identifyComponent<Record<string, any>>(activeItem.type, activeItem.filterValues)) {
       const C = typeMapper.custom;

--- a/packages/components/src/ConditionalFilter/SingleSelectFilter.tests.js
+++ b/packages/components/src/ConditionalFilter/SingleSelectFilter.tests.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import SingleSelectFilter from './SingleSelectFilter';
+import { render, screen, waitFor, within } from '@testing-library/react';
+
+const items = [
+  { value: 'op1', label: 'option 1' },
+  { value: 'op2', label: 'option 2' },
+  { value: 'op3', label: 'option 3' },
+];
+const filterId = 'my-filter';
+const setFilterData = jest.fn();
+
+describe('SingleSelectFilter component', () => {
+  it('Should handle select values', async () => {
+    render(<SingleSelectFilter onChange={setFilterData} items={items} placeholder="placeholder" value={items[0].value} />);
+
+    await waitFor(() =>
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /option 1/i,
+        })
+      )
+    );
+
+    const option1 = screen.getByRole('option', {
+      name: /option 1/i,
+    });
+    const option2 = screen.getByRole('option', {
+      name: /option 2/i,
+    });
+    const option3 = screen.getByRole('option', {
+      name: /option 3/i,
+    });
+
+    expect(
+      within(option1).getByRole('img', {
+        hidden: true,
+      })
+    ).toBeTruthy();
+    expect(
+      within(option2).queryByRole('img', {
+        hidden: true,
+      })
+    ).toBeFalsy();
+    expect(
+      within(option3).queryByRole('img', {
+        hidden: true,
+      })
+    ).toBeFalsy();
+
+    await waitFor(() => userEvent.click(option2));
+
+    expect(setFilterData).toHaveBeenCalledWith(items[1].value);
+  });
+});

--- a/packages/components/src/ConditionalFilter/SingleSelectFilter.tsx
+++ b/packages/components/src/ConditionalFilter/SingleSelectFilter.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { MenuToggle } from '@patternfly/react-core/dist/dynamic/components/MenuToggle';
+import { Select } from '@patternfly/react-core/dist/dynamic/components/Select';
+import { SelectList } from '@patternfly/react-core/dist/dynamic/components/Select';
+import { SelectOption } from '@patternfly/react-core/dist/dynamic/components/Select';
+
+import { FilterItem, FilterValue, isFilterValue } from './TextFilter';
+
+export interface SingleSelectFilterProps {
+  /** Optional className. */
+  className?: string;
+  /** Optional disabled flag. */
+  isDisabled?: boolean;
+  /** Optional list of available options. */
+  items?: FilterItem[];
+  /** Optional onChange event callback. */
+  onChange: (
+    e: React.MouseEvent | React.ChangeEvent | React.FormEvent<HTMLInputElement> | undefined,
+    newSelection: string | FilterValue | (string | FilterValue)[],
+    selection?: string | FilterValue
+  ) => void;
+  /** Optional select value placeholder. */
+  placeholder?: string;
+  /** Optional list of selected values. */
+  value?: string | FilterValue | Record<string, any>;
+  /** Input element react ref for TextFilter */
+  innerRef?: React.Ref<HTMLInputElement>;
+}
+
+/**
+ * Component that works as a single select filter for ConditionalFilter component.
+ *
+ * It was not designed to be used as a standalone component, but rather within conditionalFilter.
+ */
+const SingleSelectFilter: React.FunctionComponent<SingleSelectFilterProps> = ({
+  items = [],
+  onChange = () => undefined,
+  isDisabled = false,
+  ...props
+}) => {
+  const { placeholder, className, value } = props;
+  const [isExpanded, setExpanded] = useState(false);
+
+  const calculateSelected = () => {
+    if (value) {
+      return isFilterValue(value) ? value.value : value;
+    }
+  };
+
+  const onSelect = (event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element> | undefined, selection: string | FilterValue) => {
+    onChange(event, selection);
+  };
+
+  const checkedValue = calculateSelected();
+  return (
+    <Select
+      className={className}
+      aria-label="Select Input"
+      toggle={(menuRef) => (
+        <MenuToggle
+          aria-label="Options menu"
+          isExpanded={isExpanded}
+          onClick={() => setExpanded((prev) => !prev)}
+          isDisabled={isDisabled}
+          ref={menuRef}
+          isFullWidth
+        >
+          {placeholder}
+        </MenuToggle>
+      )}
+      onOpenChange={(value) => setExpanded(value)}
+      onSelect={(event, value) => onSelect(event, value as string | FilterValue)}
+      isOpen={isExpanded}
+      ouiaId={placeholder}
+      selected={checkedValue}
+    >
+      <SelectList aria-label="Options menu">
+        {items.map(({ value, isChecked, onChange, label, id, ...item }, key) => (
+          <SelectOption {...item} key={id || key} value={value || '' + key}>
+            {label}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default SingleSelectFilter;

--- a/packages/components/src/ConditionalFilter/conditionalFilterConstants.test.js
+++ b/packages/components/src/ConditionalFilter/conditionalFilterConstants.test.js
@@ -1,7 +1,7 @@
 import { conditionalFilterType, typeMapper } from './conditionalFilterConstants';
 
 it('should have correct types', () => {
-  expect(Object.values(conditionalFilterType).length).toBe(5);
+  expect(Object.values(conditionalFilterType).length).toBe(6);
 });
 
 it('should return correct type', () => {

--- a/packages/components/src/ConditionalFilter/conditionalFilterConstants.ts
+++ b/packages/components/src/ConditionalFilter/conditionalFilterConstants.ts
@@ -3,6 +3,7 @@ import Text, { TextFilterProps } from './TextFilter';
 import Checkbox, { CheckboxFilterProps } from './CheckboxFilter';
 import Radio, { RadioFilterProps } from './RadioFilter';
 import Group, { GroupFilterProps } from './GroupFilter';
+import SingleSelectFilter, { SingleSelectFilterProps } from './SingleSelectFilter';
 
 export const conditionalFilterType = {
   text: 'text',
@@ -10,6 +11,7 @@ export const conditionalFilterType = {
   radio: 'radio',
   custom: 'custom',
   group: 'group',
+  singleSelect: 'singleSelect',
 };
 
 export const typeMapper = {
@@ -18,11 +20,11 @@ export const typeMapper = {
   radio: Radio,
   custom: Fragment,
   group: Group,
+  singleSelect: SingleSelectFilter,
 };
 
-export function identifyComponent<T extends TextFilterProps | CheckboxFilterProps | RadioFilterProps | GroupFilterProps | Record<string, any>>(
-  type: keyof typeof conditionalFilterType,
-  props: T
-): props is T {
+export function identifyComponent<
+  T extends TextFilterProps | CheckboxFilterProps | RadioFilterProps | GroupFilterProps | SingleSelectFilterProps | Record<string, any>
+>(type: keyof typeof conditionalFilterType, props: T): props is T {
   return true;
 }

--- a/packages/components/src/ConditionalFilter/index.ts
+++ b/packages/components/src/ConditionalFilter/index.ts
@@ -9,6 +9,8 @@ export { default as CheckboxFilter } from './CheckboxFilter';
 export type { CheckboxFilterProps } from './CheckboxFilter';
 export { default as RadioFilter } from './RadioFilter';
 export type { RadioFilterProps } from './RadioFilter';
+export { default as SingleSelectFilter } from './SingleSelectFilter';
+export type { SingleSelectFilterProps } from './SingleSelectFilter';
 export { default as TextFilter } from './TextFilter';
 export type { TextFilterProps, FilterItem, FilterValue } from './TextFilter';
 export { default as GroupType } from './groupType';


### PR DESCRIPTION
This PR adds a single select filter dropdown component for use with the PrimaryToolbar. It is used on conjuction with the custom conditional filter type. Docs are included in the PR.