### PR TITLE
feat(RHINENG-24047): compliance conflict note in Advisor

### DIFF
--- a/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
+++ b/packages/advisor-components/src/ReportDetails/ReportDetails.tsx
@@ -7,6 +7,7 @@ import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { CardHeader } from '@patternfly/react-core/dist/dynamic/components/Card';
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
+import { ExpandableSection } from '@patternfly/react-core/dist/dynamic/components/ExpandableSection';
 import { Stack } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import { StackItem } from '@patternfly/react-core/dist/dynamic/layouts/Stack';
 import BullseyeIcon from '@patternfly/react-icons/dist/dynamic/icons/bullseye-icon';
@@ -21,7 +22,7 @@ import { ExternalLink } from '../common';
 
 interface Report {
   rule: RuleContentRhel | RuleContentOcp;
-  details: Record<string, string | number>;
+  details: Record<string, unknown>;
   resolution: string;
 }
 
@@ -47,7 +48,14 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({
   isProd,
 }) => {
   const { rule, details, resolution } = report;
+  // remove conflict_compliance_policies_enabled from details to avoid rendering it in templates
+  const { conflict_compliance_policies_enabled, ...filteredDetails } = details;
   const [error, setError] = useState<Error | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const onToggle = (_event: any, isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+  };
 
   const handleError = (e: Error) => {
     if (error === null) {
@@ -80,7 +88,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({
                 <BullseyeIcon className="ins-c-report-details__icon" />
                 <strong>Detected issues</strong>
               </CardHeader>
-              <CardBody>{rule.reason && <TemplateProcessor template={rule.reason} definitions={details} onError={handleError} />}</CardBody>
+              <CardBody>{rule.reason && <TemplateProcessor template={rule.reason} definitions={filteredDetails} onError={handleError} />}</CardBody>
             </Card>
           </StackItem>
           <Divider />
@@ -90,7 +98,35 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({
                 <ThumbsUpIcon className="ins-c-report-details__icon" />
                 <strong>Steps to resolve</strong>
               </CardHeader>
-              <CardBody>{resolution && <TemplateProcessor template={resolution} definitions={details} onError={handleError} />}</CardBody>
+              <CardBody>
+                {conflict_compliance_policies_enabled ? (
+                  <>
+                    <Alert isInline variant="warning" title="To maintain compliance, ignore or disable this recommendation">
+                      <p>
+                        The resolution of this Advisor recommendation conflicts with a rule defined in the Compliance service. Applying this
+                        remediation may impact your compliance status.
+                      </p>
+                      {typeof conflict_compliance_policies_enabled === 'object' && (
+                        <ul style={{ paddingLeft: 0, listStyle: 'none' }}>
+                          {Object.keys(conflict_compliance_policies_enabled as Record<string, unknown>).map((policy) => (
+                            <li key={policy}>Conflicting policy: {policy}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </Alert>
+                    <ExpandableSection
+                      isExpanded={isExpanded}
+                      onToggle={onToggle}
+                      toggleText={isExpanded ? 'Hide remediation steps' : 'I understand the risks, show remediation steps'}
+                      isIndented
+                    >
+                      {resolution && <TemplateProcessor template={resolution} definitions={filteredDetails} onError={handleError} />}
+                    </ExpandableSection>
+                  </>
+                ) : (
+                  resolution && <TemplateProcessor template={resolution} definitions={filteredDetails} onError={handleError} />
+                )}
+              </CardBody>
             </Card>
           </StackItem>
           {kbaDetail.publishedTitle !== 'N/A' && (
@@ -128,7 +164,7 @@ const ReportDetails: React.FC<ReportDetailsProps> = ({
                     <InfoCircleIcon className="ins-c-report-details__icon" />
                     <strong>Additional info</strong>
                   </CardHeader>
-                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={details} onError={handleError} />}</CardBody>
+                  <CardBody>{<TemplateProcessor template={rule.more_info} definitions={filteredDetails} onError={handleError} />}</CardBody>
                 </Card>
               </StackItem>
             </React.Fragment>

--- a/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
+++ b/packages/advisor-components/src/TemplateProcessor/TemplateProcessor.tsx
@@ -5,7 +5,7 @@ import sanitize, { simpleTransform } from 'sanitize-html';
 
 interface TemplateProcessorProps {
   template: string;
-  definitions: Record<string, string | number>;
+  definitions: Record<string, unknown>;
   onError?: (e: Error) => void;
 }
 
@@ -34,7 +34,7 @@ const TemplateProcessor: React.FC<TemplateProcessorProps> = ({ template, definit
   );
 
   try {
-    const compiledDot = Object.keys(definitions).length !== 0 ? doT.template(template, DOT_SETTINGS)(definitions) : template;
+    const compiledDot = doT.template(template, DOT_SETTINGS)(definitions);
     const compiledMd = marked(compiledDot, { async: false });
     const sanitized = sanitize(compiledMd, {
       allowedAttributes: { '*': ['href', 'target', 'class', 'style', 'rel'] },
@@ -50,7 +50,7 @@ const TemplateProcessor: React.FC<TemplateProcessorProps> = ({ template, definit
         dangerouslySetInnerHTML={{
           __html: sanitized.replace(
             /<\/a>/gim,
-            ` <i class="fas fa-external-link-alt"></i></a>` // add an icon to external links
+            ` <i class="fas fa-external-link-alt"></i></a>`, // add an icon to external links
           ),
         }}
       />


### PR DESCRIPTION
Old functionality:
<img width="1894" height="963" alt="Screenshot from 2026-04-08 20-10-00" src="https://github.com/user-attachments/assets/8a46c27a-401f-44bd-bb7a-f8918d8c6baf" />

New functionality:
<img width="1920" height="1009" alt="Screenshot from 2026-04-08 19-41-23" src="https://github.com/user-attachments/assets/c9634674-2f53-433b-a69d-99de675214a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline warnings for compliance conflicts that list conflicting policy keys.
  * Made the "Steps to resolve" section expandable with toggleable text when conflicts are present.
  * Supplemental sections (Detected issues, Additional info) now exclude conflict metadata for clearer output.

* **Improvements**
  * More reliable template rendering for remediation content, ensuring consistent processing of dynamic fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->