### PR TITLE
chore(deps): update @scalprum/react-core to ^0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,12 +123,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -137,29 +137,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -221,13 +221,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -249,13 +249,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -396,27 +396,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -498,27 +498,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -540,25 +540,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2149,31 +2149,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2181,13 +2181,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2690,9 +2690,9 @@
       }
     },
     "node_modules/@cypress/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4158,9 +4158,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6299,39 +6299,24 @@
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.4.0.tgz",
-      "integrity": "sha512-yxDv/FJoLiKo2eqIcEWvSnSpJgyYkCzJvNaFsQ2QE3rNv68IeAarlSzCo+d0QyQoPJnTETyHsOh1SSBazIzecw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.8.0.tgz",
+      "integrity": "sha512-7AaaiE4YOXFb+st6xlVDK65aNKZYR9S9ykH0q2mkHAHTgquXciAjypS8JuhmKn7Lob/2rkplMOc4YsGxG3Ng9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.4.0",
-        "@types/semver": "7.5.8",
-        "semver": "7.6.3"
-      }
-    },
-    "node_modules/@module-federation/bridge-react-webpack-plugin/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.4.0.tgz",
-      "integrity": "sha512-c46g9srroc2hDfrlHyd4Y404SLnw3v9t7Kqij+yK01Hx8C2FyZpyanTGUHVyrmzqp/0y3lPrWURUHkHfk/cJQA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.8.0.tgz",
+      "integrity": "sha512-yTxdWkCJPPo+IGASz+NqdW13cw3DhjSBEn9r85aYn1ahckDwB1WcZe0OjDWMqCcR6yi0BMLedk0SWrUeUj0fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -6343,25 +6328,23 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.4.0.tgz",
-      "integrity": "sha512-sa6v5ByyqMRHzpwDu0zc7s5mZ39EFIkG0jkRfZU09pzkrJEIy4uZ1Kt9SLysFB8RBMIAvAakAfqDlVWvf1lndg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.8.0.tgz",
+      "integrity": "sha512-defjq4jOWMEfeejezPWLP5sc8kw0O6FqTT7/E5rbZPEVyjB1A0U3ynhW6GDE5/6hk9/TzdbWS+fBNi4MqUOY6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "@module-federation/third-party-dts-extractor": "2.4.0",
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
+        "@module-federation/third-party-dts-extractor": "2.8.0",
         "adm-zip": "0.5.10",
-        "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
-        "node-schedule": "2.1.1",
-        "undici": "7.24.7",
-        "ws": "8.18.0"
+        "undici": "7.28.0",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
@@ -6371,32 +6354,31 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.4.0.tgz",
-      "integrity": "sha512-NiccK03x7V6bK2LvJNuW520kT+Onx+LJe8lyPsENjXctECCIFJdJOmYr8ABif/kLayWKrrYCzCGVNNiQXANEGQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.8.0.tgz",
+      "integrity": "sha512-h8vkLdhK7tlcSPmyYNGfGyt0pSzfDB0tYVYdyUt2tXwQRfaJAi3bsIpujMXElw3MXtOfSHESa6M/hPKrtWTHBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
-        "@module-federation/cli": "2.4.0",
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/manifest": "2.4.0",
-        "@module-federation/rspack": "2.4.0",
-        "@module-federation/runtime-tools": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "@module-federation/webpack-bundler-runtime": "2.4.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
+        "@module-federation/cli": "2.8.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/manifest": "2.8.0",
+        "@module-federation/rspack": "2.8.0",
+        "@module-federation/runtime-tools": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
+        "@module-federation/webpack-bundler-runtime": "2.8.0",
         "schema-utils": "4.3.0",
-        "tapable": "2.3.0",
-        "upath": "2.0.1"
+        "tapable": "2.3.0"
       },
       "bin": {
         "mf": "bin/mf.js"
       },
       "peerDependencies": {
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24",
         "webpack": "^5.0.0"
       },
@@ -6413,56 +6395,54 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.4.0.tgz",
-      "integrity": "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.0.tgz",
+      "integrity": "sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.4.0.tgz",
-      "integrity": "sha512-GucUMQmQXcnJC/OnJGvMz3Qy7ap8nAffhQPwDpOSi0Qwm+Iq/ppzG8N3tlLBDmv/O8hiF8HHlg789XK2kcCQtg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.8.0.tgz",
+      "integrity": "sha512-fW3jD1ZVds6r/Ul8TtUA42RsB0LfT1yjo5KjqgirH9QrmEMH21x44e3e6BC6IN820XKawRDSmz2kFA5YHIQp7Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.4.0"
+        "@module-federation/runtime-tools": "2.8.0"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.4.0.tgz",
-      "integrity": "sha512-Z8j6aog44G1gt4yIAaeDowwZ7xg0aAxTA1Hq69euJK9cR9MDEaLbLUk57jDoiRj6xLwlCiw7ozY+U15BQATk6Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.8.0.tgz",
+      "integrity": "sha512-SnVBCwmi962WGg6hLFElxZUCnrRJdR6glE2ZKPBY/iK07AHUN2ZxuaBCBsVzyws+xLZGHZxBHmVstijTh8dSUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.4.0",
-        "find-pkg": "2.0.0"
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.4.0.tgz",
-      "integrity": "sha512-ZL+W5rbtgRf9TWRP7Dupt/Svia4bJEOS6gWSj9jzemiLPRPkMO5hjWZKVHIc8oG+Vb25yzozFMmQ+luGi695wg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.8.0.tgz",
+      "integrity": "sha512-wfVeBXc4/C2F70nRFSPqJhkcwbDgo+wQyEn3jbjJTDoUqxxhYBfHFs1ACBYOk3Qm97L7hHclHGtUG0/nvDEfAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "find-pkg": "2.0.0"
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.7.42",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.42.tgz",
-      "integrity": "sha512-aX/T4L9bPbOgNLIW+30k/dA2Iohoy9/jf4yG1ka6Hkuo5h7iEBeZiQkwIqC06cnCbtKL1HnAiYlXHmrDPW5xvg==",
+      "version": "2.7.47",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.47.tgz",
+      "integrity": "sha512-mifMvCjWmLl53GS+badQws0j2bsu1ICpdGzCbez4I6kSpaYA8v86L6dwcHtVHIZtkUC6cjAZBDcgpxs4fK3nFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "2.4.0",
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/enhanced": "2.8.0",
+        "@module-federation/runtime": "2.8.0",
+        "@module-federation/sdk": "2.8.0",
         "encoding": "0.1.13",
         "node-fetch": "2.7.0",
         "tapable": "2.3.0"
