### PR TITLE
fix(@redhat-cloud-services/frontend-components-config): clean up properly with CTRL+C

### DIFF
--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -63,7 +63,7 @@ function stopContainer(containerName: string) {
   try {
     let isRunning: boolean = true;
     try {
-      execSync(`${execBin} inspect -f '{{.State.Running}}' ${containerName}\n`).toString().trim().toLowerCase() === 'true';
+      isRunning = execSync(`${execBin} inspect -f '{{.State.Running}}' ${containerName}\n`).toString().trim().toLowerCase() === 'true';
     } catch (error) {
       isRunning = false;
     }
@@ -254,22 +254,54 @@ async function devProxyScript(
   // Exec
   let commands: Command[] = [];
   let waitOnProcess: ReturnType<typeof exec> | undefined = undefined;
+  let shuttingDown = false;
 
-  const cleanup = () => {
-    commands.forEach((cmd) => {
-      if (cmd.pid) {
-        treeKill(cmd.pid, 'SIGKILL');
+  const cleanup = (onComplete?: () => void) => {
+    const pids = [
+      ...commands.map((cmd) => cmd.pid).filter((pid): pid is number => typeof pid === 'number'),
+      ...(waitOnProcess?.pid ? [waitOnProcess.pid] : []),
+    ];
+
+    const finish = () => {
+      stopContainer(DEV_PROXY_CONTAINER_NAME);
+      removeContainer(DEV_PROXY_CONTAINER_NAME);
+      if (SPAFallback) {
+        stopContainer(CHROME_CONTAINTER_NAME);
+        removeContainer(CHROME_CONTAINTER_NAME);
       }
+      console.log('\n');
+      onComplete?.();
+    };
+
+    if (pids.length === 0) {
+      finish();
+      return;
+    }
+
+    let remaining = pids.length;
+    pids.forEach((pid) => {
+      treeKill(pid, 'SIGKILL', () => {
+        remaining -= 1;
+        if (remaining === 0) {
+          finish();
+        }
+      });
     });
-    if (waitOnProcess?.pid) {
-      treeKill(waitOnProcess.pid, 'SIGKILL');
-    }
-    stopContainer(DEV_PROXY_CONTAINER_NAME);
-    if (SPAFallback) {
-      stopContainer(CHROME_CONTAINTER_NAME);
-    }
-    console.log('\n');
   };
+
+  // Register before spawning children so a signal during startup still cleans up
+  const shutdown = (exitCode = 0) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    cleanup(() => {
+      process.exit(exitCode);
+    });
+  };
+
+  process.on('SIGINT', () => shutdown(0));
+  process.on('SIGTERM', () => shutdown(0));
 
   try {
     const outputPath = webpackConfig.output.path;
@@ -304,8 +336,7 @@ async function devProxyScript(
       if (SPAFallback) {
         const handleServerError = (error: Error) => {
           fecLogger(LogType.error, error);
-          cleanup();
-          process.exit(1);
+          shutdown(1);
         };
 
         await serveChrome(
@@ -366,14 +397,8 @@ async function devProxyScript(
     );
 
     result.then(
-      () => {
-        cleanup();
-        process.exit(0);
-      },
-      () => {
-        cleanup();
-        process.exit(0);
-      },
+      () => shutdown(0),
+      () => shutdown(0),
     );
   } catch (error) {
     fecLogger(LogType.error, error);

--- a/packages/config/src/bin/dev-proxy-script.ts
+++ b/packages/config/src/bin/dev-proxy-script.ts
@@ -3,7 +3,6 @@ import concurrently, { Command } from 'concurrently';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import treeKill from 'tree-kill';
 import { LogType, fecLogger as fecLoggerDefault } from '@redhat-cloud-services/frontend-components-config-utilities';
 import { getCdnPath, setEnv, validateFECConfig } from './common';
 import serveChrome, { CONTAINER_NAME as CHROME_CONTAINTER_NAME, ContainerRuntime, checkContainerRuntime } from './serve-chrome';
@@ -22,6 +21,26 @@ const IOP_CUSTOM_ROUTES_CONTAINER_PATH = '/config/custom_routes.iop.json';
 
 let execBin: ContainerRuntime | undefined = undefined;
 let debug: boolean = false;
+
+function killProcessTree(pid: number) {
+  try {
+    const children = execSync(`pgrep -P ${pid}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] })
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(Number);
+    for (const child of children) {
+      killProcessTree(child);
+    }
+  } catch (_) {
+    // pgrep exits 1 when no children found
+  }
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (_) {
+    // process already dead
+  }
+}
 
 interface RouteConfig {
   url: string;
@@ -254,54 +273,34 @@ async function devProxyScript(
   // Exec
   let commands: Command[] = [];
   let waitOnProcess: ReturnType<typeof exec> | undefined = undefined;
-  let shuttingDown = false;
 
-  const cleanup = (onComplete?: () => void) => {
-    const pids = [
-      ...commands.map((cmd) => cmd.pid).filter((pid): pid is number => typeof pid === 'number'),
-      ...(waitOnProcess?.pid ? [waitOnProcess.pid] : []),
-    ];
-
-    const finish = () => {
-      stopContainer(DEV_PROXY_CONTAINER_NAME);
-      removeContainer(DEV_PROXY_CONTAINER_NAME);
-      if (SPAFallback) {
-        stopContainer(CHROME_CONTAINTER_NAME);
-        removeContainer(CHROME_CONTAINTER_NAME);
+  const cleanup = () => {
+    commands.forEach((cmd) => {
+      if (cmd.pid) {
+        killProcessTree(cmd.pid);
       }
-      console.log('\n');
-      onComplete?.();
-    };
-
-    if (pids.length === 0) {
-      finish();
-      return;
-    }
-
-    let remaining = pids.length;
-    pids.forEach((pid) => {
-      treeKill(pid, 'SIGKILL', () => {
-        remaining -= 1;
-        if (remaining === 0) {
-          finish();
-        }
-      });
     });
+    if (waitOnProcess?.pid) {
+      killProcessTree(waitOnProcess.pid);
+    }
+    stopContainer(DEV_PROXY_CONTAINER_NAME);
+    removeContainer(DEV_PROXY_CONTAINER_NAME);
+    if (SPAFallback) {
+      stopContainer(CHROME_CONTAINTER_NAME);
+      removeContainer(CHROME_CONTAINTER_NAME);
+    }
+    console.log('\n');
   };
 
-  // Register before spawning children so a signal during startup still cleans up
-  const shutdown = (exitCode = 0) => {
-    if (shuttingDown) {
-      return;
-    }
-    shuttingDown = true;
-    cleanup(() => {
-      process.exit(exitCode);
-    });
+  const handleSignal = () => {
+    process.off('SIGINT', handleSignal);
+    process.off('SIGTERM', handleSignal);
+    cleanup();
+    process.exit(0);
   };
 
-  process.on('SIGINT', () => shutdown(0));
-  process.on('SIGTERM', () => shutdown(0));
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
 
   try {
     const outputPath = webpackConfig.output.path;
@@ -336,7 +335,8 @@ async function devProxyScript(
       if (SPAFallback) {
         const handleServerError = (error: Error) => {
           fecLogger(LogType.error, error);
-          shutdown(1);
+          cleanup();
+          process.exit(1);
         };
 
         await serveChrome(
@@ -369,7 +369,7 @@ async function devProxyScript(
           prefixColor: 'bgGreen',
         },
         {
-          command: `${execBin} run -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}${DEV_PROXY_IMAGE_TAG} ${proxyVerbose}`,
+          command: `${execBin} run --rm -d -e HCC_ENV=${process.env.HCC_ENV} -e HCC_ENV_URL=${process.env.HCC_ENV_URL} ${proxyEnvVar} ${iopEnvVar} ${iopCustomRoutesEnvVar} -p ${argv.port || 1337}:${DEV_PROXY_CONTAINER_PORT} -v "${routesConfigPath}:/config/routes.json:ro,z" ${iopCustomRoutesMountVar} --name ${DEV_PROXY_CONTAINER_NAME} ${DEV_PROXY_IMAGE_REPO}${DEV_PROXY_IMAGE_TAG} ${proxyVerbose}`,
           name: 'PROXY',
           env: { RH_PROXY_URL: PROXY_URL },
           prefixColor: 'bgMagenta',
@@ -397,8 +397,14 @@ async function devProxyScript(
     );
 
     result.then(
-      () => shutdown(0),
-      () => shutdown(0),
+      () => {
+        cleanup();
+        process.exit(0);
+      },
+      () => {
+        cleanup();
+        process.exit(1);
+      },
     );
   } catch (error) {
     fecLogger(LogType.error, error);

--- a/packages/config/src/bin/serve-chrome.ts
+++ b/packages/config/src/bin/serve-chrome.ts
@@ -136,7 +136,7 @@ async function startServer(image: string, tag: string, serverPort: number) {
     } catch (error) {
       fecLogger(LogType.info, 'No existing chrome container found');
     }
-    const runCommand = `${execBin} run -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${image}:${tag}`;
+    const runCommand = `${execBin} run --rm -p ${serverPort}:${CONTAINER_PORT} --name ${CONTAINER_NAME} ${image}:${tag}`;
     fecLogger(LogType.debug, `Spawn ${runCommand}`);
     const child = spawn(runCommand, [], {
       stdio: 'ignore',


### PR DESCRIPTION
Theres an issue in the dev-proxy script where when trying to kill the terminal with CTRL+C, it hangs up and doesnt clean up properly. This just fixes that 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development proxy shutdown handling for interrupt and termination signals, ensuring a consistent exit flow.
  * Ensures spawned processes and proxy-related containers are properly stopped and removed before exit, including the optional Chrome container.
  * Proxy and Chrome containers now clean themselves up automatically when they stop.
  * Concurrent process failures now exit with a failure status instead of appearing successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->