### PR TITLE
feat(config): add IOP-aware dev-proxy env and custom routes mount spt

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -396,6 +396,7 @@ fec dev-proxy [options]
 - `--port, -p`: Proxy server port (default: 1337)
 - `--staticPort, -sp`: Static assets server port (default: 8003)
 - `--clouddotEnv`: Set platform environment ('stage', 'prod', 'dev', 'ephemeral')
+- `--iop`: Enable IOP mode and pass `IOP=true` to the `frontend-development-proxy` container
 
 **Requirements:**
 - Docker or Podman installed and available
@@ -412,7 +413,14 @@ fec dev-proxy --port 3000 --clouddotEnv stage
 
 # Start with custom static assets port
 fec dev-proxy --staticPort 9000
+
+# Enable IOP mode explicitly
+fec dev-proxy --iop
 ```
+
+If you prefer an npm script command like `npm run IOP`, this package auto-detects the npm lifecycle event and forwards `IOP=true` to `frontend-development-proxy` when the script name is `IOP`.
+To provide IOP-specific custom routes to the proxy container, set `FEC_IOP_CUSTOM_ROUTES_PATH` to an absolute path. In IOP mode, `fec dev-proxy` will mount this file to `/config/custom_routes.iop.json` and set `LOCAL_CUSTOM_ROUTES_PATH=/config/custom_routes.iop.json`.
+By default, `fec dev-proxy` uses `quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-development-proxy:latest`. For local image testing, set `FEC_DEV_PROXY_IMAGE` (for example `localhost/frontend-development-proxy:latest`). If you do not want `fec dev-proxy` to pull the image before startup, set `FEC_DEV_PROXY_SKIP_PULL=true`.
 
 The command will:
 1. Pull and start the development proxy container

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -420,7 +420,6 @@ fec dev-proxy --iop
 
 If you prefer an npm script command like `npm run IOP`, this package auto-detects the npm lifecycle event and forwards `IOP=true` to `frontend-development-proxy` when the script name is `IOP`.
 To provide IOP-specific custom routes to the proxy container, set `FEC_IOP_CUSTOM_ROUTES_PATH` to an absolute path. In IOP mode, `fec dev-proxy` will mount this file to `/config/custom_routes.iop.json` and set `LOCAL_CUSTOM_ROUTES_PATH=/config/custom_routes.iop.json`.
-By default, `fec dev-proxy` uses `quay.io/redhat-user-workloads/hcc-platex-services-tenant/frontend-development-proxy:latest`. For local image testing, set `FEC_DEV_PROXY_IMAGE` (for example `localhost/frontend-development-proxy:latest`). If you do not want `fec dev-proxy` to pull the image before startup, set `FEC_DEV_PROXY_SKIP_PULL=true`.
 
 The command will:
 1. Pull and start the development proxy container

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -396,7 +396,13 @@ fec dev-proxy [options]
 - `--port, -p`: Proxy server port (default: 1337)
 - `--staticPort, -sp`: Static assets server port (default: 8003)
 - `--clouddotEnv`: Set platform environment ('stage', 'prod', 'dev', 'ephemeral')
-- `--iop`: Enable IOP mode and pass `IOP=true` to the `frontend-development-proxy` container
+- `--iop`: Enable IOP (Insights on Premises) mode for Satellite/Foreman development
+
+**Environment Variables:**
+- `FEC_DEV_PROXY_IMAGE`: Use a custom proxy container image instead of pulling from quay.io (applies to all modes)
+  - Example: `FEC_DEV_PROXY_IMAGE=localhost/frontend-development-proxy:local`
+  - If the image includes a tag, it will be used as-is; otherwise `:latest` is appended
+  - Skips `podman pull` when set, allowing local proxy changes to be tested
 
 **Requirements:**
 - Docker or Podman installed and available
@@ -418,8 +424,18 @@ fec dev-proxy --staticPort 9000
 fec dev-proxy --iop
 ```
 
