### PR TITLE
fix(release): use new version of NPM when releasing packages

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -14,6 +14,9 @@ runs:
   using: "composite"
   steps:
     - uses: './.github/actions/setup-environment'
+    - name: Upgrade npm for OIDC trusted publishing
+      shell: bash
+      run: npm install -g npm@latest
     - name: Install deps
       shell: bash
       run: npm i
@@ -22,6 +25,9 @@ runs:
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
+    - name: Remove _authToken so npm uses OIDC for trusted publishing
+      shell: bash
+      run: npm config delete //registry.npmjs.org/:_authToken
     - name: Release
       shell: bash
       env:


### PR DESCRIPTION
### Description

Use newer version of NPM for releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process to use the latest npm version and OIDC-based publishing instead of stored authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->