### PR TITLE
chore(deps): add npm min-release-age cooldown

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=2


### PR DESCRIPTION
## Description
   
  Add npm package cooldown (2-day minimum release age) to harden against supply-chain attacks. Malicious/compromised packages are typically yanked within 24 hours — this forces a wait window, blocking immediate consumption before detection. 

  [RHCLOUD-49796](https://redhat.atlassian.net/browse/RHCLOUD-49796)

  ---

  ### Anything reviewers should know?

  - **No regression risk**: audited top-level deps — none require same-day install (esbuild, cypress, @swc/core, etc. need postinstall scripts, but those fire on normal 2+ day-old versions)
  - **Security vs speed trade-off intentional**: urgent CVE fixes <2 days old require manual `npm install pkg@latest --min-release-age=0` or wait. Acceptable per InfoSec guidance
  - **Excluded exemptions intentionally**: past package compromise in org scope → no `min-release-age-exclude` for `@redhat-cloud-services/*`. Own scope needs cooldown protection most
  - **Renovate sync**: `minimumReleaseAge: "2 days"` prevents bot from opening PRs for packages npm itself would reject to install

  ---

  ### Checklist
  - [x] All PR checks pass locally (build, lint, test)
  - [x] No unrelated changes included
  - [x] Non-visual change (config + deps): N/A for accessibility, QE, UX

  ### AI disclosure

  Assisted by: Claude Code


[RHCLOUD-49796]: https://redhat.atlassian.net/browse/RHCLOUD-49796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to allow additional time for new releases to mature before they are adopted.
  * Aligned automated update settings with the same release-timing policy for more consistent project maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->