### PR TITLE
fix(favorites): ensure favorite services are visible

### DIFF
--- a/packages/chrome/src/useFavoritePages/useFavoritePages.ts
+++ b/packages/chrome/src/useFavoritePages/useFavoritePages.ts
@@ -46,7 +46,7 @@ const useFavoritePages = () => {
       unsubscribe(subsId, UpdateEvents.favoritePages);
     };
   }, []);
-  return { favoritePages: getState().favoritePages, favoritePage, unfavoritePage, initialized: getState().initialized };
+  return { favoritePages: [...getState().favoritePages], favoritePage, unfavoritePage, initialized: getState().initialized };
 };
 
 export default useFavoritePages;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-42313

The "My favorite services" widget is not displaying services correctly in stage environment due to React's reference equality optimization. The useFavoritePages hook is returning a direct reference to the internal state array (getState().favoritePages), which could cause React components to miss re-renders when the array contents changed but the reference remained the same.
