### PR TITLE
fix(ci): remove debug GPG list and select signing key by email

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -24,14 +24,13 @@ runs:
       shell: bash
       run: |
         echo "${{ inputs.gpg_private_key }}" | base64 -d | gpg --batch --import
-        gpg --list-secret-keys --keyid-format LONG
     - name: git config
       shell: bash
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
-        git config user.signingkey $(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+        git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Release
       shell: bash
       env:


### PR DESCRIPTION
- Remove debugging
- Fetch GPG key by email instead of assuming it is the first one. Email address won't show in logs because it's a Github secret. 