### PR TITLE
feat(config-utils): use the module interceptor when using local proxy

### DIFF
--- a/packages/config-utils/src/feo/check-outgoing-requests.ts
+++ b/packages/config-utils/src/feo/check-outgoing-requests.ts
@@ -10,7 +10,11 @@ export function matchServiceTilesRequest(url: string): boolean {
   return !!url.match(/\/api\/chrome-service\/v1\/static\/service-tiles-generated\.json/);
 }
 
+export function matchModulesRequest(url: string): boolean {
+  return !!url.match(/\/api\/chrome-service\/v1\/static\/fed-modules-generated\.json/);
+}
+
 export function isInterceptAbleRequest(url: string): boolean {
-  const checks = [matchNavigationRequest, matchSearchIndexRequest, matchServiceTilesRequest];
+  const checks = [matchNavigationRequest, matchSearchIndexRequest, matchServiceTilesRequest, matchModulesRequest];
   return checks.some((check) => check(url));
 }


### PR DESCRIPTION
We've had some confusion around not being able to preview changes to fed-modules locally. Curious on thoughts about enabling the modules interceptor.