### PR TITLE
ci(github-actions): add token parameter to checkout steps in nx-affected jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Build
@@ -41,6 +42,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Run unit tests
@@ -53,6 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - uses: './.github/actions/cypress-cache'
@@ -71,6 +74,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Lint
@@ -103,6 +107,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: install


### PR DESCRIPTION
nrwl/nx-set-shas action fails authentication when fetching PR base branch during affected project detection. Added explicit token: ${{ secrets.GITHUB_TOKEN }} to checkout steps in jobs using nx-set-shas (build, unit-test, component-test, lint, check-circular-imports). Fixes: fatal: could not read Username for 'https://github.com': terminal prompts disabled.
  
[RHCLOUD-48486](https://redhat.atlassian.net/browse/RHCLOUD-48486)


  ---
**Anything reviewers should know?**

Root cause: actions/checkout with fetch-depth: 0 and no token parameter doesn't configure git credentials for HTTPS. Subsequent git fetch operations by nx-set-shas fail authentication.

**Why this works:** GITHUB_TOKEN is auto-injected by GitHub Actions and has sufficient permissions for git operations within the same repo.

**Why CI broke**: Commit e78491f7 (Apr 2026) changed top-level permissions: from id-token: write → contents: read. Between Jan-Apr (commit 68dcec75 to e78491f7), CI worked with id-token: write. When changed to contents: read, git credential handling broke. Explicit token parameter fixes this by ensuring actions/checkout properly configures credentials for subsequent actions like nx-set-shas.

**Not affected jobs**: install, commitlint (no nx-set-shas), release (already has custom token GH_BOT_TOKEN for pushing commits/tags to protected branch).

  ---
**Checklist**

  - [x] All PR checks pass locally (build, lint, test) — CI config only, no code changes
  - [x] No unrelated changes included
  - [x] N/A — no UI, accessibility, or logic changes

  **AI disclosure**

  Assisted by: Claude Code

[RHCLOUD-48486]: https://redhat.atlassian.net/browse/RHCLOUD-48486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