### PR TITLE
fix(config): add missing CDN path mapping to module interceptor

### DIFF
--- a/packages/config-utils/src/feo/feo-types.ts
+++ b/packages/config-utils/src/feo/feo-types.ts
@@ -34,6 +34,7 @@ type ChromeModuleAnalytics = {
 
 export type ChromeModule = {
   manifestLocation: string;
+  cdnPath?: string;
   defaultDocumentTitle?: string;
   /**
    * @deprecated

--- a/packages/config-utils/src/feo/module-interceptor.test.ts
+++ b/packages/config-utils/src/feo/module-interceptor.test.ts
@@ -6,6 +6,7 @@ describe('module-interceptor', () => {
     const moduleName = 'module-name';
     const newEntry: ChromeModule = {
       manifestLocation: 'new-location',
+      cdnPath: '/',
     };
     const frontendCRD: FrontendCRD = {
       objects: [
@@ -39,6 +40,7 @@ describe('module-interceptor', () => {
     const moduleName = 'module-name';
     const newEntry: ChromeModule = {
       manifestLocation: 'new-location',
+      cdnPath: '/',
     };
     const frontendCRD: FrontendCRD = {
       objects: [

--- a/packages/config-utils/src/feo/module-interceptor.ts
+++ b/packages/config-utils/src/feo/module-interceptor.ts
@@ -2,9 +2,13 @@ import { ChromeModuleRegistry, FrontendCRD } from './feo-types';
 
 function moduleInterceptor(moduleRegistry: ChromeModuleRegistry, frontendCRD: FrontendCRD): ChromeModuleRegistry {
   const moduleName = frontendCRD.objects[0].metadata.name;
+  const cdnPath = frontendCRD.objects[0].spec.frontend.paths[0];
   return {
     ...moduleRegistry,
-    [moduleName]: frontendCRD.objects[0].spec.module,
+    [moduleName]: {
+      ...frontendCRD.objects[0].spec.module,
+      cdnPath,
+    },
   };
 }
 


### PR DESCRIPTION
A missing feature for automated CDN path in development interceptor.