### PR TITLE
fix(config): use dev image for local fec development against prod

### DIFF
--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -6,7 +6,6 @@ import waitOn from 'wait-on';
 
 const CONTAINER_PORT = 8000;
 const CONTAINER_NAME = 'fec-chrome-local';
-const IMAGE_REPO = 'quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome';
 const IMAGE_REPO_DEV = 'quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome-dev';
 const LATEST_IMAGE_TAG = 'latest';
 const GRAPHQL_ENDPOINT = 'https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql';
@@ -187,7 +186,7 @@ async function serveChrome(distPath: string, host: string, onError: (error: Erro
   let image: string;
   if (isProd) {
     tag = await getProdRelease();
-    image = IMAGE_REPO;
+    image = IMAGE_REPO_DEV;
   } else {
     tag = LATEST_IMAGE_TAG;
     image = IMAGE_REPO_DEV;


### PR DESCRIPTION
Verified the commit currently running in prod is available in the parallel dev build (we build both dev and prod images for every commit). 

This will unblock PF6 dev for those who cannot use stage auth. If necessary we can revisit to add support for a CLI option to use the prod image.