### PR TITLE
fix(config): add fec support for using dev chrome image

### DIFF
--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -103,6 +103,7 @@ export type ProxyOptions = {
   target?: string;
   keycloakUri?: string;
   registry?: ((...args: any[]) => void)[];
+  /** @deprecated Is now turned on by default */
   isChrome?: boolean;
   onBeforeSetupMiddleware?: (opts: { chromePath?: string }) => void;
   bounceProd?: boolean;
@@ -130,7 +131,6 @@ const proxy = ({
   proxyVerbose,
   useCloud = false,
   target = '',
-  isChrome = false,
   bounceProd = false,
   useAgent = true,
   localApps = process.env.LOCAL_APPS,
@@ -275,10 +275,10 @@ const proxy = ({
       target,
       bypass: async (req, res) => {
         /**
-         * Bypass any HTML requests if using chrome
+         * Bypass any HTML to the root URL
          * Serves as a historyApiFallback when refreshing on any other URL than '/'
          */
-        if (isChrome && !req.url.match(/\/api\//) && !req.url.match(/\./) && req.headers.accept?.includes('text/html')) {
+        if (!req.url.match(/\/api\//) && !req.url.match(/\./) && req.headers.accept?.includes('text/html')) {
           return '/';
         }
 

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -156,10 +156,22 @@ function copyIndex(path: string) {
     // create dist directory if it doesn't exist
     fs.mkdirSync(path, { recursive: true });
   }
-  const copyCommand = `${execBin} cp ${CONTAINER_NAME}:/opt/app-root/src/build/stable/index.html ${path}`;
-  execSync(copyCommand, {
-    stdio: 'inherit',
-  });
+  const copyCommandSrc = `${execBin} cp ${CONTAINER_NAME}:/opt/app-root/src/build/stable/index.html ${path}`;
+  try {
+    execSync(copyCommandSrc, {
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    fecLogger(LogType.warn, `${copyCommandSrc} non-zero exit code`);
+  }
+  const copyCommandSrv = `${execBin} cp ${CONTAINER_NAME}:/srv/dist/index.html ${path}`;
+  try {
+    execSync(copyCommandSrv, {
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    fecLogger(LogType.warn, `${copyCommandSrv} non-zero exit code`);
+  }
 }
 
 async function serveChrome(distPath: string, host: string, onError: (error: Error) => void, isProd = false, serverPort = 9999) {

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -7,6 +7,7 @@ import waitOn from 'wait-on';
 const CONTAINER_PORT = 8000;
 const CONTAINER_NAME = 'fec-chrome-local';
 const IMAGE_REPO = 'quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome';
+const IMAGE_REPO_DEV = 'quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome-dev';
 const LATEST_IMAGE_TAG = 'latest';
 const GRAPHQL_ENDPOINT = 'https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql';
 
@@ -116,13 +117,13 @@ async function getProdRelease() {
   }
 }
 
-function pullImage(tag: string) {
-  execSync(`${execBin} pull ${IMAGE_REPO}:${tag}`, {
+function pullImage(repo: string, tag: string) {
+  execSync(`${execBin} pull ${repo}:${tag}`, {
     stdio: 'inherit',
   });
 }
 
-async function startServer(tag: string, serverPort: number) {
+async function startServer(image: string, tag: string, serverPort: number) {
   return new Promise<void>((resolve, reject) => {
     try {
       execSync(`${execBin} stop ${CONTAINER_NAME}`, {
@@ -134,7 +135,7 @@ async function startServer(tag: string, serverPort: number) {
     } catch (error) {
       fecLogger(LogType.info, 'No existing chrome container found');
     }
-    const runCommand = `${execBin} run -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${IMAGE_REPO}:${tag}`;
+    const runCommand = `${execBin} run -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${image}:${tag}`;
     const child = spawn(runCommand, [], {
       stdio: 'ignore',
       shell: true,
@@ -168,13 +169,16 @@ async function serveChrome(distPath: string, host: string, onError: (error: Erro
   fecLogger(LogType.info, 'Starting chrome server...');
   execBin = checkContainerRuntime();
   let tag: string;
+  let image: string;
   if (isProd) {
     tag = await getProdRelease();
+    image = IMAGE_REPO;
   } else {
     tag = LATEST_IMAGE_TAG;
+    image = IMAGE_REPO_DEV;
   }
-  pullImage(tag);
-  startServer(tag, serverPort).catch((error) => {
+  pullImage(image, tag);
+  startServer(image, tag, serverPort).catch((error) => {
     onError(error);
     process.exit(1);
   });


### PR DESCRIPTION
Changes:
* When proxying to stage - the new dev chrome image will be used
* The `isChrome` fec config boolean is now deprecated (defaults to `true` now)
* We will attempt to copy the chrome index.html from both the src (old) and srv (new) container locations (with logging)

@Hyperkid123 can you PTAL? We now have a development build of chrome pushed to https://quay.io/repository/redhat-services-prod/hcc-platex-services-tenant/insights-chrome-dev

~I tried pulling these changes into landing-page-frontend. The build works locally - but I believe since chrome will now request the development assets/hashes - there are errors requesting chrome-root etc.~ **Edit** fixed in second commit