@@ -6477,23 +6457,23 @@
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.4.0.tgz",
-      "integrity": "sha512-NWH5Vaj/fA9R7PfbwTuE1Ty/pfiAt12On0E3FzoeVPCyb5MxO1i0z+xxRHbPhF4ZOrAPGEMaMQ8Z9vH94EiElw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.8.0.tgz",
+      "integrity": "sha512-TPcrkHpaZgL25Vx3c8oSNwyv7/KktC7uo6HTQdVWlFzbq5RSoMMGkWoir5pY5124isae2/p6v5xAuqICi4r0Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/manifest": "2.4.0",
-        "@module-federation/runtime-tools": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/bridge-react-webpack-plugin": "2.8.0",
+        "@module-federation/dts-plugin": "2.8.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.8.0",
+        "@module-federation/managers": "2.8.0",
+        "@module-federation/manifest": "2.8.0",
+        "@module-federation/runtime-tools": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
-        "typescript": "^4.9.0 || ^5.0.0",
+        "typescript": "^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "vue-tsc": ">=1.0.24"
       },
       "peerDependenciesMeta": {
@@ -6506,75 +6486,63 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.4.0.tgz",
-      "integrity": "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.0.tgz",
+      "integrity": "sha512-cGtUBQ1/TVy7KrXy6xPgy3FEmOGyIYkBA2T4iGH3ZH5PNPPTmqN9jF2AfneTSOj0RtBr7Pxq3CUt81E/UCvK1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/runtime-core": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/runtime-core": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.4.0.tgz",
-      "integrity": "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.0.tgz",
+      "integrity": "sha512-Tf98+epGGiPSHqmQHuXa2uXZMMvjGf1IqJDR1/FpXfmobv5ECN0mGZCjUHGNSyxvoDyXKIkKwJu7IwEoh0ouQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.4.0.tgz",
-      "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.0.tgz",
+      "integrity": "sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/webpack-bundler-runtime": "2.4.0"
+        "@module-federation/runtime": "2.8.0",
+        "@module-federation/webpack-bundler-runtime": "2.8.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.4.0.tgz",
-      "integrity": "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.0.tgz",
+      "integrity": "sha512-yBP+9+0Z8nlvKEXAZS3AsQVy7bFbZf8eMivGk4q4ZdwG3TsLMlsPjb1dQb2i7gcAG6ux9y2LWLkj/0LVk74cnQ==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "node-fetch": "^2.7.0 || ^3.3.2"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
+      "license": "MIT"
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.4.0.tgz",
-      "integrity": "sha512-4v24t6L3dET/6abMOM2fiM3roT0c8mi21/i+uDc6WG7U0i+Xp2SojBppTs6gnT0lkwMTe+u6xIpNQakdUftHsg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.8.0.tgz",
+      "integrity": "sha512-nAMlr74OKIylkfRwlunOhytQbmsgb3gCqdXWnPQhG+ZtqWXGELLfMT4a1Q1ht3cS+sRpWj2SZRqK2M7GadI6tA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-pkg": "2.0.0",
-        "resolve": "1.22.8"
-      }
+      "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.4.0.tgz",
-      "integrity": "sha512-Ntx0+QsgcwtXlpGjL/Vf2PMdPjUHl07b3yM4kBc1kbRogW3Ee84QneBRi/X3w4/jlz4JKbHjD+CMXaqi2W6hgw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.0.tgz",
+      "integrity": "sha512-82fDy9v+7qV5fiN8TKVhOdrxhmAZnUIX/IKivYX5ulCt8aoOzVFTiwm/P1GQUDD8z6dqR48xgJdZdf0548Mc9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.8.0",
+        "@module-federation/runtime": "2.8.0",
+        "@module-federation/sdk": "2.8.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7656,23 +7624,74 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.0.0.tgz",
-      "integrity": "sha512-aQyDH7l58K5Aci0DqKeon+f4GXhvAPFLJhUcb5iLyYJUvi311HgJ/mSr7sY2J0VTkFZE+M4/iqL+KLAANbH73g==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.7.tgz",
+      "integrity": "sha512-XU9LZuqT4+/2DTrpKnGDuGFKjwe7LRr5kMfT6EOPiPYCYkmtwXriMGiaRZNabb6kliVG3L34L7+TEiMUWRPCDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "^3.1.7",
+        "ejs": "5.0.1",
         "enquirer": "~2.3.6",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.3",
+        "minimatch": "10.2.5",
+        "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
         "nx": ">= 21 <= 23 || ^22.0.0-0"
+      }
+    },
+    "node_modules/@nx/devkit/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/devkit/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/devkit/node_modules/ejs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
+      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.12.18"
+      }
+    },
+    "node_modules/@nx/devkit/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@nx/eslint": {
@@ -7703,14 +7722,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.7.2.tgz",
-      "integrity": "sha512-OgfyUt4dUrlTHcnygVLXcxP0KH7yOAaB9pfdWLe86QRWm2Ei4sRdACltPRXoa9tDeEa4EdBvDTccw0AZ3UnrvQ==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.7.7.tgz",
+      "integrity": "sha512-XSpGOoMnUAO9uUTA0ZP7hTf67V6kHJrj+bc+zrfRzGGQys3f0SIlmgTA6L7lYsyG3Z42BxClW3jlxG83Cxoxrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/js": "22.7.2",
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "@typescript-eslint/type-utils": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0",
@@ -7731,33 +7750,292 @@
         }
       }
     },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
