### PR TITLE
fix(ci): remove husky hook and harden supply chain security

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-npx --no-install nx affected -t lint
-npx --no-install nx affected -t test:unit --exclude=demo
-npx --no-install nx affected -t test:component --exclude=demo --parallel=1
-npx --no-install nx affected -t build --exclude=demo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,12 @@
 # All Konflux tekton configuration changes review from admins
 #.tekton/** @RedHatInsights/experience-services-admins
 
-# Protect .npmignore - package publish contents control
+# Protect npm configuration and lifecycle scripts from supply chain attacks
+# Root package.json contains prepare/postinstall scripts that execute during npm install
+# .npmrc controls registry settings and install behavior
+# .npmignore controls published package contents
+package.json @RedHatInsights/experience-services-admins
+.npmrc @RedHatInsights/experience-services-admins
 .npmignore @RedHatInsights/experience-services-admins
 
 # CODEOWNERS file itself requires admin review to prevent bypass attacks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,10 @@
 # This prevents unauthorized modifications to CI/CD pipelines, custom actions, and repo processes
 .github/** @RedHatInsights/experience-services-admins
 
+# Protect Git hooks from supply chain attacks
+# Husky hooks execute during npm install and git operations with user permissions
+.husky/** @RedHatInsights/experience-services-admins
+
 # All Konflux tekton configuration changes review from admins
 #.tekton/** @RedHatInsights/experience-services-admins
 


### PR DESCRIPTION
## Changes
  
  1. **Release retrigger fix** - Added `[skip ci]` to nx release commits to prevent infinite CI loops
  2. **Pre-push hook disabled** - CI already validates builds/tests/lint
  3. **Supply chain hardening** - Protected `.husky/`, `package.json`, `.npmrc` in CODEOWNERS

  ## Security Impact
  
  CODEOWNERS now requires admin approval for:
  - `.husky/**` - git hooks that execute during commits/pushes
  - `package.json` - lifecycle scripts (prepare/postinstall)
  - `.npmrc` - registry configuration
  
  Prevents malicious code injection via npm install.

  ## Testing
  
  - [ ] Verify `[skip ci]` in next release commit message
  - [ ] Confirm `git push` no longer runs local tests
  - [ ] Test CODEOWNERS enforcement (create PR modifying `.husky/pre-commit`)

  Fixes [RHCLOUD-49151](https://redhat.atlassian.net/browse/RHCLOUD-49151)

[RHCLOUD-49151]: https://redhat.atlassian.net/browse/RHCLOUD-49151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