### PR TITLE
chore(release): explicitly push git commit and tags after nx release

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -32,4 +32,12 @@ runs:
         # See: https://github.com/nrwl/nx/blob/5ea2e47acfa9d175546daa922ce40905533f1074/packages/nx/src/utils/package-manager.ts#L207-L213
         npm_config_legacy_peer_deps: false
       run: npx nx release --yes
+    - name: Push release commit and tags
+      shell: bash
+      # nx release (unified command) creates the git commit and tags locally but does not push them,
+      # regardless of the release.git.push setting in nx.json. It only pushes automatically when
+      # createRelease (GitHub/GitLab releases) is enabled. Since we use createReleaseInGitHub: false,
+      # we push manually here so that the version bumps in package.json reach the remote and
+      # nacho-bot can create PRs in consuming repos.
+      run: git push --follow-tags
   

--- a/nx.json
+++ b/nx.json
@@ -100,7 +100,6 @@
     "git": {
       "commit": true,
       "tag": true,
-      "push": true,
       "commitMessage": "chore(release): publish\n\n{releaseNotes}"
     },
     "version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9046,6 +9046,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9059,6 +9060,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9072,6 +9074,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9085,6 +9088,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9098,6 +9102,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9111,6 +9116,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9124,6 +9130,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9137,6 +9144,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9150,6 +9158,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9163,6 +9172,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9176,6 +9186,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9189,6 +9200,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9202,6 +9214,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9215,6 +9228,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9228,6 +9242,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9241,6 +9256,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9254,6 +9270,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9267,6 +9284,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
       "integrity": "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9282,6 +9300,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9295,6 +9314,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9308,6 +9328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9357,6 +9378,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9377,6 +9399,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9397,6 +9420,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9417,6 +9441,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9437,6 +9462,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9457,6 +9483,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9477,6 +9504,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9497,6 +9525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9517,6 +9546,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9537,6 +9567,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9557,6 +9588,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9577,6 +9609,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9597,6 +9630,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34075,6 +34109,7 @@
         "!riscv64",
         "!x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34085,6 +34120,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
       "integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34109,6 +34145,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34125,6 +34162,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34141,6 +34179,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34157,6 +34196,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34173,6 +34213,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34189,6 +34230,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34205,6 +34247,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34221,6 +34264,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34237,6 +34281,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34253,6 +34298,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34269,6 +34315,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34285,6 +34332,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34301,6 +34349,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34317,6 +34366,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34330,6 +34380,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.97.0.tgz",
       "integrity": "sha512-dDky3ETKeOo543myScL4sp3pj2cANLNKea5aR6v8ZCpDSCDTRxqv4Sj/goTmkVqnp/HOVF88qB3GHtQ8rFtULQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34346,6 +34397,7 @@
       "version": "1.97.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
       "integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34370,6 +34422,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -34386,6 +34439,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38711,7 +38765,7 @@
     },
     "packages/advisor-components": {
       "name": "@redhat-cloud-services/frontend-components-advisor-components",
-      "version": "3.0.54",
+      "version": "3.0.55",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^7.0.13",
@@ -38808,7 +38862,7 @@
     },
     "packages/components": {
       "name": "@redhat-cloud-services/frontend-components",
-      "version": "7.0.43",
+      "version": "7.0.44",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-component-groups": "^6.0.0",
@@ -39623,7 +39677,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/frontend-components-notifications",
-      "version": "6.1.44",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^7.0.13",
@@ -39641,7 +39695,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/frontend-components-remediations",
-      "version": "4.0.55",
+      "version": "4.0.56",
       "license": "Apache-2.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^4.0.0",
@@ -39661,7 +39715,7 @@
     },
     "packages/rule-components": {
       "name": "@redhat-cloud-services/rule-components",
-      "version": "4.0.54",
+      "version": "4.0.55",
       "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^6.0.0",

--- a/packages/advisor-components/package.json
+++ b/packages/advisor-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components-advisor-components",
-  "version": "3.0.54",
+  "version": "3.0.55",
   "description": "Components to be used in Advisor applications and integrations.",
   "main": "index.js",
   "module": "esm/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components",
-  "version": "7.0.43",
+  "version": "7.0.44",
   "description": "Common components for RedHat Cloud Services project.",
   "main": "index.js",
   "module": "esm/index.js",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components-notifications",
-  "version": "6.1.44",
+  "version": "6.2.0",
   "description": "Notifications portal to show toast notifications for RedHat Cloud Services project.",
   "browser": "index.js",
   "module": "esm/index.js",

--- a/packages/remediations/package.json
+++ b/packages/remediations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components-remediations",
-  "version": "4.0.55",
+  "version": "4.0.56",
   "description": "Remediations components for RedHat Cloud Services project.",
   "main": "index.js",
   "module": "esm/index.js",

--- a/packages/rule-components/package.json
+++ b/packages/rule-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/rule-components",
-  "version": "4.0.54",
+  "version": "4.0.55",
   "description": "Components to be used when showing rule information",
   "main": "index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
## Problem
  After switching to the unified `npx nx release` command, packages were being published to npm but the `chore(release): publish` commit was never pushed back to the repo, preventing nacho-bot from creating PRs to update version field in package.json

  ## Root Cause
  The unified `nx release` command ignores `release.git.push` in nx.json. It only pushes automatically when `createRelease` (GitHub/GitLab releases) is enabled. Since we use `createReleaseInGitHub: false`, no push ever happened — the commit existed only in the ephemeral CI environment.

  This affects nx 21.5.3 (javascript-clients) and nx 22.3.3 (frontend-components) identically.

  ## Fix
  - Add explicit `git push --follow-tags` step after `npx nx release --yes`
  - Remove misleading `push: true` from `release.git` in nx.json since it is ignored by the unified command
  - Sync package.json versions that were published to npm but never committed to the repo: advisor-components, components, notifications, remediations, rule-components