+    "node_modules/@nx/eslint-plugin/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/js": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
+      "integrity": "sha512-wjgr9LwT+ULkwjvX0CUMwK8BQ+wY53ipecGN/yCKptch5D5WXTOOBOx+YLrrrD8h+/amHy9jMqAg3ygryRkNhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-proposal-decorators": "^7.22.7",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-runtime": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-typescript": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
+        "@nx/devkit": "22.7.7",
+        "@nx/workspace": "22.7.7",
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
+        "babel-plugin-const-enum": "^1.0.1",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-typescript-metadata": "^0.3.1",
+        "chalk": "^4.1.0",
+        "columnify": "^1.6.0",
+        "detect-port": "^2.1.0",
+        "ignore": "^7.0.5",
+        "js-tokens": "^4.0.0",
+        "jsonc-parser": "3.2.0",
+        "npm-run-path": "^4.0.1",
+        "picocolors": "^1.1.0",
+        "picomatch": "4.0.4",
+        "semver": "^7.6.3",
+        "source-map-support": "0.5.19",
+        "tinyglobby": "^0.2.12",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "verdaccio": "^6.0.5"
+      },
+      "peerDependenciesMeta": {
+        "verdaccio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-arm64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
+      "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
+      "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-freebsd-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
+      "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
+      "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
+      "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
+      "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
+      "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
+      "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
+      "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
+      "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@nx/workspace": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
+      "integrity": "sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@zkochan/js-yaml": "0.0.7",
+        "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "minimatch": "10.2.5",
+        "nx": "22.7.7",
+        "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/brace-expansion": {
@@ -7773,6 +8051,44 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/@nx/eslint-plugin/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@nx/eslint-plugin/node_modules/ejs": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
@@ -7784,6 +8100,40 @@
       },
       "engines": {
         "node": ">=0.12.18"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/globals": {
@@ -7799,6 +8149,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@nx/eslint-plugin/node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nx/eslint-plugin/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7813,6 +8170,291 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/nx": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
+      "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "1.4.5",
+        "@emnapi/runtime": "1.4.5",
+        "@emnapi/wasi-threads": "1.0.4",
+        "@jest/diff-sequences": "30.0.1",
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@tybys/wasm-util": "0.9.0",
+        "@yarnpkg/lockfile": "1.1.0",
+        "@zkochan/js-yaml": "0.0.7",
+        "ansi-colors": "4.1.3",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "argparse": "2.0.1",
+        "asynckit": "0.4.0",
+        "axios": "1.16.0",
+        "balanced-match": "4.0.3",
+        "base64-js": "1.5.1",
+        "bl": "4.1.0",
+        "brace-expansion": "5.0.6",
+        "buffer": "5.7.1",
+        "call-bind-apply-helpers": "1.0.2",
+        "chalk": "4.1.2",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "8.0.1",
+        "clone": "1.0.4",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "combined-stream": "1.0.8",
+        "defaults": "1.0.4",
+        "define-lazy-prop": "2.0.0",
+        "delayed-stream": "1.0.0",
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.3",
+        "dunder-proto": "1.0.1",
+        "ejs": "5.0.1",
+        "emoji-regex": "8.0.0",
+        "end-of-stream": "1.4.5",
+        "enquirer": "2.3.6",
+        "es-define-property": "1.0.1",
+        "es-errors": "1.3.0",
+        "es-object-atoms": "1.1.1",
+        "es-set-tostringtag": "2.1.0",
+        "escalade": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "figures": "3.2.0",
+        "flat": "5.0.2",
+        "follow-redirects": "1.16.0",
+        "form-data": "4.0.6",
+        "fs-constants": "1.0.0",
+        "function-bind": "1.1.2",
+        "get-caller-file": "2.0.5",
+        "get-intrinsic": "1.3.0",
+        "get-proto": "1.0.1",
+        "gopd": "1.2.0",
+        "has-flag": "4.0.0",
+        "has-symbols": "1.1.0",
+        "has-tostringtag": "1.0.2",
+        "hasown": "2.0.4",
+        "ieee754": "1.2.1",
+        "ignore": "7.0.5",
+        "inherits": "2.0.4",
+        "is-docker": "2.2.1",
+        "is-fullwidth-code-point": "3.0.0",
+        "is-interactive": "1.0.0",
+        "is-unicode-supported": "0.1.0",
+        "is-wsl": "2.2.0",
+        "json5": "2.2.3",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "log-symbols": "4.1.0",
+        "math-intrinsics": "1.1.0",
+        "mime-db": "1.52.0",
+        "mime-types": "2.1.35",
+        "mimic-fn": "2.1.0",
+        "minimatch": "10.2.5",
+        "minimist": "1.2.8",
+        "npm-run-path": "4.0.1",
+        "once": "1.4.0",
+        "onetime": "5.1.2",
+        "open": "8.4.2",
+        "ora": "5.3.0",
+        "path-key": "3.1.1",
+        "picocolors": "1.1.1",
+        "proxy-from-env": "2.1.0",
+        "readable-stream": "3.6.2",
+        "require-directory": "2.1.1",
+        "resolve.exports": "2.0.3",
+        "restore-cursor": "3.1.0",
+        "safe-buffer": "5.2.1",
+        "semver": "7.7.4",
+        "signal-exit": "3.0.7",
+        "smol-toml": "1.6.1",
+        "string_decoder": "1.3.0",
+        "string-width": "4.2.3",
+        "strip-ansi": "6.0.1",
+        "strip-bom": "3.0.0",
+        "supports-color": "7.2.0",
+        "tar-stream": "2.2.0",
+        "tmp": "0.2.7",
+        "tree-kill": "1.2.2",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "util-deprecate": "1.0.2",
+        "wcwidth": "1.0.1",
+        "wrap-ansi": "7.0.0",
+        "wrappy": "1.0.2",
+        "y18n": "5.0.8",
+        "yaml": "2.9.0",
+        "yargs": "17.7.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "dist/bin/nx.js",
+        "nx-cloud": "dist/bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "22.7.7",
+        "@nx/nx-darwin-x64": "22.7.7",
+        "@nx/nx-freebsd-x64": "22.7.7",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.7",
+        "@nx/nx-linux-arm64-gnu": "22.7.7",
+        "@nx/nx-linux-arm64-musl": "22.7.7",
+        "@nx/nx-linux-x64-gnu": "22.7.7",
+        "@nx/nx-linux-x64-musl": "22.7.7",
+        "@nx/nx-win32-arm64-msvc": "22.7.7",
+        "@nx/nx-win32-x64-msvc": "22.7.7"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.11.1",
+        "@swc/core": "^1.15.8"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@nx/eslint-plugin/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
       }
     },
     "node_modules/@nx/eslint/node_modules/@nx/devkit": {
@@ -7832,6 +8474,179 @@
       },
       "peerDependencies": {
         "nx": ">= 21 <= 23 || ^22.0.0-0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-darwin-arm64": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-23.1.0.tgz",
+      "integrity": "sha512-wIFH5p0AXLxbYUHgYEH/zpWpPTQ9LpqESo/GcOPXkSBtUkSAZcqXZ6jmFzTPqGAeP4PBcVZIetO0TXmSSyEO7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-darwin-x64": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-23.1.0.tgz",
+      "integrity": "sha512-D7fEW3+agyb0cWGi8qgN/0irHUwcO8nsuYOrRJjphtWE6J76EORW5sMY93/YFfnLeFVhBMBNVrE6aj2Y4wYCbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-freebsd-x64": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-23.1.0.tgz",
+      "integrity": "sha512-yZoZyc9t3ViaA9WWDe5F7IlJ+58Hqdn6gqoO9UG2FH3Io1mj+KpF3jhUoj3S1m18D28MN2oItS762QIt6otO3g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-23.1.0.tgz",
+      "integrity": "sha512-D6QhBsLRUmwCc1jSjmY5MkyKOSWuQXQmu5K3BH6d1/uoX2HEZ68XgNyMkSwMA0g6jBKHIAguGkujiaCiXBEPeA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-23.1.0.tgz",
+      "integrity": "sha512-Q61stbUFVBw9TprlVLkRQmk+fuMXPlyTlvGExJ1y8KYymDTFsjs8LFk7zTnRvFpI9LVMRuhyD3osaLy2TxPU7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-23.1.0.tgz",
+      "integrity": "sha512-Lm5PC4yuBHw4gr37vcAX3kvS75prqL1VpbQkPHs4Z2Us1ri29ALxgdrEFgF6fbCXxl4w3sWmcbKGvrcMdpuvIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-23.1.0.tgz",
+      "integrity": "sha512-v1ELSkVskidK6A+mm/Ynm8TWIb5UdzGWMcD7CTgmvjTzKfXIO0QY1ToDTqvoBwnetcehWR5gnhQlhQgOSH8XFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-23.1.0.tgz",
+      "integrity": "sha512-pD/Axn0usK2/RV2bSrLX7h59YpOXGiaYHmlZynVVS+CqkKbyFzxnrvvLmRdOdMxsfM6oDXom4lCcJMg+wUYcpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-23.1.0.tgz",
+      "integrity": "sha512-lhnRaXPGUwqw/dqBnWl/6d6r8mRQXuZS7qnnTd+U5O1R7YPb2494BQyE7aSVEFLHcX9nXywMGxo5+OUCH84xQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-23.1.0.tgz",
+      "integrity": "sha512-fJaNYwNk4RiUnyEDTc0bMu69dmUzgM7iGinoqFenwYEtwaXPWREBRWL6lgRDyR3CFsJw3Wi0uc+33cfreTbhVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@nx/eslint/node_modules/balanced-match": {
@@ -7857,6 +8672,46 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/@nx/eslint/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@nx/eslint/node_modules/ejs": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
@@ -7868,6 +8723,43 @@
       },
       "engines": {
         "node": ">=0.12.18"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@nx/eslint/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@nx/eslint/node_modules/minimatch": {
@@ -7884,6 +8776,246 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/nx": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-23.1.0.tgz",
+      "integrity": "sha512-Z4hzIdRF6naDDpOTOazrJODmbU5D7slq94FR5q/dySW+evGxiOSFLO981VqDVvtNEvHPnEDh/C1wvFseWyvSrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.4.5",
+        "@emnapi/runtime": "1.4.5",
+        "@emnapi/wasi-threads": "1.0.4",
+        "@jest/diff-sequences": "30.0.1",
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@tybys/wasm-util": "0.9.0",
+        "@yarnpkg/lockfile": "1.1.0",
+        "@zkochan/js-yaml": "0.0.7",
+        "agent-base": "6.0.2",
+        "ansi-colors": "4.1.3",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "argparse": "2.0.1",
+        "asynckit": "0.4.0",
+        "axios": "1.16.1",
+        "balanced-match": "4.0.3",
+        "base64-js": "1.5.1",
+        "bl": "4.1.0",
+        "brace-expansion": "5.0.6",
+        "buffer": "5.7.1",
+        "call-bind-apply-helpers": "1.0.2",
+        "chalk": "4.1.2",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "8.0.1",
+        "clone": "1.0.4",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "combined-stream": "1.0.8",
+        "debug": "4.4.3",
+        "defaults": "1.0.4",
+        "define-lazy-prop": "2.0.0",
+        "delayed-stream": "1.0.0",
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.3",
+        "dunder-proto": "1.0.1",
+        "ejs": "5.0.1",
+        "emoji-regex": "8.0.0",
+        "end-of-stream": "1.4.5",
+        "enquirer": "2.3.6",
+        "es-define-property": "1.0.1",
+        "es-errors": "1.3.0",
+        "es-object-atoms": "1.1.1",
+        "es-set-tostringtag": "2.1.0",
+        "escalade": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "figures": "3.2.0",
+        "flat": "5.0.2",
+        "follow-redirects": "1.16.0",
+        "form-data": "4.0.6",
+        "fs-constants": "1.0.0",
+        "function-bind": "1.1.2",
+        "get-caller-file": "2.0.5",
+        "get-intrinsic": "1.3.0",
+        "get-proto": "1.0.1",
+        "gopd": "1.2.0",
+        "has-flag": "4.0.0",
+        "has-symbols": "1.1.0",
+        "has-tostringtag": "1.0.2",
+        "hasown": "2.0.4",
+        "https-proxy-agent": "5.0.1",
+        "ieee754": "1.2.1",
+        "ignore": "7.0.5",
+        "inherits": "2.0.4",
+        "is-docker": "2.2.1",
+        "is-fullwidth-code-point": "3.0.0",
+        "is-interactive": "1.0.0",
+        "is-unicode-supported": "0.1.0",
+        "is-wsl": "2.2.0",
+        "isexe": "2.0.0",
+        "json5": "2.2.3",
+        "jsonc-parser": "3.3.1",
+        "lines-and-columns": "2.0.3",
+        "log-symbols": "4.1.0",
+        "math-intrinsics": "1.1.0",
+        "mime-db": "1.52.0",
+        "mime-types": "2.1.35",
+        "mimic-fn": "2.1.0",
+        "minimatch": "10.2.5",
+        "minimist": "1.2.8",
+        "ms": "2.1.3",
+        "npm-run-path": "4.0.1",
+        "once": "1.4.0",
+        "onetime": "5.1.2",
+        "open": "8.4.2",
+        "ora": "5.4.1",
+        "path-key": "3.1.1",
+        "picocolors": "1.1.1",
+        "proxy-from-env": "2.1.0",
+        "readable-stream": "3.6.2",
+        "require-directory": "2.1.1",
+        "resolve.exports": "2.0.3",
+        "restore-cursor": "3.1.0",
+        "safe-buffer": "5.2.1",
+        "semver": "7.8.4",
+        "signal-exit": "3.0.7",
+        "smol-toml": "1.6.1",
+        "string_decoder": "1.3.0",
+        "string-width": "4.2.3",
+        "strip-ansi": "6.0.1",
+        "strip-bom": "3.0.0",
+        "supports-color": "7.2.0",
+        "tar-stream": "2.2.0",
+        "tmp": "0.2.7",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "util-deprecate": "1.0.2",
+        "wcwidth": "1.0.1",
+        "which": "3.0.1",
+        "wrap-ansi": "7.0.0",
+        "wrappy": "1.0.2",
+        "y18n": "5.0.8",
+        "yaml": "2.9.0",
+        "yargs": "17.7.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "dist/bin/nx.js",
+        "nx-cloud": "dist/bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "23.1.0",
+        "@nx/nx-darwin-x64": "23.1.0",
+        "@nx/nx-freebsd-x64": "23.1.0",
+        "@nx/nx-linux-arm-gnueabihf": "23.1.0",
+        "@nx/nx-linux-arm64-gnu": "23.1.0",
+        "@nx/nx-linux-arm64-musl": "23.1.0",
+        "@nx/nx-linux-x64-gnu": "23.1.0",
+        "@nx/nx-linux-x64-musl": "23.1.0",
+        "@nx/nx-win32-arm64-msvc": "23.1.0",
+        "@nx/nx-win32-x64-msvc": "23.1.0"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.11.1",
+        "@swc/core": "^1.15.8"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/nx/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@nx/eslint/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@nx/jest": {
@@ -8103,18 +9235,18 @@
       }
     },
     "node_modules/@nx/module-federation": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-22.7.2.tgz",
