### PR TITLE
chore(ci): use NPM_CONFIG_PROVENANCE to enable provenance

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -34,7 +34,7 @@ runs:
         # See: https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862
         # See: https://github.com/nrwl/nx/blob/5ea2e47acfa9d175546daa922ce40905533f1074/packages/nx/src/utils/package-manager.ts#L207-L213
         npm_config_legacy_peer_deps: false
-      run: npx nx release --yes --provenance
+      run: npx nx release --yes
     - name: Push release commit and tags
       shell: bash
       # nx release (unified command) creates the git commit and tags locally but does not push them,

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: './.github/actions/setup-environment'
     - name: Install deps
       shell: bash
-      run: npm i
+      run: npm ci
     - name: git config
       shell: bash
       run: |

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -34,6 +34,9 @@ runs:
         # See: https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862
         # See: https://github.com/nrwl/nx/blob/5ea2e47acfa9d175546daa922ce40905533f1074/packages/nx/src/utils/package-manager.ts#L207-L213
         npm_config_legacy_peer_deps: false
+        # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
+        # https://philna.sh/blog/2026/01/28/trusted-publishing-npm/
+        NPM_CONFIG_PROVENANCE: true
       run: npx nx release --yes
     - name: Push release commit and tags
       shell: bash


### PR DESCRIPTION
### Description
  
Fixes npm publish by using `NPM_CONFIG_PROVENANCE=true` environment variable instead of `--provenance` flag. The `--provenance` flag is an npm CLI option not supported by `nx release` — nx passes it through to npm via environment variables. Using the env var directly achieves the same goal (enable OIDC trusted publishing) without relying on flag passthrough.

[RHCLOUD-48334](https://issues.redhat.com/browse/RHCLOUD-48334)

  ---

  ### Anything reviewers should know?

  Both `--provenance` flag and `NPM_CONFIG_PROVENANCE=true` enable provenance attestations, but only the env var works when publishing through `nx release`. Per [npm docs](https://docs.npmjs.com/generating-provenance-statements/), env var is official method for CI/CD workflows.

  ---

  ### Checklist
  - [x] Accessibility: N/A (CI config change)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-48334]: https://redhat.atlassian.net/browse/RHCLOUD-48334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