### PR TITLE
fix(config-utils): updating frontend-crd.schema.json to use correct name for the groupId key

### DIFF
--- a/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+++ b/packages/config-utils/src/feo/spec/frontend-crd.schema.json
@@ -222,7 +222,7 @@
         "title": {
           "type": "string"
         },
-        "group": {
+        "groupId": {
           "type": "string"
         },
         "id": {


### PR DESCRIPTION
The key needs to be `groupId`: https://github.com/RedHatInsights/frontend-operator/blob/main/api/v1alpha1/frontend_types.go#L236