-      "integrity": "sha512-8KblqEdVw0b6uzhVSxz+RbjodN1BnHtWk1J4ndxG5XxiDLvW8bVEmpQAfn6DebsSRTIr+N/e3pah84j7xhZ9Yw==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/module-federation/-/module-federation-22.7.7.tgz",
+      "integrity": "sha512-m1T4j/E3lbob5uo02r0SQf9eLJqyX14WGI8EEOqLJ2+uQjURLxVCrOfGZpHJAmopcKK5HRVK/1zC+UvZYsAwLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@module-federation/enhanced": "^2.3.3",
         "@module-federation/node": "^2.7.21",
         "@module-federation/sdk": "^2.1.0",
-        "@nx/devkit": "22.7.2",
-        "@nx/js": "22.7.2",
-        "@nx/web": "22.7.2",
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "@nx/web": "22.7.7",
         "@rspack/core": "1.6.8",
         "express": "^4.21.2",
         "http-proxy-middleware": "^3.0.5",
@@ -8123,23 +9255,496 @@
         "webpack": "^5.101.3"
       }
     },
-    "node_modules/@nx/module-federation/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
+    "node_modules/@nx/module-federation/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/js": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
+      "integrity": "sha512-wjgr9LwT+ULkwjvX0CUMwK8BQ+wY53ipecGN/yCKptch5D5WXTOOBOx+YLrrrD8h+/amHy9jMqAg3ygryRkNhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-proposal-decorators": "^7.22.7",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-runtime": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-typescript": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
+        "@nx/devkit": "22.7.7",
+        "@nx/workspace": "22.7.7",
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
+        "babel-plugin-const-enum": "^1.0.1",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-typescript-metadata": "^0.3.1",
+        "chalk": "^4.1.0",
+        "columnify": "^1.6.0",
+        "detect-port": "^2.1.0",
+        "ignore": "^7.0.5",
+        "js-tokens": "^4.0.0",
+        "jsonc-parser": "3.2.0",
+        "npm-run-path": "^4.0.1",
+        "picocolors": "^1.1.0",
+        "picomatch": "4.0.4",
+        "semver": "^7.6.3",
+        "source-map-support": "0.5.19",
+        "tinyglobby": "^0.2.12",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "verdaccio": "^6.0.5"
+      },
+      "peerDependenciesMeta": {
+        "verdaccio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-darwin-arm64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
+      "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-darwin-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
+      "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-freebsd-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
+      "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
+      "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
+      "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
+      "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
+      "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
+      "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
+      "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
+      "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/web": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/web/-/web-22.7.7.tgz",
+      "integrity": "sha512-2XUG2IRhrPqxQvcNFxLytbslNT2sDPJvPnXE7EaZspRfD4bPt8rxVEnBzo5rm2hme5p3fht4HI4heHzcxQ4LfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "detect-port": "^2.1.0",
+        "http-server": "^14.1.0",
+        "picocolors": "^1.1.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@nx/cypress": "22.7.7",
+        "@nx/eslint": "22.7.7",
+        "@nx/jest": "22.7.7",
+        "@nx/playwright": "22.7.7",
+        "@nx/vite": "22.7.7",
+        "@nx/webpack": "22.7.7"
+      },
+      "peerDependenciesMeta": {
+        "@nx/cypress": {
+          "optional": true
+        },
+        "@nx/eslint": {
+          "optional": true
+        },
+        "@nx/jest": {
+          "optional": true
+        },
+        "@nx/playwright": {
+          "optional": true
+        },
+        "@nx/vite": {
+          "optional": true
+        },
+        "@nx/webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/workspace": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
+      "integrity": "sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@zkochan/js-yaml": "0.0.7",
+        "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "minimatch": "10.2.5",
+        "nx": "22.7.7",
+        "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/workspace/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/workspace/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/workspace/node_modules/nx": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
+      "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "1.4.5",
+        "@emnapi/runtime": "1.4.5",
+        "@emnapi/wasi-threads": "1.0.4",
+        "@jest/diff-sequences": "30.0.1",
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@tybys/wasm-util": "0.9.0",
+        "@yarnpkg/lockfile": "1.1.0",
+        "@zkochan/js-yaml": "0.0.7",
+        "ansi-colors": "4.1.3",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "argparse": "2.0.1",
+        "asynckit": "0.4.0",
+        "axios": "1.16.0",
+        "balanced-match": "4.0.3",
+        "base64-js": "1.5.1",
+        "bl": "4.1.0",
+        "brace-expansion": "5.0.6",
+        "buffer": "5.7.1",
+        "call-bind-apply-helpers": "1.0.2",
+        "chalk": "4.1.2",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "8.0.1",
+        "clone": "1.0.4",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "combined-stream": "1.0.8",
+        "defaults": "1.0.4",
+        "define-lazy-prop": "2.0.0",
+        "delayed-stream": "1.0.0",
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.3",
+        "dunder-proto": "1.0.1",
+        "ejs": "5.0.1",
+        "emoji-regex": "8.0.0",
+        "end-of-stream": "1.4.5",
+        "enquirer": "2.3.6",
+        "es-define-property": "1.0.1",
+        "es-errors": "1.3.0",
+        "es-object-atoms": "1.1.1",
+        "es-set-tostringtag": "2.1.0",
+        "escalade": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "figures": "3.2.0",
+        "flat": "5.0.2",
+        "follow-redirects": "1.16.0",
+        "form-data": "4.0.6",
+        "fs-constants": "1.0.0",
+        "function-bind": "1.1.2",
+        "get-caller-file": "2.0.5",
+        "get-intrinsic": "1.3.0",
+        "get-proto": "1.0.1",
+        "gopd": "1.2.0",
+        "has-flag": "4.0.0",
+        "has-symbols": "1.1.0",
+        "has-tostringtag": "1.0.2",
+        "hasown": "2.0.4",
+        "ieee754": "1.2.1",
+        "ignore": "7.0.5",
+        "inherits": "2.0.4",
+        "is-docker": "2.2.1",
+        "is-fullwidth-code-point": "3.0.0",
+        "is-interactive": "1.0.0",
+        "is-unicode-supported": "0.1.0",
+        "is-wsl": "2.2.0",
+        "json5": "2.2.3",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "log-symbols": "4.1.0",
+        "math-intrinsics": "1.1.0",
+        "mime-db": "1.52.0",
+        "mime-types": "2.1.35",
+        "mimic-fn": "2.1.0",
+        "minimatch": "10.2.5",
+        "minimist": "1.2.8",
+        "npm-run-path": "4.0.1",
+        "once": "1.4.0",
+        "onetime": "5.1.2",
+        "open": "8.4.2",
+        "ora": "5.3.0",
+        "path-key": "3.1.1",
+        "picocolors": "1.1.1",
+        "proxy-from-env": "2.1.0",
+        "readable-stream": "3.6.2",
+        "require-directory": "2.1.1",
+        "resolve.exports": "2.0.3",
+        "restore-cursor": "3.1.0",
+        "safe-buffer": "5.2.1",
+        "semver": "7.7.4",
+        "signal-exit": "3.0.7",
+        "smol-toml": "1.6.1",
+        "string_decoder": "1.3.0",
+        "string-width": "4.2.3",
+        "strip-ansi": "6.0.1",
+        "strip-bom": "3.0.0",
+        "supports-color": "7.2.0",
+        "tar-stream": "2.2.0",
+        "tmp": "0.2.7",
+        "tree-kill": "1.2.2",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "util-deprecate": "1.0.2",
+        "wcwidth": "1.0.1",
+        "wrap-ansi": "7.0.0",
+        "wrappy": "1.0.2",
+        "y18n": "5.0.8",
+        "yaml": "2.9.0",
+        "yargs": "17.7.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "dist/bin/nx.js",
+        "nx-cloud": "dist/bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "22.7.7",
+        "@nx/nx-darwin-x64": "22.7.7",
+        "@nx/nx-freebsd-x64": "22.7.7",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.7",
+        "@nx/nx-linux-arm64-gnu": "22.7.7",
+        "@nx/nx-linux-arm64-musl": "22.7.7",
+        "@nx/nx-linux-x64-gnu": "22.7.7",
+        "@nx/nx-linux-x64-musl": "22.7.7",
+        "@nx/nx-win32-arm64-msvc": "22.7.7",
+        "@nx/nx-win32-x64-msvc": "22.7.7"
       },
       "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
