### PR TITLE
chore(release): disable husky pre-push hook in release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -39,5 +39,8 @@ runs:
       # createRelease (GitHub/GitLab releases) is enabled. Since we use createReleaseInGitHub: false,
       # we push manually here so that the version bumps in package.json reach the remote and
       # nacho-bot can create PRs in consuming repos.
+      # HUSKY=0 disables pre-push hooks in CI — tests are run separately by the CI pipeline.
+      env:
+        HUSKY: '0'
       run: git push --follow-tags
   


### PR DESCRIPTION
## Summary

  - Sets `HUSKY=0` on the `git push --follow-tags` step in the release action
  - Prevents the pre-push hook from running Cypress component tests in CI, which was failing due to the Cypress binary not being cached in the release job
  - Tests are already run separately by the CI pipeline

  ## Root cause

  After `npx nx release --yes` publishes to npm, `git push --follow-tags` triggers the husky pre-push hook which attempts to run component tests. In the release job, the Cypress binary cache (`~/.cache/Cypress`) is not available, causing the tests to fail and the push to be aborted — leaving the release commit and tags unpushed.