### PR TITLE
fix(components): pass Inventory fallback to ScalprumComponent

### DIFF
--- a/packages/components/src/Inventory/AppInfo.tsx
+++ b/packages/components/src/Inventory/AppInfo.tsx
@@ -41,6 +41,7 @@ const BaseAppInfo = ({
           scope="inventory"
           ErrorComponent={<InventoryLoadError component="AppInfo" {...props} />}
           ref={innerRef}
+          fallback={fallback}
           {...props}
         />
       </Suspense>

--- a/packages/components/src/Inventory/DetailWrapper.tsx
+++ b/packages/components/src/Inventory/DetailWrapper.tsx
@@ -41,6 +41,7 @@ const BaseDetailWrapper = ({
           scope="inventory"
           ErrorComponent={<InventoryLoadError component="DetailWrapper" {...props} />}
           ref={innerRef}
+          fallback={fallback}
           {...props}
         />
       </Suspense>

--- a/packages/components/src/Inventory/InventoryDetail.tsx
+++ b/packages/components/src/Inventory/InventoryDetail.tsx
@@ -41,6 +41,7 @@ const BaseInventoryDetail = ({
           scope="inventory"
           ErrorComponent={<InventoryLoadError component="InventoryDetail" {...props} />}
           ref={innerRef}
+          fallback={fallback}
           {...props}
         />
       </Suspense>

--- a/packages/components/src/Inventory/InventoryDetailHead.tsx
+++ b/packages/components/src/Inventory/InventoryDetailHead.tsx
@@ -41,6 +41,7 @@ const BaseInventoryDetailHead = ({
           scope="inventory"
           ErrorComponent={<InventoryLoadError component="InventoryDetailHead" {...props} />}
           ref={innerRef}
+          fallback={fallback}
           {...props}
         />
       </Suspense>

--- a/packages/components/src/Inventory/InventoryTable.tsx
+++ b/packages/components/src/Inventory/InventoryTable.tsx
@@ -41,6 +41,7 @@ const BaseInvTable = ({
           scope="inventory"
           ErrorComponent={<InventoryLoadError component="InventoryTable" {...props} />}
           ref={innerRef}
+          fallback={fallback}
           {...props}
         />
       </Suspense>


### PR DESCRIPTION
### Description
Fixing loading state that broke [here](https://github.com/RedHatInsights/frontend-components/pull/2315) when we stopped passing fallback to scalprum component 

[RHCLOUD-49370](https://issues.redhat.com/browse/RHCLOUD-49370)

---

### Screenshots
Before:
<img width="981" height="617" alt="Screenshot 2026-07-16 at 14 33 07" src="https://github.com/user-attachments/assets/5f3a0799-417b-4b99-b393-7fa7b50c5dc4" />

After: 
no more text, spinner is shown

---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [ ] All PR checks pass locally (build, lint, test)
- [ ] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-49370]: https://redhat.atlassian.net/browse/RHCLOUD-49370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and error-state handling across inventory views.
  * Fallback content is now consistently applied when embedded inventory components are loading or unavailable.
  * Updated inventory tables, details, headers, wrappers, and app information displays for more predictable fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->