### PR TITLE
feat(@redhat-cloud-services/frontend-components-config-utilities): add bundleChromeShared for hostless module federation builds

### DIFF
--- a/packages/config-utils/doc/core-functions.md
+++ b/packages/config-utils/doc/core-functions.md
@@ -35,7 +35,8 @@ const config = federatedModules({
 | useFileHash | boolean | `true` | Include content hash in filename |
 | separateRuntime | boolean | `false` | Use separate runtime |
 | exclude | string[] | `[]` | Packages to exclude from sharing |
-| eager | boolean | `false` | ⚠️ Deprecated - Load modules eagerly |
+| bundleChromeShared | boolean | `false` | Bundle chrome-provided shared modules from local `node_modules` (no insights-chrome host) |
+| eager | boolean | `false` | ⚠️ Deprecated — use `bundleChromeShared` instead |
 | pluginMetadata | PluginBuildMetadata | auto-generated | Plugin metadata configuration |
 | extensions | EncodedExtension[] | `[]` | Dynamic plugin extensions |
 
@@ -75,6 +76,19 @@ const config = federatedModules({
 ```
 
 *Pattern verified from: `src/federated-modules.ts:76-87`*
+
+### Standalone builds without insights-chrome
+
+When the app runs without insights-chrome as the module federation host (e.g. an IoP iframe on Satellite), enable local bundling of chrome-provided shared modules:
+
+```typescript
+const config = federatedModules({
+  root: __dirname,
+  bundleChromeShared: true,
+});
+```
+
+This rewrites `import: false` shared entries to eager imports from the app's `node_modules`.
 
 ## proxy
 

--- a/packages/config-utils/doc/core-functions.md
+++ b/packages/config-utils/doc/core-functions.md
@@ -35,6 +35,7 @@ const config = federatedModules({
 | useFileHash | boolean | `true` | Include content hash in filename |
 | separateRuntime | boolean | `false` | Use separate runtime |
 | exclude | string[] | `[]` | Packages to exclude from sharing |
+| bundleChromeShared | boolean | `false` | Bundle chrome-provided shared modules from local `node_modules` (no insights-chrome host) |
 | eager | boolean | `false` | ⚠️ Deprecated - Load modules eagerly |
 | pluginMetadata | PluginBuildMetadata | auto-generated | Plugin metadata configuration |
 | extensions | EncodedExtension[] | `[]` | Dynamic plugin extensions |
@@ -75,6 +76,19 @@ const config = federatedModules({
 ```
 
 *Pattern verified from: `src/federated-modules.ts:76-87`*
+
+### Standalone builds without insights-chrome
+
+When the app runs without insights-chrome as the module federation host (e.g. an IoP iframe on Satellite), enable local bundling of chrome-provided shared modules:
+
+```typescript
+const config = federatedModules({
+  root: __dirname,
+  bundleChromeShared: true,
+});
+```
+
+This rewrites `import: false` shared entries to eager imports from the app's `node_modules`, then drops remaining host-consumed shares. Those become normal webpack dependencies instead of Module Federation shares.
 
 ## proxy
 

--- a/packages/config-utils/src/federated-modules.test.ts
+++ b/packages/config-utils/src/federated-modules.test.ts
@@ -1,4 +1,12 @@
-import { applyImpliedDeps, createIncludes, createSharedDeps, default as federatedModules, mergeSharedDeps } from './federated-modules';
+import {
+  applyImpliedDeps,
+  bundleChromeSharedLocally,
+  createIncludes,
+  createSharedDeps,
+  default as federatedModules,
+  mergeSharedDeps,
+} from './federated-modules';
+import * as resolveSharedImport from './resolve-shared-import';
 import { DynamicRemotePlugin, WebpackSharedConfig } from '@openshift/dynamic-plugin-sdk-webpack';
 
 jest.mock('@openshift/dynamic-plugin-sdk-webpack', () => ({
@@ -176,6 +184,44 @@ describe('federatedModules', () => {
     });
     expect(getSharedModules()['@unleash/proxy-client-react']).toMatchObject({ singleton: true, requiredVersion: '^1.0.0' });
   });
+
+  it('bundles chrome-provided shared modules locally when bundleChromeShared is true', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    federatedModules({
+      root,
+      moduleName,
+      dependencies: { react: '^18.3.1' },
+      bundleChromeShared: true,
+    });
+
+    expect(getSharedModules()['react']).toMatchObject({
+      singleton: true,
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+      requiredVersion: '^18.3.1',
+    });
+
+    resolveSpy.mockRestore();
+  });
+
+  it('supports deprecated eager flag as an alias for bundleChromeShared', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    federatedModules({
+      root,
+      moduleName,
+      dependencies: { react: '^18.3.1' },
+      eager: true,
+    });
+
+    expect(getSharedModules()['react']).toMatchObject({
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+    });
+
+    resolveSpy.mockRestore();
+  });
 });
 
 describe('mergeSharedDeps', () => {
@@ -327,5 +373,84 @@ describe('applyImpliedDeps', () => {
     const sharedDeps = Object.freeze(createSharedDeps(include, { react: '^18.3.1' }, [])) as Record<string, WebpackSharedConfig>;
     const deps = { react: '^18.3.1', '@redhat-cloud-services/frontend-components': '^5.0.0' };
     expect(() => applyImpliedDeps(sharedDeps, include, deps, impliedDeps)).not.toThrow();
+  });
+});
+
+describe('bundleChromeSharedLocally', () => {
+  const root = '/fake/root';
+
+  it('rewrites import:false modules to eager local imports', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    const result = bundleChromeSharedLocally(root, {
+      react: { singleton: true, eager: false, import: false, requiredVersion: '^18.3.1' },
+    });
+
+    expect(result['react']).toEqual({
+      singleton: true,
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+      requiredVersion: '^18.3.1',
+    });
+
+    resolveSpy.mockRestore();
+  });
+
+  it('leaves modules unchanged when import path cannot be resolved', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue(null);
+
+    const config = { singleton: true, eager: false, import: false as const, requiredVersion: '^1.0.0' };
+    const input = { '@redhat-cloud-services/chrome': config };
+    const result = bundleChromeSharedLocally(root, input);
+
+    expect(result['@redhat-cloud-services/chrome']).toEqual(config);
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules that are already eager with a local import', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = {
+      singleton: true,
+      eager: true,
+      import: '/already/bundled.js',
+      requiredVersion: '^18.3.1',
+    };
+    const result = bundleChromeSharedLocally(root, { react: config });
+
+    expect(result['react']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules with an existing import and eager: false', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = {
+      singleton: true,
+      eager: false,
+      import: '/custom/shared.js',
+      requiredVersion: '^1.0.0',
+    };
+    const result = bundleChromeSharedLocally(root, { 'my-lib': config });
+
+    expect(result['my-lib']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules without an import field', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = { singleton: true, eager: false, requiredVersion: '^18.3.1' };
+    const result = bundleChromeSharedLocally(root, { 'react/jsx-dev-runtime': config });
+
+    expect(result['react/jsx-dev-runtime']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
   });
 });