-If you prefer an npm script command like `npm run IOP`, this package auto-detects the npm lifecycle event and forwards `IOP=true` to `frontend-development-proxy` when the script name is `IOP`.
-To provide IOP-specific custom routes to the proxy container, set `FEC_IOP_CUSTOM_ROUTES_PATH` to an absolute path. In IOP mode, `fec dev-proxy` will mount this file to `/config/custom_routes.iop.json` and set `LOCAL_CUSTOM_ROUTES_PATH=/config/custom_routes.iop.json`.
+### IOP (Insights on Premises) Mode
+
+IOP mode is designed for local development against Satellite/Foreman instances. It can be enabled three ways:
+- `--iop` flag: `fec dev-proxy --iop`
+- `IOP=true` environment variable
+- npm script named "iop": `npm run iop` (auto-detected)
+
+**IOP-Specific Environment Variables:**
+- `FEC_IOP_CUSTOM_ROUTES_PATH`: Absolute path to custom routes file for IOP mode
+  - Example: `FEC_IOP_CUSTOM_ROUTES_PATH=$(pwd)/custom_routes.json`
+  - Mounted to `/config/custom_routes.iop.json` in the container
+  - Allows overriding specific app routes while proxying others to the IOP instance
 
 The command will:
 1. Pull and start the development proxy container

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -11,11 +11,13 @@ import serveChrome, { checkContainerRuntime, CONTAINER_NAME as CHROME_CONTAINTER
 const PROXY_URL = 'http://squid.corp.redhat.com:3128';
 const DEFAULT_LOCAL_ROUTE = 'host.docker.internal';
 const DEFAULT_CHROME_SERVER_PORT = 9998;
-const LATEST_IMAGE_TAG = 'latest';
+const DEFAULT_DEV_PROXY_IMAGE_TAG = 'latest';
 
 const DEV_PROXY_CONTAINER_PORT = 1337;
 const DEV_PROXY_CONTAINER_NAME = 'frontend-development-proxy';
+const LOCAL_PROXY_IMAGE_REPO = 'localhost/frontend-development-proxy:latest'
 const DEV_PROXY_IMAGE_REPO = `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+const IOP_CUSTOM_ROUTES_CONTAINER_PATH = '/config/custom_routes.iop.json';
 
 let execBin: ContainerRuntime | undefined = undefined;
 let debug: boolean = false;
@@ -23,6 +25,18 @@ let debug: boolean = false;
 interface RouteConfig {
   url: string;
   is_chrome?: boolean;
+}
+
+function shouldEnableIOP(argv: { iop?: boolean }) {
+  if (typeof argv.iop === 'boolean') {
+    return argv.iop;
+  }
+
+  if (process.env.IOP === 'true') {
+    return true;
+  }
+
+  return (process.env.npm_lifecycle_event || '').toLowerCase() === 'iop';
 }
 
 function fecLogger(logType: LogType, ...data: any[]) {
@@ -62,9 +76,17 @@ function stopContainer(containerName: string) {
   }
 }
 
-function pullImage(containerName: string, repo: string, tag: string) {
+function pullImage(containerName: string, imageRef: string) {
   fecLogger(LogType.info, `Pulling the container: ${containerName}`);
-  execSync(`${execBin} pull ${repo}:${tag}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+  execSync(`${execBin} pull ${imageRef}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+}
+
+function getDevProxyImageRef() {
+  if (process.env.FEC_DEV_PROXY_IMAGE) {
+    return process.env.FEC_DEV_PROXY_IMAGE;
+  }
+
+  return `${DEV_PROXY_IMAGE_REPO}:${DEFAULT_DEV_PROXY_IMAGE_TAG}`;
 }
 
 function createRoutesConfig(fecConfig: any, cdnPath: string, port: string, SPAFallback: boolean, filename: string = 'routes.json'): string {
@@ -149,6 +171,7 @@ async function devProxyScript(
     chromeServerPort?: number | string;
     clouddotEnv?: string;
     config?: any;
+    iop?: boolean;
     port?: string;
     staticPort?: string;
   },
@@ -208,8 +231,12 @@ async function devProxyScript(
   execBin = checkContainerRuntime();
   stopContainer(DEV_PROXY_CONTAINER_NAME);
   stopContainer(CHROME_CONTAINTER_NAME);
-  pullImage(DEV_PROXY_CONTAINER_NAME, DEV_PROXY_IMAGE_REPO, LATEST_IMAGE_TAG);
+  const devProxyImageRef = getDevProxyImageRef();
+  if (process.env.FEC_DEV_PROXY_SKIP_PULL !== 'true') {
+    pullImage(DEV_PROXY_CONTAINER_NAME, devProxyImageRef);
+  }
   removeContainer(DEV_PROXY_CONTAINER_NAME);
+  removeContainer(CHROME_CONTAINTER_NAME);
 
   // Exec
   let commands: Command[] = [];
@@ -234,6 +261,24 @@ async function devProxyScript(
   try {
     const outputPath = webpackConfig.output.path;
     const proxyEnvVar = process.env.HCC_ENV === 'stage' ? '-e HTTPS_PROXY=$RH_PROXY_URL' : '';
+    const iopEnabled = shouldEnableIOP(argv);
+    const iopEnvVar = iopEnabled ? '-e IOP=true' : '';
+    const iopCustomRoutesHostPath = process.env.FEC_IOP_CUSTOM_ROUTES_PATH;
+    const iopCustomRoutesEnvVar = iopEnabled ? `-e LOCAL_CUSTOM_ROUTES_PATH=${IOP_CUSTOM_ROUTES_CONTAINER_PATH}` : '';
+    let iopCustomRoutesMountVar = '';
+    if (iopEnabled) {
+      if (iopCustomRoutesHostPath && fs.existsSync(iopCustomRoutesHostPath)) {
+        iopCustomRoutesMountVar = `-v "${iopCustomRoutesHostPath}:${IOP_CUSTOM_ROUTES_CONTAINER_PATH}:ro,Z"`;
+        fecLogger(LogType.info, `Mounting IOP custom routes from ${iopCustomRoutesHostPath}`);
+      } else if (iopCustomRoutesHostPath) {
+        fecLogger(
+          LogType.warn,
+          `FEC_IOP_CUSTOM_ROUTES_PATH is set, but file was not found at "${iopCustomRoutesHostPath}". Falling back to default IOP routes.`,
+        );
+      } else {
+        fecLogger(LogType.warn, 'IOP mode enabled without FEC_IOP_CUSTOM_ROUTES_PATH. Falling back to default IOP routes.');
+      }
+    }
     const proxyVerbose = fecConfig?.proxyVerbose ? `&& ${execBin} logs -f ${DEV_PROXY_CONTAINER_NAME}` : '';
     const appUrl = fecConfig?.appUrl;
 
@@ -275,7 +320,7 @@ async function devProxyScript(
           prefixColor: 'bgGreen',
         },
         {
-          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}:${LATEST_IMAGE_TAG} ${proxyVerbose}`,
+          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${devProxyImageRef} ${proxyVerbose}`,
           name: 'PROXY',
           env: { RH_PROXY_URL: PROXY_URL },
           prefixColor: 'bgMagenta',

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -11,12 +11,12 @@ import serveChrome, { CONTAINER_NAME as CHROME_CONTAINTER_NAME, ContainerRuntime
 const PROXY_URL = 'http://squid.corp.redhat.com:3128';
 const DEFAULT_LOCAL_ROUTE = 'host.docker.internal';
 const DEFAULT_CHROME_SERVER_PORT = 9998;
-const DEFAULT_DEV_PROXY_IMAGE_TAG = 'latest';
+const LATEST_IMAGE_TAG = 'latest';
 
 const DEV_PROXY_CONTAINER_PORT = 1337;
 const DEV_PROXY_CONTAINER_NAME = 'frontend-development-proxy';
-const LOCAL_PROXY_IMAGE_REPO = 'localhost/frontend-development-proxy:latest'
-const DEV_PROXY_IMAGE_REPO = `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+const DEV_PROXY_IMAGE_REPO = process.env.FEC_DEV_PROXY_IMAGE || `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+const DEV_PROXY_IMAGE_TAG = process.env.FEC_DEV_PROXY_IMAGE?.includes(':') ? '' : `:${LATEST_IMAGE_TAG}`;
 const IOP_CUSTOM_ROUTES_CONTAINER_PATH = '/config/custom_routes.iop.json';
 
 let execBin: ContainerRuntime | undefined = undefined;
@@ -76,17 +76,9 @@ function stopContainer(containerName: string) {
   }
 }
 
-function pullImage(containerName: string, imageRef: string) {
+function pullImage(containerName: string, repo: string, tag: string) {
   fecLogger(LogType.info, `Pulling the container: ${containerName}`);
-  execSync(`${execBin} pull ${imageRef}`, debug ? { stdio: 'inherit' } : { stdio: [] });
-}
-
-function getDevProxyImageRef() {
-  if (process.env.FEC_DEV_PROXY_IMAGE) {
-    return process.env.FEC_DEV_PROXY_IMAGE;
-  }
-
-  return `${DEV_PROXY_IMAGE_REPO}:${DEFAULT_DEV_PROXY_IMAGE_TAG}`;
+  execSync(`${execBin} pull ${repo}:${tag}`, debug ? { stdio: 'inherit' } : { stdio: [] });
 }
 
 function createRoutesConfig(fecConfig: any, cdnPath: string, port: string, SPAFallback: boolean, filename: string = 'routes.json'): string {
@@ -148,21 +140,38 @@ function createRoutesConfig(fecConfig: any, cdnPath: string, port: string, SPAFa
 
 async function configureEnvVars(fecConfig: any, argv: any, cwd: string) {
   const clouddotEnvOptions = ['stage', 'prod', 'dev', 'ephemeral'];
+  const initialHccEnv = process.env.HCC_ENV;
+  const initialHccEnvUrl = process.env.HCC_ENV_URL;
+
   if (argv?.clouddotEnv) {
     if (!clouddotEnvOptions.includes(argv?.clouddotEnv)) {
       throw Error(
         `Incorrect argument value:\n--clouddotEnv must be one of: [${clouddotEnvOptions.toString()}]\nRun fec --help for more information.`,
       );
     }
-    process.env.HCC_ENV = argv?.clouddotEnv;
-    process.env.CLOUDOT_ENV = argv?.clouddotEnv;
-    process.env.FEC_ROOT_DIR = cwd;
+    process.env.HCC_ENV = argv.clouddotEnv;
+    process.env.CLOUDOT_ENV = argv.clouddotEnv;
+    process.env.FEC_ROOT_DIR = process.env.FEC_ROOT_DIR ?? cwd;
+  } else if (initialHccEnv !== undefined) {
+    process.env.CLOUDOT_ENV = process.env.CLOUDOT_ENV ?? initialHccEnv;
+    process.env.FEC_ROOT_DIR = process.env.FEC_ROOT_DIR ?? cwd;
   } else {
     await setEnv(cwd);
-    process.env.HCC_ENV = process.env.CLOUDOT_ENV;
+    process.env.HCC_ENV = process.env.CLOUDOT_ENV!;
   }
+
   const hccEnvSuffix = process.env.HCC_ENV === 'prod' ? '' : `${process.env.HCC_ENV}.`;
-  process.env.HCC_ENV_URL = process.env.HCC_ENV === 'ephemeral' ? process.env.EPHEMERAL_TARGET : `https://console.${hccEnvSuffix}redhat.com`;
+  const defaultHccEnvUrl =
+    process.env.HCC_ENV === 'ephemeral' ? process.env.EPHEMERAL_TARGET : `https://console.${hccEnvSuffix}redhat.com`;
+
+  const cliHccEnvUrl = argv?.hccEnvUrl ?? argv?.['hcc-env-url'];
+  if (cliHccEnvUrl) {
+    process.env.HCC_ENV_URL = cliHccEnvUrl;
+  } else if (initialHccEnvUrl !== undefined) {
+    process.env.HCC_ENV_URL = initialHccEnvUrl;
+  } else {
+    process.env.HCC_ENV_URL = defaultHccEnvUrl;
+  }
 
   process.env.FEC_CHROME_HOST = fecConfig?.chromeHost ?? '127.0.0.1';
   process.env.FEC_CHROME_PORT = fecConfig?.chromePort ?? DEFAULT_CHROME_SERVER_PORT;
@@ -173,6 +182,7 @@ async function devProxyScript(
     chromeServerPort?: number | string;
     clouddotEnv?: string;
     config?: any;
+    hccEnvUrl?: string;
     iop?: boolean;
     port?: string;
     staticPort?: string;
@@ -180,6 +190,7 @@ async function devProxyScript(
   cwd: string,
 ) {
   let SPAFallback = true;
+  let iopEnabled = false;
   let fecConfig: any = {};
   let webpackConfig;
   const webpackConfigPath: string =
@@ -196,6 +207,16 @@ async function devProxyScript(
     fecLogger(LogType.error, 'Failed to get the FEC config:', error);
     process.exit(1);
   }
+  // Process environment variables before webpack config load (webpack reads CLOUDOT_ENV / FEC_ROOT_DIR)
+  try {
+    SPAFallback = fecConfig?.SPAFallback ?? true;
+    iopEnabled = shouldEnableIOP(argv);
+    await configureEnvVars(fecConfig, argv, cwd);
+  } catch (error) {
+    fecLogger(LogType.error, 'Failed to setup environment from args and config:', error);
+    process.exit(1);
+  }
+
   try {
     fs.statSync(webpackConfigPath);
     webpackConfig = require(webpackConfigPath);
@@ -205,15 +226,6 @@ async function devProxyScript(
     webpackConfig = await webpackConfig;
   } catch (error) {
     fecLogger(LogType.error, 'Failed to get the Webpack config:', error);
-    process.exit(1);
-  }
-
-  // Process environment variables, SPA fallback
-  try {
-    SPAFallback = fecConfig?.SPAFallback ?? true;
-    await configureEnvVars(fecConfig, argv, cwd);
-  } catch (error) {
-    fecLogger(LogType.error, 'Failed to setup environment from args and config:', error);
     process.exit(1);
   }
 
@@ -233,12 +245,11 @@ async function devProxyScript(
   execBin = checkContainerRuntime();
   stopContainer(DEV_PROXY_CONTAINER_NAME);
   stopContainer(CHROME_CONTAINTER_NAME);
-  const devProxyImageRef = getDevProxyImageRef();
-  if (process.env.FEC_DEV_PROXY_SKIP_PULL !== 'true') {
-    pullImage(DEV_PROXY_CONTAINER_NAME, devProxyImageRef);
+  // Skip pulling if using a local image
+  if (!process.env.FEC_DEV_PROXY_IMAGE) {
+    pullImage(DEV_PROXY_CONTAINER_NAME, DEV_PROXY_IMAGE_REPO, LATEST_IMAGE_TAG);
   }
   removeContainer(DEV_PROXY_CONTAINER_NAME);
-  removeContainer(CHROME_CONTAINTER_NAME);
 
   // Exec
   let commands: Command[] = [];
@@ -263,7 +274,6 @@ async function devProxyScript(
   try {
     const outputPath = webpackConfig.output.path;
     const proxyEnvVar = process.env.HCC_ENV === 'stage' ? '-e HTTPS_PROXY=$RH_PROXY_URL' : '';
-    const iopEnabled = shouldEnableIOP(argv);
     const iopEnvVar = iopEnabled ? '-e IOP=true' : '';
     const iopCustomRoutesHostPath = process.env.FEC_IOP_CUSTOM_ROUTES_PATH;
     const iopCustomRoutesEnvVar = iopEnabled ? `-e LOCAL_CUSTOM_ROUTES_PATH=${IOP_CUSTOM_ROUTES_CONTAINER_PATH}` : '';
@@ -322,7 +332,7 @@ async function devProxyScript(
           prefixColor: 'bgGreen',
         },
         {
-          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${devProxyImageRef} ${proxyVerbose}`,
+          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}${DEV_PROXY_IMAGE_TAG} ${proxyVerbose}`,
           name: 'PROXY',
           env: { RH_PROXY_URL: PROXY_URL },
           prefixColor: 'bgMagenta',

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -11,11 +11,13 @@ import serveChrome, { CONTAINER_NAME as CHROME_CONTAINTER_NAME, ContainerRuntime
 const PROXY_URL = 'http://squid.corp.redhat.com:3128';
 const DEFAULT_LOCAL_ROUTE = 'host.docker.internal';
 const DEFAULT_CHROME_SERVER_PORT = 9998;
-const LATEST_IMAGE_TAG = 'latest';
+const DEFAULT_DEV_PROXY_IMAGE_TAG = 'latest';
 
 const DEV_PROXY_CONTAINER_PORT = 1337;
 const DEV_PROXY_CONTAINER_NAME = 'frontend-development-proxy';
+const LOCAL_PROXY_IMAGE_REPO = 'localhost/frontend-development-proxy:latest'
 const DEV_PROXY_IMAGE_REPO = `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+const IOP_CUSTOM_ROUTES_CONTAINER_PATH = '/config/custom_routes.iop.json';
 
 let execBin: ContainerRuntime | undefined = undefined;
 let debug: boolean = false;
@@ -23,6 +25,18 @@ let debug: boolean = false;
 interface RouteConfig {
   url: string;
   is_chrome?: boolean;
+}
+
+function shouldEnableIOP(argv: { iop?: boolean }) {
+  if (typeof argv.iop === 'boolean') {
+    return argv.iop;
+  }
+
+  if (process.env.IOP === 'true') {
+    return true;
+  }
+
+  return (process.env.npm_lifecycle_event || '').toLowerCase() === 'iop';
 }
 
 function fecLogger(logType: LogType, ...data: any[]) {
@@ -62,9 +76,17 @@ function stopContainer(containerName: string) {
   }
 }
 
-function pullImage(containerName: string, repo: string, tag: string) {
+function pullImage(containerName: string, imageRef: string) {
   fecLogger(LogType.info, `Pulling the container: ${containerName}`);
-  execSync(`${execBin} pull ${repo}:${tag}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+  execSync(`${execBin} pull ${imageRef}`, debug ? { stdio: 'inherit' } : { stdio: [] });
+}
+
+function getDevProxyImageRef() {
+  if (process.env.FEC_DEV_PROXY_IMAGE) {
+    return process.env.FEC_DEV_PROXY_IMAGE;
+  }
+
+  return `${DEV_PROXY_IMAGE_REPO}:${DEFAULT_DEV_PROXY_IMAGE_TAG}`;
 }
 
 function createRoutesConfig(fecConfig: any, cdnPath: string, port: string, SPAFallback: boolean, filename: string = 'routes.json'): string {
@@ -151,6 +173,7 @@ async function devProxyScript(
     chromeServerPort?: number | string;
     clouddotEnv?: string;
     config?: any;
+    iop?: boolean;
     port?: string;
     staticPort?: string;
   },
@@ -210,8 +233,12 @@ async function devProxyScript(
   execBin = checkContainerRuntime();
   stopContainer(DEV_PROXY_CONTAINER_NAME);
   stopContainer(CHROME_CONTAINTER_NAME);
-  pullImage(DEV_PROXY_CONTAINER_NAME, DEV_PROXY_IMAGE_REPO, LATEST_IMAGE_TAG);
+  const devProxyImageRef = getDevProxyImageRef();
+  if (process.env.FEC_DEV_PROXY_SKIP_PULL !== 'true') {
+    pullImage(DEV_PROXY_CONTAINER_NAME, devProxyImageRef);
+  }
   removeContainer(DEV_PROXY_CONTAINER_NAME);
+  removeContainer(CHROME_CONTAINTER_NAME);
 
   // Exec
   let commands: Command[] = [];
@@ -236,6 +263,24 @@ async function devProxyScript(
   try {
     const outputPath = webpackConfig.output.path;
     const proxyEnvVar = process.env.HCC_ENV === 'stage' ? '-e HTTPS_PROXY=$RH_PROXY_URL' : '';
+    const iopEnabled = shouldEnableIOP(argv);
+    const iopEnvVar = iopEnabled ? '-e IOP=true' : '';
+    const iopCustomRoutesHostPath = process.env.FEC_IOP_CUSTOM_ROUTES_PATH;
+    const iopCustomRoutesEnvVar = iopEnabled ? `-e LOCAL_CUSTOM_ROUTES_PATH=${IOP_CUSTOM_ROUTES_CONTAINER_PATH}` : '';
+    let iopCustomRoutesMountVar = '';
+    if (iopEnabled) {
+      if (iopCustomRoutesHostPath && fs.existsSync(iopCustomRoutesHostPath)) {
+        iopCustomRoutesMountVar = `-v "${iopCustomRoutesHostPath}:${IOP_CUSTOM_ROUTES_CONTAINER_PATH}:ro,Z"`;
+        fecLogger(LogType.info, `Mounting IOP custom routes from ${iopCustomRoutesHostPath}`);
+      } else if (iopCustomRoutesHostPath) {
+        fecLogger(
+          LogType.warn,
+          `FEC_IOP_CUSTOM_ROUTES_PATH is set, but file was not found at "${iopCustomRoutesHostPath}". Falling back to default IOP routes.`,
+        );
+      } else {
+        fecLogger(LogType.warn, 'IOP mode enabled without FEC_IOP_CUSTOM_ROUTES_PATH. Falling back to default IOP routes.');
+      }
+    }
     const proxyVerbose = fecConfig?.proxyVerbose ? `&& ${execBin} logs -f ${DEV_PROXY_CONTAINER_NAME}` : '';
     const appUrl = fecConfig?.appUrl;
 
@@ -277,7 +322,7 @@ async function devProxyScript(
           prefixColor: 'bgGreen',
         },
         {
-          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}:${LATEST_IMAGE_TAG} ${proxyVerbose}`,
+          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${devProxyImageRef} ${proxyVerbose}`,
           name: 'PROXY',
           env: { RH_PROXY_URL: PROXY_URL },
           prefixColor: 'bgMagenta',

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -15,7 +15,8 @@ const LATEST_IMAGE_TAG = 'latest';
 
 const DEV_PROXY_CONTAINER_PORT = 1337;
 const DEV_PROXY_CONTAINER_NAME = 'frontend-development-proxy';
-const DEV_PROXY_IMAGE_REPO = process.env.FEC_DEV_PROXY_IMAGE || `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
+const DEV_PROXY_IMAGE_REPO =
+  process.env.FEC_DEV_PROXY_IMAGE || `quay.io/redhat-user-workloads/hcc-platex-services-tenant/${DEV_PROXY_CONTAINER_NAME}`;
 const DEV_PROXY_IMAGE_TAG = process.env.FEC_DEV_PROXY_IMAGE?.includes(':') ? '' : `:${LATEST_IMAGE_TAG}`;
 const IOP_CUSTOM_ROUTES_CONTAINER_PATH = '/config/custom_routes.iop.json';
 
@@ -161,8 +162,7 @@ async function configureEnvVars(fecConfig: any, argv: any, cwd: string) {
   }
 
   const hccEnvSuffix = process.env.HCC_ENV === 'prod' ? '' : `${process.env.HCC_ENV}.`;
-  const defaultHccEnvUrl =
-    process.env.HCC_ENV === 'ephemeral' ? process.env.EPHEMERAL_TARGET : `https://console.${hccEnvSuffix}redhat.com`;
+  const defaultHccEnvUrl = process.env.HCC_ENV === 'ephemeral' ? process.env.EPHEMERAL_TARGET : `https://console.${hccEnvSuffix}redhat.com`;
 
   const cliHccEnvUrl = argv?.hccEnvUrl ?? argv?.['hcc-env-url'];
   if (cliHccEnvUrl) {
@@ -279,14 +279,20 @@ async function devProxyScript(
     const iopCustomRoutesEnvVar = iopEnabled ? `-e LOCAL_CUSTOM_ROUTES_PATH=${IOP_CUSTOM_ROUTES_CONTAINER_PATH}` : '';
     let iopCustomRoutesMountVar = '';
     if (iopEnabled) {
-      if (iopCustomRoutesHostPath && fs.existsSync(iopCustomRoutesHostPath)) {
-        iopCustomRoutesMountVar = `-v "${iopCustomRoutesHostPath}:${IOP_CUSTOM_ROUTES_CONTAINER_PATH}:ro,Z"`;
-        fecLogger(LogType.info, `Mounting IOP custom routes from ${iopCustomRoutesHostPath}`);
-      } else if (iopCustomRoutesHostPath) {
-        fecLogger(
-          LogType.warn,
-          `FEC_IOP_CUSTOM_ROUTES_PATH is set, but file was not found at "${iopCustomRoutesHostPath}". Falling back to default IOP routes.`,
-        );
+      if (iopCustomRoutesHostPath) {
+        // Validate absolute path
+        if (!path.isAbsolute(iopCustomRoutesHostPath)) {
+          fecLogger(LogType.warn, `FEC_IOP_CUSTOM_ROUTES_PATH should be an absolute path, got: ${iopCustomRoutesHostPath}`);
+        }
+        if (fs.existsSync(iopCustomRoutesHostPath)) {
+          iopCustomRoutesMountVar = `-v "${iopCustomRoutesHostPath}:${IOP_CUSTOM_ROUTES_CONTAINER_PATH}:ro,z"`;
+          fecLogger(LogType.info, `Mounting IOP custom routes from ${iopCustomRoutesHostPath}`);
+        } else {
+          fecLogger(
+            LogType.warn,
+            `FEC_IOP_CUSTOM_ROUTES_PATH is set, but file was not found at "${iopCustomRoutesHostPath}". Falling back to default IOP routes.`,
+          );
+        }
       } else {
         fecLogger(LogType.warn, 'IOP mode enabled without FEC_IOP_CUSTOM_ROUTES_PATH. Falling back to default IOP routes.');
       }
@@ -332,7 +338,7 @@ async function devProxyScript(
           prefixColor: 'bgGreen',
         },
         {
-          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,Z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}${DEV_PROXY_IMAGE_TAG} ${proxyVerbose}`,
+          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}${DEV_PROXY_IMAGE_TAG} ${proxyVerbose}`,
           name: 'PROXY',
           env: { RH_PROXY_URL: PROXY_URL },
           prefixColor: 'bgMagenta',

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -146,6 +146,10 @@ const argv = yargs
         alias: 'sp',
         describe: 'Static assets server port',
         default: 8003,
+      })
+      .option('iop', {
+        type: 'boolean',
+        describe: 'Enable IOP mode and pass IOP=true to frontend-development-proxy',
       });
   })
   .command('build', 'Build production bundle', (yargs) => {

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -149,6 +149,10 @@ const argv = yargs
         alias: 'sp',
         describe: 'Static assets server port',
         default: 8003,
+      })
+      .option('iop', {
+        type: 'boolean',
+        describe: 'Enable IOP mode and pass IOP=true to frontend-development-proxy',
       });
   })
   .command('build', 'Build production bundle', (yargs) => {

--- a/packages/config/src/bin/fec.ts
+++ b/packages/config/src/bin/fec.ts
@@ -153,6 +153,10 @@ const argv = yargs
       .option('iop', {
         type: 'boolean',
         describe: 'Enable IOP mode and pass IOP=true to frontend-development-proxy',
+      })
+      .option('hccEnvUrl', {
+        type: 'string',
+        describe: 'Override HCC_ENV_URL for the proxy container (useful with IOP mode). Same as exporting HCC_ENV_URL before running.',
       });
   })
   .command('build', 'Build production bundle', (yargs) => {


### PR DESCRIPTION
## Summary
- Adds IOP support to `fec dev-proxy` so consumers can trigger IOP mode via:
  - `--iop`
  - `IOP=true`
  - npm lifecycle event `IOP` (e.g. `npm run IOP`)
- Passes `IOP=true` into the `frontend-development-proxy` container when enabled.
- Adds optional IOP custom routes support:
  - Reads host env `FEC_IOP_CUSTOM_ROUTES_PATH`
  - Mounts it into container as `/config/custom_routes.iop.json`
  - Sets `LOCAL_CUSTOM_ROUTES_PATH=/config/custom_routes.iop.json` in IOP mode
- Restores/removes stale proxy/chrome containers before startup to avoid name collisions.
- Updates `packages/config/README.md` with IOP usage and custom-routes wiring.

## Why
IOP mode worked when running proxy directly with compose, but not when launched from app -> `fec dev-proxy`.  
This aligns the advisor/fec launch contract with the proxy entrypoint expectations.

## Test plan
- Build and install local config package in a consumer app.
- Run `fec dev-proxy --iop` and verify:
  - container env includes `IOP=true`
  - when `FEC_IOP_CUSTOM_ROUTES_PATH` is set to an existing file, log shows custom routes mount
  - proxy no longer reports default-only behavior for the same setup
- Re-run multiple times and verify container name conflicts do not recur.



This is how I linked everything because npm link was giving me issues
Bring down the proxy locally and use this PR: 
https://github.com/RedHatInsights/frontend-development-proxy/pull/131
In Advisor youll have to use this PR that just adds the script: 
https://github.com/RedHatInsights/insights-advisor-frontend/pull/1894

In frontend-components (this repo), rebuild + pack:
cd /whereveryoukeepthis/frontend-components
**npx nx run @redhat-cloud-services/frontend-components-config:build**
**npm pack ./dist/@redhat-cloud-services/frontend-components-config --pack-destination ./dist**
In insights-advisor-frontend, reinstall that tarball:
cd /Users/whereveryoukeepthis/Desktop/RedHat/insights-advisor-frontend
**npm i -D @redhat-cloud-services/frontend-components-config@file:/Users/apuente/Desktop/RedHat/frontend-components/dist/redhat-cloud-services-frontend-components-config-6.9.0.tgz**

Ensure advisor script is this (in package.json) (it should be if you brought down the advisor pr):
"start:proxy:iop": "PROXY=true IOP=true FEC_IOP_CUSTOM_ROUTES_PATH=/Users/apuente/Desktop/RedHat/insights-advisor-frontend/custom_routes.json fec dev-proxy --iop"
Run it:
npm run start:proxy:iop

Confirm these logs appear:
IOP mode enabled (IOP=true)
Mounting IOP custom routes from /Users/apuente/Desktop/RedHat/insights-advisor-frontend/custom_routes.json
no crash from proxy startup

Open app:
https://stage.foo.redhat.com:1337/insights/advisor/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `--iop` flag to the `dev-proxy` command to enable IOP mode.
  * Added `FEC_IOP_CUSTOM_ROUTES_PATH` support to load IOP-specific custom routes into the proxy container.
  * Improved `FEC_DEV_PROXY_IMAGE` handling for local proxy image overrides (including smarter `:latest` tagging).

* **Documentation**
  * Updated README with `fec dev-proxy --iop` guidance, including enabling IOP via `--iop`, `IOP=true`, or `npm run iop`, plus custom routes mounting details.

* **Bug Fixes**
  * Custom routes loading now warns and falls back to default IOP routes when the provided path is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  - https://github.com/RedHatInsights/frontend-components/pull/2308
  - vulnerability-ui: foreman-3.16 branch IOP setup:  https://github.com/RedHatInsights/vulnerability-ui/pull/2695
  - insights-advisor-frontend: foreman-3.16 branch IOP setup: https://github.com/RedHatInsights/insights-advisor-frontend/pull/2036
  -proxy: https://github.com/RedHatInsights/frontend-development-proxy/pull/131