### PR TITLE
chore(ci): use git tag --merged in verify-versions.sh to match nx rel…

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -30,6 +30,7 @@ runs:
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
+        git config tag.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Verify version consistency
       shell: bash

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -47,7 +47,7 @@ for dir in "$REPO_ROOT"/packages/*/; do
   # After stripping "${pkg}-", the utilities tags become "utilities-4.12.0" which does NOT
   # start with a digit, so grep '^[0-9]' filters them out.
   tag_ver="$(
-    git tag --list "${pkg}-*" \
+    git tag --merged HEAD --list "${pkg}-*" \
       | sed "s|^${pkg}-||" \
       | grep '^[0-9]' \
       | sort -V \


### PR DESCRIPTION
### Description
  
  Changed verify-versions.sh to use `git tag --merged HEAD` instead of `git tag --list` to match nx release's tag resolution behavior. Previously, the script saw all tags
  (including orphaned ones from failed release pushes), while nx only considers tags reachable from HEAD, causing the script to pass validation when nx would fail.

  This prevents false-positive validations where versions appear aligned but nx cannot see the tags during release.

Also added git config to sign tags, which are currently showing as unverified. 

  ---

  ### Screenshots

  N/A - CI script change only

  ---

  ### Anything reviewers should know?

  **Context:** After PR #2373 merged, the release job failed because nx resolved `@redhat-cloud-services/tsc-transform-imports` version as 1.3.0 (from reachable tags) but the 1.3.1 tag already existed on an orphaned commit from a previous failed release push. The verify-versions.sh script incorrectly passed because it saw all tags regardless of reachability.

  **Separate cleanup:** The 14 orphaned x.y.1 tags were force-moved from commit `4944bc90` to `23ec19b0` (the correct release commit on master) via direct `git push --force` to upstream. This is a one-time cleanup and not part of the PR.

  **How nx works:** Uses `git tag --merged` by default, meaning it only considers tags whose commits are ancestors of HEAD. The script now matches this behavior.

  ---

  ### Checklist
  - [x] Accessibility: N/A (script-only change)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version verification accuracy by limiting tag checks to those already merged into the current release branch.
  * Prevented unrelated or unmerged tags from impacting package version comparisons.
* **Chores**
  * Enabled GPG signing for tag objects during the release process to complement existing commit signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->