### PR TITLE
fix(@redhat-cloud-services/frontend-components): fix bottom pagination margin

### DIFF
--- a/packages/components/src/TableToolbar/TableToolbar.scss
+++ b/packages/components/src/TableToolbar/TableToolbar.scss
@@ -2,13 +2,12 @@
 
 :root {
     --ins-c-table-toolbar--PaddingVertical: 16px;
-    --ins-c-table-toolbar--PaddingHorizontal: 32px;
 }
 
 .ins-c-table__toolbar, .ins-c-table__toolbar-results {
   background: var(--pf-t--global--background--color--primary--default);
   border-bottom: 1px solid var(--pf-t--global--background--color--secondary--default);
-  padding: var(--ins-c-table-toolbar--PaddingVertical) var(--ins-c-table-toolbar--PaddingHorizontal);
+  padding: var(--ins-c-table-toolbar--PaddingVertical) 0;
 }
 
 .ins-c-table__toolbar.ins-m-footer { border-top: 1px solid var(--pf-t--global--background--color--secondary--default); }


### PR DESCRIPTION
### Description
Fix bottom pagination alignment. It has too much right margin and is misaligned with the top pagination.

[HMS-11245](https://redhat.atlassian.net/browse/HMS-11245)

---

### Screenshots
#### Before:
<img width="510" height="98" alt="image" src="https://github.com/user-attachments/assets/cba41410-c1bd-462f-96c7-8fade317aca9" />

#### After:
<img width="510" height="94" alt="image" src="https://github.com/user-attachments/assets/14f8945c-6860-4dd7-89ee-dc60550729a7" />

---

### Anything reviewers should know?
This is only a partial solution. There remains 8px of right margin, it comes from the default styles for bottom pagination from PatternFly. 

---

### Checklist
- [ ] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[HMS-11245]: https://redhat.atlassian.net/browse/HMS-11245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated table toolbar spacing by removing horizontal padding while preserving vertical padding.
  - Simplified the toolbar layout styling for more consistent alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->