### PR TITLE
fix(config): add jsx to resolve extensions

### DIFF
--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -254,7 +254,7 @@ export const createConfig = ({
     },
     resolve: {
       ...resolve,
-      extensions: ['.ts', '.tsx', '.mjs', '.js', '.scss', ...(resolve.extensions, [])],
+      extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.scss', ...(resolve.extensions || [])],
       alias: {
         ...(bundlePfModules
           ? {}


### PR DESCRIPTION
Ran into an issue getting an application onboarded to the fec binary.

First, the spread operator for the passed in `resolve.extensions` was wrong, resulting in a spread of an empty array every time (so we essentially ignore whatever value you pass in).

Second, even though our config has `jsx` support in the module rules, we do not include `jsx` by default in the resolve extensions.

We will need to pull this into chrome in order to see the local development builds working with the app (pulling the latest chrome image).