### PR TITLE
fix(config): default useFileHash to false in fec static

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,15 @@ Releases are **fully automated** — the commit type directly controls whether p
 4. If a commit includes both source code changes and non-code changes (e.g., a new feature plus updated docs), use `feat:` or `fix:` — the release is warranted by the code change.
 5. The commit scope (e.g., `feat(utils):`) is informational only and does not affect which packages are released. Nx determines affected packages by which files were changed, not by the scope.
 
+### Package Dependency Updates (config ↔ config-utils)
+
+When changes to `config-utils` are required by `config` package:
+
+1. **Initial PR**: Release both packages together (commit triggers releases for both)
+2. **Follow-up PR**: Pin config-utils version in `packages/config/package.json` after release
+
+**Note**: Don't pin version in initial PR — CI install happens before release, causing npm install failure for unreleased versions.
+
 ## Testing Strategy
 
 ### Component Testing (Preferred)

--- a/packages/config-utils/src/serve-federated.ts
+++ b/packages/config-utils/src/serve-federated.ts
@@ -5,7 +5,17 @@ import { hasFEOFeaturesEnabled, readFrontendCRD } from './feo/crd-check';
 import { FrontendCRD } from './feo/feo-types';
 import { LogType, fecLogger } from '.';
 
+/**
+ * Serves federated modules for local development via `fec static` command.
+ *
+ * Runs webpack in watch mode and serves output via http-server. Used when developing
+ * federated modules that will be consumed by insights-chrome.
+ *
+ * This is NOT used for production builds - see build-script.ts for `fec build`.
+ */
 function federate(argv: Record<string, any>, cwd: string) {
+  // Disable file hashing for static mode — content hashes are unnecessary during local development
+  process.env.FEC_STATIC = 'true';
   let configPath: string = argv.config || './node_modules/@redhat-cloud-services/frontend-components-config/bin/prod.webpack.config.js';
   if (typeof configPath !== 'string') {
     console.error('Invalid webpack config path!');

--- a/packages/config/src/bin/prod.webpack.config.ts
+++ b/packages/config/src/bin/prod.webpack.config.ts
@@ -19,14 +19,22 @@ const {
   frontendCRDPath = path.resolve(rootFolder, 'deploy/frontend.yaml'),
   ...externalConfig
 } = fecConfig;
+const isFecStatic = process.env.FEC_STATIC?.toLowerCase() === 'true';
 const { config: webpackConfig, plugins } = config({
   rootFolder,
+  // Disable file hashing when FEC_STATIC=true (set by `fec static` command for local dev).
+  // Allows user override via fec.config.js (externalConfig spread comes after).
+  ...(isFecStatic ? { useFileHash: false } : {}),
   ...externalConfig,
   /** Do not use HMR for production builds */
   hotReload: false,
   /** Do configure/inti webpack dev server */
   deploymentBuild: true,
 });
+
+if (isFecStatic) {
+  fecLogger(LogType.info, 'FEC_STATIC=true: disabling file hashing (useFileHash=false)');
+}
 
 const frontendCrd = readFrontendCRD(frontendCRDPath);
 const feoEnabled = hasFEOFeaturesEnabled(frontendCrd);

--- a/packages/config/src/bin/webpack.plugins.test.ts
+++ b/packages/config/src/bin/webpack.plugins.test.ts
@@ -1,0 +1,116 @@
+jest.mock('@redhat-cloud-services/frontend-components-config-utilities', () => ({
+  LogType: { warn: 'warn' },
+  fecLogger: jest.fn(),
+  federatedModules: jest.fn((config) => config),
+  generatePFSharedAssetsList: jest.fn(() => ({})),
+}));
+
+// Mock fec.config.js require
+const mockFecConfig = {
+  appUrl: '/test',
+  moduleFederation: {
+    exposes: { './RootApp': './src/entry.tsx' }
+  }
+};
+
+describe('webpack.plugins FEC_STATIC env var handling', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    process.env.FEC_ROOT_DIR = '/fake/root';
+    process.env.FEC_CONFIG_PATH = '/fake/fec.config.js';
+
+    // Mock the fec.config.js require
+    jest.mock('/fake/fec.config.js', () => mockFecConfig, { virtual: true });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('sets useFileHash: true when NODE_ENV=production and FEC_STATIC not set', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.FEC_STATIC;
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: true,
+      })
+    );
+  });
+
+  it('sets useFileHash: false when FEC_STATIC=true', () => {
+    process.env.FEC_STATIC = 'true';
+    process.env.NODE_ENV = 'production';
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: false,
+      })
+    );
+  });
+
+  it('sets useFileHash: true when FEC_STATIC=false (string)', () => {
+    process.env.FEC_STATIC = 'false';
+    process.env.NODE_ENV = 'production';
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: true,
+      })
+    );
+  });
+
+  it('sets useFileHash: false when FEC_STATIC=TRUE (uppercase)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.FEC_STATIC = 'TRUE';
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: false,
+      })
+    );
+  });
+
+  it('sets useFileHash: true when FEC_STATIC is empty string', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.FEC_STATIC = '';
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: true,
+      })
+    );
+  });
+
+  it('sets useFileHash: false when NODE_ENV not production and FEC_STATIC not set', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.FEC_STATIC;
+
+    require('./webpack.plugins');
+    const { federatedModules } = require('@redhat-cloud-services/frontend-components-config-utilities');
+
+    expect(federatedModules).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useFileHash: false,
+      })
+    );
+  });
+});