--- a/packages/config-utils/src/federated-modules.test.ts
+++ b/packages/config-utils/src/federated-modules.test.ts
@@ -1,4 +1,13 @@
-import { applyImpliedDeps, createIncludes, createSharedDeps, default as federatedModules, mergeSharedDeps } from './federated-modules';
+import {
+  applyImpliedDeps,
+  bundleChromeSharedLocally,
+  createIncludes,
+  createSharedDeps,
+  default as federatedModules,
+  mergeSharedDeps,
+  omitHostConsumedShared,
+} from './federated-modules';
+import * as resolveSharedImport from './resolve-shared-import';
 import { DynamicRemotePlugin, WebpackSharedConfig } from '@openshift/dynamic-plugin-sdk-webpack';
 
 jest.mock('@openshift/dynamic-plugin-sdk-webpack', () => ({
@@ -176,6 +185,46 @@ describe('federatedModules', () => {
     });
     expect(getSharedModules()['@unleash/proxy-client-react']).toMatchObject({ singleton: true, requiredVersion: '^1.0.0' });
   });
+
+  it('bundles chrome-provided shared modules locally when bundleChromeShared is true', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    federatedModules({
+      root,
+      moduleName,
+      dependencies: { react: '^18.3.1' },
+      bundleChromeShared: true,
+    });
+
+    expect(getSharedModules()['react']).toMatchObject({
+      singleton: true,
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+      requiredVersion: '^18.3.1',
+    });
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not share PatternFly version-only modules when bundleChromeShared is true', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    federatedModules({
+      root,
+      moduleName,
+      dependencies: { react: '^18.3.1' },
+      bundleChromeShared: true,
+      shared: [{ '@patternfly/react-core/dist/dynamic/components/Page': { version: '^6.6.0' } }],
+    });
+
+    expect(getSharedModules()['react']).toMatchObject({
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+    });
+    expect(getSharedModules()['@patternfly/react-core/dist/dynamic/components/Page']).toBeUndefined();
+
+    resolveSpy.mockRestore();
+  });
 });
 
 describe('mergeSharedDeps', () => {
@@ -327,5 +376,105 @@ describe('applyImpliedDeps', () => {
     const sharedDeps = Object.freeze(createSharedDeps(include, { react: '^18.3.1' }, [])) as Record<string, WebpackSharedConfig>;
     const deps = { react: '^18.3.1', '@redhat-cloud-services/frontend-components': '^5.0.0' };
     expect(() => applyImpliedDeps(sharedDeps, include, deps, impliedDeps)).not.toThrow();
+  });
+});
+
+describe('bundleChromeSharedLocally', () => {
+  const root = '/fake/root';
+
+  it('rewrites import:false modules to eager local imports', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue('/fake/root/node_modules/react/index.js');
+
+    const result = bundleChromeSharedLocally(root, {
+      react: { singleton: true, import: false, requiredVersion: '^18.3.1' },
+    });
+
+    expect(result['react']).toEqual({
+      singleton: true,
+      eager: true,
+      import: '/fake/root/node_modules/react/index.js',
+      requiredVersion: '^18.3.1',
+    });
+
+    resolveSpy.mockRestore();
+  });
+
+  it('leaves modules unchanged when import path cannot be resolved', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath').mockReturnValue(null);
+
+    const config = { singleton: true, eager: false, import: false as const, requiredVersion: '^1.0.0' };
+    const input = { '@redhat-cloud-services/chrome': config };
+    const result = bundleChromeSharedLocally(root, input);
+
+    expect(result['@redhat-cloud-services/chrome']).toEqual(config);
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules that are already eager with a local import', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = {
+      singleton: true,
+      eager: true,
+      import: '/already/bundled.js',
+      requiredVersion: '^18.3.1',
+    };
+    const result = bundleChromeSharedLocally(root, { react: config });
+
+    expect(result['react']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules with an existing import and eager: false', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = {
+      singleton: true,
+      eager: false,
+      import: '/custom/shared.js',
+      requiredVersion: '^1.0.0',
+    };
+    const result = bundleChromeSharedLocally(root, { 'my-lib': config });
+
+    expect(result['my-lib']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
+  });
+
+  it('does not rewrite modules without an import field', () => {
+    const resolveSpy = jest.spyOn(resolveSharedImport, 'resolveSharedImportPath');
+
+    const config = { singleton: true, eager: false, requiredVersion: '^18.3.1' };
+    const result = bundleChromeSharedLocally(root, { 'react/jsx-dev-runtime': config });
+
+    expect(result['react/jsx-dev-runtime']).toEqual(config);
+    expect(resolveSpy).not.toHaveBeenCalled();
+
+    resolveSpy.mockRestore();
+  });
+});
+
+describe('omitHostConsumedShared', () => {
+  it('keeps modules with a local import path', () => {
+    const config = { singleton: true, eager: true, import: '/fake/react.js', requiredVersion: '^18.3.1' };
+    expect(omitHostConsumedShared({ react: config })).toEqual({ react: config });
+  });
+
+  it('drops PatternFly version-only shares', () => {
+    const result = omitHostConsumedShared({
+      '@patternfly/react-core/dist/dynamic/components/Page': { version: '^6.6.0' },
+    });
+    expect(result).toEqual({});
+  });
+
+  it('drops unresolved import:false modules', () => {
+    const result = omitHostConsumedShared({
+      '@redhat-cloud-services/chrome': { singleton: true, import: false, requiredVersion: '^1.0.0' },
+    });
+    expect(result).toEqual({});
   });
 });

