### PR TITLE
feat(conditional-filter): add ability to pass preselected filter

### DIFF
--- a/packages/components/doc/conditionalFilter.md
+++ b/packages/components/doc/conditionalFilter.md
@@ -10,6 +10,8 @@ If you do not pass any items to this component Text filter will be rendered by d
 
 You can control which filter is active by passing `onChange` and `value` (you have to pass both props, otherwise state values will be used).
 
+You can also mark a filter item with `default: true` to select it when no `value` is set. If no item is marked as default, the first item is used.
+
 There are 3 components predesigned for you to use, plus one custom definition component if you need to use something completely different.
 
 ### 1) Textual component

--- a/packages/components/src/ConditionalFilter/ConditionalFilter.test.js
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.test.js
@@ -160,6 +160,51 @@ describe('ConditionalFilter', () => {
       expect(onChange).toHaveBeenCalled();
     });
 
+    it('should select the item marked as default when uncontrolled', () => {
+      const items = [
+        {
+          label: 'Operating system',
+          value: 'operating-system-filter',
+          type: 'text',
+          filterValues: { placeholder: 'Filter by operating system' },
+        },
+        {
+          label: 'Name',
+          value: 'name-filter',
+          type: 'text',
+          default: true,
+          filterValues: { placeholder: 'Filter by name' },
+        },
+        {
+          label: 'Compliance',
+          type: 'checkbox',
+          filterValues: { items: [] },
+        },
+      ];
+
+      render(<ConditionalFilter {...initialProps} items={items} />);
+      expect(screen.getByRole('button', { name: 'Conditional filter toggle' })).toHaveTextContent('Name');
+    });
+
+    it('should fall back to the first item when no default is set', () => {
+      const items = [
+        {
+          label: 'Operating system',
+          value: 'operating-system-filter',
+          type: 'text',
+          filterValues: { placeholder: 'Filter by operating system' },
+        },
+        {
+          label: 'Compliance',
+          type: 'checkbox',
+          filterValues: { items: [] },
+        },
+      ];
+
+      render(<ConditionalFilter {...initialProps} items={items} />);
+      expect(screen.getByRole('button', { name: 'Conditional filter toggle' })).toHaveTextContent('Operating system');
+    });
+
     it('should update state on select', async () => {
       render(<ConditionalFilter {...initialProps} items={config} />);
       act(() => {

--- a/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
+++ b/packages/components/src/ConditionalFilter/ConditionalFilter.tsx
@@ -49,6 +49,7 @@ export type ConditionalFilterItem = {
   label?: ReactNode;
   placeholder?: string;
   value?: string;
+  default?: boolean;
 } & (
   | {
       type: 'checkbox';
@@ -84,6 +85,22 @@ export interface ConditionalFilterProps<R extends HTMLElement = NonNullable<any>
   innerRef?: React.RefObject<R>;
 }
 
+const resolveActiveItem = (items: ConditionalFilterItem[], currentValue?: number | string) => {
+  if (!items?.length) {
+    return undefined;
+  }
+
+  if (currentValue !== undefined && currentValue !== '') {
+    const matched = items.find((item, key) => item.value === currentValue || key === Number(currentValue));
+
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return items.find((item) => item.default) || items[0];
+};
+
 const ConditionalFilter: React.FunctionComponent<ConditionalFilterProps> = ({
   hideLabel = false,
   id = 'default-input',
@@ -112,7 +129,7 @@ const ConditionalFilter: React.FunctionComponent<ConditionalFilterProps> = ({
   }, []);
 
   const currentValue = onChange ? value : stateValue;
-  const activeItem = items && items.length && (items.find((item, key) => item.value === currentValue || key === Number(currentValue)) || items[0]);
+  const activeItem = resolveActiveItem(items, currentValue);
   const onChangeDefault = (_e: FormEvent<HTMLInputElement>, value: number | string) => setStateValue(value);
   const onChangeCallback = onChange || onChangeDefault;
 


### PR DESCRIPTION
### Description
This feature allows to pass default pre-selected conditional filter value. It helps to select correct default filter when multiple apps are merging filters.
[RHINENG-24124](https://redhat.atlassian.net/browse/RHINENG-24124)

Tested with linking this change to [insights-inventory frontend ](https://github.com/RedHatInsights/insights-inventory-frontend/pull/3268)and [compliance-frontend](https://github.com/RedHatInsights/compliance-frontend/pull/2865) PRs. 

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
<img width="1586" height="1107" alt="image" src="https://github.com/user-attachments/assets/d7cf64fe-ee26-48f0-9943-9929c34dfee8" />


#### After:
<img width="1836" height="1143" alt="image" src="https://github.com/user-attachments/assets/ce1cadd0-d0db-4a05-94a7-21b90c0e5b1f" />


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHINENG-24124]: https://redhat.atlassian.net/browse/RHINENG-24124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `ConditionalFilter` to support a `default: true` option on individual filter items, so the marked item is selected when no initial value is provided. If none is marked, the first item is selected.

* **Bug Fixes**
  * Improved uncontrolled initial selection behavior to follow the new default-item rules.

* **Documentation**
  * Refreshed `ConditionalFilter` documentation to describe how default selection works.

* **Tests**
  * Added coverage for uncontrolled initialization with and without a default-marked item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->