### PR TITLE
fix(build): fix release postTarget nested dependencies

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,11 @@
       "inputs": ["default", "{workspaceRoot}/.eslintrc.js", "{workspaceRoot}/.eslintignore", "{workspaceRoot}/eslint.config.js"]
     },
     "test:unit": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["^test:unit"],
+      "cache": true
+    },   
+    "test:component": {
+      "dependsOn": ["^test:component"],
       "cache": true
     },   
     "version": {

--- a/packages/advisor-components/project.json
+++ b/packages/advisor-components/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-advisor-components",
         "sourceDir": "packages/advisor-components"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-advisor-components",
@@ -33,7 +33,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-advisor-components"

--- a/packages/advisor-components/project.json
+++ b/packages/advisor-components/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-advisor-components:build:bundles", "nx run @redhat-cloud-services/frontend-components-advisor-components:build:styles", "nx run @redhat-cloud-services/frontend-components-advisor-components:build:packages", "nx run @redhat-cloud-services/frontend-components-advisor-components:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/chrome/project.json
+++ b/packages/chrome/project.json
@@ -31,8 +31,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:packages"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/chrome:build:bundles", "nx run @redhat-cloud-services/chrome:build:packages"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/chrome/project.json
+++ b/packages/chrome/project.json
@@ -17,7 +17,7 @@
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components",

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components:build:bundles", "nx run @redhat-cloud-services/frontend-components:build:styles", "nx run @redhat-cloud-services/frontend-components:build:packages", "nx run @redhat-cloud-services/frontend-components:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components",
         "sourceDir": "packages/components"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components",
@@ -33,7 +33,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components"

--- a/packages/executors/src/executors/builder/executor.ts
+++ b/packages/executors/src/executors/builder/executor.ts
@@ -53,8 +53,8 @@ export default async function runExecutor(options: BuilderExecutorSchemaType, co
 
   const { cjsTsConfig, esmTsConfig, ...tscOptions } = options;
   const esmOutputDir = options.outputPath + '/esm';
-  const cjsTscOptions = { ...tscOptions, tsConfig: cjsTsConfig };
-  const esmTscOptions = { ...tscOptions, outputPath: esmOutputDir, tsConfig: esmTsConfig };
+  const cjsTscOptions: TscExecutorOptions = { clean: false, ...tscOptions, tsConfig: cjsTsConfig };
+  const esmTscOptions: TscExecutorOptions = { clean: false, ...tscOptions, outputPath: esmOutputDir, tsConfig: esmTsConfig };
   let executionResult = { success: false };
   const results = await Promise.all([tscExecutor(cjsTscOptions, context as any), tscExecutor(esmTscOptions, context as any)]);
   executionResult = await resolveExecutors(...results);

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-notifications",
         "sourceDir": "packages/notifications"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-notifications",
@@ -33,7 +33,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-notifications"

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-notifications:build:bundles", "nx run @redhat-cloud-services/frontend-components-notifications:build:styles", "nx run @redhat-cloud-services/frontend-components-notifications:build:packages", "nx run @redhat-cloud-services/frontend-components-notifications:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/remediations/project.json
+++ b/packages/remediations/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-remediations",
         "sourceDir": "packages/remediations"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-remediations",
@@ -39,7 +39,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-remediations"

--- a/packages/remediations/project.json
+++ b/packages/remediations/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-remediations:build:bundles", "nx run @redhat-cloud-services/frontend-components-remediations:build:styles", "nx run @redhat-cloud-services/frontend-components-remediations:build:packages", "nx run @redhat-cloud-services/frontend-components-remediations:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/rule-components/project.json
+++ b/packages/rule-components/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/rule-components:build:bundles", "nx run @redhat-cloud-services/rule-components:build:styles", "nx run @redhat-cloud-services/rule-components:build:packages", "nx run @redhat-cloud-services/rule-components:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/rule-components/project.json
+++ b/packages/rule-components/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/rule-components",
         "sourceDir": "packages/rule-components"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/rule-components",
@@ -33,7 +33,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/rule-components"

--- a/packages/testing/project.json
+++ b/packages/testing/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-testing",
         "sourceDir": "packages/testing"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-testing",
@@ -39,7 +39,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-testing"

--- a/packages/testing/project.json
+++ b/packages/testing/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-testing:build:bundles", "nx run @redhat-cloud-services/frontend-components-testing:build:styles", "nx run @redhat-cloud-services/frontend-components-testing:build:packages", "nx run @redhat-cloud-services/frontend-components-testing:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/translations/project.json
+++ b/packages/translations/project.json
@@ -30,14 +30,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-translations",
         "sourceDir": "packages/translations"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-translations",
@@ -45,7 +45,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-translations"

--- a/packages/translations/project.json
+++ b/packages/translations/project.json
@@ -58,8 +58,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-translations:build:bundles", "nx run @redhat-cloud-services/frontend-components-translations:build:styles", "nx run @redhat-cloud-services/frontend-components-translations:build:packages", "nx run @redhat-cloud-services/frontend-components-translations:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -18,14 +18,14 @@
     },
     "build:styles": {
       "executor": "@redhat-cloud-services/frontend-components-executors:build-styles",
-      "dependsOn": ["^build:styles", "build:bundles"],
+      "dependsOn": ["^build:styles"],
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-utilities",
         "sourceDir": "packages/utils"
       }
     },
     "build:packages": {
-      "dependsOn": ["^build:packages", "build:bundles"],
+      "dependsOn": ["^build:packages"],
       "executor": "@redhat-cloud-services/frontend-components-executors:build-packages",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-utilities",
@@ -33,7 +33,7 @@
       }
     },
     "transform:scss": {
-      "dependsOn": ["^transform:scss", "build:bundles"],
+      "dependsOn": ["^transform:scss"],
       "executor": "@redhat-cloud-services/frontend-components-executors:transform-scss",
       "options": {
         "outputPath": "dist/@redhat-cloud-services/frontend-components-utilities"

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -46,8 +46,12 @@
       }
     },
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": ["^build", "build:styles", "build:packages", "transform:scss"]
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": ["nx run @redhat-cloud-services/frontend-components-utilities:build:bundles", "nx run @redhat-cloud-services/frontend-components-utilities:build:styles", "nx run @redhat-cloud-services/frontend-components-utilities:build:packages", "nx run @redhat-cloud-services/frontend-components-utilities:transform:scss"]
+      },
+      "dependsOn": ["^build"]
     },
     "lint": {
       "executor": "@nx/eslint:lint",


### PR DESCRIPTION
- Fixes issues with release version numbers
  - the post target runs were not properly triggering the `dependsOn` jobs
- Enables cache for the cypress component tests