### PR TITLE
ci(release): use npm ci for clean installs and lockfile validation

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: './.github/actions/setup-environment'
     - name: Install deps
       shell: bash
-      run: npm i
+      run: npm ci
     - name: git config
       shell: bash
       run: |


### PR DESCRIPTION
### Description
  
  Replaces `npm i` with `npm ci` in the release action for improved security and reproducibility. `npm ci` deletes `node_modules` before install, fails on lockfile drift, and prevents package-lock tampering.

  [RHCLOUD-48545](https://issues.redhat.com/browse/RHCLOUD-48545)

  ---

  ### Anything reviewers should know?

  Part of NPM hardening epic (RHCLOUD-48273). CI best practice - ensures clean, reproducible builds.

  ---

  ### Checklist
  - [ ] Accessibility: N/A (CI config only)
  - [ ] All PR checks pass locally (build, lint, test)
  - [ ] No unrelated changes included
  - [ ] _(Optional) QE: N/A_
  - [ ] _(Optional) UX: N/A_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-48545]: https://redhat.atlassian.net/browse/RHCLOUD-48545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation process in the release workflow for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->