### PR TITLE
feat!: pf6 chrome, translations, and types

### DIFF
--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -2,8 +2,6 @@
 
 This package is intended to be used as a public interface to all shared data or functions exposed by chrome to its modules
 
-The package is currently in an experimental phase. Please do not use it.
-
 ## Installation: TDB
 
 ## Development: TDB

--- a/packages/translations/README.md
+++ b/packages/translations/README.md
@@ -1,6 +1,6 @@
 # RedHat Cloud Services frontend components - translations
 
-This package is for setting [react-intl](https://www.npmjs.com/package/react-intl) with default messages translated accross entire platform. For futher understanding how to pass messages and such follow up `react-intl` documentation.
+This package is for setting [react-intl](https://www.npmjs.com/package/react-intl) with default messages translated accross the entire platform. For futher understanding how to pass messages and such follow up `react-intl` documentation.
 
 
 ## Usage

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,3 @@
+# Types package
+
+This package is intended to expose the common types when using the chrome API


### PR DESCRIPTION
After merging https://github.com/RedHatInsights/frontend-components/pull/2176 - the incorrect versions of 3 packages were published:
- `@redhat-cloud-services/frontend-components-translations@3.2.22`
- `@redhat-cloud-services/types@1.0.24`
- `@redhat-cloud-services/chrome@1.0.21)`

I did not realize we made changes to the dev/optional dependencies of these packages. Some shouldn't be an issue - however chrome will be - so I will remove those published versions from NPM as to not break others.