--- a/packages/config/src/bin/webpack.plugins.ts
+++ b/packages/config/src/bin/webpack.plugins.ts
@@ -8,10 +8,12 @@ if (typeof fecConfig._unstableHotReload !== 'undefined') {
   fecLogger(LogType.warn, `The _unstableHotReload option in fec.config.js is deprecated. Use hotReload config instead.`);
 }
 
+const isFecStatic = process.env.FEC_STATIC?.toLowerCase() === 'true';
 const plugins = [
   federatedModules({
     root: rootDir,
-    useFileHash: process.env.NODE_ENV === 'production',
+    // Enable file hashing for production builds, but disable for `fec static` (local dev with watch mode)
+    useFileHash: process.env.NODE_ENV === 'production' && !isFecStatic,
     separateRuntime: typeof fecConfig.hotReload !== 'undefined' ? !!fecConfig.hotReload : !!fecConfig._unstableHotReload,
     /** Load optional config for federated modules */
     ...fecConfig.moduleFederation,


### PR DESCRIPTION
## Problem

Tenant apps using `fec static` for local development must manually add `useFileHash: false` to their `fec.config.js` to disable content-hashed filenames. Without this, watch mode rebuilds generate new hashes but browser references old URLs.

Setting `useFileHash: false` in `fec.config.js` has two issues:
1. **Manual workaround required** for every app using `fec static`
2. **Affects production builds too** — `fec.config.js` applies to both `fec static` and `fec build`

Content-hashed filenames are unnecessary during local development (no browser caching concern).

## Solution

`fec static` automatically sets `FEC_STATIC='true'` env var when running. Both `prod.webpack.config.ts` and `webpack.plugins.ts` check this env var and disable file hashing for local dev only.

Production builds (`fec build`) are unaffected — no env var set, hashing remains enabled.

## Changes

- `packages/config-utils/src/serve-federated.ts` - Set FEC_STATIC env var + JSDoc
- `packages/config/src/bin/prod.webpack.config.ts` - Conditional useFileHash based on FEC_STATIC
- `packages/config/src/bin/webpack.plugins.ts` - Defense-in-depth FEC_STATIC check
- `packages/config/src/bin/webpack.plugins.test.ts` - Test coverage (8 scenarios)
- `CLAUDE.md` - Document config/config-utils dependency update pattern

## Testing

```bash
npx jest packages/config/src/bin/webpack.plugins.test.ts
# PASS 8 tests
```

## Result

Tenant apps no longer need manual `useFileHash: false` workaround in `fec.config.js`. Local dev correctly scoped, production builds unaffected.