### PR TITLE
fix(@redhat-cloud-services/frontend-components): improve bulkSelect

### DIFF
--- a/packages/components/src/BulkSelect/BulkSelect.tsx
+++ b/packages/components/src/BulkSelect/BulkSelect.tsx
@@ -77,25 +77,28 @@ const BulkSelect = ({
               ref={toggleRef}
               onClick={() => setIsOpen((prev) => !prev)}
               ouiaId={dropdownOuiaId ?? 'BulkSelect'}
+              splitButtonItems={
+                !toggleProps?.children
+                  ? [
+                      <MenuToggleCheckbox
+                        key={'split-checkbox-with-text'}
+                        id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
+                        aria-label="Select all"
+                        onChange={(checked, event) => {
+                          setIsOpen(false);
+                          onSelect?.(checked, event);
+                        }}
+                        isDisabled={isDisabled}
+                        isChecked={checked}
+                        ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
+                      >
+                        {!hasError && count ? `${count} selected` : ''}
+                      </MenuToggleCheckbox>,
+                    ]
+                  : []
+              }
             >
-              {toggleProps?.children ? (
-                toggleProps?.children
-              ) : (
-                <Fragment key="split-checkbox">
-                  <MenuToggleCheckbox
-                    id={id ? `${id}-toggle-checkbox` : 'toggle-checkbox'}
-                    aria-label="Select all"
-                    onChange={(checked, event) => {
-                      setIsOpen(false);
-                      onSelect?.(checked, event);
-                    }}
-                    isChecked={checked}
-                    ouiaId={checkboxOuiaId ?? 'BulkSelectCheckbox'}
-                  >
-                    {!hasError && count ? `${count} selected` : ''}
-                  </MenuToggleCheckbox>
-                </Fragment>
-              )}
+              {toggleProps?.children}
             </MenuToggle>
           )}
           isOpen={isOpen}

--- a/packages/components/src/BulkSelect/__snapshots__/BulkSelect.test.js.snap
+++ b/packages/components/src/BulkSelect/__snapshots__/BulkSelect.test.js.snap
@@ -21,219 +21,219 @@ exports[`BulkSelect should render correctly - no data 1`] = `
 
 exports[`BulkSelect should render correctly - null checked 1`] = `
 <div>
-  <button
-    aria-expanded="false"
-    class="pf-v6-c-menu-toggle"
-    data-ouia-component-id="BulkSelect"
-    data-ouia-component-type="PF6/MenuToggle"
-    data-ouia-safe="true"
-    type="button"
+  <div
+    class="pf-v6-c-menu-toggle pf-m-split-button"
   >
-    <span
-      class="pf-v6-c-menu-toggle__text"
+    <label
+      class="pf-v6-c-check pf-m-standalone"
     >
-      <label
-        class="pf-v6-c-check pf-m-standalone"
-      >
-        <input
-          aria-invalid="false"
-          aria-label="Select all"
-          class="pf-v6-c-check__input"
-          data-ouia-component-id="BulkSelectCheckbox"
-          data-ouia-component-type="PF6/MenuToggleCheckbox"
-          data-ouia-safe="true"
-          name="toggle-checkbox"
-          type="checkbox"
-        />
-      </label>
-    </span>
-    <span
-      class="pf-v6-c-menu-toggle__controls"
+      <input
+        aria-invalid="false"
+        aria-label="Select all"
+        class="pf-v6-c-check__input"
+        data-ouia-component-id="BulkSelectCheckbox"
+        data-ouia-component-type="PF6/MenuToggleCheckbox"
+        data-ouia-safe="true"
+        name="toggle-checkbox"
+        type="checkbox"
+      />
+    </label>
+    <button
+      aria-expanded="false"
+      class="pf-v6-c-menu-toggle__button"
+      data-ouia-component-id="BulkSelect"
+      data-ouia-component-type="PF6/MenuToggle"
+      data-ouia-safe="true"
+      type="button"
     >
       <span
-        class="pf-v6-c-menu-toggle__toggle-icon"
+        class="pf-v6-c-menu-toggle__controls"
       >
