### PR TITLE
fix(components): groupFilterConstants remove key

### DIFF
--- a/packages/components/src/ConditionalFilter/groupFilterConstants.ts
+++ b/packages/components/src/ConditionalFilter/groupFilterConstants.ts
@@ -190,7 +190,6 @@ export const getMenuItems = (
     items.map((item: GroupFilterItem, index: number) => ({
       ...item,
       className: `${item?.className || 'pf-v5-u-pl-sm'}`,
-      key: item.id || item.value || index,
       value: String(item.value || item.id || index),
       onClick: (event: React.FormEvent | React.MouseEventHandler, treeViewItem?: TreeViewItem, checked?: boolean) => {
         const params: [


### PR DESCRIPTION
When running Inventory locally and opening OS filter dropdown, I'm getting an error `Cannot read properties of undefined (reading 'getStackAddendum')`, after debugging the error is caused by this additional key.