### PR TITLE
fix(components): align items in primary toolbar filter group

### DIFF
--- a/packages/components/src/PrimaryToolbar/primary-toolbar.scss
+++ b/packages/components/src/PrimaryToolbar/primary-toolbar.scss
@@ -19,6 +19,7 @@
   }
   .ins-c-primary-toolbar__group-filter {
     flex-grow: initial;
+    align-items: center;
     .ins-c-primary-toolbar__filter {
       flex: initial;
     }


### PR DESCRIPTION
### Description

Fixes vertical alignment of filter items in the PrimaryToolbar component. Filter items within `.ins-c-primary-toolbar__group-filter` were not properly centered, causing visual misalignment. This adds `align-items: center` to the flex container to ensure consistent vertical centering of filter elements.

Before:
<img width="625" height="79" alt="Screenshot From 2026-06-25 08-48-39" src="https://github.com/user-attachments/assets/fbbfd5fb-0d67-4ff3-8ebb-9dd98f667b40" />
<img width="625" height="79" alt="Screenshot From 2026-06-25 08-48-46" src="https://github.com/user-attachments/assets/129cacd8-f20f-4498-83d8-186c03c7915d" />

After:
<img width="625" height="79" alt="Screenshot From 2026-06-25 09-20-02" src="https://github.com/user-attachments/assets/4112d9b3-924b-44ce-a222-8d17ce217b03" />
<img width="625" height="79" alt="Screenshot From 2026-06-25 09-20-07" src="https://github.com/user-attachments/assets/bc78e3f3-7162-4cd3-9c4c-27d61bf9ad05" />


[RHINENG-24158](https://redhat.atlassian.net/browse/RHINENG-24158)

---

### Anything reviewers should know?

Minor CSS-only change to improve visual alignment of filter items. No functional changes.

---

### Checklist
- [x] Accessibility: N/A (CSS alignment fix)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
Assisted by: Claude Code

[RHINENG-24158]: https://redhat.atlassian.net/browse/RHINENG-24158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