-        <svg
-          aria-hidden="true"
-          class="pf-v6-svg"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          viewBox="0 0 20 20"
-          width="1em"
+        <span
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
-          <path
-            d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-          />
-        </svg>
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 20 20"
+            width="1em"
+          >
+            <path
+              d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+            />
+          </svg>
+        </span>
       </span>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`BulkSelect should render correctly 1`] = `
 <div>
-  <button
-    aria-expanded="false"
-    class="pf-v6-c-menu-toggle"
-    data-ouia-component-id="BulkSelect"
-    data-ouia-component-type="PF6/MenuToggle"
-    data-ouia-safe="true"
-    type="button"
+  <div
+    class="pf-v6-c-menu-toggle pf-m-split-button"
   >
-    <span
-      class="pf-v6-c-menu-toggle__text"
+    <label
+      class="pf-v6-c-check"
     >
-      <label
-        class="pf-v6-c-check"
+      <input
+        aria-invalid="false"
+        aria-label="Select all"
+        class="pf-v6-c-check__input"
+        data-ouia-component-id="BulkSelectCheckbox"
+        data-ouia-component-type="PF6/MenuToggleCheckbox"
+        data-ouia-safe="true"
+        name="some-id-toggle-checkbox"
+        type="checkbox"
+      />
+      <span
+        aria-hidden="true"
+        class="pf-v6-c-check__label"
+        id="some-id-toggle-checkbox"
       >
-        <input
-          aria-invalid="false"
-          aria-label="Select all"
-          class="pf-v6-c-check__input"
-          data-ouia-component-id="BulkSelectCheckbox"
-          data-ouia-component-type="PF6/MenuToggleCheckbox"
-          data-ouia-safe="true"
-          name="some-id-toggle-checkbox"
-          type="checkbox"
-        />
-        <span
-          aria-hidden="true"
-          class="pf-v6-c-check__label"
-          id="some-id-toggle-checkbox"
-        >
-          30 selected
-        </span>
-      </label>
-    </span>
-    <span
-      class="pf-v6-c-menu-toggle__controls"
+        30 selected
+      </span>
+    </label>
+    <button
+      aria-expanded="false"
+      class="pf-v6-c-menu-toggle__button"
+      data-ouia-component-id="BulkSelect"
+      data-ouia-component-type="PF6/MenuToggle"
+      data-ouia-safe="true"
+      type="button"
     >
       <span
-        class="pf-v6-c-menu-toggle__toggle-icon"
+        class="pf-v6-c-menu-toggle__controls"
       >
-        <svg
-          aria-hidden="true"
-          class="pf-v6-svg"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          viewBox="0 0 20 20"
-          width="1em"
+        <span
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
-          <path
-            d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-          />
-        </svg>
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 20 20"
+            width="1em"
+          >
+            <path
+              d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+            />
+          </svg>
+        </span>
       </span>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`BulkSelect should render correctly 2`] = `
 <div>
-  <button
-    aria-expanded="false"
-    class="pf-v6-c-menu-toggle"
-    data-ouia-component-id="BulkSelect"
-    data-ouia-component-type="PF6/MenuToggle"
-    data-ouia-safe="true"
-    type="button"
+  <div
+    class="pf-v6-c-menu-toggle pf-m-split-button"
   >
-    <span
-      class="pf-v6-c-menu-toggle__text"
+    <label
+      class="pf-v6-c-check pf-m-standalone"
     >
-      <label
-        class="pf-v6-c-check pf-m-standalone"
-      >
-        <input
-          aria-invalid="false"
-          aria-label="Select all"
-          class="pf-v6-c-check__input"
-          data-ouia-component-id="BulkSelectCheckbox"
-          data-ouia-component-type="PF6/MenuToggleCheckbox"
-          data-ouia-safe="true"
-          name="toggle-checkbox"
-          type="checkbox"
-        />
-      </label>
-    </span>
-    <span
-      class="pf-v6-c-menu-toggle__controls"
+      <input
+        aria-invalid="false"
+        aria-label="Select all"
+        class="pf-v6-c-check__input"
+        data-ouia-component-id="BulkSelectCheckbox"
+        data-ouia-component-type="PF6/MenuToggleCheckbox"
+        data-ouia-safe="true"
+        name="toggle-checkbox"
+        type="checkbox"
+      />
+    </label>
+    <button
+      aria-expanded="false"
+      class="pf-v6-c-menu-toggle__button"
+      data-ouia-component-id="BulkSelect"
+      data-ouia-component-type="PF6/MenuToggle"
+      data-ouia-safe="true"
+      type="button"
     >
       <span
-        class="pf-v6-c-menu-toggle__toggle-icon"
+        class="pf-v6-c-menu-toggle__controls"
       >
