### PR TITLE
fix: force release for scalprum peer dependency update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,7 @@ With `conventionalCommits: true`, Nx reads the current version from the latest m
 4. Apply conventional-commit bump rules (see [Commit Message & Release Rules](#commit-message--release-rules-important-for-ai-tools) above)
 5. Highest bump across all matching commits wins
 6. **No matching `feat`/`fix` commits = package is skipped entirely** -- no bump, no publish
+7. Nx requires **actual file changes** in the package directory for versioning commits (`feat`/`fix`). Empty commits with correct scope/type are **ignored** -- Nx reports "No files changed as a result of running versioning" and skips publishing. To force a release, touch a real file (e.g., add whitespace to `src/index.ts`).
 
 **What `package.json` version means**: Updated by `nx release` in both `{projectRoot}/package.json` and `dist/{projectName}/package.json`. It reflects the last released version, not the source for calculating the next one.
 

--- a/packages/chrome/src/index.ts
+++ b/packages/chrome/src/index.ts
@@ -1,5 +1,6 @@
 export * from './ChromeProvider';
 export * from './ChromeContext';
+
 export * from './useLastVisited';
 export * from './useFavoritePages';
 export * from './useVisitedBundles';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 import * as t from '@redhat-cloud-services/types'; // required to get the API. We can't use simple import due to tree shaking
+
 export * from './Section';
 export * from './Ansible';
 export * from './Main';


### PR DESCRIPTION
### Description

  PR #2383 updated `@scalprum/react-core` from `^0.11.x` to `^0.13.1` in chrome and components packages but used `chore(deps):` commit type, which doesn't trigger releases. 
  PR #2385 attempted to force releases with empty `fix()` commits, but Nx requires actual file changes alongside correct commit scope to bump versions — empty commits are  ignored. This PR adds trivial whitespace changes to trigger patch releases (chrome 2.4.1 → 2.4.2, components 7.10.2 → 7.10.3) that will publish the scalprum 0.13.1 peer dependency update to npm, unblocking insights-chrome TypeScript compilation.

  [RHCLOUD-49441](https://issues.redhat.com/browse/RHCLOUD-49441)

  ---

  ### Screenshots

  N/A — non-visual change (dependency version release)

  ---

  ### Anything reviewers should know?

  - **Why whitespace changes**: Nx `useCommitScope: true` requires file diffs in package directories for `feat`/`fix` commits to trigger version bumps. Empty commits with correct scope are silently skipped during `nx release`.
  - **Verification**: After merge, check `npm view @redhat-cloud-services/chrome@2.4.2 peerDependencies` — should show `@scalprum/react-core: ^0.13.1` (currently shows
  `^0.11.1`).
  - **Unblocks**: RHCLOUD-48802 (insights-chrome TS compilation failures due to old scalprum peer dep).
  - **Docs update**: Added note to CLAUDE.md documenting that empty commits don't trigger Nx releases (prevents future confusion).

  ---

  ### Checklist
  - [x] Accessibility: N/A — no UI changes
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-49441]: https://redhat.atlassian.net/browse/RHCLOUD-49441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the Chrome package’s publicly available exports, making additional functionality accessible to consumers.

- **Documentation**
  - Clarified how versioning handles commits without actual package file changes, including when releases may be skipped and how to trigger a release when needed.

- **Style**
  - Applied a minor formatting improvement to the components package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->