### PR TITLE
chore(config): deprecate config option for interceptChromeConfig

### DIFF
--- a/packages/config/src/lib/fec.config.ts
+++ b/packages/config/src/lib/fec.config.ts
@@ -8,6 +8,7 @@ export interface FECConfiguration
   appName: never;
   appUrl: string | string[] | (string | RegExp)[];
   plugins?: WebpackPluginDefinition[];
+  /** @deprecated dynamic FEO config is automatically intercepted locally as of @redhat-cloud-services/frontend-components-config >= 6.5.4 and @redhat-cloud-services/frontend-components-config-utilities >= 4.3.1 */
   interceptChromeConfig?: boolean;
   moduleFederation: Omit<FederatedModulesConfig, 'root' | 'separateRuntime'>;
   debug?: boolean;


### PR DESCRIPTION
While interceptChromeConfig is not _technically_ doing the same thing as our new FEO config interceptors - it has created confusion when migrating to the FEO (and what is automagically intercepted locally).

I'm proposing we deprecate this option to avoid confusion, however open to other approaches (renaming, etc). 