-        <svg
-          aria-hidden="true"
-          class="pf-v6-svg"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          viewBox="0 0 20 20"
-          width="1em"
+        <span
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
-          <path
-            d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-          />
-        </svg>
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 20 20"
+            width="1em"
+          >
+            <path
+              d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+            />
+          </svg>
+        </span>
       </span>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;
 
 exports[`BulkSelect should render custom props 1`] = `
 <div>
-  <button
-    aria-expanded="false"
-    class="pf-v6-c-menu-toggle"
-    data-ouia-component-id="BulkSelect"
-    data-ouia-component-type="PF6/MenuToggle"
-    data-ouia-safe="true"
-    type="button"
+  <div
+    class="pf-v6-c-menu-toggle pf-m-split-button"
   >
-    <span
-      class="pf-v6-c-menu-toggle__text"
+    <label
+      class="pf-v6-c-check pf-m-standalone"
     >
-      <label
-        class="pf-v6-c-check pf-m-standalone"
-      >
-        <input
-          aria-invalid="false"
-          aria-label="Select all"
-          class="pf-v6-c-check__input"
-          data-ouia-component-id="BulkSelectCheckbox"
-          data-ouia-component-type="PF6/MenuToggleCheckbox"
-          data-ouia-safe="true"
-          name="toggle-checkbox"
-          type="checkbox"
-        />
-      </label>
-    </span>
-    <span
-      class="pf-v6-c-menu-toggle__controls"
+      <input
+        aria-invalid="false"
+        aria-label="Select all"
+        class="pf-v6-c-check__input"
+        data-ouia-component-id="BulkSelectCheckbox"
+        data-ouia-component-type="PF6/MenuToggleCheckbox"
+        data-ouia-safe="true"
+        name="toggle-checkbox"
+        type="checkbox"
+      />
+    </label>
+    <button
+      aria-expanded="false"
+      class="pf-v6-c-menu-toggle__button"
+      data-ouia-component-id="BulkSelect"
+      data-ouia-component-type="PF6/MenuToggle"
+      data-ouia-safe="true"
+      type="button"
     >
       <span
-        class="pf-v6-c-menu-toggle__toggle-icon"
+        class="pf-v6-c-menu-toggle__controls"
       >
-        <svg
-          aria-hidden="true"
-          class="pf-v6-svg"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          viewBox="0 0 20 20"
-          width="1em"
+        <span
+          class="pf-v6-c-menu-toggle__toggle-icon"
         >
-          <path
-            d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-          />
-        </svg>
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 20 20"
+            width="1em"
+          >
+            <path
+              d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+            />
+          </svg>
+        </span>
       </span>
-    </span>
-  </button>
+    </button>
+  </div>
 </div>
 `;

--- a/packages/components/src/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
+++ b/packages/components/src/PrimaryToolbar/__snapshots__/PrimaryToolbar.test.js.snap
@@ -177,54 +177,54 @@ exports[`PrimaryToolbar should render with data full config 1`] = `
         <div
           class="pf-v6-c-toolbar__item"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-menu-toggle"
-            data-ouia-component-id="BulkSelect"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-menu-toggle pf-m-split-button"
           >
-            <span
-              class="pf-v6-c-menu-toggle__text"
+            <label
+              class="pf-v6-c-check pf-m-standalone"
             >
-              <label
-                class="pf-v6-c-check pf-m-standalone"
-              >
-                <input
-                  aria-invalid="false"
-                  aria-label="Select all"
-                  class="pf-v6-c-check__input"
-                  data-ouia-component-id="BulkSelectCheckbox"
-                  data-ouia-component-type="PF6/MenuToggleCheckbox"
-                  data-ouia-safe="true"
-                  name="toggle-checkbox"
-                  type="checkbox"
-                />
-              </label>
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
+              <input
+                aria-invalid="false"
+                aria-label="Select all"
+                class="pf-v6-c-check__input"
+                data-ouia-component-id="BulkSelectCheckbox"
+                data-ouia-component-type="PF6/MenuToggleCheckbox"
+                data-ouia-safe="true"
+                name="toggle-checkbox"
+                type="checkbox"
+              />
+            </label>
+            <button
+              aria-expanded="false"
+              class="pf-v6-c-menu-toggle__button"
+              data-ouia-component-id="BulkSelect"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              type="button"
             >
               <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
+                class="pf-v6-c-menu-toggle__controls"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 20 20"
-                  width="1em"
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
                 >
-                  <path
-                    d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width="1em"
+                  >
+                    <path
+                      d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
         <div
           class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
@@ -996,54 +996,54 @@ exports[`PrimaryToolbar should render with data only - bulk select 1`] = `
         <div
           class="pf-v6-c-toolbar__item"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-menu-toggle"
