### PR TITLE
chore(renovate): update node and npm versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>RedHatInsights/shared-workflows//renovate/frontend"],
-  "commitMessagePrefix": "fix(deps):",
+  "commitMessageLowerCase": "auto",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "fix",
+  "semanticCommitScope": "deps",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
-      "commitMessagePrefix": "chore(deps-dev):"
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps-dev"
+    },
+    {
+      "description": "Use chore commit type for GitHub Actions version updates (no package release should be triggered)",
+      "matchManagers": ["github-actions"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "ci"
     },
     {
       "description": "Update Node.js version in .nvmrc and package.json engines.node",

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,20 @@
     {
       "matchDepTypes": ["devDependencies"],
       "commitMessagePrefix": "chore(deps-dev):"
+    },
+    {
+      "description": "Update Node.js version in .nvmrc and package.json engines.node",
+      "matchManagers": ["nvm", "npm"],
+      "matchDepNames": ["node"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": false
+    },
+    {
+      "description": "Update npm version in package.json (engines.npm and packageManager)",
+      "matchManagers": ["npm"],
+      "matchDepNames": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,8 @@
       "matchManagers": ["nvm", "npm"],
       "matchDepNames": ["node"],
       "matchUpdateTypes": ["minor", "patch"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "node",
       "automerge": false
     },
     {
@@ -29,6 +31,8 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "npm",
       "automerge": false
     }
   ]


### PR DESCRIPTION
### Description

Adding full node version in `.nvmrc` file and full npm version to `packageManager` field in `package.json` ensures that local and CI environments don't drift, thereby preventing the version discrepancy errors that prompt us to increment versions. Therefore I am trialing this renovate config to apply the version increments for us.   

https://redhat.atlassian.net/browse/RHCLOUD-50924

Config tested and validated using these commands:

```shell
LOG_LEVEL=debug npx renovate@latest --platform=local
```

Reference: https://docs.renovatebot.com/modules/platform/local/

---

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->

Assisted by: Goose using claude-sonnet-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for Node.js and npm.
  * Updates are limited to minor and patch releases and require pull request review instead of automatic merging.
  * Added automated version update handling for GitHub Actions.
  * Standardized dependency update commit messages for clearer release and maintenance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->