### PR TITLE
feat(config): add new dev-proxy cmd to fec bin

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -30,6 +30,7 @@
 - [fec node scripts](#fec-node-scripts)
   - [Usage](#usage-1)
   - [Patch etc hosts](#patch-etc-hosts)
+  - [Dev proxy](#dev-proxy)
   - [Static](#static)
     - [Inventory example](#inventory-example)
     - [In inventory UI repository changes](#in-inventory-ui-repository-changes)
@@ -379,6 +380,52 @@ Use binary in your `package.json` scripts section:
 
 ## Patch etc hosts
 This is a required step for first time setup. It will allow your localhost to map to [env].foo.redhat.com. This is required to run only once on your machine. **Your OS may require running the script as sudo**!
+
+## Dev proxy
+
+A script that starts up a complete development environment with webpack build, static asset serving and a containerized development proxy for environment proxying.
+This command provides an alternative to the traditional webpack dev server approach by using a customized Caddy server container to handle proxy routing, which should be more reliable and faster due to HTTP2 support and better websocket handling.
+The used containerized proxy and its documentation can be found in this repo: [frontend-development-proxy](https://github.com/RedHatInsights/frontend-development-proxy).
+
+**Usage:**
+```bash
+fec dev-proxy [options]
+```
+
+**Options:**
+- `--port, -p`: Proxy server port (default: 1337)
+- `--staticPort, -sp`: Static assets server port (default: 8003)
+- `--clouddotEnv`: Set platform environment ('stage', 'prod', 'dev', 'ephemeral')
+
+**Requirements:**
+- Docker or Podman installed and available
+- Valid FEC configuration file (fec.config.js)
+- Network access to Red Hat proxy services (for stage environments)
+
+**Example:**
+```bash
+# Start development proxy on default ports
+fec dev-proxy
+
+# Start with custom port and target stage environment
+fec dev-proxy --port 3000 --clouddotEnv stage
+
+# Start with custom static assets port
+fec dev-proxy --staticPort 9000
+```
+
+The command will:
+1. Pull and start the development proxy container
+2. Start webpack in watch mode to build your assets
+3. Serve static assets via http-server
+4. Configure routing based on your FEC config (configuration is the same as for the dev command, [Custom routes](#custom-routes))
+5. Start a local Chrome UI server _(this can be disabled by setting `SPAFallback` var to `false` in the FEC config)_
+6. Display the development URL when ready
+
+Your application will be available at `https://[env].foo.redhat.com:[port]` where `[env]` is determined by your configuration or the `--clouddotEnv` flag.
+
+**Limitations:**
+This command currently doesn't work in DinD environments. The new proxy can still be used there when launched manually with different network settings for running alongside frontends started with the static command. [1](https://github.com/RedHatInsights/frontend-development-proxy?tab=readme-ov-file#dind-docker-in-docker-ci)
 
 ## Static
 

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -1,0 +1,321 @@
+import { exec, execSync } from 'child_process';
+import concurrently, { Command } from 'concurrently';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import treeKill from 'tree-kill';
+import { fecLogger as fecLoggerDefault, LogType } from '@redhat-cloud-services/frontend-components-config-utilities';
+import { getCdnPath, setEnv, validateFECConfig } from './common';
+import serveChrome, { checkContainerRuntime, CONTAINER_NAME as CHROME_CONTAINTER_NAME, ContainerRuntime } from './serve-chrome';
+
+const PROXY_URL = 'http://squid.corp.redhat.com:3128';
+const DEFAULT_LOCAL_ROUTE = 'host.docker.internal';
+const DEFAULT_CHROME_SERVER_PORT = 9998;
+const LATEST_IMAGE_TAG = 'latest';
+
+const DEV_PROXY_CONTAINER_PORT = 1337;
+const DEV_PROXY_CONTAINER_NAME = 'frontend-development-proxy';
+const DEV_PROXY_IMAGE_REPO = `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+
+let execBin: ContainerRuntime | undefined = undefined;
+let debug: boolean = false;
+
+interface RouteConfig {
+  url: string;
+  is_chrome?: boolean;
+}
+
+function fecLogger(logType: LogType, ...data: any[]) {
+  if (logType === LogType.debug) {
+    if (debug) {
+      fecLoggerDefault(logType, ...data);
+    }
+  } else {
+    fecLoggerDefault(logType, ...data);
+  }
+}
+
+function removeContainer(containerName: string) {
+  try {
+    fecLogger(LogType.info, `Removing existing container: ${containerName}`);
+    execSync(`${execBin} rm ${containerName}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+  } catch (error) {
+    fecLogger(LogType.error, `Failed to remove the container: ${containerName}`);
+  }
+}
+
+function stopContainer(containerName: string) {
+  try {
+    let isRunning: boolean = true;
+    try {
+      execSync(`${execBin} inspect -f '{{.State.Running}}' ${containerName}\n`).toString().trim().toLowerCase() === 'true';
+    } catch (error) {
+      isRunning = false;
+    }
+
+    if (isRunning) {
+      fecLogger(LogType.info, `Stopping container: ${containerName}`);
+      execSync(`${execBin} stop ${containerName}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+    }
+  } catch (error) {
+    fecLogger(LogType.error, `Failed to stop the container: ${containerName}`);
+  }
+}
+
+function pullImage(containerName: string, repo: string, tag: string) {
+  fecLogger(LogType.info, `Pulling the container: ${containerName}`);
+  execSync(`${execBin} pull ${repo}:${tag}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+}
+
+function createRoutesConfig(fecConfig: any, cdnPath: string, port: string, SPAFallback: boolean, filename: string = 'routes.json'): string {
+  let routes: Map<string, RouteConfig> = new Map();
+
+  let fecRoutes = fecConfig?.routes || undefined;
+  if (fecConfig?.routesPath) {
+    fecRoutes = require(fecConfig.routesPath);
+  }
+  if (fecRoutes) {
+    fecRoutes = fecRoutes?.routes || fecRoutes;
+  }
+  const fecRoutesEntries = Object.entries<any>(fecRoutes || {});
+  const chromeEntry = fecRoutesEntries.find(([_, config]) => !!config?.is_chrome);
+
+  if (SPAFallback) {
+    if (!chromeEntry) {
+      let chromeHost = process.env.FEC_CHROME_HOST;
+      if (chromeHost) {
+        chromeHost = chromeHost.replace(/localhost/, DEFAULT_LOCAL_ROUTE).replace(/127\.0\.0\.1/, DEFAULT_LOCAL_ROUTE);
+      } else {
+        chromeHost = DEFAULT_LOCAL_ROUTE;
+      }
+      routes.set('/apps/chrome/*', {
+        url: `${chromeHost}:${process.env.FEC_CHROME_PORT}`,
+        is_chrome: true,
+      });
+    } else if (chromeEntry) {
+      const [handle, config] = chromeEntry;
+      if (config?.host) {
+        const host = config.host.replace(/localhost/, DEFAULT_LOCAL_ROUTE).replace(/127\.0\.0\.1/, DEFAULT_LOCAL_ROUTE);
+        routes.set(`${handle}*`, {
+          url: host,
+          is_chrome: true,
+        });
+      }
+    }
+  }
+
+  routes.set(`${cdnPath}*`, { url: `${DEFAULT_LOCAL_ROUTE}:${port}` });
+
+  fecRoutesEntries
+    .filter(([_, config]) => !config?.is_chrome)
+    .forEach(([handle, config]) => {
+      if (config?.host) {
+        const host = config.host.replace(/localhost/, DEFAULT_LOCAL_ROUTE).replace(/127\.0\.0\.1/, DEFAULT_LOCAL_ROUTE);
+        routes.set(`${handle}*`, { url: host });
+      }
+    });
+
+  const tempDir = os.tmpdir();
+  const tempFilePath = path.join(tempDir, filename);
+  const jsonContent = JSON.stringify(Object.fromEntries(routes));
+  console.log(jsonContent);
+  fs.writeFileSync(tempFilePath, jsonContent, { flag: 'w' });
+
+  return tempFilePath;
+}
+
+async function configureEnvVars(fecConfig: any, argv: any, cwd: string) {
+  const clouddotEnvOptions = ['stage', 'prod', 'dev', 'ephemeral'];
+  if (argv?.clouddotEnv) {
+    if (!clouddotEnvOptions.includes(argv?.clouddotEnv)) {
+      throw Error(
+        `Incorrect argument value:\n--clouddotEnv must be one of: [${clouddotEnvOptions.toString()}]\nRun fec --help for more information.`,
+      );
+    }
+    process.env.HCC_ENV = argv?.clouddotEnv;
+  } else {
+    await setEnv(cwd);
+    process.env.HCC_ENV = process.env.CLOUDOT_ENV;
+  }
+  const hccEnvSuffix = process.env.HCC_ENV === 'prod' ? '' : `${process.env.HCC_ENV}.`;
+  process.env.HCC_ENV_URL = process.env.HCC_ENV === 'ephemeral' ? process.env.EPHEMERAL_TARGET : `https://console.${hccEnvSuffix}redhat.com`;
+
+  process.env.FEC_CHROME_HOST = fecConfig?.chromeHost ?? '127.0.0.1';
+  process.env.FEC_CHROME_PORT = fecConfig?.chromePort ?? DEFAULT_CHROME_SERVER_PORT;
+}
+
+async function devProxyScript(
+  argv: {
+    chromeServerPort?: number | string;
+    clouddotEnv?: string;
+    config?: any;
+    port?: string;
+    staticPort?: string;
+  },
+  cwd: string,
+) {
+  let SPAFallback = true;
+  let fecConfig: any = {};
+  let webpackConfig;
+  const webpackConfigPath: string =
+    argv.config || `${cwd}/node_modules/@redhat-cloud-services/frontend-components-config/bin/dev-proxy.webpack.config.js`;
+  process.env.FEC_DEV_PROXY = 'true';
+
+  // Get Configs
+  try {
+    validateFECConfig(cwd);
+    fecConfig = require(process.env.FEC_CONFIG_PATH!);
+    fecConfig = structuredClone(fecConfig);
+    debug = fecConfig?.debug ?? false;
+  } catch (error) {
+    fecLogger(LogType.error, 'Failed to get the FEC config:', error);
+    process.exit(1);
+  }
+  try {
+    fs.statSync(webpackConfigPath);
+    webpackConfig = require(webpackConfigPath);
+    if (typeof webpackConfig === 'function') {
+      webpackConfig = webpackConfig(process.env);
+    }
+    webpackConfig = await webpackConfig;
+  } catch (error) {
+    fecLogger(LogType.error, 'Failed to get the Webpack config:', error);
+    process.exit(1);
+  }
+
+  // Process environment variables, SPA fallback
+  try {
+    SPAFallback = fecConfig?.SPAFallback ?? true;
+    await configureEnvVars(fecConfig, argv, cwd);
+  } catch (error) {
+    fecLogger(LogType.error, 'Failed to setup environment from args and config:', error);
+    process.exit(1);
+  }
+
+  // Setup Routes
+  let cdnPath: string;
+  let routesConfigPath: string;
+  const staticPort = argv.staticPort ?? '8003';
+  try {
+    cdnPath = getCdnPath(fecConfig, webpackConfig, cwd);
+    routesConfigPath = createRoutesConfig(fecConfig, cdnPath, staticPort, SPAFallback);
+  } catch (error) {
+    fecLogger(LogType.error, 'Failed to generate the proxy routes config:', error);
+    process.exit(1);
+  }
+
+  // Setup Container
+  execBin = checkContainerRuntime();
+  stopContainer(DEV_PROXY_CONTAINER_NAME);
+  stopContainer(CHROME_CONTAINTER_NAME);
+  pullImage(DEV_PROXY_CONTAINER_NAME, DEV_PROXY_IMAGE_REPO, LATEST_IMAGE_TAG);
+  removeContainer(DEV_PROXY_CONTAINER_NAME);
+
+  // Exec
+  let commands: Command[] = [];
+  let waitOnProcess: ReturnType<typeof exec> | undefined = undefined;
+
+  const cleanup = () => {
+    commands.forEach((cmd) => {
+      if (cmd.pid) {
+        treeKill(cmd.pid, 'SIGKILL');
+      }
+    });
+    if (waitOnProcess?.pid) {
+      treeKill(waitOnProcess.pid, 'SIGKILL');
+    }
+    stopContainer(DEV_PROXY_CONTAINER_NAME);
+    if (SPAFallback) {
+      stopContainer(CHROME_CONTAINTER_NAME);
+    }
+    console.log('\n');
+  };
+
+  try {
+    const outputPath = webpackConfig.output.path;
+    const proxyEnvVar = process.env.HCC_ENV === 'stage' ? '-e HTTPS_PROXY=$RH_PROXY_URL' : '';
+    const proxyVerbose = fecConfig?.proxyVerbose ? `&& ${execBin} logs -f ${DEV_PROXY_CONTAINER_NAME}` : '';
+    const appUrl = fecConfig?.appUrl;
+
+    try {
+      if (SPAFallback) {
+        const handleServerError = (error: Error) => {
+          fecLogger(LogType.error, error);
+          cleanup();
+          process.exit(1);
+        };
+
+        await serveChrome(
+          outputPath,
+          process.env.FEC_CHROME_HOST ?? '127.0.0.1',
+          handleServerError,
+          process.env.CLOUDOT_ENV === 'prod',
+          parseInt(process.env.FEC_CHROME_PORT!),
+        ).catch((error) => {
+          fecLogger(LogType.error, 'Chrome server stopped!');
+          handleServerError(error);
+        });
+      }
+    } catch (error) {
+      fecLogger(LogType.error, 'Unable to start local Chrome UI server!');
+      fecLogger(LogType.error, error);
+      process.exit(1);
+    }
+
+    const { result, commands: cmds } = concurrently(
+      [
+        {
+          command: `npm exec -- webpack --config ${webpackConfigPath} --watch --output-path ${path.join(outputPath, cdnPath)}`,
+          name: 'BUILD',
+          prefixColor: 'bgBlue',
+        },
+        {
+          command: `npm exec -- http-server ${outputPath} -p ${staticPort} -c-1 -a :: --cors=*`,
+          name: 'SERVE',
+          prefixColor: 'bgGreen',
+        },
+        {
+          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}:${LATEST_IMAGE_TAG} ${proxyVerbose}`,
+          name: 'PROXY',
+          env: { RH_PROXY_URL: PROXY_URL },
+          prefixColor: 'bgMagenta',
+        },
+      ],
+      {
+        prefix: 'name',
+        killOthers: ['failure'],
+        pauseInputStreamOnFinish: true,
+      },
+    );
+    commands = cmds;
+
+    waitOnProcess = exec(
+      `npm exec -- wait-on --timeout 60000 --delay 10000 https://${process.env.HCC_ENV}.foo.redhat.com:${argv.port || 1337}${appUrl}`,
+      (error) => {
+        if (error) {
+          return;
+        }
+        console.log('\u001b[43m[INFO ]\x1b[0m App should run on:');
+        console.log(`\u001b[43m[INFO ]\x1b[0m \t- \u001b[34mhttps://${process.env.HCC_ENV}.foo.redhat.com:${argv.port || 1337}${appUrl}\x1b[0m`);
+        console.log('\u001b[43m[INFO ]\x1b[0m Static assets are available at:');
+        console.log(`\u001b[43m[INFO ]\x1b[0m \t- \u001b[34mhttps://${process.env.HCC_ENV}.foo.redhat.com:${argv.port || 1337}${cdnPath}\x1b[0m`);
+      },
+    );
+
+    result.then(
+      () => {
+        cleanup();
+        process.exit(0);
+      },
+      () => {
+        cleanup();
+        process.exit(0);
+      },
+    );
+  } catch (error) {
+    fecLogger(LogType.error, error);
+    process.exit(1);
+  }
+}
+
+module.exports = devProxyScript;

--- a/packages/config/src/bin/dev-proxy.webpack.config.ts
+++ b/packages/config/src/bin/dev-proxy.webpack.config.ts
@@ -1,0 +1,60 @@
+import config, { FrontendEnv } from '../lib';
+import FECConfiguration from '../lib/fec.config';
+import commonPlugins from './webpack.plugins';
+const fecConfig: FECConfiguration = require(process.env.FEC_CONFIG_PATH!);
+
+type Configuration = import('webpack').Configuration;
+
+function parseRegexpURL(url: RegExp) {
+  return [new RegExp(url.toString())];
+}
+
+function createAppUrl(appUrl: string | string[] | (string | RegExp)[]) {
+  if (Array.isArray(appUrl)) {
+    return appUrl
+      .map((url) => {
+        if (url instanceof RegExp) {
+          return parseRegexpURL(url);
+        } else if (typeof url === 'string') {
+          return url;
+        } else {
+          throw `Invalid appURL format! Expected string or regexp, got ${typeof url}. Check your fec.config.js:appUrl.`;
+        }
+      })
+      .flat();
+  } else if (typeof appUrl === 'object') {
+    return parseRegexpURL(appUrl);
+  } else if (typeof appUrl === 'string') {
+    return [appUrl];
+  } else {
+    throw `Invalid appURL format! Expected string or regexp, got ${typeof appUrl}. Check your fec.config.js:appUrl.`;
+  }
+}
+
+const appUrl = createAppUrl(fecConfig.appUrl);
+
+const { plugins: externalPlugins = [], ...externalConfig } = fecConfig;
+
+const { config: webpackConfig, plugins } = config({
+  useFileHash: false,
+  useCache: true,
+  ...externalConfig,
+  appUrl,
+  deployment: 'apps',
+  env: `${process.env.CLOUDOT_ENV}-stable` as FrontendEnv,
+  rootFolder: process.env.FEC_ROOT_DIR || process.cwd(),
+  blockLegacyChrome: true,
+});
+plugins.push(...commonPlugins, ...externalPlugins);
+
+const devConfig: Configuration = {
+  ...webpackConfig,
+  plugins,
+};
+
+if (devConfig.devServer) {
+  delete devConfig.devServer;
+}
+
+module.exports = devConfig;
+export default devConfig;

--- a/packages/config/src/bin/dev-script.ts
+++ b/packages/config/src/bin/dev-script.ts
@@ -1,38 +1,12 @@
 /* eslint-disable no-console */
-import inquirer from 'inquirer';
 const { resolve } = require('path');
 import { spawn } from 'child_process';
 import treeKill from 'tree-kill';
-import { getWebpackConfigPath, validateFECConfig } from './common';
+import { getWebpackConfigPath, setEnv, validateFECConfig } from './common';
 import serveChrome from './serve-chrome';
 import { LogType, fecLogger } from '@redhat-cloud-services/frontend-components-config-utilities';
+
 const DEFAULT_CHROME_SERVER_PORT = 9998;
-
-async function setEnv(cwd: string) {
-  return inquirer
-    .prompt([
-      {
-        type: 'list',
-        name: 'clouddotEnv',
-        message: 'Which platform environment you want to use?',
-        choices: ['stage', 'prod', 'dev', 'ephemeral'],
-      },
-    ])
-    .then(async (answers) => {
-      const { clouddotEnv } = answers;
-
-      if (clouddotEnv === 'ephemeral') {
-        const answer = await inquirer.prompt([{
-          type: 'input',
-          name: 'clouddotEnv',
-          message: 'Please provide the gateway route of your ephemeral environment:',
-        }]);
-        process.env.EPHEMERAL_TARGET = answer.clouddotEnv
-      }
-      process.env.CLOUDOT_ENV = clouddotEnv ? clouddotEnv : 'stage';
-      process.env.FEC_ROOT_DIR = cwd;
-    });
-}
 
 async function devScript(
   argv: {

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 
 const devScript = require('./dev-script');
+const devProxyScript = require('./dev-proxy-script');
 const buildScript = require('./build-script');
 
 const promisifiedLookup = promisify(lookup);
@@ -131,6 +132,21 @@ const argv = yargs
         default: 1337,
       });
   })
+  .command('dev-proxy', 'Start development proxy', (yargs) => {
+    yargs
+      .option('port', {
+        type: 'number',
+        alias: 'p',
+        describe: 'Proxy server port',
+        default: 1337,
+      })
+      .option('staticPort', {
+        type: 'number',
+        alias: 'sp',
+        describe: 'Static assets server port',
+        default: 8003,
+      });
+  })
   .command('build', 'Build production bundle', (yargs) => {
     yargs.positional('webpack-config', {
       type: 'string',
@@ -153,6 +169,9 @@ const scripts: { [name: string]: (...args: any[]) => void } = {
   dev: (argv: any, cwd: string) => {
     devScript(argv, cwd);
   },
+  'dev-proxy': (argv: any, cwd: string) => {
+    devProxyScript(argv, cwd);
+  },
   build: buildScript,
   'patch-ts': () => patchTs(checkDependencies().join(' ')),
 };
@@ -166,8 +185,8 @@ async function run() {
   }
   const missingHosts = await checkHosts();
   if (missingHosts.length > 0) {
-    fecLogger(LogType.warn,`Found missing hosts`);
-    fecLogger(LogType.warn,`\`fec dev\` will likely not work correctly. Please consider running \`fec patch-etc-hosts\` to fix the problem.`);
+    fecLogger(LogType.warn, `Found missing hosts`);
+    fecLogger(LogType.warn, `\`fec dev\` will likely not work correctly. Please consider running \`fec patch-etc-hosts\` to fix the problem.`);
     fecLogger(LogType.warn, `Missing hosts`);
     fecLogger(LogType.warn, missingHosts.join(' '));
   }

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -5,12 +5,12 @@ import { fecLogger, LogType } from '@redhat-cloud-services/frontend-components-c
 import waitOn from 'wait-on';
 
 const CONTAINER_PORT = 8000;
-const CONTAINER_NAME = 'fec-chrome-local';
+export const CONTAINER_NAME = 'fec-chrome-local';
 const IMAGE_REPO_DEV = 'quay.io/redhat-services-prod/hcc-platex-services-tenant/insights-chrome-dev';
 const LATEST_IMAGE_TAG = 'latest';
 const GRAPHQL_ENDPOINT = 'https://app-interface.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/graphql';
 
-type ContainerRuntime = 'docker' | 'podman';
+export type ContainerRuntime = 'docker' | 'podman';
 let execBin: ContainerRuntime | undefined = undefined;
 
 const APPS_QUERY = `{
@@ -46,7 +46,7 @@ const APPS_QUERY = `{
 
 // const checkoutCommand = `git archive --remote=${chromeDeploymentConfig.repo}  HEAD ${chromeDeploymentConfig.deployFile} |  tar xvf - -C ${chromeDeploymentConfig.tarTarget}`;
 
-function checkContainerRuntime(): ContainerRuntime {
+export function checkContainerRuntime(): ContainerRuntime {
   try {
     if (execSync('which podman').toString().trim().length > 0) {
       return 'podman';

--- a/packages/config/src/lib/index.ts
+++ b/packages/config/src/lib/index.ts
@@ -91,10 +91,12 @@ const createFecConfig = (
     fecLogger(LogType.debug, `Using deployments: ${appDeployment}`);
     fecLogger(LogType.debug, `CDN path: ${cdnPath}`);
     fecLogger(LogType.debug, `App entry: ${appEntry}`);
-    fecLogger(LogType.debug, `Use proxy: ${configurations.useProxy ? 'true' : 'false'}`);
-    if (!(configurations.useProxy || configurations.standalone)) {
-      fecLogger(LogType.warn, 'Insights-proxy is deprecated in favor of "useProxy" or "standalone".');
-      fecLogger(LogType.warn, 'See https://github.com/RedHatInsights/frontend-components/blob/master/packages/config/README.md');
+    if (!process.env.FEC_DEV_PROXY) {
+      fecLogger(LogType.debug, `Use proxy: ${configurations.useProxy ? 'true' : 'false'}`);
+      if (!(configurations.useProxy || configurations.standalone)) {
+        fecLogger(LogType.warn, 'Insights-proxy is deprecated in favor of "useProxy" or "standalone".');
+        fecLogger(LogType.warn, 'See https://github.com/RedHatInsights/frontend-components/blob/master/packages/config/README.md');
+      }
     }
 
     console.groupEnd();


### PR DESCRIPTION
This adds a new `dev-proxy` command to the FEC binary in the config package. This new command uses the new and better
[frontend-development-proxy](https://github.com/RedHatInsights/frontend-development-proxy) which is based on Caddy, where the main benefits alongside speed are HTTP2 support and better websocket support. The new command imitates the behavior of the `dev` command as much as possible so it should be a drop-in replacement for the consumers.

[[issue link 🔗](https://issues.redhat.com/browse/HMS-8689)]

cc: @Hyperkid123 