### PR TITLE
chore(deps): add more major versions to react-redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36617,7 +36617,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "2.0.9",
+      "version": "2.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.1",
@@ -37045,7 +37045,7 @@
     },
     "packages/chrome": {
       "name": "@redhat-cloud-services/chrome",
-      "version": "1.0.15",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -37106,7 +37106,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "5.1.3",
+      "version": "5.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.5.5",
@@ -37136,7 +37136,7 @@
         "react": "^18.2.0",
         "react-content-loader": "^6.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0",
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
@@ -37708,11 +37708,11 @@
     },
     "packages/config": {
       "name": "@redhat-cloud-services/frontend-components-config",
-      "version": "6.3.8",
+      "version": "6.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.0.4",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.1.3",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
@@ -37764,7 +37764,7 @@
     },
     "packages/config-utils": {
       "name": "@redhat-cloud-services/frontend-components-config-utilities",
-      "version": "4.0.6",
+      "version": "4.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -38403,7 +38403,7 @@
     },
     "packages/eslint-config": {
       "name": "@redhat-cloud-services/eslint-config-redhat-cloud-services",
-      "version": "2.0.10",
+      "version": "2.0.12",
       "license": "Apache",
       "dependencies": {
         "@babel/eslint-parser": "^7.19.1",
@@ -38921,7 +38921,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "4.1.10",
+      "version": "4.1.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^5.0.5",
@@ -38938,7 +38938,7 @@
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^7.2.9",
+        "react-redux": "^7.2.9 || ^8.0.0 || ^9.0.0",
         "redux": ">=4.2.0"
       }
     },
@@ -39014,7 +39014,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "3.2.21",
+      "version": "3.2.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.21.0",
@@ -39031,12 +39031,12 @@
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0"
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "3.2.18",
+      "version": "3.2.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^5.0.0",
@@ -39052,12 +39052,12 @@
     },
     "packages/testing": {
       "name": "@redhat-cloud-services/frontend-components-testing",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "Apache-2.0"
     },
     "packages/translations": {
       "name": "@redhat-cloud-services/frontend-components-translations",
-      "version": "3.2.15",
+      "version": "3.2.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@formatjs/cli": "^6.1.3",
@@ -39117,7 +39117,7 @@
     },
     "packages/tsc-transform-imports": {
       "name": "@redhat-cloud-services/tsc-transform-imports",
-      "version": "1.0.21",
+      "version": "1.0.23",
       "dependencies": {
         "glob": "10.3.3"
       },
@@ -39167,7 +39167,7 @@
     },
     "packages/types": {
       "name": "@redhat-cloud-services/types",
-      "version": "1.0.19",
+      "version": "1.0.21",
       "license": "Apache-2.0",
       "devDependencies": {
         "@patternfly/quickstarts": "^5.0.0",
@@ -39221,7 +39221,7 @@
     },
     "packages/utils": {
       "name": "@redhat-cloud-services/frontend-components-utilities",
-      "version": "5.0.7",
+      "version": "5.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
@@ -39245,7 +39245,7 @@
         "@patternfly/react-table": "^5.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0",
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,7 +32,7 @@
     "react": "^18.2.0",
     "react-content-loader": "^6.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^7.0.0",
+    "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "react-router-dom": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -26,7 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "redux": ">=4.2.0",
-    "react-redux": "^7.2.9"
+    "react-redux": "^7.2.9 || ^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "redux-promise-middleware": "6.1.3",

--- a/packages/remediations/package.json
+++ b/packages/remediations/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^7.0.0"
+    "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "^3.21.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
     "@patternfly/react-table": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^7.0.0",
+    "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "react-router-dom": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Some of our apps (eg Advisor) use newer versions of Redux