### PR TITLE
feat(types): add organization.name to ChromeUser

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -68,6 +68,9 @@ export declare type ChromeUser = {
       is_org_admin: boolean;
       locale: string;
     };
+    organization?: {
+      name?: string;
+    };
   };
 };
 


### PR DESCRIPTION
Adds the optional `organization` object with a `name` property to the `ChromeUser`  type.

This field is now populated by the CIAM in the JWT token.

https://issues.redhat.com/browse/RHCLOUD-39628