--- a/packages/config-utils/src/federated-modules.ts
+++ b/packages/config-utils/src/federated-modules.ts
@@ -2,6 +2,7 @@ import { relative, resolve } from 'path';
 import { DynamicRemotePlugin, EncodedExtension, PluginBuildMetadata, WebpackSharedConfig } from '@openshift/dynamic-plugin-sdk-webpack';
 import jsVarName from './jsVarName';
 import fecLogger, { LogType } from './fec-logger';
+import { resolveSharedImportPath } from './resolve-shared-import';
 
 const defaultPluginMetaDataJSON = {
   version: '1.0.0',
@@ -65,13 +66,48 @@ export type FederatedModulesConfig = {
   separateRuntime?: boolean;
   exclude?: string[];
   /**
-   *  @deprecated
-   * Using eager loading will bloat your build output
+   * Bundle chrome-provided shared modules from local node_modules instead of
+   * expecting insights-chrome as the module federation host (e.g. IoP iframe).
+   */
+  bundleChromeShared?: boolean;
+  /**
+   * @deprecated Use bundleChromeShared instead.
    */
   eager?: boolean;
   pluginMetadata?: PluginBuildMetadata;
   extensions?: EncodedExtension[];
 };
+
+/**
+ * Rewrites chrome-provided shared modules (import: false) to eager local imports.
+ * Used when the app runs without insights-chrome as federation host.
+ */
+export const bundleChromeSharedLocally = (
+  root: string,
+  sharedModules: Record<string, WebpackSharedConfig> = {},
+): Record<string, WebpackSharedConfig> =>
+  Object.fromEntries(
+    Object.entries(sharedModules).map(([moduleName, config]) => {
+      if (config.import !== false) {
+        return [moduleName, config];
+      }
+
+      const importPath = resolveSharedImportPath(root, moduleName);
+
+      if (!importPath) {
+        return [moduleName, config];
+      }
+
+      return [
+        moduleName,
+        {
+          ...config,
+          eager: true,
+          import: importPath,
+        },
+      ];
+    }),
+  );
 
 const getRootPackage = (key: string): string => {
   if (key.startsWith('@')) {
@@ -181,6 +217,8 @@ const federatedModules = ({
   useFileHash = true,
   separateRuntime = false,
   exclude = [],
+  bundleChromeShared = false,
+  eager = false,
   pluginMetadata,
   extensions = [],
 }: FederatedModulesConfig): DynamicRemotePlugin => {
@@ -198,6 +236,10 @@ const federatedModules = ({
   sharedDeps = applyImpliedDeps(sharedDeps, include, dependencies, impliedDeps);
   sharedDeps = mergeSharedDeps(sharedDeps, shared, chromeProvided);
 
+  if (bundleChromeShared || eager) {
+    sharedDeps = bundleChromeSharedLocally(root, sharedDeps);
+  }
+
   if (debug) {
     console.log('Using package at path: ', resolve(root, './package.json'));
     console.log('Using appName: ', appName);
@@ -206,6 +248,9 @@ const federatedModules = ({
     console.log('Number of merged shared modules is: ', Object.keys(sharedDeps).length);
     if (exclude.length > 0) {
       console.log('Excluding default packages', exclude);
+    }
+    if (bundleChromeShared || eager) {
+      console.log('Bundling chrome-provided shared modules from local node_modules');
     }
   }
 

--- a/packages/config-utils/src/federated-modules.ts
+++ b/packages/config-utils/src/federated-modules.ts
@@ -2,6 +2,7 @@ import { relative, resolve } from 'path';
 import { DynamicRemotePlugin, EncodedExtension, PluginBuildMetadata, WebpackSharedConfig } from '@openshift/dynamic-plugin-sdk-webpack';
 import jsVarName from './jsVarName';
 import fecLogger, { LogType } from './fec-logger';
+import { resolveSharedImportPath } from './resolve-shared-import';
 
 const defaultPluginMetaDataJSON = {
   version: '1.0.0',
@@ -65,13 +66,55 @@ export type FederatedModulesConfig = {
   separateRuntime?: boolean;
   exclude?: string[];
   /**
-   *  @deprecated
+   * Bundle chrome-provided shared modules from local node_modules instead of
+   * expecting insights-chrome as the module federation host (e.g. IoP iframe).
+   */
+  bundleChromeShared?: boolean;
+  /**
+   * @deprecated
    * Using eager loading will bloat your build output
    */
   eager?: boolean;
   pluginMetadata?: PluginBuildMetadata;
   extensions?: EncodedExtension[];
 };
+
+/**
+ * Rewrites chrome-provided shared modules (import: false) to eager local imports.
+ * Used when the app runs without insights-chrome as federation host.
+ */
+export const bundleChromeSharedLocally = (
+  root: string,
+  sharedModules: Record<string, WebpackSharedConfig> = {},
+): Record<string, WebpackSharedConfig> =>
+  Object.fromEntries(
+    Object.entries(sharedModules).map(([moduleName, config]) => {
+      if (config.import !== false) {
+        return [moduleName, config];
+      }
+
+      const importPath = resolveSharedImportPath(root, moduleName);
+
+      if (!importPath) {
+        return [moduleName, config];
+      }
+
+      return [
+        moduleName,
+        {
+          ...config,
+          eager: true,
+          import: importPath,
+        },
+      ];
+    }),
+  );
+
+/**
+ * Drops shared entries that still expect a host to provide them.
+ */
+export const omitHostConsumedShared = (sharedModules: Record<string, WebpackSharedConfig> = {}): Record<string, WebpackSharedConfig> =>
+  Object.fromEntries(Object.entries(sharedModules).filter(([, config]) => typeof config.import === 'string'));
 
 const getRootPackage = (key: string): string => {
   if (key.startsWith('@')) {
@@ -181,6 +224,7 @@ const federatedModules = ({
   useFileHash = true,
   separateRuntime = false,
   exclude = [],
+  bundleChromeShared = false,
   pluginMetadata,
   extensions = [],
 }: FederatedModulesConfig): DynamicRemotePlugin => {
@@ -198,6 +242,10 @@ const federatedModules = ({
   sharedDeps = applyImpliedDeps(sharedDeps, include, dependencies, impliedDeps);
   sharedDeps = mergeSharedDeps(sharedDeps, shared, chromeProvided);
 
+  if (bundleChromeShared) {
+    sharedDeps = omitHostConsumedShared(bundleChromeSharedLocally(root, sharedDeps));
+  }
+
   if (debug) {
     console.log('Using package at path: ', resolve(root, './package.json'));
     console.log('Using appName: ', appName);
@@ -206,6 +254,9 @@ const federatedModules = ({
     console.log('Number of merged shared modules is: ', Object.keys(sharedDeps).length);
     if (exclude.length > 0) {
       console.log('Excluding default packages', exclude);
+    }
+    if (bundleChromeShared) {
+      console.log('Bundling chrome-provided shared modules from local node_modules');
     }
   }
 

--- a/packages/config-utils/src/resolve-shared-import.ts
+++ b/packages/config-utils/src/resolve-shared-import.ts
@@ -1,0 +1,9 @@
+import { resolve } from 'path';
+
+export const resolveSharedImportPath = (root: string, moduleName: string): string | null => {
+  try {
+    return require.resolve(moduleName, { paths: [resolve(root)] });
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
### Description

This PR adds `bundleChromeShared` to `@redhat-cloud-services/frontend-components-config-utilities` so apps can run without `insights-chrome` as the module federation host (we need it specifically for IoP iframe builds).

When enabled, shared modules that were previously `import: false` (host-provided) are rewritten to eager local imports resolved from the app’s `node_modules`. This prevents missing shared module runtime failures in hostless environments while preserving current behavior by default.

**Note that:**
- Non-visual/config-only change (no UI impact).
- Default behavior is unchanged unless `bundleChromeShared: true` is set.
- If a shared import path cannot be resolved locally, config is left unchanged.


[RHINENG-27055](https://redhat.atlassian.net/browse/RHINENG-27055)

---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:


#### After:


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHINENG-27055]: https://redhat.atlassian.net/browse/RHINENG-27055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `bundleChromeShared` support for standalone builds without insights-chrome.
  * Chrome-provided shared modules can be bundled locally as eager imports when resolvable.
  * Host-provided shared modules without local paths are omitted when local bundling is enabled.
  * Existing configurations remain unchanged when modules cannot be resolved or already define import behavior.

* **Documentation**
  * Documented the new configuration option and standalone build behavior.
  * Clarified handling of shared modules configured with `import: false`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->