### PR TITLE
feat(utils): add Kessel param build helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8465,6 +8465,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8478,6 +8479,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8491,6 +8493,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8504,6 +8507,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8517,6 +8521,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8530,6 +8535,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8543,6 +8549,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8556,6 +8563,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8569,6 +8577,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8582,6 +8591,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8595,6 +8605,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8608,6 +8619,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8621,6 +8633,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8634,6 +8647,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8647,6 +8661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8660,6 +8675,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8673,6 +8689,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8686,6 +8703,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
       "integrity": "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8701,6 +8719,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8714,6 +8733,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8727,6 +8747,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8776,6 +8797,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8796,6 +8818,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8816,6 +8839,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8836,6 +8860,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8856,6 +8881,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8876,6 +8902,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8896,6 +8923,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8916,6 +8944,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8936,6 +8965,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8956,6 +8986,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8976,6 +9007,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8996,6 +9028,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9016,6 +9049,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9248,6 +9282,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@project-kessel/react-kessel-access-check": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.3.1.tgz",
+      "integrity": "sha512-0b0aV5N0rpjSt95feHV/HI6q8scZGGBwuSRg6mjiXrxOqh1Y/eBBoZ3qml9sCeUs3WHpvWEobXH6zdJ4I67qbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@redhat-cloud-services/chrome": {
       "resolved": "packages/chrome",
@@ -34409,6 +34453,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34419,6 +34464,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
       "integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34443,6 +34489,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34459,6 +34506,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34475,6 +34523,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34491,6 +34540,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34507,6 +34557,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34523,6 +34574,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34539,6 +34591,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34555,6 +34608,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34571,6 +34625,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34587,6 +34642,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34603,6 +34659,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34619,6 +34676,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34635,6 +34693,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34651,6 +34710,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34664,6 +34724,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.0.tgz",
       "integrity": "sha512-dDky3ETKeOo543myScL4sp3pj2cANLNKea5aR6v8ZCpDSCDTRxqv4Sj/goTmkVqnp/HOVF88qB3GHtQ8rFtULQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34680,6 +34741,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
       "integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34704,6 +34766,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34720,6 +34783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -39926,6 +39990,7 @@
         "react-content-loader": "^6.2.0"
       },
       "devDependencies": {
+        "@project-kessel/react-kessel-access-check": "^0.3.1",
         "@types/react": "^18.0.0",
         "glob": "10.5.0",
         "react-intl": "^6.6.8",
@@ -39934,10 +39999,16 @@
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-table": "^6.0.0",
+        "@project-kessel/react-kessel-access-check": "^0.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@project-kessel/react-kessel-access-check": {
+          "optional": true
+        }
       }
     },
     "packages/utils/node_modules/commander": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
