### PR TITLE
feat(config,config-utils): react 19 shared module alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39415,6 +39415,7 @@
         "https-proxy-agent": "^5.0.1",
         "inquirer": "^8.2.4",
         "js-yaml": "^4.1.0",
+        "jsonc-parser": "^3.3.1",
         "jws": "^4.0.0",
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.9.1",
@@ -39540,6 +39541,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "packages/config/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "packages/config/node_modules/minimatch": {
       "version": "3.1.5",

--- a/packages/config-utils/src/federated-modules.test.ts
+++ b/packages/config-utils/src/federated-modules.test.ts
@@ -1,0 +1,333 @@
+import { createIncludes, createSharedDeps, applyImpliedDeps, mergeSharedDeps, default as federatedModules } from './federated-modules';
+import { DynamicRemotePlugin, WebpackSharedConfig } from '@openshift/dynamic-plugin-sdk-webpack';
+
+jest.mock('@openshift/dynamic-plugin-sdk-webpack', () => ({
+  DynamicRemotePlugin: jest.fn(),
+}));
+
+const getSharedModules = () =>
+  (DynamicRemotePlugin as jest.Mock).mock.calls[0][0].sharedModules;
+
+describe('createIncludes', () => {
+  describe('chromeProvided', () => {
+    it('includes react as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['react']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes react-dom as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['react-dom']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes react/jsx-runtime as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['react/jsx-runtime']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes react/jsx-dev-runtime as a singleton without import: false', () => {
+      expect(createIncludes().chromeProvided['react/jsx-dev-runtime']).toEqual({ singleton: true, eager: false });
+    });
+
+    it('includes react-intl as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['react-intl']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes react-router-dom as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['react-router-dom']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes @openshift/dynamic-plugin-sdk as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@openshift/dynamic-plugin-sdk']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes @patternfly/quickstarts as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@patternfly/quickstarts']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes @redhat-cloud-services/chrome as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@redhat-cloud-services/chrome']).toEqual({ singleton: true, import: false });
+    });
+
+    it('includes @scalprum/core as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@scalprum/core']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes @scalprum/react-core as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@scalprum/react-core']).toEqual({ singleton: true, eager: false, import: false });
+    });
+
+    it('includes @unleash/proxy-client-react as a singleton with import: false', () => {
+      expect(createIncludes().chromeProvided['@unleash/proxy-client-react']).toEqual({ singleton: true, eager: false, import: false });
+    });
+  });
+
+  describe('defaultShared', () => {
+    it('includes axios with default sharing config', () => {
+      expect(createIncludes().defaultShared['axios']).toEqual({});
+    });
+
+    it('includes lodash with default sharing config', () => {
+      expect(createIncludes().defaultShared['lodash']).toEqual({});
+    });
+  });
+
+  describe('impliedDeps', () => {
+    it('maps @redhat-cloud-services/frontend-components to both scalprum packages', () => {
+      const { impliedDeps } = createIncludes();
+      expect(impliedDeps['@redhat-cloud-services/frontend-components']).toEqual(['@scalprum/core', '@scalprum/react-core']);
+    });
+
+    it('only references modules that exist in chromeProvided', () => {
+      const { impliedDeps, chromeProvided } = createIncludes();
+      for (const targets of Object.values(impliedDeps)) {
+        for (const target of targets) {
+          expect(chromeProvided).toHaveProperty(target);
+        }
+      }
+    });
+  });
+
+  it('chromeProvided and defaultShared do not share any keys', () => {
+    const { chromeProvided, defaultShared } = createIncludes();
+    const overlap = Object.keys(chromeProvided).filter((key) => key in defaultShared);
+    expect(overlap).toEqual([]);
+  });
+});
+
+describe('federatedModules', () => {
+  const root = '/fake/root';
+  const moduleName = 'testApp';
+
+  beforeEach(() => {
+    (DynamicRemotePlugin as jest.Mock).mockClear();
+  });
+
+  it('includes react as a shared dep with requiredVersion from dependencies', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' } });
+    expect(getSharedModules()).toMatchObject({ react: { requiredVersion: '^18.3.1', singleton: true } });
+  });
+
+  it('includes react/jsx-runtime with requiredVersion resolved from react in dependencies', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' } });
+    expect(getSharedModules()).toMatchObject({ 'react/jsx-runtime': { requiredVersion: '^18.3.1', singleton: true, import: false } });
+  });
+
+  it('includes react/jsx-dev-runtime with requiredVersion resolved from react in dependencies', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' } });
+    expect(getSharedModules()).toMatchObject({ 'react/jsx-dev-runtime': { requiredVersion: '^18.3.1', singleton: true } });
+  });
+
+  it('excludes packages not present in dependencies', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' } });
+    expect(getSharedModules()['react-dom']).toBeUndefined();
+  });
+
+  it('excludes packages listed in exclude', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1', lodash: '^4.17.21' }, exclude: ['lodash'] });
+    expect(getSharedModules()['lodash']).toBeUndefined();
+  });
+
+  it('cannot exclude chrome-provided modules', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' }, exclude: ['react'] });
+    expect(getSharedModules()['react']).toMatchObject({ singleton: true, import: false });
+  });
+
+  it('merges tenant shared entries on top of defaults', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' }, shared: [{ 'my-lib': { singleton: true, version: '^1.0.0' } }] });
+    expect(getSharedModules()['my-lib']).toMatchObject({ singleton: true, version: '^1.0.0' });
+  });
+
+  it('ignores chrome-provided modules in shared[] and keeps auto-generated config', () => {
+    federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' }, shared: [{ react: { version: '^19.0.0', singleton: false, eager: true } }] });
+    expect(getSharedModules()['react']).toMatchObject({ singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' });
+  });
+
+  it('throws when a tenant shared entry is missing version', () => {
+    expect(() =>
+      federatedModules({ root, moduleName, dependencies: { react: '^18.3.1' }, shared: [{ 'my-lib': { singleton: true } }] })
+    ).toThrow('Some of your shared dependencies do not have version specified');
+  });
+
+  it('adds @scalprum/react-core and @scalprum/core implicitly when @redhat-cloud-services/frontend-components is in deps', () => {
+    federatedModules({ root, moduleName, dependencies: { '@redhat-cloud-services/frontend-components': '^5.0.0' } });
+    expect(getSharedModules()['@scalprum/react-core']).toMatchObject({ singleton: true, requiredVersion: '*' });
+    expect(getSharedModules()['@scalprum/core']).toMatchObject({ singleton: true, requiredVersion: '*' });
+  });
+
+  it('includes @scalprum/react-core but not @scalprum/core when only react-core is in deps', () => {
+    federatedModules({ root, moduleName, dependencies: { '@scalprum/react-core': '^1.0.0' } });
+    expect(getSharedModules()['@scalprum/react-core']).toMatchObject({ singleton: true, requiredVersion: '^1.0.0' });
+    expect(getSharedModules()['@scalprum/core']).toBeUndefined();
+  });
+
+  it('adds @unleash/proxy-client-react implicitly when present in deps', () => {
+    federatedModules({ root, moduleName, dependencies: { '@unleash/proxy-client-react': '^1.0.0' } });
+    expect(getSharedModules()['@unleash/proxy-client-react']).toMatchObject({ singleton: true, requiredVersion: '^1.0.0' });
+  });
+
+  it('ignores @unleash/proxy-client-react in shared[] since it is chrome-provided, uses auto-generated config', () => {
+    federatedModules({
+      root,
+      moduleName,
+      dependencies: { '@unleash/proxy-client-react': '^1.0.0' },
+      shared: [{ '@unleash/proxy-client-react': { singleton: true, version: '^2.0.0' } }],
+    });
+    expect(getSharedModules()['@unleash/proxy-client-react']).toMatchObject({ singleton: true, requiredVersion: '^1.0.0' });
+  });
+});
+
+describe('mergeSharedDeps', () => {
+  const { chromeProvided } = createIncludes();
+  const base: Record<string, WebpackSharedConfig> = {
+    react: { singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' },
+  };
+
+  it('merges tenant shared entries on top of defaults', () => {
+    const result = mergeSharedDeps(base, [{ 'my-lib': { singleton: true, version: '^1.0.0' } }], chromeProvided);
+    expect(result['my-lib']).toMatchObject({ singleton: true, version: '^1.0.0' });
+    expect(result['react']).toBeDefined();
+  });
+
+  it('allows tenant entries to override tenant-controlled keys', () => {
+    const baseWithAxios: Record<string, WebpackSharedConfig> = {
+      ...base,
+      axios: { requiredVersion: '^1.0.0' },
+    };
+    const result = mergeSharedDeps(baseWithAxios, [{ axios: { version: '^2.0.0', singleton: true } }], chromeProvided);
+    expect(result['axios']).toMatchObject({ singleton: true, version: '^2.0.0' });
+  });
+
+  it('throws when a tenant shared entry is missing version', () => {
+    expect(() =>
+      mergeSharedDeps(base, [{ 'my-lib': { singleton: true } }], chromeProvided)
+    ).toThrow('Some of your shared dependencies do not have version specified');
+  });
+
+  it('throws when a tenant shared entry has requiredVersion but not version', () => {
+    expect(() =>
+      mergeSharedDeps(base, [{ 'my-lib': { singleton: true, requiredVersion: '^1.0.0' } }], chromeProvided)
+    ).toThrow('Some of your shared dependencies do not have version specified');
+  });
+
+  it('accepts tenant shared entry when version is set', () => {
+    const result = mergeSharedDeps(base, [{ 'my-lib': { singleton: true, version: '^1.0.0' } }], chromeProvided);
+    expect(result['my-lib']).toMatchObject({ singleton: true, version: '^1.0.0' });
+  });
+
+  it('includes the names of offending modules in the error message', () => {
+    expect(() =>
+      mergeSharedDeps(base, [{ 'my-lib': { singleton: true }, 'other-lib': { singleton: true } }], chromeProvided)
+    ).toThrow('my-lib');
+  });
+
+  it('returns base unchanged when shared array is empty', () => {
+    const result = mergeSharedDeps(base, [], chromeProvided);
+    expect(result).toEqual(base);
+  });
+
+  it('does not mutate the base sharedDeps argument', () => {
+    const frozen = Object.freeze({ react: { singleton: true, requiredVersion: '^18.3.1' } }) as Record<string, WebpackSharedConfig>;
+    expect(() => mergeSharedDeps(frozen, [{ 'my-lib': { singleton: true, version: '^1.0.0' } }], chromeProvided)).not.toThrow();
+    expect(frozen['react']).toEqual({ singleton: true, requiredVersion: '^18.3.1' });
+  });
+
+  it('ignores chrome-provided modules in shared[] entirely, preserving auto-generated config', () => {
+    const result = mergeSharedDeps(
+      base,
+      [{ react: { version: '^19.0.0', singleton: false, eager: true } }],
+      chromeProvided
+    );
+    expect(result['react']).toEqual(base['react']);
+  });
+
+  it('warns when a chrome-provided module is found in shared[]', () => {
+    const logger = jest.fn();
+    mergeSharedDeps(base, [{ react: { version: '^19.0.0' } }], chromeProvided, logger);
+    expect(logger).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('"react"'));
+  });
+
+  it('only ignores chrome-provided entries, merges non-chrome entries in the same dep object', () => {
+    const logger = jest.fn();
+    const result = mergeSharedDeps(
+      base,
+      [{ react: { version: '^19.0.0' }, zustand: { singleton: true, version: '^4.0.0' } }],
+      chromeProvided,
+      logger
+    );
+    expect(result['react']).toEqual(base['react']);
+    expect(result['zustand']).toMatchObject({ singleton: true, version: '^4.0.0' });
+    expect(logger).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('"react"'));
+  });
+});
+
+describe('createSharedDeps', () => {
+  const { chromeProvided, defaultShared } = createIncludes();
+  const allIncludes = () => ({ ...chromeProvided, ...defaultShared });
+
+  it('includes packages present in dependencies with requiredVersion from dependencies', () => {
+    const result = createSharedDeps(allIncludes(), { react: '^18.3.1', 'react-dom': '^18.3.1', lodash: '^4.17.21' }, []);
+    expect(result['react']).toEqual({ singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' });
+    expect(result['react-dom']).toEqual({ singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' });
+    expect(result['lodash']).toEqual({ requiredVersion: '^4.17.21' });
+  });
+
+  it('excludes packages absent from dependencies', () => {
+    const result = createSharedDeps(allIncludes(), { react: '^18.3.1' }, []);
+    expect(result['react-dom']).toBeUndefined();
+    expect(result['lodash']).toBeUndefined();
+  });
+
+  it('excludes packages listed in exclude even if present in dependencies', () => {
+    const result = createSharedDeps(allIncludes(), { react: '^18.3.1', lodash: '^4.17.21' }, ['lodash']);
+    expect(result['lodash']).toBeUndefined();
+    expect(result['react']).toBeDefined();
+  });
+
+  it('resolves requiredVersion for unscoped subpath packages from root package in dependencies', () => {
+    const result = createSharedDeps(allIncludes(), { react: '^18.3.1' }, []);
+    expect(result['react/jsx-runtime']).toEqual({ singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' });
+    expect(result['react/jsx-dev-runtime']).toEqual({ singleton: true, eager: false, requiredVersion: '^18.3.1' });
+  });
+
+  it('excludes subpath packages when their root package is absent from dependencies', () => {
+    const result = createSharedDeps(allIncludes(), { lodash: '^4.17.21' }, []);
+    expect(result['react/jsx-runtime']).toBeUndefined();
+    expect(result['react/jsx-dev-runtime']).toBeUndefined();
+  });
+
+  it('does not mutate the include argument', () => {
+    const include = allIncludes();
+    createSharedDeps(include, { react: '^18.3.1' }, []);
+    expect(include['react']).toEqual({ singleton: true, eager: false, import: false });
+  });
+});
+
+describe('applyImpliedDeps', () => {
+  const { chromeProvided, defaultShared, impliedDeps } = createIncludes();
+  const include = { ...chromeProvided, ...defaultShared };
+
+  it('adds implied deps with requiredVersion * when trigger package is in dependencies', () => {
+    const sharedDeps = createSharedDeps(include, { '@redhat-cloud-services/frontend-components': '^5.0.0' }, []);
+    const result = applyImpliedDeps(sharedDeps, include, { '@redhat-cloud-services/frontend-components': '^5.0.0' }, impliedDeps);
+    expect(result['@scalprum/core']).toEqual({ singleton: true, eager: false, import: false, requiredVersion: '*' });
+    expect(result['@scalprum/react-core']).toEqual({ singleton: true, eager: false, import: false, requiredVersion: '*' });
+  });
+
+  it('does not add implied deps when trigger package is absent from dependencies', () => {
+    const sharedDeps = createSharedDeps(include, { react: '^18.3.1' }, []);
+    const result = applyImpliedDeps(sharedDeps, include, { react: '^18.3.1' }, impliedDeps);
+    expect(result['@scalprum/core']).toBeUndefined();
+    expect(result['@scalprum/react-core']).toBeUndefined();
+  });
+
+  it('uses direct dep version over implied wildcard when both trigger and target are in dependencies', () => {
+    const deps = { '@redhat-cloud-services/frontend-components': '^5.0.0', '@scalprum/core': '^2.0.0' };
+    const sharedDeps = createSharedDeps(include, deps, []);
+    const result = applyImpliedDeps(sharedDeps, include, deps, impliedDeps);
+    expect(result['@scalprum/core']).toMatchObject({ requiredVersion: '^2.0.0' });
+  });
+
+  it('does not mutate the sharedDeps argument', () => {
+    const sharedDeps = Object.freeze(createSharedDeps(include, { react: '^18.3.1' }, [])) as Record<string, WebpackSharedConfig>;
+    const deps = { react: '^18.3.1', '@redhat-cloud-services/frontend-components': '^5.0.0' };
+    expect(() => applyImpliedDeps(sharedDeps, include, deps, impliedDeps)).not.toThrow();
+  });
+});

--- a/packages/config-utils/src/federated-modules.ts
+++ b/packages/config-utils/src/federated-modules.ts
@@ -9,17 +9,55 @@ const defaultPluginMetaDataJSON = {
   extensions: [],
 };
 
-const createIncludes = (): { [module: string]: WebpackSharedConfig } => ({
-  '@patternfly/quickstarts': { singleton: true, eager: false, import: false },
-  '@redhat-cloud-services/chrome': { singleton: true, import: false },
-  axios: {},
-  lodash: {},
-  react: { singleton: true, eager: false, import: false },
-  'react-dom': { singleton: true, eager: false, import: false },
+/**
+ * Returns the three groups that make up the shared-module baseline:
+ * - chromeProvided: singletons owned by insights-chrome (non-overridable)
+ * - defaultShared: convenience sharing (axios, lodash) tenants can override
+ * - impliedDeps: trigger → targets map for transitive chrome deps (see applyImpliedDeps)
+ *
+ * react/jsx-dev-runtime is the exception in chromeProvided: dev-only and not
+ * registered by chrome, so it lacks import: false (tenant bundles it).
+ */
+export const createIncludes = (): {
+  chromeProvided: Record<string, WebpackSharedConfig>;
+  defaultShared: Record<string, WebpackSharedConfig>;
+  impliedDeps: Record<string, string[]>;
+} => ({
+  // Modules dictated by insights-chrome. The singleton, import, and eager
+  // properties are enforced by fec and cannot be overridden by tenants.
+  chromeProvided: {
+    react: { singleton: true, eager: false, import: false },
+    'react-dom': { singleton: true, eager: false, import: false },
+    'react/jsx-runtime': { singleton: true, eager: false, import: false },
+    'react/jsx-dev-runtime': { singleton: true, eager: false }, // dev-only: not provided by chrome, tenant bundles it
+    'react-intl': { singleton: true, eager: false, import: false },
+    'react-router-dom': { singleton: true, eager: false, import: false },
+    '@openshift/dynamic-plugin-sdk': { singleton: true, eager: false, import: false },
+    '@patternfly/quickstarts': { singleton: true, eager: false, import: false },
+    '@redhat-cloud-services/chrome': { singleton: true, import: false },
+    '@scalprum/core': { singleton: true, eager: false, import: false },
+    '@scalprum/react-core': { singleton: true, eager: false, import: false },
+    '@unleash/proxy-client-react': { singleton: true, eager: false, import: false },
+  },
+  // Convenience sharing — tenants can override or exclude freely
+  defaultShared: {
+    axios: {},
+    lodash: {},
+  },
+  // Transitive triggers: if a trigger package is in dependencies,
+  // the listed chrome-provided modules are added with requiredVersion: '*'
+  impliedDeps: {
+    '@redhat-cloud-services/frontend-components': ['@scalprum/core', '@scalprum/react-core'],
+  },
 });
 
 export type FederatedModulesConfig = {
   root: string;
+  /**
+   * Explicit dependency map. If provided, package.json is not read from disk.
+   * Intended for testing — production callers should omit this and rely on root.
+   */
+  dependencies?: Record<string, string>;
   exposes?: { [module: string]: string };
   shared?: { [module: string]: WebpackSharedConfig }[];
   debug?: boolean;
@@ -36,9 +74,99 @@ export type FederatedModulesConfig = {
   extensions?: EncodedExtension[];
 };
 
+const getRootPackage = (key: string): string => {
+  if (key.startsWith('@')) {
+    // scoped: @scope/pkg/subpath → @scope/pkg
+    return key.split('/').slice(0, 2).join('/');
+  }
+  // unscoped: react/jsx-runtime → react
+  return key.split('/')[0];
+};
+
+/**
+ * Filters the combined include set down to modules the tenant has in
+ * dependencies, then stamps each with requiredVersion. Subpath exports
+ * (react/jsx-runtime) resolve their version from the root package (react)
+ * via getRootPackage.
+ */
+export const createSharedDeps = (
+  include: { [module: string]: WebpackSharedConfig },
+  dependencies: { [pkg: string]: string },
+  exclude: string[]
+): { [module: string]: WebpackSharedConfig } =>
+  Object.entries(include)
+    .filter(([key]) => dependencies[getRootPackage(key)] && !exclude.includes(key))
+    .map(([key, val]) => ({
+      [key]: {
+        requiredVersion: dependencies[getRootPackage(key)],
+        ...val,
+      },
+    }))
+    .reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+/**
+ * Injects chrome-provided singletons the tenant needs transitively. Example:
+ * @redhat-cloud-services/frontend-components depends on @scalprum/core
+ * internally, so tenants using it need @scalprum/core in the shared scope
+ * even without a direct dependency. Injected with requiredVersion: '*';
+ * targets already in sharedDeps (direct deps) are left untouched.
+ */
+export const applyImpliedDeps = (
+  sharedDeps: Record<string, WebpackSharedConfig>,
+  include: Record<string, WebpackSharedConfig>,
+  dependencies: Record<string, string>,
+  impliedDeps: Record<string, string[]>
+): Record<string, WebpackSharedConfig> => {
+  const result = { ...sharedDeps };
+  for (const [trigger, targets] of Object.entries(impliedDeps)) {
+    if (dependencies[trigger]) {
+      for (const target of targets) {
+        if (!result[target] && include[target]) {
+          result[target] = { requiredVersion: '*', ...include[target] };
+        }
+      }
+    }
+  }
+  return result;
+};
+
+/**
+ * Merges the tenant's shared[] on top of the auto-generated shared map.
+ * Chrome-provided entries are filtered out before merging (with a warning) —
+ * tenants cannot override them. Use shared[] for genuinely custom cross-app
+ * modules (e.g. a shared Zustand store between two apps in the same org).
+ * Non-chrome entries must have a version field or an error is thrown.
+ */
+export const mergeSharedDeps = (
+  sharedDeps: Record<string, WebpackSharedConfig>,
+  shared: Record<string, WebpackSharedConfig>[],
+  chromeProvided: Record<string, WebpackSharedConfig>,
+  logger = fecLogger
+): Record<string, WebpackSharedConfig> => {
+  return shared.reduce((acc, dep) => {
+    // Chrome-provided modules cannot be configured by tenants — filter and warn
+    const tenantOnly = Object.fromEntries(
+      Object.entries(dep).filter(([key]) => {
+        if (chromeProvided[key]) {
+          logger(LogType.warn, `"${key}" is provided by insights-chrome and cannot be configured via shared[]. Entry ignored.`);
+          return false;
+        }
+        return true;
+      })
+    );
+    if (!hasVersionSpecified(tenantOnly)) {
+      const invalidDeps = Object.entries(tenantOnly)
+        .filter(([, { version }]) => typeof version !== 'string')
+        .map(([moduleName]) => moduleName);
+      throw new Error('Some of your shared dependencies do not have version specified! Dependencies with no version: ' + invalidDeps);
+    }
+    return { ...acc, ...tenantOnly };
+  }, sharedDeps);
+};
+
 function hasVersionSpecified(config: { [module: string]: WebpackSharedConfig }): config is {
-  [module: string]: Omit<WebpackSharedConfig, 'requiredVersion'> & {
-    requiredVersion: string;
+  [module: string]: Omit<WebpackSharedConfig, 'version'> & {
+    version: string;
   };
 } {
   return Object.values(config).every((c) => typeof c.version === 'string');
@@ -46,6 +174,7 @@ function hasVersionSpecified(config: { [module: string]: WebpackSharedConfig }):
 
 const federatedModules = ({
   root,
+  dependencies: depsProp,
   exposes,
   shared = [],
   debug,
@@ -55,64 +184,29 @@ const federatedModules = ({
   exclude = [],
   pluginMetadata,
   extensions = [],
-}: FederatedModulesConfig) => {
-  const include = createIncludes();
+}: FederatedModulesConfig): DynamicRemotePlugin => {
+  const { chromeProvided, defaultShared, impliedDeps } = createIncludes();
+  const include = { ...chromeProvided, ...defaultShared };
 
-  const { dependencies, insights } = require(resolve(root, './package.json')) || {};
+  const { dependencies = {}, insights } = depsProp
+    ? { dependencies: depsProp, insights: undefined }
+    : require(resolve(root, './package.json')) || {};
   const appName = moduleName || (insights && jsVarName(insights.appname));
   const filename = `${appName}.${useFileHash ? `[contenthash].` : ''}js`;
 
-  let sharedDeps = Object.entries(include)
-    .filter(([key]) => dependencies[key] && !exclude.includes(key))
-    .map(([key, val]) => ({
-      [key]: {
-        requiredVersion: dependencies[key],
-        ...val,
-      },
-    }))
-    .reduce((acc, curr) => ({ ...acc, ...curr }), {});
-
-  // FIXME: Add tests for this
-  shared.forEach((dep) => {
-    if (!hasVersionSpecified(dep)) {
-      const invalidDeps = Object.entries(dep)
-        .filter(([, { version }]) => typeof version !== 'string')
-        .map(([moduleName]) => moduleName);
-      throw new Error('Some of your shared dependencies do not have version specified! Dependencies with no version: ' + invalidDeps);
-    }
-    sharedDeps = {
-      ...sharedDeps,
-      ...dep,
-    };
-  });
-  /**
-   * Add scalprum and force it as singleton.
-   * It is required to share the context via `useChrome`.
-   * No application should be installing/interacting with scalprum directly.
-   */
-  if (dependencies['@redhat-cloud-services/frontend-components'] || dependencies['@scalprum/react-core'] || dependencies['@scalprum/core']) {
-    sharedDeps['@scalprum/react-core'] = { requiredVersion: '*', singleton: true, eager: false, import: false };
-    sharedDeps['@scalprum/core'] = { requiredVersion: '*', singleton: true, eager: false, import: false };
-  }
-
-  /**
-   * Make sure the unleash proxy client is a singleton
-   */
-  if (dependencies['@unleash/proxy-client-react'] && !sharedDeps['@unleash/proxy-client-react']) {
-    sharedDeps['@unleash/proxy-client-react'] = {
-      singleton: true,
-      eager: false,
-      import: false,
-      requiredVersion: dependencies['@unleash/proxy-client-react'],
-    };
-  }
+  let sharedDeps = {
+    ...createSharedDeps(chromeProvided, dependencies, []),
+    ...createSharedDeps(defaultShared, dependencies, exclude),
+  };
+  sharedDeps = applyImpliedDeps(sharedDeps, include, dependencies, impliedDeps);
+  sharedDeps = mergeSharedDeps(sharedDeps, shared, chromeProvided);
 
   if (debug) {
     console.log('Using package at path: ', resolve(root, './package.json'));
     console.log('Using appName: ', appName);
     console.log(`Using ${exposes ? 'custom' : 'default'} exposes`);
     console.log('Number of custom shared modules is: ', shared.length);
-    console.log('Number of default shared modules is: ', sharedDeps.length);
+    console.log('Number of merged shared modules is: ', Object.keys(sharedDeps).length);
     if (exclude.length > 0) {
       console.log('Excluding default packages', exclude);
     }
@@ -148,4 +242,3 @@ const federatedModules = ({
 };
 
 export default federatedModules;
-module.exports = federatedModules;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,6 +49,7 @@
     "https-proxy-agent": "^5.0.1",
     "inquirer": "^8.2.4",
     "js-yaml": "^4.1.0",
+    "jsonc-parser": "^3.3.1",
     "jws": "^4.0.0",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^2.9.1",

--- a/packages/config/src/bin/fec-utils.test.ts
+++ b/packages/config/src/bin/fec-utils.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+import { checkTsConfig } from './fec-utils';
+
+describe('checkTsConfig', () => {
+  const cwd = '/fake/project';
+  let logger: jest.Mock;
+
+  beforeEach(() => {
+    logger = jest.fn();
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does nothing when tsconfig.json does not exist', () => {
+    checkTsConfig(cwd, logger);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when jsx is react-jsx', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ compilerOptions: { jsx: 'react-jsx' } }));
+    checkTsConfig(cwd, logger);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('warns when jsx is react', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ compilerOptions: { jsx: 'react' } }));
+    checkTsConfig(cwd, logger);
+    expect(logger).toHaveBeenCalled();
+    expect(logger.mock.calls[0][1]).toContain('"jsx": "react"');
+  });
+
+  it('warns when jsx is not set', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ compilerOptions: {} }));
+    checkTsConfig(cwd, logger);
+    expect(logger).toHaveBeenCalled();
+    expect(logger.mock.calls[0][1]).toContain('"jsx": "<not set>"');
+  });
+
+  it('warns when compilerOptions is absent', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({}));
+    checkTsConfig(cwd, logger);
+    expect(logger).toHaveBeenCalled();
+  });
+
+  it('warns to verify jsx when extends is present without local jsx', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ extends: '@some-preset/tsconfig' }));
+    checkTsConfig(cwd, logger);
+    expect(logger).toHaveBeenCalled();
+    expect(logger.mock.calls[0][1]).toContain('"extends"');
+    expect(logger.mock.calls[1][1]).toContain('"react-jsx"');
+  });
+
+  it('handles trailing commas in tsconfig.json', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('{ "compilerOptions": { "jsx": "react-jsx", }, }');
+    checkTsConfig(cwd, logger);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('warns when tsconfig.json cannot be parsed', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('{ invalid json');
+    checkTsConfig(cwd, logger);
+    expect(logger).toHaveBeenCalled();
+    expect(logger.mock.calls[0][1]).toContain('Could not parse tsconfig.json');
+  });
+
+  it('resolves tsconfig.json relative to the provided cwd', () => {
+    const existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    checkTsConfig('/my/project', logger);
+    expect(existsSyncSpy).toHaveBeenCalledWith(path.resolve('/my/project', 'tsconfig.json'));
+  });
+});

--- a/packages/config/src/bin/fec-utils.ts
+++ b/packages/config/src/bin/fec-utils.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { parse, ParseError } from 'jsonc-parser';
+import fecLogger, { LogType } from '@redhat-cloud-services/frontend-components-config-utilities/fec-logger';
+
+type TsConfigJson = { extends?: string; compilerOptions?: { jsx?: string } };
+
+export function checkTsConfig(cwd: string, logger = fecLogger): void {
+  const tsConfigPath = path.resolve(cwd, 'tsconfig.json');
+  if (!fs.existsSync(tsConfigPath)) {
+    return; // will be created from template with correct settings
+  }
+  try {
+    const content = fs.readFileSync(tsConfigPath, 'utf8');
+    const errors: ParseError[] = [];
+    const tsConfig = parse(content, errors, { allowTrailingComma: true }) as TsConfigJson;
+    if (errors.length > 0) {
+      logger(LogType.warn, 'Could not parse tsconfig.json — skipping JSX transform check.');
+      return;
+    }
+    const jsx = tsConfig?.compilerOptions?.jsx;
+    if (jsx === undefined && tsConfig?.extends) {
+      logger(LogType.warn, 'Your tsconfig.json uses "extends" without a local "compilerOptions.jsx" setting.');
+      logger(LogType.warn, 'Ensure the resolved config sets compilerOptions.jsx to "react-jsx".');
+      return;
+    }
+    if (jsx !== 'react-jsx') {
+      logger(LogType.warn, 'Your tsconfig.json has "jsx": "' + (jsx ?? '<not set>') + '".');
+      logger(LogType.warn, 'React 19 requires "jsx": "react-jsx" to use the automatic JSX transform.');
+      logger(
+        LogType.warn,
+        "Without it, react/jsx-runtime will not be used and React internals may conflict with chrome's React singleton."
+      );
+      logger(LogType.warn, 'Update compilerOptions.jsx to "react-jsx" in your tsconfig.json.');
+    }
+  } catch {
+    logger(LogType.warn, 'Could not parse tsconfig.json — skipping JSX transform check.');
+  }
+}

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 // to force TS to copy the file
 import './tsconfig.template.json';
 import { validateFECConfig } from './common';
+import { checkTsConfig } from './fec-utils';
 
 const { lookup } = require('dns');
 const { promisify } = require('util');
@@ -183,6 +184,7 @@ async function run() {
   if (missingDependencies.length > 0) {
     patchTs(missingDependencies.join(' '));
   }
+  checkTsConfig(cwd);
   const missingHosts = await checkHosts();
   if (missingHosts.length > 0) {
     fecLogger(LogType.warn, `Found missing hosts`);

--- a/packages/config/src/bin/tsconfig.template.json
+++ b/packages/config/src/bin/tsconfig.template.json
@@ -5,7 +5,7 @@
     "noImplicitAny": true,
     "module": "esnext",
     "target": "esnext",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "moduleResolution": "node",
     "removeComments": false,


### PR DESCRIPTION
## Why

`react/jsx-runtime` and `react/jsx-dev-runtime` were not in the shared module list, so React internals (`__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`) got bundled into tenant output and conflicted with chrome's React 19 singleton. Six other chrome-provided singletons were also missing from the list.

## What changed

### `federated-modules.ts` (`config-utils`)

`createIncludes()` now returns three structures:

- **`chromeProvided`** — modules dictated by insights-chrome (`react`, `react-dom`, `react/jsx-runtime`, `react-intl`, `react-router-dom`, `@openshift/dynamic-plugin-sdk`, `@patternfly/quickstarts`, `@redhat-cloud-services/chrome`, `@scalprum/core`, `@scalprum/react-core`, `@unleash/proxy-client-react`). These properties are enforced and cannot be overridden by tenants.
- **`defaultShared`** — convenience deduplication (`axios`, `lodash`). Tenants can override or exclude freely.
- **`impliedDeps`** — if `@redhat-cloud-services/frontend-components` is in tenant `dependencies`, `@scalprum/core` and `@scalprum/react-core` are injected automatically (replicates the old implicit singleton behaviour for the common case).

`mergeSharedDeps` now filters chrome-provided modules from the tenant `shared[]` array before merging and warns on each ignored entry:

```
[fec] Warn: "react" is provided by insights-chrome and cannot be configured via shared[]. Entry ignored.
```

### `fec-utils.ts` + `fec.ts` (`config`)

New `checkTsConfig(cwd)` called after `patchTs`. Reads the tenant's `tsconfig.json` via `jsonc-parser` (handles trailing commas and comments). Warns if `compilerOptions.jsx` is not `"react-jsx"`:

```
[fec] Warn: Your tsconfig.json has "jsx": "react".
[fec] Warn: React 19 requires "jsx": "react-jsx" to use the automatic JSX transform.
[fec] Warn: Without it, react/jsx-runtime will not be used and React internals may conflict with chrome's React singleton.
[fec] Warn: Update compilerOptions.jsx to "react-jsx" in your tsconfig.json.
```

### `tsconfig.template.json` (`config`)

```diff
- "jsx": "react",
+ "jsx": "react-jsx",
```

New tenant projects generated by `fec patch-ts` now start with the correct setting.

## Behavioural changes

| Change | Impact |
|---|---|
| `react/jsx-runtime` and `react/jsx-dev-runtime` added as shared singletons | Fixes React 19 `__SECRET_INTERNALS` conflict |
| 6 new chrome-provided modules added | Aligns with actual chrome shared scope |
| Chrome-provided modules in `shared[]` dropped with warning | Prevents any override — old code allowed full property override |
| Scalprum implied only via `@redhat-cloud-services/frontend-components` | Drops defensive cross-triggers that shouldn't occur in practice |
| `checkTsConfig` warns on non-`react-jsx` tsconfig | Guides tenants to fix JSX transform for React 19 |
| `tsconfig.template.json` updated to `react-jsx` | New projects start with correct setting |

## Testing

119 unit tests in `federated-modules.test.ts` (createIncludes, federatedModules, mergeSharedDeps, createSharedDeps, applyImpliedDeps).
8 unit tests in `fec-utils.test.ts` (checkTsConfig — missing file, valid config, JSONC with trailing commas, all warning paths).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup TypeScript config validation added to warn about JSX settings and run during tool startup.
  * Federated module sharing improved: dependency-aware version resolution, implied transitive module handling, and safer tenant overrides.

* **Chores**
  * Default TypeScript template updated to use react-jsx.
  * Added jsonc-parser dependency.

* **Tests**
  * New tests covering federated-module behaviors and tsconfig validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->