### PR TITLE
chore(ci): add npm-publish environment to release job for trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,7 @@ jobs:
     needs: [install, build, unit-test, component-test, lint, commitlint, check-circular-imports]
     # Only run on push to master branch (never on PRs, workflow_dispatch, etc.)
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
### Description

Enable NPM trusted publishing by adding the `npm-publish` environment to the release job in the CI workflow. This allows NPM to verify package provenance via GitHub's OIDC token instead of relying on stored auth tokens, improving supply chain security.

No JIRA ticket — infrastructure hardening.

---

### Anything reviewers should know?

- The `npm-publish` environment must be created in the GitHub repo settings before merging, otherwise the release job will hang waiting for approval (or fail if the environment doesn't exist).
- Each package also needs the trusted publishing fields configured on npmjs.com: repository owner `RedHatInsights`, repository name `frontend-components`, workflow `ci.yaml`, environment `npm-publish`.
- This is a `chore:` commit so it won't trigger any package releases.

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure

Assisted by: Claude Code (Claude Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process security by implementing environment-scoped deployments for production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->