### PR TITLE
feat(RHINENG-24090): allow other apps to pass Rem button tooltip content

### DIFF
--- a/packages/remediations/src/RemediationButton/index.js
+++ b/packages/remediations/src/RemediationButton/index.js
@@ -34,6 +34,8 @@ const RemediationButton = React.forwardRef((props, ref) => <BaseRemediationButto
 RemediationButton.propTypes = {
   /** React Suspense fallback component. <a href="https://reactjs.org/docs/code-splitting.html#reactlazy" target="_blank">Learn more</a>. */
   fallback: PropTypes.node,
+  /** Optional tooltip text when the user may remediate; shown after permission/selection checks. */
+  buttonTooltipContent: PropTypes.string,
 };
 
 RemediationButton.defaultProps = {


### PR DESCRIPTION
based on https://github.com/RedHatInsights/insights-remediations-frontend/pull/787 and https://github.com/RedHatInsights/compliance-frontend/pull/2790 adding new prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RemediationButton now supports custom tooltip content for improved user guidance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->