-            data-ouia-component-id="BulkSelect"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-menu-toggle pf-m-split-button"
           >
-            <span
-              class="pf-v6-c-menu-toggle__text"
+            <label
+              class="pf-v6-c-check pf-m-standalone"
             >
-              <label
-                class="pf-v6-c-check pf-m-standalone"
-              >
-                <input
-                  aria-invalid="false"
-                  aria-label="Select all"
-                  class="pf-v6-c-check__input"
-                  data-ouia-component-id="BulkSelectCheckbox"
-                  data-ouia-component-type="PF6/MenuToggleCheckbox"
-                  data-ouia-safe="true"
-                  name="toggle-checkbox"
-                  type="checkbox"
-                />
-              </label>
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
+              <input
+                aria-invalid="false"
+                aria-label="Select all"
+                class="pf-v6-c-check__input"
+                data-ouia-component-id="BulkSelectCheckbox"
+                data-ouia-component-type="PF6/MenuToggleCheckbox"
+                data-ouia-safe="true"
+                name="toggle-checkbox"
+                type="checkbox"
+              />
+            </label>
+            <button
+              aria-expanded="false"
+              class="pf-v6-c-menu-toggle__button"
+              data-ouia-component-id="BulkSelect"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              type="button"
             >
               <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
+                class="pf-v6-c-menu-toggle__controls"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 20 20"
-                  width="1em"
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
                 >
-                  <path
-                    d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width="1em"
+                  >
+                    <path
+                      d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1252,54 +1252,54 @@ exports[`PrimaryToolbar should render wrong actionsConfig 1`] = `
         <div
           class="pf-v6-c-toolbar__item"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-menu-toggle"
-            data-ouia-component-id="BulkSelect"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-menu-toggle pf-m-split-button"
           >
-            <span
-              class="pf-v6-c-menu-toggle__text"
+            <label
+              class="pf-v6-c-check pf-m-standalone"
             >
-              <label
-                class="pf-v6-c-check pf-m-standalone"
-              >
-                <input
-                  aria-invalid="false"
-                  aria-label="Select all"
-                  class="pf-v6-c-check__input"
-                  data-ouia-component-id="BulkSelectCheckbox"
-                  data-ouia-component-type="PF6/MenuToggleCheckbox"
-                  data-ouia-safe="true"
-                  name="toggle-checkbox"
-                  type="checkbox"
-                />
-              </label>
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
+              <input
+                aria-invalid="false"
+                aria-label="Select all"
+                class="pf-v6-c-check__input"
+                data-ouia-component-id="BulkSelectCheckbox"
+                data-ouia-component-type="PF6/MenuToggleCheckbox"
+                data-ouia-safe="true"
+                name="toggle-checkbox"
+                type="checkbox"
+              />
+            </label>
+            <button
+              aria-expanded="false"
+              class="pf-v6-c-menu-toggle__button"
+              data-ouia-component-id="BulkSelect"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              type="button"
             >
               <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
+                class="pf-v6-c-menu-toggle__controls"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 20 20"
-                  width="1em"
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
                 >
-                  <path
-                    d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width="1em"
+                  >
+                    <path
+                      d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
         <div
           class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"

--- a/packages/components/src/TagModal/__snapshots__/TableWithFilter.test.js.snap
+++ b/packages/components/src/TagModal/__snapshots__/TableWithFilter.test.js.snap
@@ -254,54 +254,54 @@ exports[`TableWithFilter should render with data and bulk select with calculate 
         <div
           class="pf-v6-c-toolbar__item"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-menu-toggle"
-            data-ouia-component-id="BulkSelect"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-menu-toggle pf-m-split-button"
           >
-            <span
-              class="pf-v6-c-menu-toggle__text"
+            <label
+              class="pf-v6-c-check pf-m-standalone"
             >