+        "@swc-node/register": "^1.11.1",
+        "@swc/core": "^1.15.8"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@nx/module-federation/node_modules/balanced-match": {
@@ -8153,9 +9758,9 @@
       }
     },
     "node_modules/@nx/module-federation/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8163,6 +9768,44 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nx/module-federation/node_modules/ejs": {
@@ -8178,6 +9821,47 @@
         "node": ">=0.12.18"
       }
     },
+    "node_modules/@nx/module-federation/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nx/module-federation/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nx/module-federation/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -8192,6 +9876,96 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
@@ -8335,18 +10109,18 @@
       ]
     },
     "node_modules/@nx/react": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/react/-/react-22.7.2.tgz",
-      "integrity": "sha512-4DtY5mtG1FT4MyavECkBzp0mehapM/DOeqeLjEtuYBvHkh3UnRcrGkV6eX5i0xZy3jQF8dhnO4HgCsSWOCbWCA==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/react/-/react-22.7.7.tgz",
+      "integrity": "sha512-vw1r8TA1PrB7yHSKub9LZZ67x6AUTR7/d2BGheClUgI62gwMqZOnZaB2u7EnKnU7JjeKEGMZgie0/NznV9GuFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/eslint": "22.7.2",
-        "@nx/js": "22.7.2",
-        "@nx/module-federation": "22.7.2",
-        "@nx/rollup": "22.7.2",
-        "@nx/web": "22.7.2",
+        "@nx/devkit": "22.7.7",
+        "@nx/eslint": "22.7.7",
+        "@nx/js": "22.7.7",
+        "@nx/module-federation": "22.7.7",
+        "@nx/rollup": "22.7.7",
+        "@nx/web": "22.7.7",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "@svgr/webpack": "^8.0.1",
         "express": "^4.21.2",
@@ -8357,26 +10131,581 @@
         "tslib": "^2.3.0"
       },
       "optionalDependencies": {
-        "@nx/vite": "22.7.2"
+        "@nx/vite": "22.7.7"
       }
     },
