### PR TITLE
chore: set commitlint header-max-length = 256

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -21,6 +21,7 @@ module.exports = {
     'scope-case': [0],
     'body-max-length': [0],
     'body-max-line-length': [0],
+    'header-max-length': [2, 'always', 256],
     'scope-full-name-for-versioning': [2, 'always'],
   },
   plugins: [


### PR DESCRIPTION
Align commitlint pr title length validation with github max length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 256-character maximum length requirement for commit headers.
  * Commits exceeding the configured limit will now be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->