### PR TITLE
fix: add missing repository field to enable package publishing

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -22,7 +22,15 @@
     "@babel/core": "^7.14.0",
     "eslint": "^9.24.0"
   },
-  "license": "Apache",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RedHatInsights/frontend-components.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/RedHatInsights/frontend-components/issues"
+  },
+  "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/eslint-config#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/tsc-transform-imports/package.json
+++ b/packages/tsc-transform-imports/package.json
@@ -10,5 +10,14 @@
   "peerDependencies": {
     "typescript": "^5.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RedHatInsights/frontend-components.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/RedHatInsights/frontend-components/issues"
+  },
+  "homepage": "https://github.com/RedHatInsights/frontend-components/tree/master/packages/tsc-transform-imports#readme",
   "scripts": {}
 }


### PR DESCRIPTION
Nx 22.3.1 introduced stricter requirements for npm trusted publishing that now require the repository field in `package.json` files. 

The following packages are still due a version increment and release related to the glob dependency vulnerability:                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                            
`@redhat-cloud-services/tsc-transform-imports`                                                                                                      
                                                                                                                   