-    "node_modules/@nx/react/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
+    "node_modules/@nx/react/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/eslint": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.7.tgz",
+      "integrity": "sha512-mR4/EnzC8mR4tyH6jPbtaUq6dgq/dkpZrkm7WOlr8trvEhn8YoNPCnpIbsRmiJY0mZv8NX67IE8SpmBnzMpqnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "typescript": "~5.9.2"
+      },
+      "peerDependencies": {
+        "@nx/jest": "22.7.7",
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nx/jest": {
+          "optional": true
+        },
+        "@zkochan/js-yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/js": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
+      "integrity": "sha512-wjgr9LwT+ULkwjvX0CUMwK8BQ+wY53ipecGN/yCKptch5D5WXTOOBOx+YLrrrD8h+/amHy9jMqAg3ygryRkNhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-proposal-decorators": "^7.22.7",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-runtime": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-typescript": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
+        "@nx/devkit": "22.7.7",
+        "@nx/workspace": "22.7.7",
+        "@zkochan/js-yaml": "0.0.7",
+        "babel-plugin-const-enum": "^1.0.1",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-typescript-metadata": "^0.3.1",
+        "chalk": "^4.1.0",
+        "columnify": "^1.6.0",
+        "detect-port": "^2.1.0",
+        "ignore": "^7.0.5",
+        "js-tokens": "^4.0.0",
+        "jsonc-parser": "3.2.0",
+        "npm-run-path": "^4.0.1",
+        "picocolors": "^1.1.0",
+        "picomatch": "4.0.4",
+        "semver": "^7.6.3",
+        "source-map-support": "0.5.19",
+        "tinyglobby": "^0.2.12",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "verdaccio": "^6.0.5"
+      },
+      "peerDependenciesMeta": {
+        "verdaccio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-darwin-arm64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
+      "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-darwin-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
+      "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-freebsd-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
+      "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
+      "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
+      "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
+      "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
+      "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
+      "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
+      "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
+      "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/react/node_modules/@nx/vite": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/vite/-/vite-22.7.7.tgz",
+      "integrity": "sha512-t1zI8l1rzmaTA2jK2xsY26x6HZHvh53MSBHzqAnLDaxJgWcl/Gno2blAft7BaK7TORDMdF4Eo+kHzRk/mSHYWQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "@nx/vitest": "22.7.7",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "ajv": "^8.0.0",
         "enquirer": "~2.3.6",
-        "minimatch": "10.2.5",
+        "picomatch": "4.0.4",
+        "semver": "^7.6.3",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/vite/node_modules/@nx/vitest": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/vitest/-/vitest-22.7.7.tgz",
+      "integrity": "sha512-Xf4nTiwEYpjFmWP7Y6NuLIVOL8O2vs9JZWcQld0uyGoeyWnSHqbkwocOpt03kHpGKgzHnwA3QUG0avqksSaUZw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@nx/eslint": "22.7.7",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nx/eslint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/web": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/web/-/web-22.7.7.tgz",
+      "integrity": "sha512-2XUG2IRhrPqxQvcNFxLytbslNT2sDPJvPnXE7EaZspRfD4bPt8rxVEnBzo5rm2hme5p3fht4HI4heHzcxQ4LfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
+        "detect-port": "^2.1.0",
+        "http-server": "^14.1.0",
+        "picocolors": "^1.1.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@nx/cypress": "22.7.7",
+        "@nx/eslint": "22.7.7",
+        "@nx/jest": "22.7.7",
+        "@nx/playwright": "22.7.7",
+        "@nx/vite": "22.7.7",
+        "@nx/webpack": "22.7.7"
+      },
+      "peerDependenciesMeta": {
+        "@nx/cypress": {
+          "optional": true
+        },
+        "@nx/eslint": {
+          "optional": true
+        },
+        "@nx/jest": {
+          "optional": true
+        },
+        "@nx/playwright": {
+          "optional": true
+        },
+        "@nx/vite": {
+          "optional": true
+        },
+        "@nx/webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/workspace": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
+      "integrity": "sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@zkochan/js-yaml": "0.0.7",
+        "chalk": "^4.1.0",
+        "enquirer": "~2.3.6",
+        "nx": "22.7.7",
+        "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/workspace/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/workspace/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/react/node_modules/@nx/workspace/node_modules/nx": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
+      "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "1.4.5",
+        "@emnapi/runtime": "1.4.5",
+        "@emnapi/wasi-threads": "1.0.4",
+        "@jest/diff-sequences": "30.0.1",
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@tybys/wasm-util": "0.9.0",
+        "@yarnpkg/lockfile": "1.1.0",
+        "@zkochan/js-yaml": "0.0.7",
+        "ansi-colors": "4.1.3",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "argparse": "2.0.1",
+        "asynckit": "0.4.0",
+        "axios": "1.16.0",
+        "balanced-match": "4.0.3",
+        "base64-js": "1.5.1",
+        "bl": "4.1.0",
+        "brace-expansion": "5.0.6",
+        "buffer": "5.7.1",
+        "call-bind-apply-helpers": "1.0.2",
+        "chalk": "4.1.2",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "8.0.1",
+        "clone": "1.0.4",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "combined-stream": "1.0.8",
+        "defaults": "1.0.4",
+        "define-lazy-prop": "2.0.0",
+        "delayed-stream": "1.0.0",
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.3",
+        "dunder-proto": "1.0.1",
+        "ejs": "5.0.1",
+        "emoji-regex": "8.0.0",
+        "end-of-stream": "1.4.5",
+        "enquirer": "2.3.6",
+        "es-define-property": "1.0.1",
+        "es-errors": "1.3.0",
+        "es-object-atoms": "1.1.1",
+        "es-set-tostringtag": "2.1.0",
+        "escalade": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "figures": "3.2.0",
+        "flat": "5.0.2",
+        "follow-redirects": "1.16.0",
+        "form-data": "4.0.6",
+        "fs-constants": "1.0.0",
+        "function-bind": "1.1.2",
+        "get-caller-file": "2.0.5",
+        "get-intrinsic": "1.3.0",
+        "get-proto": "1.0.1",
+        "gopd": "1.2.0",
+        "has-flag": "4.0.0",
+        "has-symbols": "1.1.0",
+        "has-tostringtag": "1.0.2",
+        "hasown": "2.0.4",
+        "ieee754": "1.2.1",
+        "ignore": "7.0.5",
+        "inherits": "2.0.4",
+        "is-docker": "2.2.1",
+        "is-fullwidth-code-point": "3.0.0",
+        "is-interactive": "1.0.0",
+        "is-unicode-supported": "0.1.0",
+        "is-wsl": "2.2.0",
+        "json5": "2.2.3",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "log-symbols": "4.1.0",
+        "math-intrinsics": "1.1.0",
+        "mime-db": "1.52.0",
+        "mime-types": "2.1.35",
+        "mimic-fn": "2.1.0",
+        "minimatch": "10.2.5",
+        "minimist": "1.2.8",
+        "npm-run-path": "4.0.1",
+        "once": "1.4.0",
+        "onetime": "5.1.2",
+        "open": "8.4.2",
+        "ora": "5.3.0",
+        "path-key": "3.1.1",
+        "picocolors": "1.1.1",
+        "proxy-from-env": "2.1.0",
+        "readable-stream": "3.6.2",
+        "require-directory": "2.1.1",
+        "resolve.exports": "2.0.3",
+        "restore-cursor": "3.1.0",
+        "safe-buffer": "5.2.1",
+        "semver": "7.7.4",
+        "signal-exit": "3.0.7",
+        "smol-toml": "1.6.1",
+        "string_decoder": "1.3.0",
+        "string-width": "4.2.3",
+        "strip-ansi": "6.0.1",
+        "strip-bom": "3.0.0",
+        "supports-color": "7.2.0",
+        "tar-stream": "2.2.0",
+        "tmp": "0.2.7",
+        "tree-kill": "1.2.2",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "util-deprecate": "1.0.2",
+        "wcwidth": "1.0.1",
+        "wrap-ansi": "7.0.0",
+        "wrappy": "1.0.2",
+        "y18n": "5.0.8",
+        "yaml": "2.9.0",
+        "yargs": "17.7.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "dist/bin/nx.js",
+        "nx-cloud": "dist/bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "22.7.7",
+        "@nx/nx-darwin-x64": "22.7.7",
+        "@nx/nx-freebsd-x64": "22.7.7",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.7",
+        "@nx/nx-linux-arm64-gnu": "22.7.7",
+        "@nx/nx-linux-arm64-musl": "22.7.7",
+        "@nx/nx-linux-x64-gnu": "22.7.7",
+        "@nx/nx-linux-x64-musl": "22.7.7",
+        "@nx/nx-win32-arm64-msvc": "22.7.7",
+        "@nx/nx-win32-x64-msvc": "22.7.7"
       },
       "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
+        "@swc-node/register": "^1.11.1",
+        "@swc/core": "^1.15.8"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@nx/react/node_modules/balanced-match": {
@@ -8390,9 +10719,9 @@
       }
     },
     "node_modules/@nx/react/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8400,6 +10729,44 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nx/react/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@nx/react/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nx/react/node_modules/ejs": {
@@ -8414,6 +10781,47 @@
       "engines": {
         "node": ">=0.12.18"
       }
+    },
+    "node_modules/@nx/react/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nx/react/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nx/react/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@nx/react/node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nx/react/node_modules/minimatch": {
       "version": "10.2.5",
@@ -8431,15 +10839,200 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@nx/rollup": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/rollup/-/rollup-22.7.2.tgz",
-      "integrity": "sha512-GBONmIlDoDXHbkCk81a9mRUwk2yILRmkOMO2hcb62KwIEldEfzbZxSDk9eubryjEm29hx1WByi9lXyOrL6v5vw==",
+    "node_modules/@nx/react/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/js": "22.7.2",
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nx/react/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/react/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/react/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nx/react/node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/react/node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nx/react/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@nx/react/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@nx/rollup": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/rollup/-/rollup-22.7.7.tgz",
+      "integrity": "sha512-unS9+IR07ozRlWfoRO3PC/MiD+7i3/DUB/rPtfqZE4KmxgiBR5Dnj6MA5eElF9l2g8FCcb0b8B5C5fDU5Mcktg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@nx/js": "22.7.7",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-image": "^3.0.3",
@@ -8457,33 +11050,292 @@
         "tslib": "^2.3.0"
       }
     },
-    "node_modules/@nx/rollup/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
+    "node_modules/@nx/rollup/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/js": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.7.tgz",
+      "integrity": "sha512-wjgr9LwT+ULkwjvX0CUMwK8BQ+wY53ipecGN/yCKptch5D5WXTOOBOx+YLrrrD8h+/amHy9jMqAg3ygryRkNhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@babel/plugin-proposal-decorators": "^7.22.7",
+        "@babel/plugin-transform-class-properties": "^7.22.5",
+        "@babel/plugin-transform-runtime": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-typescript": "^7.22.5",
+        "@babel/runtime": "^7.22.6",
+        "@nx/devkit": "22.7.7",
+        "@nx/workspace": "22.7.7",
         "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
