### PR TITLE
ci(release): add --provenance flag to enable OIDC trusted publishing

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -34,7 +34,7 @@ runs:
         # See: https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862
         # See: https://github.com/nrwl/nx/blob/5ea2e47acfa9d175546daa922ce40905533f1074/packages/nx/src/utils/package-manager.ts#L207-L213
         npm_config_legacy_peer_deps: false
-      run: npx nx release --yes
+      run: npx nx release --yes --provenance
     - name: Push release commit and tags
       shell: bash
       # nx release (unified command) creates the git commit and tags locally but does not push them,


### PR DESCRIPTION
### Description

  Fixes npm publish failures in GitHub Actions release job. Publish was failing with "not logged in" error despite trusted publishing being configured, because npm defaulted to legacy token auth instead of OIDC. Adding `--provenance` flag forces npm to use OIDC authentication with the `npm-publish` environment.

  Despite [official npm docs](https://docs.npmjs.com/trusted-publishers/) claiming provenance is automatic with trusted publishing, [real-world testing](https://philna.sh/blog/2026/01/28/trusted-publishing-npm/) shows the `--provenance` flag is required in practice.

  Resolves: [Failed releases on 2026-06-17](./tmp/logs/failed-releases.txt)

  ---

  ### Anything reviewers should know?

  Provenance generates cryptographic attestations linking published packages to source commits. Required for OIDC trusted publishing to work. Without this flag, npm falls back to token auth which we explicitly delete on line 27.

  ---

  ### Checklist
  - [x] Accessibility: N/A (CI config change)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code