### PR TITLE
chore(security): add CODEOWNERS and strengthen workflow permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,8 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     needs: [install, build, unit-test, component-test, lint, commitlint, check-circular-imports]
-    if: github.event_name != 'pull_request'
+    # Only run on push to master branch (never on PRs, workflow_dispatch, etc.)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
       contents: write
       id-token: write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default owners for everything in the repo
+* @RedHatInsights/experience-services-committers
+
+# All GitHub configuration requires review from admins
+# This prevents unauthorized modifications to CI/CD pipelines, custom actions, and repo processes
+.github/** @RedHatInsights/experience-services-admins
+
+# All Konflux tekton configuration changes review from admins
+#.tekton/** @RedHatInsights/experience-services-admins
+
+# CODEOWNERS file itself requires admin review to prevent bypass attacks
+# Must come after wildcard so this rule takes precedence (last match wins)
+CODEOWNERS @RedHatInsights/experience-services-admins


### PR DESCRIPTION
## Summary
- Adds a CODEOWNERS file to protect GitHub configuration files from unauthorized modifications
- Requires code owner review from @RedHatInsights/experience-services-admins for all changes to `.github/**` and `CODEOWNERS` itself
- Strengthens release job conditional to only run on explicit push events to master branch

## Why
Changes to GitHub Actions workflows and custom actions can:
- Execute arbitrary code in CI/CD pipelines
- Access repository secrets
- Modify release processes
- Affect all contributors

This PR adds multiple layers of defense:
1. **CODEOWNERS protection** - Prevents merging malicious workflow changes without admin approval
2. **Strict release conditions** - Prevents accidental/malicious releases from non-push events or non-master branches
3. **Self-protection** - CODEOWNERS file requires admin review to prevent bypass attacks

## Changes
- New `CODEOWNERS` file with:
  - Default ownership: @RedHatInsights/experience-services-committers
  - GitHub config protection: @RedHatInsights/experience-services-admins (`.github/**`)
  - Self-protection: @RedHatInsights/experience-services-admins (`CODEOWNERS`)
  - Placeholder for future `.tekton/**` protection
- Modified `.github/workflows/ci.yaml`:
  - Changed release job condition from `if: github.event_name != 'pull_request'` to `if: github.event_name == 'push' && github.ref == 'refs/heads/master'`
  - Prevents release job from running on workflow_dispatch, schedule, or other non-push events

## Manual Steps Required After Merge
To fully enable this protection, repository admins need to:

1. **Enable Code Owner Review Enforcement:**
   - https://github.com/RedHatInsights/frontend-components/settings/branches
   - Edit `master` branch protection
   - ✓ "Require review from Code Owners"

2. **Enable Fork Workflow Approval:**
   - https://github.com/RedHatInsights/frontend-components/settings/actions
   - Under "Fork pull request workflows from outside collaborators"
   - ✓ "Require approval for all outside collaborators" (recommended)

3. **Create Ruleset to Prevent Direct Branch Pushes (Optional but Recommended):**
   - https://github.com/RedHatInsights/frontend-components/settings/rules
   - Create new ruleset targeting all branches
   - Enable "Restrict creations" and "Restrict updates"
   - Add bypass for: Repository admins, @RedHatInsights/experience-services-admins, bot users

## Test plan
- [x] CODEOWNERS file syntax is valid
- [x] Workflow condition correctly restricts write permissions to master pushes only
- [ ] After merge, verify PR touching `.github/` requires code owner review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to ensure release jobs execute specifically on `master` branch pushes
  * Added code ownership definitions to establish repository maintenance responsibilities and review requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->