### PR TITLE
fix(RHINENG-24556): fix remove after clearNotifications

### DIFF
--- a/packages/notifications/src/state/notificationStore.test.ts
+++ b/packages/notifications/src/state/notificationStore.test.ts
@@ -78,4 +78,14 @@ describe('Notification Store', () => {
     expect(callback1).toHaveBeenCalledTimes(1);
     expect(callback2).toHaveBeenCalledTimes(2);
   });
+
+  it('should remove notifications after clearNotifications', () => {
+    const store = createStore();
+    store.addNotification({ title: 'Before clear', variant: 'info' });
+    store.clearNotifications();
+    store.addNotification({ title: 'After clear', variant: 'success' });
+    const id = store.getNotifications()[0].id;
+    store.removeNotification(id);
+    expect(store.getNotifications()).toHaveLength(0);
+  });
 });

--- a/packages/notifications/src/state/notificationStore.ts
+++ b/packages/notifications/src/state/notificationStore.ts
@@ -40,7 +40,7 @@ export function createStore() {
     }
   };
   const clearNotifications = () => {
-    store.notifications = [];
+    notifications.length = 0;
   };
   const subscribe = (callback: () => void) => {
     const id = window.crypto.randomUUID();


### PR DESCRIPTION
### Description
Fix for clearNotifications, because clearNotifications replaced the array reference while removeNotification still searched the original notifications array, so removals failed after clear.


https://redhat.atlassian.net/browse/RHINENG-24556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `clearNotifications()` to properly handle notifications added after clearing, ensuring they can be successfully removed.

* **Tests**
  * Added test coverage for removing notifications following a clear operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->