-              <label
-                class="pf-v6-c-check pf-m-standalone"
-              >
-                <input
-                  aria-invalid="false"
-                  aria-label="Select all"
-                  class="pf-v6-c-check__input"
-                  data-ouia-component-id="BulkSelectCheckbox"
-                  data-ouia-component-type="PF6/MenuToggleCheckbox"
-                  data-ouia-safe="true"
-                  name="toggle-checkbox"
-                  type="checkbox"
-                />
-              </label>
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
+              <input
+                aria-invalid="false"
+                aria-label="Select all"
+                class="pf-v6-c-check__input"
+                data-ouia-component-id="BulkSelectCheckbox"
+                data-ouia-component-type="PF6/MenuToggleCheckbox"
+                data-ouia-safe="true"
+                name="toggle-checkbox"
+                type="checkbox"
+              />
+            </label>
+            <button
+              aria-expanded="false"
+              class="pf-v6-c-menu-toggle__button"
+              data-ouia-component-id="BulkSelect"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              type="button"
             >
               <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
+                class="pf-v6-c-menu-toggle__controls"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 20 20"
-                  width="1em"
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
                 >
-                  <path
-                    d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width="1em"
+                  >
+                    <path
+                      d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
         <div
           class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
@@ -862,54 +862,54 @@ exports[`TableWithFilter should render with data and bulk select without calcula
         <div
           class="pf-v6-c-toolbar__item"
         >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-menu-toggle"
-            data-ouia-component-id="BulkSelect"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-menu-toggle pf-m-split-button"
           >
-            <span
-              class="pf-v6-c-menu-toggle__text"
+            <label
+              class="pf-v6-c-check pf-m-standalone"
             >
-              <label
-                class="pf-v6-c-check pf-m-standalone"
-              >
-                <input
-                  aria-invalid="false"
-                  aria-label="Select all"
-                  class="pf-v6-c-check__input"
-                  data-ouia-component-id="BulkSelectCheckbox"
-                  data-ouia-component-type="PF6/MenuToggleCheckbox"
-                  data-ouia-safe="true"
-                  name="toggle-checkbox"
-                  type="checkbox"
-                />
-              </label>
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
+              <input
+                aria-invalid="false"
+                aria-label="Select all"
+                class="pf-v6-c-check__input"
+                data-ouia-component-id="BulkSelectCheckbox"
+                data-ouia-component-type="PF6/MenuToggleCheckbox"
+                data-ouia-safe="true"
+                name="toggle-checkbox"
+                type="checkbox"
+              />
+            </label>
+            <button
+              aria-expanded="false"
+              class="pf-v6-c-menu-toggle__button"
+              data-ouia-component-id="BulkSelect"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              type="button"
             >
               <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
+                class="pf-v6-c-menu-toggle__controls"
               >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 20 20"
-                  width="1em"
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
                 >
-                  <path
-                    d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 20 20"
+                    width="1em"
+                  >
+                    <path
+                      d="m17.65 8.76-6.674 5.72a1.496 1.496 0 0 1-.976.365c-.347 0-.694-.122-.978-.366l-6.673-5.72A1 1 0 0 1 3 7h14a1 1 0 0 1 .65 1.76Z"
+                    />
+                  </svg>
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
         <div
           class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"


### PR DESCRIPTION
### Description
Fix BulkSelect zero state height issue. Make BulkSelect appearance in line with native PatternFly BulkSelect component (uses [Split toggle with labeled checkbox](https://www.patternfly.org/components/menus/menu-toggle/#split-toggle-with-labeled-checkbox)).

[HMS-11116](https://redhat.atlassian.net/browse/HMS-11116)

---

### Screenshots
#### Before:
<img width="87" height="51" alt="Screenshot From 2026-08-27 11-12-31" src="https://github.com/user-attachments/assets/a9f5f344-898c-40f4-94a4-29634427df47" />
<img width="167" height="51" alt="Screenshot From 2026-08-27 11-12-10" src="https://github.com/user-attachments/assets/c9764bb5-fee2-438a-81cd-902a3dbe9052" />

#### After:
<img width="105" height="51" alt="Screenshot From 2026-08-27 11-10-48" src="https://github.com/user-attachments/assets/ec70e4be-e6ff-4fc8-86cf-4455b568c800" />
<img width="189" height="51" alt="Screenshot From 2026-08-27 11-11-10" src="https://github.com/user-attachments/assets/da8a81cf-dd73-4078-a1a8-eba48dcf1eec" />


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
No AI code included.

[HMS-11116]: https://redhat.atlassian.net/browse/HMS-11116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Bulk Select menu toggle’s rendering behavior while preserving the “Select all” checkbox, accessibility labels, selection handling, and item count display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->