-    "react-router-dom": "^5.0.0 || ^6.0.0"
+    "react-router-dom": "^5.0.0 || ^6.0.0",
+    "@project-kessel/react-kessel-access-check": "^0.3.1"
   },
   "dependencies": {
     "@redhat-cloud-services/rbac-client": "^4.2.3",
@@ -38,10 +39,16 @@
     "react-content-loader": "^6.2.0"
   },
   "devDependencies": {
+    "@project-kessel/react-kessel-access-check": "^0.3.1",
     "@types/react": "^18.0.0",
     "glob": "10.5.0",
     "react-intl": "^6.6.8",
     "redux-mock-store": "^1.5.4"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "peerDependenciesMeta": {
+    "@project-kessel/react-kessel-access-check": {
+      "optional": true
+    }
+  }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,3 +22,4 @@ export * from './usePromiseQueue';
 export * from './useFetchBatched';
 export * from './useSuspenseLoader';
 export * from './TestingUtils/JestUtils';
+export * from './kesselPermissions';

--- a/packages/utils/src/kesselPermissions/index.ts
+++ b/packages/utils/src/kesselPermissions/index.ts
@@ -1,0 +1,7 @@
+export {
+  getKesselAccessCheckParams,
+  type PermissionMap,
+  type GetKesselAccessCheckParamsOptions,
+  type KesselResourceOptions,
+  type SelfAccessCheckParams,
+} from './kesselPermissions';

--- a/packages/utils/src/kesselPermissions/kesselPermissions.test.ts
+++ b/packages/utils/src/kesselPermissions/kesselPermissions.test.ts
@@ -1,0 +1,169 @@
+import { getKesselAccessCheckParams } from './kesselPermissions';
+import type { SelfAccessCheckResourceWithRelation } from '@project-kessel/react-kessel-access-check';
+
+const PERMISSION_MAP = {
+  'app:resource:read': 'app_resource_view',
+  'app:resource:write': 'app_resource_edit',
+} as const;
+
+describe('getKesselAccessCheckParams with permissionMap provided', () => {
+  it('returns { resources: [] } when workspaceId is undefined', () => {
+    const result = getKesselAccessCheckParams({
+      permissionMap: PERMISSION_MAP,
+      requiredPermissions: ['app:resource:read'],
+      resourceIdOrIds: undefined,
+    });
+    expect(result).toEqual({ resources: [] });
+  });
+
+  it('returns { resources: [] } when requiredPermissions is empty', () => {
+    const result = getKesselAccessCheckParams({
+      permissionMap: PERMISSION_MAP,
+      requiredPermissions: [],
+      resourceIdOrIds: 'workspace-123',
+    });
+    expect(result).toEqual({ resources: [] });
+  });
+
+  it('returns single-resource shape when one permission is given', () => {
+    const result = getKesselAccessCheckParams({
+      permissionMap: PERMISSION_MAP,
+      requiredPermissions: ['app:resource:read'],
+      resourceIdOrIds: 'workspace-123',
+    });
+    expect('relation' in result).toBe(true);
+    expect('resource' in result).toBe(true);
+    expect(result).toEqual({
+      resource: {
+        id: 'workspace-123',
+        type: 'workspace',
+        reporter: { type: 'rbac' },
+      },
+      relation: 'app_resource_view',
+    });
+  });
+
+  it('returns resources array shape when multiple permissions are given', () => {
+    const result = getKesselAccessCheckParams({
+      permissionMap: PERMISSION_MAP,
+      requiredPermissions: ['app:resource:read', 'app:resource:write'],
+      resourceIdOrIds: 'workspace-456',
+    });
+    expect('resources' in result).toBe(true);
+    expect(Array.isArray((result as { resources: SelfAccessCheckResourceWithRelation[] }).resources)).toBe(true);
+    expect((result as { resources: SelfAccessCheckResourceWithRelation[] }).resources).toHaveLength(2);
+    expect((result as { resources: { id: string; type: string; relation: string }[] }).resources).toEqual([
+      { id: 'workspace-456', type: 'workspace', relation: 'app_resource_view', reporter: { type: 'rbac' } },
+      { id: 'workspace-456', type: 'workspace', relation: 'app_resource_edit', reporter: { type: 'rbac' } },
+    ]);
+  });
+
+  it('skips permissions with no mapping and warns', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = getKesselAccessCheckParams({
+      permissionMap: PERMISSION_MAP,
+      requiredPermissions: ['app:resource:read', 'unknown:permission'],
+      resourceIdOrIds: 'workspace-123',
+    });
+    expect(warnSpy).toHaveBeenCalledWith('No Kessel mapping for: unknown:permission');
+    expect('relation' in result).toBe(true);
+    expect((result as { resource: { id: string }; relation: string }).relation).toBe('app_resource_view');
+    warnSpy.mockRestore();
+  });
+});
+
+describe('getKesselAccessCheckParams without permissionMap provided', () => {
+  it('returns { resources: [] } when resourceId is undefined', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['app_resource_view'],
+      resourceIdOrIds: undefined,
+    });
+    expect(result).toEqual({ resources: [] });
+  });
+
+  it('uses each requiredPermission as the relation and returns single-resource shape', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['app_resource_view'],
+      resourceIdOrIds: 'workspace-123',
+    });
+    expect(result).toEqual({
+      resource: {
+        id: 'workspace-123',
+        type: 'workspace',
+        reporter: { type: 'rbac' },
+      },
+      relation: 'app_resource_view',
+    });
+  });
+
+  it('uses each requiredPermission as the relation and returns resources array for multiple', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['app_resource_view', 'app_resource_edit'],
+      resourceIdOrIds: 'workspace-456',
+    });
+    expect('resources' in result).toBe(true);
+    expect((result as { resources: { relation: string }[] }).resources).toEqual([
+      { id: 'workspace-456', type: 'workspace', relation: 'app_resource_view', reporter: { type: 'rbac' } },
+      { id: 'workspace-456', type: 'workspace', relation: 'app_resource_edit', reporter: { type: 'rbac' } },
+    ]);
+  });
+});
+
+describe('getKesselAccessCheckParams with custom options (resourceType, reporter)', () => {
+  it('returns host/hbi resource when options are passed (single id)', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['update'],
+      resourceIdOrIds: 'host-abc',
+      options: { resourceType: 'host', reporter: { type: 'hbi' } },
+    });
+    expect(result).toEqual({
+      resource: {
+        id: 'host-abc',
+        type: 'host',
+        reporter: { type: 'hbi' },
+      },
+      relation: 'update',
+    });
+  });
+
+  it('returns resources array with host/hbi for multiple relations', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['update', 'delete'],
+      resourceIdOrIds: 'host-xyz',
+      options: { resourceType: 'host', reporter: { type: 'hbi' } },
+    });
+    expect('resources' in result).toBe(true);
+    expect((result as { resources: SelfAccessCheckResourceWithRelation[] }).resources).toEqual([
+      { id: 'host-xyz', type: 'host', relation: 'update', reporter: { type: 'hbi' } },
+      { id: 'host-xyz', type: 'host', relation: 'delete', reporter: { type: 'hbi' } },
+    ]);
+  });
+});
+
+describe('getKesselAccessCheckParams with multiple resource IDs', () => {
+  it('returns flat resources array (each id × each relation)', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['update', 'delete'],
+      resourceIdOrIds: ['host-1', 'host-2'],
+      options: { resourceType: 'host', reporter: { type: 'hbi' } },
+    });
+    expect('resources' in result).toBe(true);
+    const resources = (result as { resources: SelfAccessCheckResourceWithRelation[] }).resources;
+    expect(resources).toHaveLength(4);
+    expect(resources).toEqual([
+      { id: 'host-1', type: 'host', relation: 'update', reporter: { type: 'hbi' } },
+      { id: 'host-1', type: 'host', relation: 'delete', reporter: { type: 'hbi' } },
+      { id: 'host-2', type: 'host', relation: 'update', reporter: { type: 'hbi' } },
+      { id: 'host-2', type: 'host', relation: 'delete', reporter: { type: 'hbi' } },
+    ]);
+  });
+
+  it('returns { resources: [] } when resourceIds array is empty', () => {
+    const result = getKesselAccessCheckParams({
+      requiredPermissions: ['update'],
+      resourceIdOrIds: [],
+      options: { resourceType: 'host', reporter: { type: 'hbi' } },
+    });
+    expect(result).toEqual({ resources: [] });
+  });
+});

