### PR TITLE
build(release): migrate from @jscutlery/semver to native Nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -116,7 +116,10 @@
     },
     "changelog": {
       "workspaceChangelog": false,
-      "projectChangelogs": false
+      "projectChangelogs": {
+        "file": "{projectRoot}/CHANGELOG.md",
+        "createReleaseInGitHub": false
+      }
     },
     "releaseTagPattern": "{projectName}-{version}"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
-    "@jscutlery/semver": "^5.3.1",
     "@nx/cypress": "^22.3.1",
     "@nx/eslint": "^22.3.1",
     "@nx/eslint-plugin": "^22.3.1",

--- a/packages/advisor-components/project.json
+++ b/packages/advisor-components/project.json
@@ -78,23 +78,6 @@
         "skipServe": true
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/advisor-components/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/chrome/project.json
+++ b/packages/chrome/project.json
@@ -52,23 +52,6 @@
         "jestConfig": "packages/chrome/jest.config.ts"
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/chrome/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/components/project.json
+++ b/packages/components/project.json
@@ -75,23 +75,6 @@
         "skipServe": true
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/components/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/config-utils/project.json
+++ b/packages/config-utils/project.json
@@ -27,23 +27,6 @@
         "lintFilePatterns": ["packages/config-utils/src/**/*", "packages/config-utils/package.json"]
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/config-utils/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/config/project.json
+++ b/packages/config/project.json
@@ -35,23 +35,6 @@
         "jestConfig": "packages/config/jest.config.ts"
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/config/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/eslint-config/project.json
+++ b/packages/eslint-config/project.json
@@ -22,23 +22,6 @@
         "lintFilePatterns": ["packages/eslint-config/**/*.ts", "packages/eslint-config/package.json"]
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/eslint-config/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -67,23 +67,6 @@
         "jestConfig": "packages/notifications/jest.config.ts"
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/notifications/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/remediations/project.json
+++ b/packages/remediations/project.json
@@ -68,23 +68,6 @@
         "passWithNoTests": true
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/remediations/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/rule-components/project.json
+++ b/packages/rule-components/project.json
@@ -68,23 +68,6 @@
         "passWithNoTests": true
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/rule-components/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/testing/project.json
+++ b/packages/testing/project.json
@@ -60,23 +60,6 @@
         "lintFilePatterns": ["packages/testing/src/**/*", "packages/testing/package.json"]
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/testing/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/translations/project.json
+++ b/packages/translations/project.json
@@ -79,23 +79,6 @@
         "jestConfig": "packages/translations/jest.config.ts"
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/translations/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/tsc-transform-imports/project.json
+++ b/packages/tsc-transform-imports/project.json
@@ -27,23 +27,6 @@
         "lintFilePatterns": ["packages/tsc-transform-imports/src/**/*.ts", "packages/tsc-transform-imports/package.json"]
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/tsc-transform-imports/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -21,23 +21,6 @@
         "lintFilePatterns": ["packages/types/**/*.ts", "packages/types/package.json"]
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/types/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -67,23 +67,6 @@
         "jestConfig": "packages/utils/jest.config.ts"
       }
     },
-    "version": {
-      "executor": "@jscutlery/semver:version",
-      "options": {
-        "push": true,
-        "preset": "conventionalcommits",
-        "commitMessageFormat": "chore: bump {projectName} to {version} [skip ci]",
-        "trackDeps": true
-      },
-      "dependsOn": ["^version"]
-    },
-    "github": {
-      "executor": "@jscutlery/semver:github",
-      "options": {
-        "tag": "${tag}",
-        "notesFile": "packages/utils/CHANGELOG.md"
-      }
-    },
     "deploy": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {


### PR DESCRIPTION
- Remove @jscutlery/semver dependency and executors from all packages                                                                                                      
- Enable native Nx changelog generation in nx.json                                                                                                                         
- Preserve existing release workflow and changelog format