### PR TITLE
ci(workflows): serialize release jobs to prevent push conflicts

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -32,11 +32,21 @@ runs:
         git config commit.gpgsign true
         git config tag.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
+    - name: Fast-forward to latest master
+      shell: bash
+      # Checkout is pinned to github.sha. If a prior release pushed commits/tags while this job
+      # was queued, those tags won't be reachable from our stale HEAD. Both verify-versions.sh and
+      # nx release use --merged HEAD for tag resolution, so HEAD must be current. This rebase is
+      # always a fast-forward (no local commits yet).
+      run: |
+        git fetch origin master
+        git rebase origin/master
     - name: Verify version consistency
       shell: bash
       run: bash .github/scripts/verify-versions.sh
     - name: Release
       shell: bash
+      # Skip publish to avoid orphaned npm versions if push fails.
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
         GITHUB_TOKEN: ${{ inputs.gh_token }}
@@ -47,7 +57,7 @@ runs:
         # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
         # https://philna.sh/blog/2026/01/28/trusted-publishing-npm/
         NPM_CONFIG_PROVENANCE: true
-      run: npx nx release --yes
+      run: npx nx release --skip-publish
     - name: Push release commit and tags
       shell: bash
       # nx release (unified command) creates the git commit and tags locally but does not push them,
@@ -55,8 +65,23 @@ runs:
       # createRelease (GitHub/GitLab releases) is enabled. Since we use createReleaseInGitHub: false,
       # we push manually here so that the version bumps in package.json reach the remote and
       # nacho-bot can create PRs in consuming repos.
+      # Rebase before push: if a PR merged to master while nx release was running, the version
+      # commit needs to be on top of latest master to avoid non-fast-forward rejection. This rebase
+      # replays only the single version commit created by nx release (merge commit that triggered
+      # this workflow is always an ancestor of origin/master).
       # HUSKY=0 disables pre-push hooks in CI — tests are run separately by the CI pipeline.
       env:
         HUSKY: '0'
-      run: git push --follow-tags
-  
+      run: |
+        git fetch origin master
+        git rebase origin/master
+        git push --follow-tags
+    - name: Publish to npm
+      shell: bash
+      # Publish only after push succeeds to prevent orphaned npm versions.
+      # If push failed, re-running this job is safe — no npm versions published yet.
+      # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
+      # https://philna.sh/blog/2026/01/28/trusted-publishing-npm/
+      env:
+        NPM_CONFIG_PROVENANCE: true
+      run: npx nx release publish

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -82,6 +82,10 @@ done
 echo ""
 if [[ $mismatch -ne 0 ]]; then
   echo "Version verification FAILED. Fix mismatches before releasing."
+  echo ""
+  echo "If disk and tag match but npm is behind, a prior npm publish likely failed."
+  echo "Pull latest main with tags, build, and run 'npx nx release publish' to recover."
+  echo "Subsequent releases will remain blocked until the missing version is published."
   exit 1
 else
   echo "All package versions are aligned across disk, git tags, and npm registry."

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 mismatch=0
+registry_error=0
+npm_stderr_file="$(mktemp)"
+trap 'rm -f "$npm_stderr_file"' EXIT  # clean up temp file on exit
 # Column widths for alignment
 printf "%-60s %-12s %-12s %-15s %s\n" "PACKAGE" "DISK" "GIT TAG" "NPM" "STATUS"
 printf '%.0s-' {1..110}
@@ -56,13 +59,25 @@ for dir in "$REPO_ROOT"/packages/*/; do
   [[ -z "$tag_ver" ]] && tag_ver="NONE"
 
   # --- npm registry version ---
-  npm_ver="$(npm view "$pkg" version --fetch-timeout=10000 2>/dev/null)" || true
-  [[ -z "$npm_ver" ]] && npm_ver="NOT_ON_NPM"
+  npm_ver="$(npm view "$pkg" version --fetch-timeout=10000 2>"$npm_stderr_file")" && npm_rc=0 || npm_rc=$?
+  if [[ $npm_rc -ne 0 ]]; then
+    if grep -q 'E404' "$npm_stderr_file"; then
+      npm_ver="NOT_ON_NPM"
+    else
+      npm_ver="REGISTRY_ERROR"
+    fi
+  fi
 
   # --- Compare ---
   if [[ "$disk_ver" == "$tag_ver" && "$disk_ver" == "$npm_ver" ]]; then
     status="OK"
     marker="✓"
+  elif [[ "$npm_ver" == "REGISTRY_ERROR" ]]; then
+    status="REGISTRY_ERROR"
+    marker="✗"
+    mismatch=1
+    registry_error=1
+    echo "::error::${pkg}: npm registry lookup failed (timeout, auth, or outage). Cannot verify npm version."
   elif [[ "$tag_ver" == "NONE" && "$npm_ver" == "NOT_ON_NPM" ]]; then
     # New package: no tag, not published. Flag as informational but still a mismatch.
     status="NEW_PACKAGE"
@@ -82,10 +97,16 @@ done
 echo ""
 if [[ $mismatch -ne 0 ]]; then
   echo "Version verification FAILED. Fix mismatches before releasing."
-  echo ""
-  echo "If disk and tag match but npm is behind, a prior npm publish likely failed."
-  echo "Pull latest main with tags, build, and run 'npx nx release publish' to recover."
-  echo "Subsequent releases will remain blocked until the missing version is published."
+  if [[ $registry_error -ne 0 ]]; then
+    echo ""
+    echo "npm registry lookup failed for one or more packages. Check registry status,"
+    echo "network connectivity, and npm authentication before re-running."
+  else
+    echo ""
+    echo "If disk and tag match but npm is behind, a prior npm publish likely failed."
+    echo "Pull latest main with tags, build, and run 'npx nx release publish' to recover."
+    echo "Subsequent releases will remain blocked until the missing version is published."
+  fi
   exit 1
 else
   echo "All package versions are aligned across disk, git tags, and npm registry."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,11 @@ jobs:
     # Only run on push to master branch (never on PRs, workflow_dispatch, etc.)
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     environment: npm-publish
+    # Serialize release jobs to prevent concurrent git pushes to master.
+    concurrency:
+      group: ${{ github.workflow }}-release
+      cancel-in-progress: false
+      queue: max
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
### Description

  [RHCLOUD-49470](https://issues.redhat.com/browse/RHCLOUD-49470)

  Adds concurrency control to the release job in CI workflow to prevent race conditions when multiple commits land on master in quick succession. Previously, overlapping release jobs would fail with `git push --follow-tags` non-fast-forward errors. The `concurrency` block creates a FIFO queue that serializes release jobs instead of allowing them to run in parallel.

  ---

  ### Anything reviewers should know?

  Fix 1 from RHCLOUD-49470 (commitlint `body-max-line-length`) was already resolved in PR #2379. This PR only addresses Fix 2 (release job serialization).

  The `cancel-in-progress: false` setting ensures jobs queue rather than cancel in-flight releases.

  ---

  ### Checklist
  - [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-49470]: https://redhat.atlassian.net/browse/RHCLOUD-49470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced non-fast-forward release push failures by rebasing queued work onto the latest `master` before release steps and again before pushing.
  * Prevented orphaned npm releases by publishing only after a successful push.
* **Chores**
  * Serialized `master` release runs with concurrency control to avoid overlapping releases.
  * Improved version verification messaging by clearly separating npm registry lookup errors from actual version mismatches, with more targeted recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->