+        "babel-plugin-const-enum": "^1.0.1",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-typescript-metadata": "^0.3.1",
+        "chalk": "^4.1.0",
+        "columnify": "^1.6.0",
+        "detect-port": "^2.1.0",
+        "ignore": "^7.0.5",
+        "js-tokens": "^4.0.0",
+        "jsonc-parser": "3.2.0",
+        "npm-run-path": "^4.0.1",
+        "picocolors": "^1.1.0",
+        "picomatch": "4.0.4",
+        "semver": "^7.6.3",
+        "source-map-support": "0.5.19",
+        "tinyglobby": "^0.2.12",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "verdaccio": "^6.0.5"
+      },
+      "peerDependenciesMeta": {
+        "verdaccio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-darwin-arm64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
+      "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-darwin-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
+      "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-freebsd-x64": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
+      "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-linux-arm-gnueabihf": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
+      "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-linux-arm64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
+      "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-linux-arm64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
+      "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-linux-x64-gnu": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
+      "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-linux-x64-musl": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
+      "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-win32-arm64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
+      "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/nx-win32-x64-msvc": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
+      "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@nx/rollup/node_modules/@nx/workspace": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.7.tgz",
+      "integrity": "sha512-tDSOWUEjTyEjoUKGSFyUGrFaCpScoFa8lRR0jorM169a3dA4iqwgkppcltR/uwklLw/aNSSW6J92DAzSRuOLnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nx/devkit": "22.7.7",
+        "@zkochan/js-yaml": "0.0.7",
+        "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "minimatch": "10.2.5",
+        "nx": "22.7.7",
+        "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@nx/rollup/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@nx/rollup/node_modules/brace-expansion": {
@@ -8499,6 +11351,44 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/@nx/rollup/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@nx/rollup/node_modules/ejs": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
@@ -8511,6 +11401,47 @@
       "engines": {
         "node": ">=0.12.18"
       }
+    },
+    "node_modules/@nx/rollup/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nx/rollup/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nx/rollup/node_modules/minimatch": {
       "version": "10.2.5",
@@ -8528,211 +11459,242 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@nx/vite": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/vite/-/vite-22.7.2.tgz",
-      "integrity": "sha512-EsFOp00f3/eFL4GirRBuHktFj/Bm7VL7kvMFru73bCqqQZsdFSGZT8puwYm77NBZB0if5cxkaynysiEmNpVCpw==",
+    "node_modules/@nx/rollup/node_modules/nx": {
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
+      "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/js": "22.7.2",
-        "@nx/vitest": "22.7.2",
-        "@phenomnomnominal/tsquery": "~6.2.0",
-        "ajv": "^8.0.0",
-        "enquirer": "~2.3.6",
-        "picomatch": "4.0.4",
-        "semver": "^7.6.3",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@nx/vite/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
+        "@emnapi/core": "1.4.5",
+        "@emnapi/runtime": "1.4.5",
+        "@emnapi/wasi-threads": "1.0.4",
+        "@jest/diff-sequences": "30.0.1",
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@tybys/wasm-util": "0.9.0",
+        "@yarnpkg/lockfile": "1.1.0",
         "@zkochan/js-yaml": "0.0.7",
+        "ansi-colors": "4.1.3",
+        "ansi-regex": "5.0.1",
+        "ansi-styles": "4.3.0",
+        "argparse": "2.0.1",
+        "asynckit": "0.4.0",
+        "axios": "1.16.0",
+        "balanced-match": "4.0.3",
+        "base64-js": "1.5.1",
+        "bl": "4.1.0",
+        "brace-expansion": "5.0.6",
+        "buffer": "5.7.1",
+        "call-bind-apply-helpers": "1.0.2",
+        "chalk": "4.1.2",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "8.0.1",
+        "clone": "1.0.4",
+        "color-convert": "2.0.1",
+        "color-name": "1.1.4",
+        "combined-stream": "1.0.8",
+        "defaults": "1.0.4",
+        "define-lazy-prop": "2.0.0",
+        "delayed-stream": "1.0.0",
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.3",
+        "dunder-proto": "1.0.1",
         "ejs": "5.0.1",
-        "enquirer": "~2.3.6",
+        "emoji-regex": "8.0.0",
+        "end-of-stream": "1.4.5",
+        "enquirer": "2.3.6",
+        "es-define-property": "1.0.1",
+        "es-errors": "1.3.0",
+        "es-object-atoms": "1.1.1",
+        "es-set-tostringtag": "2.1.0",
+        "escalade": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "figures": "3.2.0",
+        "flat": "5.0.2",
+        "follow-redirects": "1.16.0",
+        "form-data": "4.0.6",
+        "fs-constants": "1.0.0",
+        "function-bind": "1.1.2",
+        "get-caller-file": "2.0.5",
+        "get-intrinsic": "1.3.0",
+        "get-proto": "1.0.1",
+        "gopd": "1.2.0",
+        "has-flag": "4.0.0",
+        "has-symbols": "1.1.0",
+        "has-tostringtag": "1.0.2",
+        "hasown": "2.0.4",
+        "ieee754": "1.2.1",
+        "ignore": "7.0.5",
+        "inherits": "2.0.4",
+        "is-docker": "2.2.1",
+        "is-fullwidth-code-point": "3.0.0",
+        "is-interactive": "1.0.0",
+        "is-unicode-supported": "0.1.0",
+        "is-wsl": "2.2.0",
+        "json5": "2.2.3",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "log-symbols": "4.1.0",
+        "math-intrinsics": "1.1.0",
+        "mime-db": "1.52.0",
+        "mime-types": "2.1.35",
+        "mimic-fn": "2.1.0",
         "minimatch": "10.2.5",
-        "semver": "^7.6.3",
-        "tslib": "^2.3.0",
+        "minimist": "1.2.8",
+        "npm-run-path": "4.0.1",
+        "once": "1.4.0",
+        "onetime": "5.1.2",
+        "open": "8.4.2",
+        "ora": "5.3.0",
+        "path-key": "3.1.1",
+        "picocolors": "1.1.1",
+        "proxy-from-env": "2.1.0",
+        "readable-stream": "3.6.2",
+        "require-directory": "2.1.1",
+        "resolve.exports": "2.0.3",
+        "restore-cursor": "3.1.0",
+        "safe-buffer": "5.2.1",
+        "semver": "7.7.4",
+        "signal-exit": "3.0.7",
+        "smol-toml": "1.6.1",
+        "string_decoder": "1.3.0",
+        "string-width": "4.2.3",
+        "strip-ansi": "6.0.1",
+        "strip-bom": "3.0.0",
+        "supports-color": "7.2.0",
+        "tar-stream": "2.2.0",
+        "tmp": "0.2.7",
+        "tree-kill": "1.2.2",
+        "tsconfig-paths": "4.2.0",
+        "tslib": "2.8.1",
+        "util-deprecate": "1.0.2",
+        "wcwidth": "1.0.1",
+        "wrap-ansi": "7.0.0",
+        "wrappy": "1.0.2",
+        "y18n": "5.0.8",
+        "yaml": "2.9.0",
+        "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
       },
-      "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
-      }
-    },
-    "node_modules/@nx/vite/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/vite/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/vite/node_modules/ejs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
-      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
       "bin": {
-        "ejs": "bin/cli.js"
+        "nx": "dist/bin/nx.js",
+        "nx-cloud": "dist/bin/nx-cloud.js"
       },
-      "engines": {
-        "node": ">=0.12.18"
-      }
-    },
-    "node_modules/@nx/vite/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@nx/vitest": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/vitest/-/vitest-22.7.2.tgz",
-      "integrity": "sha512-i3Tl3tgxi8Gr6DGodvbZSF9cJE2Uno5/HOQENn5DfWnXa1KDyBR4+w4lZhf2T3TCeTOFghZd1pESWVCDfgCjvA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/js": "22.7.2",
-        "@phenomnomnominal/tsquery": "~6.2.0",
-        "semver": "^7.6.3",
-        "tslib": "^2.3.0"
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "22.7.7",
+        "@nx/nx-darwin-x64": "22.7.7",
+        "@nx/nx-freebsd-x64": "22.7.7",
+        "@nx/nx-linux-arm-gnueabihf": "22.7.7",
+        "@nx/nx-linux-arm64-gnu": "22.7.7",
+        "@nx/nx-linux-arm64-musl": "22.7.7",
+        "@nx/nx-linux-x64-gnu": "22.7.7",
+        "@nx/nx-linux-x64-musl": "22.7.7",
+        "@nx/nx-win32-arm64-msvc": "22.7.7",
+        "@nx/nx-win32-x64-msvc": "22.7.7"
       },
       "peerDependencies": {
-        "@nx/eslint": "22.7.2",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+        "@swc-node/register": "^1.11.1",
+        "@swc/core": "^1.15.8"
       },
       "peerDependenciesMeta": {
-        "@nx/eslint": {
+        "@swc-node/register": {
           "optional": true
         },
-        "vite": {
-          "optional": true
-        },
-        "vitest": {
+        "@swc/core": {
           "optional": true
         }
       }
     },
-    "node_modules/@nx/vitest/node_modules/@nx/devkit": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.2.tgz",
-      "integrity": "sha512-oE2SFUxQeZm/EmFABHpWQ4Pi0fBKbJbXKGPvdFaHoMumRxhqBhuBVf/ap5kYFg8Y9bK/zHJkpsEbGyiyRrhvog==",
+    "node_modules/@nx/rollup/node_modules/ora": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@zkochan/js-yaml": "0.0.7",
-        "ejs": "5.0.1",
-        "enquirer": "~2.3.6",
-        "minimatch": "10.2.5",
-        "semver": "^7.6.3",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
-      }
-    },
-    "node_modules/@nx/vitest/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/vitest/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
+        "bl": "^4.0.3",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^4.0.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@nx/vitest/node_modules/ejs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
-      "integrity": "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.12.18"
-      }
-    },
-    "node_modules/@nx/vitest/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@nx/rollup/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@nx/web": {
@@ -10587,14 +13549,370 @@
       "link": true
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.1.0",
@@ -10779,9 +14097,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11397,9 +14715,9 @@
       "license": "MIT"
     },
     "node_modules/@scalprum/core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.9.2.tgz",
