### PR TITLE
fix(@redhat-cloud-services/frontend-components): update scalprum core to ^0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12058,18 +12058,18 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-5.0.1.tgz",
-      "integrity": "sha512-+azUBN6FgcDmlcWMzG0bthcRUJC1u12wf9xa2aJGFbC/uTiOXwjrkcQ7LW/PyK5Em7wDhwaUdapaeOgh8I6Kjg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-8.2.0.tgz",
+      "integrity": "sha512-HKt8ILsf4+He+XqhIZI1PU7Xm+orA03WoVSQDYZdfpYByJbc8JxmBmv5u0Z8RZG0bg+EkCzicKvU91manNP2fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21",
-        "semver": "^7.3.7",
+        "lodash": "^4.17.23",
+        "semver": "^7.7.3",
         "uuid": "^8.3.2",
-        "yup": "^0.32.11"
+        "yup": "^1.7.1"
       },
       "peerDependencies": {
-        "react": "^17 || ^18"
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack": {
@@ -12087,6 +12087,30 @@
       },
       "peerDependencies": {
         "webpack": "^5.75.0"
+      }
+    },
+    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/yup": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
+      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -14715,12 +14739,12 @@
       "license": "MIT"
     },
     "node_modules/@scalprum/core": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.9.3.tgz",
-      "integrity": "sha512-n21OtoG44zIaqafuUKPn65MELbpRRo4Jv2/Ci8UsMm00Nk6oMB4h/mBy8Y/ztqjo0vKDFrHfR4sryVSy7uS0Bw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.10.1.tgz",
+      "integrity": "sha512-LlUy0stiE2HQ1j41G6yTh+9IPQiJAglVGxmaX8MGExI9SVOSjkjUaG7wd6cSga9XKRsvrFU8FzQ9bj6BWmz4lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
+        "@openshift/dynamic-plugin-sdk": "^8.0.0",
         "tslib": "^2.6.2"
       }
     },
@@ -14737,55 +14761,6 @@
       "peerDependencies": {
         "react": ">=17.0.0 <20.0.0",
         "react-dom": ">=17.0.0 <20.0.0"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/@openshift/dynamic-plugin-sdk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-8.2.0.tgz",
-      "integrity": "sha512-HKt8ILsf4+He+XqhIZI1PU7Xm+orA03WoVSQDYZdfpYByJbc8JxmBmv5u0Z8RZG0bg+EkCzicKvU91manNP2fQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lodash": "^4.17.23",
-        "semver": "^7.7.3",
-        "uuid": "^8.3.2",
-        "yup": "^1.7.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.10.1.tgz",
-      "integrity": "sha512-LlUy0stiE2HQ1j41G6yTh+9IPQiJAglVGxmaX8MGExI9SVOSjkjUaG7wd6cSga9XKRsvrFU8FzQ9bj6BWmz4lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^8.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/yup": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
-      "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
-      "license": "MIT",
-      "dependencies": {
-        "property-expr": "^2.0.5",
-        "tiny-case": "^1.0.3",
-        "toposort": "^2.0.2",
-        "type-fest": "^2.19.0"
       }
     },
     "node_modules/@segment/analytics-core": {
@@ -46533,7 +46508,7 @@
         "@patternfly/react-component-groups": "^6.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.0",
         "@redhat-cloud-services/types": "^3.0.0",
-        "@scalprum/core": "^0.9.2",
+        "@scalprum/core": "^0.10.1",
         "@scalprum/react-core": "^0.13.1",
         "classnames": "^2.2.5",
         "sanitize-html": "^2.13.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
     "@patternfly/react-component-groups": "^6.0.0",
     "@redhat-cloud-services/frontend-components-utilities": "^7.0.0",
     "@redhat-cloud-services/types": "^3.0.0",
-    "@scalprum/core": "^0.9.2",
+    "@scalprum/core": "^0.10.1",
     "@scalprum/react-core": "^0.13.1",
     "classnames": "^2.2.5",
     "sanitize-html": "^2.13.1"


### PR DESCRIPTION
### Description
   
  Bump `@scalprum/core` from `^0.9.2` to `^0.10.1`.

  `^0.9.2` caps at `<0.10.0`, preventing npm deduplication when insights-chrome uses `@scalprum/core@0.10.1`. This creates nested copy with stale `@openshift/dynamic-plugin-sdk@5.x`. Upgrade allows dedup and eliminates duplicate SDK copies. Dependency-only change, no code impact.

  [RHCLOUD-49561](https://redhat.atlassian.net/browse/RHCLOUD-49561) | Blocks [RHCLOUD-48802](https://redhat.atlassian.net/browse/RHCLOUD-48802)

  ---

  ### Screenshots
  N/A — dependency update only

  ---

  ### Anything reviewers should know?
  This is Phase 0 of SDK v8 upgrade path. Must land before RHCLOUD-48802 Phase 1 or insights-chrome will have duplicate SDK copies.

  ---

  ### Checklist
  - [x] N/A — no UI or code changes
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-49561]: https://redhat.atlassian.net/browse/RHCLOUD-49561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-48802]: https://redhat.atlassian.net/browse/RHCLOUD-48802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal component dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->