### PR TITLE
ci(security): sha-pin all actions, add environment protection

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     # cache node modules for all jobs to use
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: node_modules-cache
       with:
         path: | 

--- a/.github/actions/cypress-cache/action.yaml
+++ b/.github/actions/cypress-cache/action.yaml
@@ -3,8 +3,8 @@ description: Retrieve and cache the cypress runner
 runs:
   using: "composite"
   steps:
-    # cache cypress runner 
-    - uses: actions/cache@v4
+    # cache cypress runner
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cypress-cache
       with:
         path: ~/.cache/Cypress

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -13,7 +13,7 @@ runs:
         which node && node --version || echo "No default Node.js found"
         echo "=== .nvmrc content ==="
         cat .nvmrc 2>/dev/null || echo "No .nvmrc file found"
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -26,11 +26,11 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Build
         run: npm run build
   unit-test:
@@ -38,11 +38,11 @@ jobs:
     needs: [install]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Run unit tests
         run: npm run test:unit
   component-test:
@@ -50,17 +50,17 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - uses: './.github/actions/cypress-cache'
       - name: Install deps
         shell: bash
         run: npm i
       - name: Run component tests
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@be1bab96b388bbd9ce3887e397d373c8557e15af # v6.9.2
         with:
           command: npx nx affected -t test:component --exclude=demo --outputStyle=static --parallel=1
   lint:
@@ -68,11 +68,11 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Lint
         run: npx nx affected -t lint --exclude=demo --outputStyle=static
   commitlint:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -100,11 +100,11 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: install
         shell: bash
         run: npm i
@@ -115,11 +115,12 @@ jobs:
     needs: [install, build, unit-test, component-test, lint, commitlint, check-circular-imports]
     # Only run on push to master branch (never on PRs, workflow_dispatch, etc.)
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
### Description
  
  Hardens GitHub Actions CI pipeline against supply chain attacks by SHA-pinning all external actions and adding environment protection to the release job. SHA pins prevent tag-swap attacks (CVE-2025-30066 pattern), while the npm-publish environment adds defense-in-depth beyond OIDC validation alone. 

  N/A - Infrastructure security hardening

  ---

  ### Screenshots

  _N/A - CI/CD configuration changes only_

  ---

  ### Anything reviewers should know?

  **Required before merge:** Create GitHub Environment in repo settings:
  1. Settings → Environments → New environment: `npm-publish`
  2. Deployment branches: `master` only
  3. Optional: add required reviewer for additional gate

  After merge, update npm trusted publisher config to include environment name `npm-publish` for tighter OIDC claim validation.

  **SHA verification:** All external actions now pinned to commit SHAs with inline version comments. No `@v*` tags remain (verified via grep).

  ---

  ### Checklist
  - [x] Accessibility: N/A (CI config only)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [x] _(Optional) QE: N/A_
  - [x] _(Optional) UX: N/A_

  ### AI disclosure
  Assisted by: Claude Code (Sonnet 4.5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions to specific commit versions instead of floating tags across multiple configurations. Changes include cache operations, Node environment setup, code checkout, and CI workflow steps for building, testing, linting, commit validation, import checking, and release processes.
  * Enhanced the release workflow job with explicit permissions and environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->