### PR TITLE
ci: add PR title validation with commitlint

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,27 @@
+name: PR title lint
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: './.github/actions/setup-environment'
+      - name: Install
+        shell: bash
+        run: npm ci
+      - name: Validate PR title with commitlint
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint --verbose


### PR DESCRIPTION
### Description
     
  Add PR title validation workflow to prevent invalid squash-merge commit messages. New workflow runs commitlint against PR title on open/edit/reopen, applying same rules as individual commits including custom `scope-full-name-for-versioning` check. Since GitHub uses PR title as default squash-merge message, this catches format violations before merge.

  ---

  ### Anything reviewers should know?

  **Limitation**: Reviewers can still override squash-merge message in GitHub UI to invalid format. This workflow only validates PR title (the default). Post-merge commitlint on `push` will catch overrides, but commit already on `master` by then. No technical solution exists for blocking reviewer override at squash-merge time (GitHub limitation).

  **After merge**: Add `pr-title-lint` job as required status check in branch protection settings.

  **Separate workflow file**: Uses `.github/workflows/pr-title.yaml` instead of adding to `ci.yaml` to avoid re-triggering full CI when PR title/body edited. Only this lightweight job reruns on `edited` events.

  ---

  ### Checklist
  - [x] Accessibility: N/A (CI config only)
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
  - [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

  ### AI disclosure
  Assisted by: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull request titles targeting the master branch.
  * Pull requests are checked when opened, edited, or reopened to ensure titles follow the project’s commit message conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->