### PR TITLE
chore(ci): add GPG signing for release commits

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -10,6 +10,9 @@ inputs:
   gh_email:
     description: 'Github email'
     required: true
+  gpg_private_key:
+    description: 'GPG private key for signing commits (passphrase-less)'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -17,11 +20,18 @@ runs:
     - name: Install deps
       shell: bash
       run: npm ci
+    - name: Import GPG key
+      shell: bash
+      run: |
+        echo "${{ inputs.gpg_private_key }}" | base64 -d | gpg --batch --import
+        gpg --list-secret-keys --keyid-format LONG
     - name: git config
       shell: bash
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
+        git config commit.gpgsign true
+        git config user.signingkey $(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
     - name: Release
       shell: bash
       env:

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -31,7 +31,7 @@ runs:
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
-        git config user.signingkey $(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | cut -d'/' -f2)
+        git config user.signingkey $(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
     - name: Release
       shell: bash
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,3 +175,4 @@ jobs:
           gh_token: ${{ secrets.GH_BOT_TOKEN }}
           gh_name: ${{ secrets.BOT_NAME }}
           gh_email: ${{ secrets.BOT_EMAIL }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
## Error

```
remote: error: GH013: Repository rule violations found for refs/heads/master.        
remote: Review all repository rules at https://github.com/RedHatInsights/frontend-components/rules?ref=refs%2Fheads%2Fmaster        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation:        
remote: 
remote:   72a01922f4422e1723351a6be600f6291664e5cd        
remote: 
```

## Description

Adds GPG signing for bot commits in the CI release pipeline. GitHub repository rules now require verified signatures on commits to master, blocking releases since the bot's commits were unsigned. This change imports a passphrase-less GPG key from secrets, configures git to sign commits, and unblocks the automated release workflow.

[RHCLOUD-49061](https://redhat.atlassian.net/browse/RHCLOUD-49061)

---
 Anything reviewers should know?
   
 - The GPG private key (GPG_PRIVATE_KEY secret) is passphrase-less and base64-encoded
 - Public key must be added to nacho-bot's GitHub account for signature verification
 - The key extraction uses grep | awk | cut pipeline - assumes standard gpg output format                                                             
 - This unblocks 38 unreleased commits blocked since the supply chain attack cleanup

 ---
 Checklist

 - [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
 - [x] All PR checks pass locally (build, lint, test)
 - [x] No unrelated changes included
 - [x] (Optional) QE: OUIA changed, test impact, no coverage
 - [x] (Optional) UX: end-user UX modified, designs need sign-off

 AI disclosure

 Assisted by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release commits can now be GPG-signed, adding stronger authenticity and traceability to published releases.
  * The release workflow now passes the required signing credentials automatically during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHCLOUD-49061]: https://redhat.atlassian.net/browse/RHCLOUD-49061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