### PR TITLE
ci: add stale workflow to auto-close inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Handle stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run daily at midnight UTC
+  workflow_dispatch: # Allow manual triggers
+
+jobs:
+  call-stale-workflow:
+    uses: RedHatInsights/shared-workflows/.github/workflows/stale.yml@master
+    # Optional: customize inputs
+    # with:
+    #   days-before-stale: 60
+    #   days-before-close: 5
+    #   exempt-issue-labels: "work-in-progress, in-progress, in-review, help-wanted, blocked, wip, depfu, dependabot, dependencies"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-stale-workflow:
-    uses: RedHatInsights/shared-workflows/.github/workflows/stale.yml@master
+    uses: RedHatInsights/shared-workflows/.github/workflows/stale.yml@c7a98838b91e581bbc4e3e7607416b73e8a46787 # Pin to specific commit for security
     # Optional: customize inputs
     # with:
     #   days-before-stale: 60


### PR DESCRIPTION
Add stale PR workflow to autoclose stale PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage stale issues and pull requests.
  * Runs daily at midnight UTC and can also be triggered manually.
  * Supports optional configuration for tuning when items are marked stale and for exempt labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->