### PR TITLE
ci: add pre-release version verification check

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -31,6 +31,9 @@ runs:
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
+    - name: Verify version consistency
+      shell: bash
+      run: bash .github/scripts/verify-versions.sh
     - name: Release
       shell: bash
       env:

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -56,7 +56,7 @@ for dir in "$REPO_ROOT"/packages/*/; do
   [[ -z "$tag_ver" ]] && tag_ver="NONE"
 
   # --- npm registry version ---
-  npm_ver="$(npm view "$pkg" version 2>/dev/null)" || true
+  npm_ver="$(npm view "$pkg" version --fetch-timeout=10000 2>/dev/null)" || true
   [[ -z "$npm_ver" ]] && npm_ver="NOT_ON_NPM"
 
   # --- Compare ---

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -7,6 +7,8 @@
 #
 # Exit 0: all versions aligned
 # Exit 1: at least one mismatch detected
+# Note: When running locally in a fork, ensure tags are synced first:
+#   git fetch upstream --tags
 
 set -euo pipefail
 
@@ -21,11 +23,6 @@ printf '\n'
 for dir in "$REPO_ROOT"/packages/*/; do
   dirname="$(basename "$dir")"
 
-  # Skip executors -- not released (matches nx.json release.projects exclusion)
-  if [[ "$dirname" == "executors" ]]; then
-    continue
-  fi
-
   pkg_json="$dir/package.json"
   if [[ ! -f "$pkg_json" ]]; then
     continue
@@ -35,6 +32,12 @@ for dir in "$REPO_ROOT"/packages/*/; do
   # avoids jq dependency and handles edge cases better than grep/sed)
   pkg="$(node -p "require('$pkg_json').name")"
   disk_ver="$(node -p "require('$pkg_json').version")"
+
+  # Skip private packages — they are not published to npm or tagged
+  private="$(node -p "require('$pkg_json').private || false")"
+  if [[ "$private" == "true" ]]; then
+    continue
+  fi
 
   # --- Git tag version ---
   # Tag pattern from nx.json: {projectName}-{version} where projectName = npm package name

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# verify-versions.sh
+#
+# Compares package versions across three sources (package.json, git tags, npm registry)
+# for all releasable packages in this monorepo. Intended to run before `nx release`
+# in CI to prevent releasing from an inconsistent state.
+#
+# Exit 0: all versions aligned
+# Exit 1: at least one mismatch detected
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+mismatch=0
+# Column widths for alignment
+printf "%-60s %-12s %-12s %-15s %s\n" "PACKAGE" "DISK" "GIT TAG" "NPM" "STATUS"
+printf '%.0s-' {1..110}
+printf '\n'
+
+for dir in "$REPO_ROOT"/packages/*/; do
+  dirname="$(basename "$dir")"
+
+  # Skip executors -- not released (matches nx.json release.projects exclusion)
+  if [[ "$dirname" == "executors" ]]; then
+    continue
+  fi
+
+  pkg_json="$dir/package.json"
+  if [[ ! -f "$pkg_json" ]]; then
+    continue
+  fi
+
+  # Read package name and version from package.json using node (always available in CI,
+  # avoids jq dependency and handles edge cases better than grep/sed)
+  pkg="$(node -p "require('$pkg_json').name")"
+  disk_ver="$(node -p "require('$pkg_json').version")"
+
+  # --- Git tag version ---
+  # Tag pattern from nx.json: {projectName}-{version} where projectName = npm package name
+  # Use glob "${pkg}-*" then strip the prefix and filter for version-like results.
+  # This handles the ambiguity where e.g. "@redhat-cloud-services/frontend-components-config-*"
+  # also matches "@redhat-cloud-services/frontend-components-config-utilities-*".
+  # After stripping "${pkg}-", the utilities tags become "utilities-4.12.0" which does NOT
+  # start with a digit, so grep '^[0-9]' filters them out.
+  tag_ver="$(
+    git tag --list "${pkg}-*" \
+      | sed "s|^${pkg}-||" \
+      | grep '^[0-9]' \
+      | sort -V \
+      | tail -1
+  )" || true
+  [[ -z "$tag_ver" ]] && tag_ver="NONE"
+
+  # --- npm registry version ---
+  npm_ver="$(npm view "$pkg" version 2>/dev/null)" || true
+  [[ -z "$npm_ver" ]] && npm_ver="NOT_ON_NPM"
+
+  # --- Compare ---
+  if [[ "$disk_ver" == "$tag_ver" && "$disk_ver" == "$npm_ver" ]]; then
+    status="OK"
+    marker="✓"
+  elif [[ "$tag_ver" == "NONE" && "$npm_ver" == "NOT_ON_NPM" ]]; then
+    # New package: no tag, not published. Flag as informational but still a mismatch.
+    status="NEW_PACKAGE"
+    marker="!"
+    mismatch=1
+    echo "::error::${pkg}: new/unpublished package (disk=${disk_ver}, tag=NONE, npm=NOT_ON_NPM). Verify this is intentional."
+  else
+    status="MISMATCH"
+    marker="✗"
+    mismatch=1
+    echo "::error::${pkg}: version mismatch (disk=${disk_ver}, tag=${tag_ver}, npm=${npm_ver})"
+  fi
+
+  printf "%-60s %-12s %-12s %-15s %s %s\n" "$pkg" "$disk_ver" "$tag_ver" "$npm_ver" "$marker" "$status"
+done
+
+echo ""
+if [[ $mismatch -ne 0 ]]; then
+  echo "Version verification FAILED. Fix mismatches before releasing."
+  exit 1
+else
+  echo "All package versions are aligned across disk, git tags, and npm registry."
+  exit 0
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: './.github/actions/setup-environment'
       - uses: './.github/actions/cypress-cache'
       - name: Install dependencies


### PR DESCRIPTION
The version verification script acts as a pre-release safety gate by ensuring `package.json` versions, git tags, and npm registry versions are aligned before `nx release` runs. It prevents silent corruption scenarios like: (1) incorrect tags being pushed that would cause version skipping on npm, (2) release commit push failures that leave the remote in an inconsistent state (packages published but tags/package.json not updated), and (3) malicious or accidental npm publishes without corresponding git tags. By failing fast with clear diagnostics when versions are misaligned, it catches state corruption before nx release compounds the problem, saving manual cleanup effort and preventing consumer-facing version gaps.

  Script: `.github/scripts/verify-versions.sh`
  - Handles tag disambiguation (frontend-components vs frontend-components-config)
  - Reports mismatches via GitHub Actions error annotations
  - Verified locally: all 14 packages aligned, mismatch detection works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an automated release validation step to detect inconsistent package versions before publishing.
  * Reports mismatches between package metadata, Git tags, and npm versions.
  * Flags newly added or unpublished packages that lack a corresponding release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->