### PR TITLE
Enable public path auto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36547,7 +36547,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^6.0.0",
@@ -37036,7 +37036,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",
@@ -37639,11 +37639,11 @@
     },
     "packages/config": {
       "name": "@redhat-cloud-services/frontend-components-config",
-      "version": "6.4.7",
+      "version": "6.4.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^4.1.6",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^4.2.0",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
@@ -37695,7 +37695,7 @@
     },
     "packages/config-utils": {
       "name": "@redhat-cloud-services/frontend-components-config-utilities",
-      "version": "4.1.6",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -38852,7 +38852,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^6.0.0",
@@ -38945,7 +38945,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^4.0.0",
@@ -39029,7 +39029,7 @@
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^6.0.0",

--- a/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
@@ -155,7 +155,7 @@ const ConditionalFilter: React.FunctionComponent<ConditionalFilterProps> = ({
       const C = typeMapper.custom;
       // make sure no invalid props are passed to the Fragment element which is mapped to the custom component
       const { key, children } = activeItem.filterValues;
-      return <C key={key} children={children} />;
+      return <C key={key}>{children}</C>;
     } else {
       throw new Error(`Invalid conditional filter component type! Expected one of ${Object.keys(conditionalFilterType)}, got ${activeItem.type}.`);
     }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,7 +27,7 @@
   "scripts": {},
   "dependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-    "@redhat-cloud-services/frontend-components-config-utilities": "^4.1.6",
+    "@redhat-cloud-services/frontend-components-config-utilities": "^4.2.0",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.21",
     "@swc/core": "^1.3.76",
     "assert": "^2.0.0",

--- a/packages/config/src/bin/common.ts
+++ b/packages/config/src/bin/common.ts
@@ -17,6 +17,11 @@ export function validateFECConfig(cwd: string) {
     fecLogger(LogType.error, 'Missing config "appUrl" in fec.config.js');
     throw 'fec.config.js validation failed, missing "appUrl" config';
   }
+
+  if (config.publicPath && config.publicPath !== 'auto') {
+    fecLogger(LogType.error, 'Invalid config "publicPath" in fec.config.js, must be empty or set to "auto"');
+    throw 'fec.config.js validation failed, "publicPath" must be empty or set to "auto"';
+  }
   process.env.FEC_CONFIG_PATH = configPath;
 }
 

--- a/packages/config/src/lib/config.test.js
+++ b/packages/config/src/lib/config.test.js
@@ -10,7 +10,6 @@ describe('should create dummy config with no options', () => {
     appEntry: '/foo/bar',
     appName: 'Fooapp',
     env: 'stage-stable',
-    publicPath: 'foo/bar',
     frontendCRDPath: crdMockPath,
   });
 
@@ -35,7 +34,6 @@ describe('should create dummy config with no options', () => {
     expect(output).toEqual({
       filename: expect.stringMatching(/js\/\[name\]\.\[contenthash\]\.js/),
       path: '/dist',
-      publicPath: 'foo/bar',
       chunkFilename: expect.stringMatching(/js\/\[name\]\.\[contenthash\]\.js/),
     });
   });
@@ -95,10 +93,13 @@ test('appEntry correctly set', () => {
 });
 
 describe('publicPath', () => {
-  const { output } = configBuilder({ publicPath: 'test-value' });
-
-  test('output', () => {
-    expect(output.publicPath).toBe('test-value');
+  test('should ignore unknown public path', () => {
+    const { output } = configBuilder({ publicPath: 'test-value' });
+    expect(output.publicPath).toBe(undefined);
+  });
+  test('should propagate public path auto', () => {
+    const { output } = configBuilder({ publicPath: 'auto' });
+    expect(output.publicPath).toBe('auto');
   });
 });
 


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHCLOUD-38931

Enables remote modules to be build with publicPath: "auto"

Also a small linter fix that was preventing check from passing.