### PR TITLE
fix(release): use npm trusted publisher with OIDC provenance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Frontend components CI pipeline
 permissions:
-  id-token: write
+  contents: read
 on:
   pull_request:
     branches:
@@ -114,6 +114,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [install, build, unit-test, component-test, lint, commitlint, check-circular-imports]
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,8 @@
   "targetDefaults": {
     "nx-release-publish": {
       "options": {
-        "packageRoot": "dist/{projectName}"
+        "packageRoot": "dist/{projectName}",
+        "provenance": true
       }
     },
     "build": {


### PR DESCRIPTION
### Description

Add permissions to perform releases after recent NPM OIDC token auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI workflow permissions to limit access to only what's needed for automated releases, reducing surface area for accidental or excessive privileges.
  * Enabled package provenance for release publishing so users can independently verify package origin and integrity before installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->