--- a/packages/utils/src/kesselPermissions/kesselPermissions.ts
+++ b/packages/utils/src/kesselPermissions/kesselPermissions.ts
@@ -1,0 +1,131 @@
+import type {
+  SelfAccessCheckResourceWithRelation,
+  SelfAccessCheckParams as SingleSelfAccessCheckParams,
+  BulkSelfAccessCheckNestedRelationsParams,
+} from '@project-kessel/react-kessel-access-check';
+
+export type PermissionMap = Record<string, string>;
+
+export interface KesselResourceOptions {
+  resourceType?: string;
+  reporter?: { type: string };
+}
+
+const DEFAULT_RESOURCE_OPTIONS: Required<KesselResourceOptions> = {
+  resourceType: 'workspace',
+  reporter: { type: 'rbac' },
+};
+
+export interface GetKesselAccessCheckParamsOptions {
+  permissionMap?: PermissionMap;
+  requiredPermissions: string[];
+  resourceIdOrIds: string | string[] | undefined;
+  options?: KesselResourceOptions;
+}
+
+export type SelfAccessCheckParams =
+  | SingleSelfAccessCheckParams
+  | BulkSelfAccessCheckNestedRelationsParams
+  | { resources: SelfAccessCheckResourceWithRelation[] };
+
+
+function buildKesselResource(
+  resourceId: string,
+  relation: string,
+  options: Required<KesselResourceOptions>
+): SelfAccessCheckResourceWithRelation {
+  return {
+    id: resourceId,
+    type: options.resourceType,
+    relation,
+    reporter: options.reporter,
+  };
+}
+
+function getResourcesForIds(
+  resourceIdOrIds: string | string[] | undefined,
+  relations: string[],
+  options: Required<KesselResourceOptions>
+): SelfAccessCheckResourceWithRelation[] {
+  if (!resourceIdOrIds || relations.length === 0) {
+    return [];
+  }
+  const ids = Array.isArray(resourceIdOrIds) ? resourceIdOrIds : [resourceIdOrIds];
+  if (ids.length === 0) {
+    return [];
+  }
+  return ids.flatMap((resourceId) =>
+    relations.map((relation) => buildKesselResource(resourceId, relation, options))
+  );
+}
+
+function mapPermissionsToKessel(
+  permissionMap: PermissionMap,
+  requiredPermissions: string[],
+  resourceIdOrIds: string | string[] | undefined,
+  options: Required<KesselResourceOptions>
+): SelfAccessCheckResourceWithRelation[] {
+  const relations = requiredPermissions
+    .map((perm) => {
+      const relation = permissionMap[perm];
+      if (!relation) {
+        console.warn(`No Kessel mapping for: ${perm}`);
+        return null;
+      }
+      return relation;
+    })
+    .filter((r): r is string => r !== null);
+  return getResourcesForIds(resourceIdOrIds, relations, options);
+}
+
+function requiredPermissionsToKesselResources(
+  requiredPermissions: string[],
+  resourceIdOrIds: string | string[] | undefined,
+  options: Required<KesselResourceOptions>
+): SelfAccessCheckResourceWithRelation[] {
+  return getResourcesForIds(resourceIdOrIds, requiredPermissions, options);
+}
+
+function buildSelfAccessCheckParams(
+  resources: SelfAccessCheckResourceWithRelation[]
+): SelfAccessCheckParams {
+  if (resources.length === 1) {
+    const resource = resources[0];
+    return {
+      resource: {
+        id: resource.id,
+        type: resource.type,
+        reporter: resource.reporter,
+      },
+      relation: resource.relation,
+    };
+  }
+  return { resources };
+}
+
+/**
+ * Build useSelfAccessCheck params from permissions and resource id(s).
+ *
+ * @param params - Options object: permissionMap (optional), requiredPermissions, resourceIdOrIds, options (optional resourceType/reporter).
+ * @returns Params for useSelfAccessCheck.
+ */
+export function getKesselAccessCheckParams(
+  params: GetKesselAccessCheckParamsOptions
+): SelfAccessCheckParams {
+  const { permissionMap, requiredPermissions, resourceIdOrIds, options } = params;
+  const resolvedOptions = { ...DEFAULT_RESOURCE_OPTIONS, ...options };
+  const resources =
+    permissionMap !== undefined
+      ? mapPermissionsToKessel(
+          permissionMap,
+          requiredPermissions,
+          resourceIdOrIds,
+          resolvedOptions
+        )
+      : requiredPermissionsToKesselResources(
+          requiredPermissions,
+          resourceIdOrIds,
+          resolvedOptions
+        );
+  return buildSelfAccessCheckParams(resources);
+}


### PR DESCRIPTION
Adding helper that will map RBACv1 permissions to Kessel and build parameters for selfAccessCheck hook

This will help us avoid duplicated implementation across apps while migrating from RBACv1 to Kessel

Apps now will be able to call kessel helper funtion 2 ways:

1. When you need to use permission mapper RBACv1->Kessel

```
      getKesselAccessCheckParams(
        PERMISSION_MAP,
        requiredPermissions,
        resourceIdOrIds,
      ),
```
2. When you have removed RBACv1 permissions and you just ask to build selfAccessCheck params with Kessel permissions only
```
      getKesselAccessCheckParams(
        undefined,
        requiredPermissions,
        resourceIdOrIds,
      ),
```
3. Another option is added for host resource type.  Example:
```
    const result = getKesselAccessCheckParams(
      undefined,
      ['update', 'delete'],
      ['host-id-1', 'host-id-2'],
      { resourceType: 'host', reporter: { type: 'hbi' } }
    );
```