-      "integrity": "sha512-IfyoERrtCY3ZcfAyHx9qSU5Uf5hYWGqZeDgwY2gmSd1UO4XyVS4AY8NkUPAgsGGIQuDqkWWSe6qVwbv/f7WAfg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.9.3.tgz",
+      "integrity": "sha512-n21OtoG44zIaqafuUKPn65MELbpRRo4Jv2/Ci8UsMm00Nk6oMB4h/mBy8Y/ztqjo0vKDFrHfR4sryVSy7uS0Bw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
@@ -11407,18 +14725,67 @@
       }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.11.2.tgz",
-      "integrity": "sha512-9vasr0Ucaea5ssEmAIUb0lyyQTjkd+FV6khbfwTMBV0AdEH6FWW89DIttPEoDrbtEcO1D3ufDNAY5fn1PIDLkA==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.13.1.tgz",
+      "integrity": "sha512-uSQzA6mPMVbR6bhmh6u2JjaJJLMo2oO3Akf/SGvDgwPOjDReQESsY3eIBiFBaRNmGodAYcTwjVrmfoyIh6KmMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.9.1",
+        "@openshift/dynamic-plugin-sdk": "^8.0.0",
+        "@scalprum/core": "^0.10.1",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
+        "react": ">=17.0.0 <20.0.0",
+        "react-dom": ">=17.0.0 <20.0.0"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-8.2.0.tgz",
+      "integrity": "sha512-HKt8ILsf4+He+XqhIZI1PU7Xm+orA03WoVSQDYZdfpYByJbc8JxmBmv5u0Z8RZG0bg+EkCzicKvU91manNP2fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.23",
+        "semver": "^7.7.3",
+        "uuid": "^8.3.2",
+        "yup": "^1.7.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.10.1.tgz",
+      "integrity": "sha512-LlUy0stiE2HQ1j41G6yTh+9IPQiJAglVGxmaX8MGExI9SVOSjkjUaG7wd6cSga9XKRsvrFU8FzQ9bj6BWmz4lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^8.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@segment/analytics-core": {
@@ -14909,13 +18276,6 @@
         "htmlparser2": "^10.1"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -16284,9 +19644,9 @@
       }
     },
     "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -17606,12 +20966,13 @@
       "license": "MIT"
     },
     "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -19653,19 +23014,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "luxon": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -21209,9 +24557,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -22752,19 +26100,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "homedir-polyfill": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/expect": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
@@ -22924,12 +26259,13 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -23301,32 +26637,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-file-up": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
-      "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-dir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
-      "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-file-up": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-process": {
@@ -24118,58 +27428,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/global-modules": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix/node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/globals": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
@@ -24455,9 +27713,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -25199,9 +28457,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25213,7 +28471,7 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-server": {
@@ -30873,9 +34131,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -30902,9 +34160,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -31436,13 +34704,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/launder": {
@@ -31595,6 +34863,292 @@
         "webpack-sources": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -31906,13 +35460,6 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
-    "node_modules/long-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -31953,16 +35500,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -32954,9 +36491,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -33037,16 +36574,16 @@
       }
     },
     "node_modules/ngx-deploy-npm": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-deploy-npm/-/ngx-deploy-npm-9.0.0.tgz",
-      "integrity": "sha512-1SKx2vbW5MShHtSE9OsNDb+N2I5CrUF5gUE+OqgyWiNGT36i/fLBghLPO1EI84jTV9navEslngbD73hZRJGgaA==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-deploy-npm/-/ngx-deploy-npm-9.2.1.tgz",
+      "integrity": "sha512-tB6YZbK9A2YpV6V9MhvV6QLzrB1YNoJBjsUpDD4xK221wLJzvyPJhxbRGNucbpS70G1QPHC0PT9mt8vCPMSePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@nx/devkit": ">=19.0.0 <=22.0.0",
+        "@nx/devkit": ">=19.0.0",
         "tslib": "^2.3.0"
       }
     },
@@ -33184,21 +36721,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
       "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "license": "MIT"
-    },
-    "node_modules/node-schedule": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
-      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cron-parser": "^4.2.0",
-        "long-timeout": "0.1.1",
-        "sorted-array-functions": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/node-source-walk": {
       "version": "7.0.2",
@@ -33464,6 +36986,36 @@
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/nx/node_modules/axios/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/nx/node_modules/axios/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/nx/node_modules/balanced-match": {
@@ -35031,9 +38583,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -35050,7 +38602,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -36458,13 +40010,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -36474,14 +40026,14 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -37007,20 +40559,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -37164,6 +40702,54 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/rollup": {
@@ -38053,9 +41639,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -38298,9 +41884,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -38310,14 +41896,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -38462,13 +42048,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/sorted-array-functions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
-      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -39935,6 +43514,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -39968,9 +43553,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -40038,9 +43623,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -40685,9 +44270,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -41005,17 +44590,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/upath": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -42086,9 +45660,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -42110,7 +45684,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
@@ -42195,9 +45769,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -42411,9 +45985,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
@@ -42691,9 +46265,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -42945,7 +46519,7 @@
         "@types/react": "^18.0.0"
       },
       "peerDependencies": {
-        "@scalprum/react-core": "^0.11.1",
+        "@scalprum/react-core": "^0.13.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.0.0"
@@ -42960,7 +46534,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.0",
         "@redhat-cloud-services/types": "^3.0.0",
         "@scalprum/core": "^0.9.2",
-        "@scalprum/react-core": "^0.11.2",
+        "@scalprum/react-core": "^0.13.1",
         "classnames": "^2.2.5",
         "sanitize-html": "^2.13.1"
       },
@@ -43280,9 +46854,9 @@
       }
     },
     "packages/config/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15649,13 +15649,6 @@
         }
       }
     },
-    "node_modules/@storybook/preset-react-webpack/node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@storybook/react": {
       "version": "10.4.6",
       "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.6.tgz",
@@ -18275,6 +18268,13 @@
       "dependencies": {
         "htmlparser2": "^10.1"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -47048,7 +47048,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@types/fs-extra": "^11.0.4"
+        "@types/fs-extra": "^11.0.4",
+        "@types/semver": "^7.5.8"
       }
     },
     "packages/executors/node_modules/@jest/schemas": {

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@scalprum/react-core": "^0.11.1",
+    "@scalprum/react-core": "^0.13.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.0.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,7 +41,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "^7.0.0",
     "@redhat-cloud-services/types": "^3.0.0",
     "@scalprum/core": "^0.9.2",
-    "@scalprum/react-core": "^0.11.2",
+    "@scalprum/react-core": "^0.13.1",
     "classnames": "^2.2.5",
     "sanitize-html": "^2.13.1"
   },

--- a/packages/executors/package.json
+++ b/packages/executors/package.json
@@ -15,6 +15,7 @@
   "typings": "./src/index.d.ts",
   "executors": "./executors.json",
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4"
+    "@types/fs-extra": "^11.0.4",
+    "@types/semver": "^7.5.8"
   }
 }


### PR DESCRIPTION
### Description
     
  [RHCLOUD-49441](https://issues.redhat.com/browse/RHCLOUD-49441)

  Updates `@scalprum/react-core` peer dependency from `^0.11.x` to `^0.13.1` in chrome and components packages. Version 0.13.1 fixes TypeScript compilation errors when passing extra props to `ScalprumComponent` by changing the `Props` generic default from `{}` to `Record<string, any>`. This unblocks insights-chrome from building with custom props on federated components.

  ---

  ### Screenshots

  _(Deleted - no UI changes, peer dependency update only)_

  ---

  ### Anything reviewers should know?

  - Peer dependency only - no source code changes in chrome or components packages
  - Consuming apps (insights-chrome) will need to upgrade these packages to get the fix
  - Scalprum fixed the type issue in [commit e137d07](https://github.com/scalprum/scaffolding/commit/e137d07)

  ---

  ### Checklist
  - [x] Accessibility: N/A (no UI changes)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [x] _(Optional) QE: N/A - peer dependency version bump_
  - [x] _(Optional) UX: N/A - no user-facing changes_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-49441]: https://redhat.atlassian.net/browse/RHCLOUD-49441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the React core library version used by the Chrome package and shared components.
  * Incorporates the latest available React core improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->