### PR TITLE
feat: add support for proxying to a custom ephemeral environment

### DIFF
--- a/packages/config-utils/src/proxy.ts
+++ b/packages/config-utils/src/proxy.ts
@@ -191,10 +191,11 @@ const proxy = ({
 
   const isProd = env.startsWith('prod');
   const isStage = env.startsWith('stage');
+  const isEphemeral = env.startsWith('ephemeral');
 
   const shouldBounceProdRequests = isProd && bounceProd && !useAgent;
 
-  if (isStage || (isProd && useAgent)) {
+  if (isStage || isEphemeral || (isProd && useAgent)) {
     // stage is deployed with Akamai which requires a corporate proxy
     agent = new HttpsProxyAgent(proxyURL);
   }
@@ -203,6 +204,10 @@ const proxy = ({
     // stage-stable branches don't exist in build repos
     // Currently stage pulls from QA
     env = env.replace('stage', 'qa');
+  }
+
+  if (isEphemeral) {
+    env = env.replace('ephemeral', 'qa');
   }
 
   if (!Array.isArray(appUrl)) {

--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -15,11 +15,20 @@ async function setEnv(cwd: string) {
         type: 'list',
         name: 'clouddotEnv',
         message: 'Which platform environment you want to use?',
-        choices: ['stage', 'prod', 'dev'],
+        choices: ['stage', 'prod', 'dev', 'ephemeral'],
       },
     ])
-    .then((answers) => {
+    .then(async (answers) => {
       const { clouddotEnv } = answers;
+
+      if (clouddotEnv === 'ephemeral') {
+        const answer = await inquirer.prompt([{
+          type: 'input',
+          name: 'clouddotEnv',
+          message: 'Please provide the gateway route of your ephemeral environment:',
+        }]);
+        process.env.EPHEMERAL_TARGET = answer.clouddotEnv
+      }
       process.env.CLOUDOT_ENV = clouddotEnv ? clouddotEnv : 'stage';
       process.env.FEC_ROOT_DIR = cwd;
     });
@@ -57,7 +66,7 @@ async function devScript(
       configPath = resolve(__dirname, './dev.webpack.config.js');
     }
 
-    const clouddotEnvOptions = ['stage', 'prod', 'dev'];
+    const clouddotEnvOptions = ['stage', 'prod', 'dev', 'ephemeral'];
     if (argv?.clouddotEnv) {
       if (clouddotEnvOptions.includes(argv.clouddotEnv)) {
         process.env.CLOUDOT_ENV = argv.clouddotEnv;

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -14,7 +14,7 @@ const { fecLogger, LogType } = require('@redhat-cloud-services/frontend-componen
 
 function patchHosts() {
   const command = `
-    for host in prod.foo.redhat.com stage.foo.redhat.com qa.foo.redhat.com ci.foo.redhat.com
+    for host in prod.foo.redhat.com stage.foo.redhat.com qa.foo.redhat.com ci.foo.redhat.com ephemeral.foo.redhat.com
 do
     grep -q $host /etc/hosts 2>/dev/null
     if [ $? -ne 0 ]
@@ -116,7 +116,7 @@ const argv = yargs
     });
   })
   .option('clouddotEnv', {
-    describe: "Set platform environment ['stage', 'prod']",
+    describe: "Set platform environment ['stage', 'prod', 'ephemeral']",
     type: 'string',
   })
   .example('$0 dev --clouddotEnv=stage', 'Example of usage in non-interactive environments')

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -1,20 +1,28 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
 import serveStatic from '@redhat-cloud-services/frontend-components-config-utilities/serve-federated';
-const fs = require('fs');
-const path = require('path');
+const { fecLogger, LogType } = require('@redhat-cloud-services/frontend-components-config-utilities');
 import yargs from 'yargs';
 // to force TS to copy the file
 import './tsconfig.template.json';
 import { validateFECConfig } from './common';
 
+const { lookup } = require('dns');
+const { promisify } = require('util');
+const { execSync } = require('child_process');
+
+const fs = require('fs');
+const path = require('path');
+
 const devScript = require('./dev-script');
 const buildScript = require('./build-script');
-const { fecLogger, LogType } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+const promisifiedLookup = promisify(lookup);
+
+const hosts = ['prod.foo.redhat.com', 'stage.foo.redhat.com', 'qa.foo.redhat.com', 'ci.foo.redhat.com', 'ephemeral.foo.redhat.com'];
 
 function patchHosts() {
   const command = `
-    for host in prod.foo.redhat.com stage.foo.redhat.com qa.foo.redhat.com ci.foo.redhat.com ephemeral.foo.redhat.com
+    for host in ${hosts.join(' ')} 
 do
     grep -q $host /etc/hosts 2>/dev/null
     if [ $? -ne 0 ]
@@ -33,6 +41,19 @@ done
 }
 
 const cwd = process.cwd();
+
+async function checkHostname(hostname: string) {
+  try {
+    await promisifiedLookup(hostname);
+  } catch {
+    return hostname;
+  }
+}
+
+async function checkHosts(): Promise<string[]> {
+  const missingHosts = await Promise.allSettled<string | undefined>(hosts.map(checkHostname));
+  return missingHosts.filter((v) => v.status === 'fulfilled').filter(v => v.value !== undefined).map(v => v.value!);
+}
 
 function checkDependencies() {
   const requiredDependencies = ['typescript', 'ts-patch', '@redhat-cloud-services/tsc-transform-imports'];
@@ -59,6 +80,7 @@ function checkDependencies() {
 
   return missingDependencies;
 }
+
 function patchTs(dependencies: string) {
   const usesYarn = fs.existsSync(path.resolve(cwd, 'yarn.lock'));
   if (dependencies.length > 0) {
@@ -137,10 +159,17 @@ const scripts: { [name: string]: (...args: any[]) => void } = {
 
 const args = [argv, cwd];
 
-function run() {
+async function run() {
   const missingDependencies = checkDependencies();
   if (missingDependencies.length > 0) {
     patchTs(missingDependencies.join(' '));
+  }
+  const missingHosts = await checkHosts();
+  if (missingHosts.length > 0) {
+    fecLogger(LogType.warn,`Found missing hosts`);
+    fecLogger(LogType.warn,`\`fec dev\` will likely not work correctly. Please consider running \`fec patch-etc-hosts\` to fix the problem.`);
+    fecLogger(LogType.warn, `Missing hosts`);
+    fecLogger(LogType.warn, missingHosts.join(' '));
   }
   if (!(argv as any)._.length || (argv as any)._.length === 0) {
     console.error('Script name must be specified. Run fec --help for more information.');
@@ -150,4 +179,4 @@ function run() {
   scripts[(argv as any)._[0]](...args);
 }
 
-run();
+void run();

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import fs from 'fs';
 import { execSync, spawn } from 'child_process';
-import { LogType, fecLogger } from '@redhat-cloud-services/frontend-components-config-utilities';
+import { fecLogger, LogType } from '@redhat-cloud-services/frontend-components-config-utilities';
 import waitOn from 'wait-on';
 
 const CONTAINER_PORT = 8000;
@@ -126,9 +126,11 @@ function pullImage(repo: string, tag: string) {
 async function startServer(image: string, tag: string, serverPort: number) {
   return new Promise<void>((resolve, reject) => {
     try {
+      fecLogger(LogType.debug, `Stop existing ${CONTAINER_NAME}`);
       execSync(`${execBin} stop ${CONTAINER_NAME}`, {
         stdio: 'inherit',
       });
+      fecLogger(LogType.debug, `Remove existing ${CONTAINER_NAME}`);
       execSync(`${execBin} rm ${CONTAINER_NAME}`, {
         stdio: 'inherit',
       });
@@ -136,6 +138,7 @@ async function startServer(image: string, tag: string, serverPort: number) {
       fecLogger(LogType.info, 'No existing chrome container found');
     }
     const runCommand = `${execBin} run -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${image}:${tag}`;
+    fecLogger(LogType.debug, `Spawn ${runCommand}`);
     const child = spawn(runCommand, [], {
       stdio: 'ignore',
       shell: true,

--- a/packages/config/src/lib/createConfig.ts
+++ b/packages/config/src/lib/createConfig.ts
@@ -18,7 +18,7 @@ export interface CommonConfigOptions {
   hotReload?: boolean;
   useFileHash?: boolean;
 }
-export type FrontendEnv = 'stage-stable' | 'prod-stable' | 'dev-stable';
+export type FrontendEnv = 'stage-stable' | 'prod-stable' | 'dev-stable' |'ephemeral-stable';
 export interface CreateConfigOptions extends CommonConfigOptions {
   port?: number;
   publicPath?: 'auto';

--- a/packages/config/src/lib/index.ts
+++ b/packages/config/src/lib/index.ts
@@ -108,6 +108,7 @@ const createFecConfig = (
       publicPath: configurations.publicPath,
       appEntry,
       appName: insights.appname,
+      target: process.env.EPHEMERAL_TARGET ?? ''
     }),
     plugins: createPlugins({
       ...configurations,


### PR DESCRIPTION
This adds an `ephemeral` option to the list of environments supported by `fec dev`. It will prompt for an url, which is going to be the same returned by `bonfire namespace describe`. You'll know it works because the provided url will be printed in the output decribing the proxy config.

[![asciicast](https://asciinema.org/a/KQakKwIMwliR83sosPZWBtott.svg)](https://asciinema.org/a/KQakKwIMwliR83sosPZWBtott)