### PR TITLE
ci(release): remove registry-url to prevent NODE_AUTH_TOKEN blocking OIDC

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -22,9 +22,6 @@ runs:
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
-    - name: Remove _authToken so npm uses OIDC for trusted publishing
-      shell: bash
-      run: npm config delete //registry.npmjs.org/:_authToken
     - name: Release
       shell: bash
       env:

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -16,7 +16,6 @@ runs:
     - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
-        registry-url: 'https://registry.npmjs.org'
     - name: Verify npm version
       shell: bash
       run: |


### PR DESCRIPTION
### Description
   
  Fixes npm publish failures by removing `registry-url` from `actions/setup-node`. When `registry-url` is set, setup-node automatically sets the `NODE_AUTH_TOKEN` environment variable ([source: authutil.ts:50-52](https://github.com/actions/setup-node/blob/v5.0.0/src/authutil.ts#L50-L52)). This blocks OIDC authentication because npm attempts to use the token instead of falling back to OIDC ([source: NPM publish using OIDC discussion](https://github.com/orgs/community/discussions/176761#discussioncomment-12089719)). CI logs confirm `NODE_AUTH_TOKEN` was set in all steps preventing trusted publishing from working.

  [RHCLOUD-48334](https://issues.redhat.com/browse/RHCLOUD-48334)

  ---

  ### Anything reviewers should know?

  **Root cause:** `actions/setup-node` with `registry-url` parameter writes auth config to `.npmrc` and sets `NODE_AUTH_TOKEN` env var ([authutil.ts:19-53](https://github.com/actions/setup-node/blob/v5.0.0/src/authutil.ts#L19-L53)). Even though we deleted the `.npmrc` auth token in a later step, the environment variable persisted and blocked OIDC.

  **Why removal is safe:** npm defaults to `registry.npmjs.org` without `registry-url` configured. OIDC authentication via `NPM_CONFIG_PROVENANCE=true` works when `NODE_AUTH_TOKEN` is completely unset ([source](https://dev.to/zhangjintao/from-deprecated-npm-classic-tokens-to-oidc-trusted-publishing-a-cicd-troubleshooting-journey-4h8b)). Per npm docs, an empty string is still a value — only a completely unset variable triggers OIDC fallback.

  **Changes:**
  - Removed `registry-url: 'https://registry.npmjs.org'` from setup-node config
  - Removed `npm config delete` step (no longer needed)

  ---

  ### Checklist
  - [x] Accessibility: N/A (CI config change)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-48334]: https://redhat.atlassian.net/browse/RHCLOUD-48334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