### PR TITLE
fix(toolbar): fix filter chip spacing after PF6 upgrade

### DIFF
--- a/packages/components/src/FilterChips/filter-chips.scss
+++ b/packages/components/src/FilterChips/filter-chips.scss
@@ -8,7 +8,7 @@
 }
 
 .ins-c-chip-filters {
-  .pf-v6-c-chip-group:not(:last-child) {
+  .pf-v6-c-label-group:not(:last-child) {
     margin-right: var(--pf-t--global--spacer--sm);
   }
 }


### PR DESCRIPTION
The classname was renamed in PF6. I don't know about the spacing between dropdowns above, PF have not yet updated their design guidelines.

## Before
![Screenshot From 2025-06-23 17-16-09](https://github.com/user-attachments/assets/5ec36e82-08d7-45db-b9d8-991432072bc1)

## After
![Screenshot From 2025-06-23 17-18-02](https://github.com/user-attachments/assets/ad846eef-5ec2-433d-8716-afeb96f73cf3)
