### PR TITLE
feat(useVA): add use VA to chrome API

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -321,6 +321,9 @@ export interface ChromeAPI {
   enablePackagesDebug: () => void;
   requestPdf: (options: PDFRequestOptions) => Promise<void>;
   drawerActions: DrawerPanelActions;
+  useVirtualAssistant?: () => {
+    openVA: (message: string) => void
+  };
   search?: ChromeSearchAPI;
 }
 


### PR DESCRIPTION
### Description

As a consumer I should be able to use VA anywhere on the site. Open it from any place or pass a message to it.