### PR TITLE
fix(CI): fix broken node 22.22.2

### DIFF
--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -21,6 +21,10 @@ runs:
       shell: bash
       run: |
         echo "=== Updating npm to support trusted publishing ==="
+        # Node 22.22.2 bundles a broken npm (missing promise-retry); going straight to
+        # npm@latest fails. Bootstrap via 10.9.8 first — see https://github.com/nodejs/node/issues/62425
+        # and https://github.com/npm/cli/issues/9151 — remove the first line once fixed upstream.
+        npm install -g npm@10.9.8
         npm install -g npm@latest
     - name: Show final Node.js version
       shell: bash


### PR DESCRIPTION
there is a bug with node 22.22.2 version where npm fails to install in latest node 22 https://github.com/npm/cli/issues/9151