### PR TITLE
ci(github-actions): upgrade actions/checkout to v6.0.3 to fix auth failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -26,10 +26,9 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Build
@@ -39,10 +38,9 @@ jobs:
     needs: [install]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Run unit tests
@@ -52,10 +50,9 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - uses: './.github/actions/cypress-cache'
@@ -71,10 +68,9 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Lint
@@ -84,7 +80,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -104,10 +100,9 @@ jobs:
     needs: install
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: './.github/actions/setup-environment'
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: install
@@ -125,7 +120,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Problem

  After security commit 35b69aca (ha-pin all actions), CI jobs fail at checkout with:
  fatal: could not read Username for 'https://github.com': terminal prompts disabled

  Root cause: Pin downgraded `actions/checkout` from v4.3.1 to v4.2.2, which has broken git auth setup. Also, v4.x uses Node.js 20 which hits deprecation enforcement June 16.

  ## Solution

  - Upgrade `actions/checkout` to v6.0.3 (SHA `df4cb1c069e1874edd31b4311f1884172cec0e10`)
    - Fixes auth by storing credentials in `$RUNNER_TEMP` instead of local git config
    - Runs on Node.js 24 natively (avoids deprecation)
    - Runner v2.335.1 meets v6 requirement (v2.329.0+)
  - Remove redundant `token: ${{ secrets.GITHUB_TOKEN }}` from 5 nx-affected jobs
    - PR #2345 added these as workaround for v4.2.2 auth bug
    - v6.0.3 handles default `github.token` correctly

  ## Changed

  All 8 checkout steps in `.github/workflows/ci.yaml`:
  - install, build, unit-test, component-test, lint, commitlint, check-circular-imports, release

  ## Verification

  - [ ] Push to PR branch
  - [ ] All CI jobs pass checkout step
  - [ ] No Node.js 20 deprecation warnings in logs
  - [ ] After merge, release job completes successfully

  Fixes RHCLOUD-48486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow dependencies to enhance build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->